### PR TITLE
auto command help: be able to load multi-line arg description text from azure-sdk-for-python 

### DIFF
--- a/src/azure/cli/commands/__init__.py
+++ b/src/azure/cli/commands/__init__.py
@@ -18,7 +18,7 @@ COMMON_PARAMETERS = {
         'name': '--resource-group -g',
         'dest': RESOURCE_GROUP_ARG_NAME,
         'metavar': 'RESOURCEGROUP',
-        'help': 'Name of resource group',
+        'help': 'The name of the resource group.',
         'required': True
     },
     'location': {
@@ -30,7 +30,7 @@ COMMON_PARAMETERS = {
     'deployment_name': {
         'name': '--deployment-name',
         'metavar': 'DEPLOYMENTNAME',
-        'help': 'Name of the resource deployment',
+        'help': 'The name of the resource deployment.',
         'default': 'azurecli' + str(time.time()) + str(random.randint(0, 10000000)),
         'required': False
     }

--- a/src/azure/cli/tests/test_autocommand.py
+++ b/src/azure/cli/tests/test_autocommand.py
@@ -1,7 +1,7 @@
 import logging
 import unittest
 
-from azure.cli.commands._auto_command import build_operation
+from azure.cli.commands._auto_command import build_operation, _option_descriptions
 from azure.cli.commands import CommandTable
 from azure.cli.commands._auto_command import AutoCommandDefinition
 from azure.cli.main import main as cli
@@ -27,7 +27,8 @@ class Test_autocommand(unittest.TestCase):
         :type resource_group_name: str
         :param vm_name: The name of the virtual machine.
         :type vm_name: str
-        :param opt_param: Used to verify auto-command correctly identifies optional params
+        :param opt_param: Used to verify auto-command correctly 
+        identifies optional params.
         :type opt_param: object
         :param expand: The expand expression to apply on the operation.
         :type expand: str
@@ -53,9 +54,10 @@ class Test_autocommand(unittest.TestCase):
         self.assertEqual(command_metadata['name'], 'test autocommand sample-vm-get', 'Unexpected command name...')
         self.assertEqual(len(command_metadata['arguments']), 4, 'We expected exactly 4 arguments')
         some_expected_arguments = [
-            {'name': '--resource-group -g', 'dest': 'resource_group_name', 'required': True},
-            {'name': '--vm-name', 'dest': 'vm_name', 'required': True},
-            {'name': '--opt-param', 'required': False},
+            {'name': '--resource-group -g', 'dest': 'resource_group_name', 'required': True, 'help':'The name of the resource group.'},
+            {'name': '--vm-name', 'dest': 'vm_name', 'required': True, 'help': 'The name of the virtual machine.'},
+            {'name': '--opt-param', 'required': False, 'help': 'Used to verify auto-command correctly identifies optional params.'},
+            {'name': '--expand', 'required': False, 'help': 'The expand expression to apply on the operation.'},
             ]
 
         for probe in some_expected_arguments:
@@ -143,6 +145,41 @@ class Test_autocommand(unittest.TestCase):
         self.assertEqual(len(command_table), 1, 'We expect exactly one command in the command table')
         command_metadata = list(command_table.values())[0]
         self.assertEqual(command_metadata['name'], 'test autocommand woot', 'Unexpected command name...')
+
+    def test_autocommand_build_argument_help_text(self):
+        def sample_sdk_method_with_weired_docstring(self, param_a, param_b, param_c):
+            """
+            An operation with nothing good.
+
+            :param dict param_a:
+            :param param_b: The name 
+            of 
+            nothing.
+            :param param_c: The name 
+            of
+
+            nothing2.
+            """        
+        command_table = CommandTable()
+        build_operation("test autocommand",
+                        "",
+                        None,
+                        [
+                            AutoCommandDefinition(sample_sdk_method_with_weired_docstring, None)
+                        ],
+                        command_table)
+
+        command_metadata = list(command_table.values())[0]
+        self.assertEqual(len(command_metadata['arguments']), 3, 'We expected exactly 3 arguments')
+        some_expected_arguments = [
+            {'name': '--param-a', 'dest': 'param_a', 'required': True, 'help': ''},
+            {'name': '--param-b', 'dest': 'param_b', 'required': True, 'help': 'The name of nothing.'},
+            {'name': '--param-c', 'dest': 'param_c', 'required': True, 'help': 'The name of nothing2.'},
+            ]
+
+        for probe in some_expected_arguments:
+            existing = next(arg for arg in command_metadata['arguments'] if arg['name'] == probe['name'])
+            self.assertDictContainsSubset(probe, existing)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
#155 should be addressed as well.
