### PR TITLE
Show az versions and python version (with platform)

### DIFF
--- a/src/azure/cli/_util.py
+++ b/src/azure/cli/_util.py
@@ -1,3 +1,10 @@
+from __future__ import print_function
+import sys
+import platform
+
+CLI_PACKAGE_NAME = 'azure-cli'
+COMPONENT_PREFIX = 'azure-cli-'
+
 class CLIError(Exception):
     """Base class for exceptions that occur during
     normal operation of the application.
@@ -7,3 +14,29 @@ class CLIError(Exception):
 
 def normalize_newlines(str_to_normalize):
     return str_to_normalize.replace('\r\n', '\n')
+
+def show_version_info_exit(out_file):
+    from pip import get_installed_distributions
+    installed_dists = get_installed_distributions(local_only=True)
+
+    cli_info = None
+    for dist in installed_dists:
+        if dist.key == CLI_PACKAGE_NAME:
+            cli_info = {'name': dist.key, 'version': dist.version}
+            break
+
+    if cli_info:
+        print('{} ({})'.format(cli_info['name'], cli_info['version']), file=out_file)
+
+    component_version_info = sorted([{'name': dist.key.replace(COMPONENT_PREFIX, ''),
+                                      'version': dist.version}
+                                     for dist in installed_dists
+                                     if dist.key.startswith(COMPONENT_PREFIX)],
+                                    key=lambda x: x['name'])
+
+    print(file=out_file)
+    print('\n'.join(['{} ({})'.format(c['name'], c['version']) for c in component_version_info]),
+          file=out_file)
+    print(file=out_file)
+    print('Python ({}) {}'.format(platform.system(), sys.version), file=out_file)
+    sys.exit(0)

--- a/src/azure/cli/main.py
+++ b/src/azure/cli/main.py
@@ -5,7 +5,7 @@ from azure.cli.application import APPLICATION, Configuration
 import azure.cli._logging as _logging
 from ._session import Session
 from ._output import OutputProducer
-from ._util import CLIError
+from ._util import CLIError, show_version_info_exit
 
 logger = _logging.get_az_logger(__name__)
 
@@ -21,6 +21,9 @@ SESSION = Session()
 
 def main(args, file=sys.stdout): #pylint: disable=redefined-builtin
     _logging.configure_logging(args)
+
+    if len(args) > 0 and args[0] == '--version':
+        show_version_info_exit(file)
 
     azure_folder = os.path.expanduser('~/.azure')
     if not os.path.exists(azure_folder):


### PR DESCRIPTION
Get version info with 'az --version':

Example output:

```
azure-cli (0.0.32)

component (0.0.9)
network (0.0.5)
profile (0.0.3)
resource (0.0.5)
storage (0.0.5)
taskhelp (0.0.3)
vm (0.0.5)
webapp (0.0.1)

Python (Darwin) 3.5.1 (v3.5.1:37a07cee5969, Dec  5 2015, 21:12:44) 
[GCC 4.2.1 (Apple Inc. build 5666) (dot 3)]
```
