### PR TITLE
use full module path in __main__.py

### DIFF
--- a/src/azure/cli/__main__.py
+++ b/src/azure/cli/__main__.py
@@ -1,8 +1,8 @@
-import sys
+﻿import sys
 
 import azure.cli.main
 
-from ._telemetry import init_telemetry, user_agrees_to_telemetry, telemetry_flush
+from azure.cli._telemetry import init_telemetry, user_agrees_to_telemetry, telemetry_flush
 
 try:
     try:


### PR DESCRIPTION
I saw azure-cli can't load in windows, and this one line change should fix it
Per, https://www.python.org/dev/peps/pep-0328/#relative-imports-and-name, "__main__" will be treated as top level module; hence relative import won't work 
