### PR TITLE
Fixes issue on master in Python 3.5.

### DIFF
--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
@@ -158,7 +158,7 @@ PARAMETER_ALIASES = patch_aliases(GLOBAL_COMMON_PARAMETERS, {
     'key': {
         'name': '--key',
         'help': 'The key to renew (omit to renew both)',
-        'choices': storage_account_key_options.keys()
+        'choices': list(storage_account_key_options.keys())
     },
     'lease_break_period': {
         'name': '--lease-break-period',


### PR DESCRIPTION
Fixes the issue on master for the error "cannot pickle dict_keys". It is necessary to wrap `dict.keys()` with a list operation for in parameter aliases.

So instead of:

``` Python
'choice': foo.keys()
```

use:

``` Python
'choice': list(foo.keys())
```
