### PR TITLE
az resource-graph --include displayNames fails on ubuntu

### DIFF
--- a/src/azure/cli/tests/test_output.py
+++ b/src/azure/cli/tests/test_output.py
@@ -3,11 +3,12 @@ from __future__ import print_function
 import unittest
 
 try:
+    # on Python2, we like to use the module "StringIO" rather "io" so to 
+    # avoid "print" errors like: TypeError: string argument expected, got 'str'
+    from StringIO import StringIO
+except ImportError:
     # Python 3
     from io import StringIO
-except ImportError:
-    # Python 2
-    from StringIO import StringIO
 
 from azure.cli._output import (OutputProducer, OutputFormatException, format_json, format_table, format_list, format_text,
                                 ListOutput)


### PR DESCRIPTION
## Describe the bug
az resource-graph --include displayNames fails on ubuntu, below is my Az pipeline 
```yml
trigger:
  branches:
    include:
      - '*'
stages:
  - stage: 
    jobs:
      - job: 
        pool:
          vmImage: 'ubuntu-latest'
        steps:
          - task: AzureCLI@1
            inputs:
              azureSubscription: 'SERVICECONNECTION'
              scriptLocation: inlineScript
              inlineScript: | 
                az extension add --name resource-graph
                az graph query -q "where type =~ 'Microsoft.Compute/virtualMachines' | project id" --include displayNames
**Warning:**
**_WARNING: Failed to include displayNames to result. Error: 'displayName'_**

**Works fine in windows-latest**
```yml
trigger:
  branches:
    include:
      - '*'
stages:
  - stage: 
    jobs:
      - job: 
        pool:
          vmImage: 'windows-latest'
        steps:
          - task: AzureCLI@1
            inputs:
              azureSubscription: 'SERVICECONNECTION'
              scriptLocation: inlineScript
              inlineScript: | 
                az extension add --name resource-graph
                az graph query -q "where type =~ 'Microsoft.Compute/virtualMachines' | project id" --include displayNames
```
## Environment Summary
```
Windows-10-10.0.16299-SP0
Python 3.6.6
Shell: cmd.exe

azure-cli 2.0.74 *

Extensions:
log-analytics 0.1.3
resource-graph 1.0.0

```
## Additional Context

<!--Please don't remove this:-->
<!--auto-generated-->

