### PR TITLE
Fix 'storage account check' command not working

### DIFF
--- a/src/azure/cli/_output.py
+++ b/src/azure/cli/_output.py
@@ -216,7 +216,7 @@ class TextOutput(object):
                     # TODO: Need to handle complex objects
                     io.write("null")
                 else:
-                    io.write(col)
+                    io.write(str(col))
                 io.write('\t')
             io.write('\n')
         result = io.getvalue()

--- a/src/azure/cli/commands/storage.py
+++ b/src/azure/cli/commands/storage.py
@@ -2,7 +2,6 @@
 from ..commands import command, description, option
 from ._command_creation import get_mgmt_service_client, get_data_service_client
 from .._argparse import IncorrectUsageError
-from .._logging  import logger
 from .._locale import L
 
 @command('storage account list')
@@ -25,11 +24,12 @@ def list_accounts(args, unexpected): #pylint: disable=unused-argument
     return list(accounts)
 
 @command('storage account check')
-@option('--account-name -an <name>')
+@option('--account-name -an <name>', required=True)
 def checkname(args, unexpected): #pylint: disable=unused-argument
     from azure.mgmt.storage import StorageManagementClient, StorageManagementClientConfiguration
     smc = get_mgmt_service_client(StorageManagementClient, StorageManagementClientConfiguration)
-    logger.warning(smc.storage_accounts.check_name_availability(args.account_name))
+    availability = smc.storage_accounts.check_name_availability(args.get('account-name'))
+    return availability
 
 # TODO: update this once enums are supported in commands first-class (task #115175885)
 public_access_types = {'none': None,


### PR DESCRIPTION
1. Although account name was required, is wasn't specified as such.
2. args.account_name was not the correct way to get the property as it is actually called 'account-name'
3. The result should be returned so it can be output instead of sending it to a logger.
