### PR TITLE
Allow user to specify an output format [114821361]

### DIFF
--- a/src/azure/cli/_argparse.py
+++ b/src/azure/cli/_argparse.py
@@ -3,6 +3,7 @@ import sys
 
 from ._locale import L, get_file as locale_get_file
 from ._logging import logger
+from ._output import OutputProducer
 
 # Named arguments are prefixed with one of these strings
 ARG_PREFIXES = sorted(('-', '--', '/'), key=len, reverse=True)
@@ -57,6 +58,10 @@ def _index(string, char, default=sys.maxsize):
     except ValueError:
         return default
 
+class ArgumentParserResult(object):  #pylint: disable=too-few-public-methods
+    def __init__(self, result, output_format=None):
+        self.result = result
+        self.output_format = output_format
 
 class ArgumentParser(object):
     def __init__(self, prog):
@@ -125,6 +130,7 @@ class ArgumentParser(object):
     #pylint: disable=too-many-branches
     #pylint: disable=too-many-statements
     #pylint: disable=too-many-locals
+    #pylint: disable=too-many-return-statements
     def execute(self,
                 args,
                 show_usage=False,
@@ -177,9 +183,9 @@ class ArgumentParser(object):
             show_usage = True
 
         if show_completions:
-            return self._display_completions(m, args, out)
+            return ArgumentParserResult(self._display_completions(m, args, out))
         if show_usage:
-            return self._display_usage(nouns, m, out)
+            return ArgumentParserResult(self._display_usage(nouns, m, out))
 
         parsed = Arguments()
         others = Arguments()
@@ -199,7 +205,7 @@ class ArgumentParser(object):
                     if value is not None:
                         print(L("argument '{0}' does not take a value").format(key_n),
                               file=out)
-                        return self._display_usage(nouns, m, out)
+                        return ArgumentParserResult(self._display_usage(nouns, m, out))
                     parsed.add_from_dotted(target_value[0], True)
                 else:
                     # Arg with a value
@@ -217,15 +223,24 @@ class ArgumentParser(object):
                 parsed[a]
             except KeyError:
                 print(L("Missing required argument {}".format(a)))
-                return self._display_usage(nouns, m, out)
+                return ArgumentParserResult(self._display_usage(nouns, m, out))
+
+        output_format = None
+        if others and 'output' in others:
+            if others['output'] in OutputProducer.format_dict:
+                output_format = others['output']
+                del others['output']
+            else:
+                print(L("Invalid output format '{}' specified".format(others['output'])))
+                return ArgumentParserResult(self._display_usage(nouns, m, out))
 
         old_stdout = sys.stdout
         try:
             sys.stdout = out
-            return handler(parsed, others)
+            return ArgumentParserResult(handler(parsed, others), output_format)
         except IncorrectUsageError as ex:
             print(str(ex), file=out)
-            return self._display_usage(nouns, m, out)
+            return ArgumentParserResult(self._display_usage(nouns, m, out))
         finally:
             sys.stdout = old_stdout
 

--- a/src/azure/cli/_output.py
+++ b/src/azure/cli/_output.py
@@ -42,12 +42,22 @@ def format_text(obj):
 
 class OutputProducer(object): #pylint: disable=too-few-public-methods
 
+    format_dict = {
+        'json': format_json,
+        'table': format_table,
+        'text': format_text
+    }
+
     def __init__(self, formatter=format_json, file=sys.stdout): #pylint: disable=redefined-builtin
         self.formatter = formatter
         self.file = file
 
     def out(self, obj):
         print(self.formatter(obj), file=self.file)
+
+    @staticmethod
+    def get_formatter(format_type):
+        return OutputProducer.format_dict.get(format_type, format_json)
 
 class TableOutput(object):
     def __init__(self):

--- a/src/azure/cli/main.py
+++ b/src/azure/cli/main.py
@@ -38,11 +38,12 @@ def main(args):
         commands.add_to_parser(parser)
 
     try:
-        result = parser.execute(args)
+        cmd_res = parser.execute(args)
         # Commands can return a dictionary/list of results
         # If they do, we print the results.
-        if result:
-            OutputProducer().out(result)
+        if cmd_res.result:
+            formatter = OutputProducer.get_formatter(cmd_res.output_format)
+            OutputProducer(formatter=formatter).out(cmd_res.result)
     except RuntimeError as ex:
         logger.error(ex.args[0])
         return ex.args[1] if len(ex.args) >= 2 else -1

--- a/src/azure/cli/tests/test_autocommand.py
+++ b/src/azure/cli/tests/test_autocommand.py
@@ -72,8 +72,8 @@ class Test_autocommand(unittest.TestCase):
         p = ArgumentParser('automcommandtest')
         add_to_parser(p, 'test')
 
-        result = p.execute(command_name.split(' ') + '--tre wombat'.split(' '))
-        self.assertEqual(result, func)
+        cmd_res = p.execute(command_name.split(' ') + '--tre wombat'.split(' '))
+        self.assertEqual(cmd_res.result, func)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Also,
Argument Parser returns an object containing the result and the output format specified
Add tests for command output format specifying
