### PR TITLE
login: do not persist several token fields not used for token acquisition

### DIFF
--- a/src/azure/cli/tests/test_profile.py
+++ b/src/azure/cli/tests/test_profile.py
@@ -226,6 +226,29 @@ class Test_Profile(unittest.TestCase):
         self.assertEqual(mock_read_cred_file.call_count, 1)
         self.assertEqual(mock_persist_creds.call_count, 1)
 
+    @mock.patch('azure.cli._profile._delete_file', autospec=True)
+    def test_logout_all(self, mock_delete_cred_file):
+        #setup
+        storage_mock = {'subscriptions': None}
+        profile = Profile(storage_mock)
+        consolidated = Profile._normalize_properties(self.user1, 
+                                                [self.subscription1],
+                                                False,
+                                                ENV_DEFAULT)
+        consolidated2 = Profile._normalize_properties(self.user2, 
+                                                [self.subscription2],
+                                                False,
+                                                ENV_DEFAULT)
+        profile._set_subscriptions(consolidated + consolidated2)
+
+        self.assertEqual(2, len(storage_mock['subscriptions']))
+        #action
+        profile.logout_all()
+
+        #verify
+        self.assertEqual(0, len(storage_mock['subscriptions']))
+        self.assertEqual(mock_delete_cred_file.call_count, 1)
+
     @mock.patch('adal.AuthenticationContext', autospec=True)
     def test_find_subscriptions_thru_username_password(self, mock_auth_context):
         mock_auth_context.acquire_token_with_username_password.return_value = self.token_entry1

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/account.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/account.py
@@ -1,4 +1,4 @@
-from azure.cli._profile import Profile
+﻿from azure.cli._profile import Profile
 from azure.cli.commands import CommandTable
 from azure.cli._locale import L
 from .command_tables import COMMAND_TABLES
@@ -32,3 +32,11 @@ def set_active_subscription(args):
 
     profile = Profile()
     profile.set_active_subscription(subscription_name_or_id)
+
+@command_table.command('account clear')
+@command_table.description(L('Clear all stored subscriptions. '
+                             'To clear individual, use "logout".'))
+def clear(_):
+    profile = Profile()
+    profile.logout_all()
+


### PR DESCRIPTION
This is needed for creds sharing with the xplat-cli. 
Also adding "account clear" to clean up local cached accounts and token information. This bring the functionality in par with xplat cli 
