### PR TITLE
remove yaml required param.  

### DIFF
--- a/src/azure/cli/_help.py
+++ b/src/azure/cli/_help.py
@@ -273,12 +273,6 @@ class HelpParameter(object): #pylint: disable=too-few-public-methods, too-many-i
                                          .format(self.name,
                                                  data.get('name')))
 
-        if self.required != data.get('required', False):
-            raise HelpAuthoringException("mismatched required {0} vs. {1}, {2}"
-                                         .format(self.required,
-                                                 data.get('required'),
-                                                 data.get('name')))
-
         if data.get('type'):
             self.type = data.get('type')
 

--- a/src/azure/cli/tests/test_help.py
+++ b/src/azure/cli/tests/test_help.py
@@ -314,39 +314,6 @@ Examples
 '''
         self.assertEqual(s, io.getvalue())
 
-    @redirect_io
-    def test_help_mismatched_required_params(self):
-        app = Application(Configuration([]))
-        def test_handler(args):
-            pass
-
-        cmd_table = {
-            test_handler: {
-                'name': 'n1',
-                'help_file': '''
-                    parameters: 
-                      - name: --foobar -fb
-                        type: string
-                        required: false
-                        short-summary: one line partial sentence
-                        long-summary: text, markdown, etc.
-                        populator-commands: 
-                            - az vm list
-                            - default
-                    ''',
-                'arguments': [
-                    {'name': '--foobar -fb', 'required': True}
-                    ]
-                }
-            }
-        config = Configuration([])
-        config.get_command_table = lambda: cmd_table
-        app = Application(config)
-
-        self.assertRaisesRegexp(HelpAuthoringException,
-                               '.*mismatched required True vs\. False, --foobar -fb.*',
-                                lambda: app.execute('n1 -h'.split()))
-
     # TODO: Restore test when Python 2.7 bug fix applied
     #@redirect_io
     #def test_help_extra_help_params(self):


### PR DESCRIPTION
This is no longer necessary and cause unnecessary failures.  We will only get required-ness from the code, not from the help files
