### PR TITLE
Require msrestazure as a dependency in our application as we need it.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ DEPENDENCIES = [
     'colorama',
     'jmespath',
     'msrest',
+    'msrestazure',
     'pip',
     'pyyaml',
     'requests',


### PR DESCRIPTION
This is instead of depending on another dependency installing msrestazure.
