### PR TITLE
command consistency: use category name of 'availability-set' and 'extensions'

### DIFF
--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/generated.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/generated.py
@@ -31,7 +31,7 @@ command_table = CommandTable()
 
 # pylint: disable=line-too-long
 build_operation(
-    'vm availset', 'availability_sets', _compute_client_factory,
+    'vm availability-set', 'availability_sets', _compute_client_factory,
     [
         CommandDefinition(AvailabilitySetsOperations.delete, None),
         CommandDefinition(AvailabilitySetsOperations.get, 'AvailabilitySet', command_alias='show'),
@@ -43,7 +43,7 @@ build_operation(
         }))
 
 build_operation(
-    'vm machine-extension-image', 'virtual_machine_extension_images', _compute_client_factory,
+    'vm extension image', 'virtual_machine_extension_images', _compute_client_factory,
     [
         CommandDefinition(VirtualMachineExtensionImagesOperations.get, 'VirtualMachineExtensionImage', command_alias='show'),
         CommandDefinition(VirtualMachineExtensionImagesOperations.list_types, '[VirtualMachineImageResource]'),

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/command_specs.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/command_specs.py
@@ -315,23 +315,23 @@ class VMAvailSetScenarioTest(CommandTestScript):
         pass
 
     def test_body(self):
-        self.test('vm availset list --resource-group {}'.format(self.resource_group), [
+        self.test('vm availability-set list --resource-group {}'.format(self.resource_group), [
             JMESPathComparator('length(@)', 1),
             JMESPathComparator('[0].name', self.name),
             JMESPathComparator('[0].resourceGroup', self.resource_group),
             JMESPathComparator('[0].location', self.location),
         ])
-        self.test('vm availset list-sizes --resource-group {} --name {}'.format(
+        self.test('vm availability-set list-sizes --resource-group {} --name {}'.format(
             self.resource_group, self.name), JMESPathComparator('type(@)', 'array'))
-        self.test('vm availset show --resource-group {} --name {}'.format(
+        self.test('vm availability-set show --resource-group {} --name {}'.format(
             self.resource_group, self.name), [
                 JMESPathComparator('type(@)', 'object'),
                 JMESPathComparator('name', self.name),
                 JMESPathComparator('resourceGroup', self.resource_group),
                 JMESPathComparator('location', self.location)])
-        self.test('vm availset delete --resource-group {} --name {}'.format(
+        self.test('vm availability-set delete --resource-group {} --name {}'.format(
             self.resource_group, self.name), None)
-        self.test('vm availset list --resource-group {}'.format(
+        self.test('vm availability-set list --resource-group {}'.format(
             self.resource_group), None)
 
     def tear_down(self):
@@ -373,19 +373,19 @@ class VMMachineExtensionImageScenarioTest(CommandTestScript):
         super(VMMachineExtensionImageScenarioTest, self).__init__(None, self.test_body, None)
 
     def test_body(self):
-        self.test('vm machine-extension-image list-types --location {} --publisher-name {}'.format(
+        self.test('vm extension image list-types --location {} --publisher-name {}'.format(
             self.location, self.publisher), [
                 JMESPathComparator('type(@)', 'array'),
                 JMESPathComparator("length([?location == '{}']) == length(@)".format(self.location),
                                    True),
             ])
-        self.test('vm machine-extension-image list-versions --location {} --publisher-name {} --type {}'.format( #pylint: disable=line-too-long
+        self.test('vm extension image list-versions --location {} --publisher-name {} --type {}'.format( #pylint: disable=line-too-long
             self.location, self.publisher, self.type), [
                 JMESPathComparator('type(@)', 'array'),
                 JMESPathComparator("length([?location == '{}']) == length(@)".format(self.location),
                                    True),
             ])
-        self.test('vm machine-extension-image show --location {} --publisher-name {} --type {} --version {}'.format( #pylint: disable=line-too-long
+        self.test('vm extension image show --location {} --publisher-name {} --type {} --version {}'.format( #pylint: disable=line-too-long
             self.location, self.publisher, self.type, self.version), [
                 JMESPathComparator('type(@)', 'object'),
                 JMESPathComparator('location', self.location),


### PR DESCRIPTION
w/o the change, I see both 'availability-set' and 'availset', which is wrong
Also it makes more sense to have "machine-extension-image" come under "vm extension"
