### PR TITLE
[Install] Don't use pip cache when installing packages

### DIFF
--- a/scripts/install/install.py
+++ b/scripts/install/install.py
@@ -85,7 +85,7 @@ def get_pip_install_command(module_name, path_to_pip):
     version = '==' + PACKAGE_VERSION if PACKAGE_VERSION else ''
     param_extra_index_url = '--extra-index-url '+PRIVATE_PYPI_URL if PRIVATE_PYPI_URL else ''
     param_trusted_host = '--trusted-host '+PRIVATE_PYPI_HOST if PRIVATE_PYPI_HOST else ''
-    return '{pip} install {module_name}{version} {param_extra_index_url} {param_trusted_host}'.format(
+    return '{pip} install --no-cache-dir {module_name}{version} {param_extra_index_url} {param_trusted_host}'.format(
         pip=path_to_pip,
         module_name=module_name,
         version=version,


### PR DESCRIPTION
By default, the pip cache is used which is in the user directory (https://pip.pypa.io/en/latest/reference/pip_install/#caching). When you install the CLI with sudo, the elevated user isn't the owner of the pip cache, as it's in the user directory.

This causes the following warning message. The CLI still installs successfully though.

```
The directory '/Users/debekoe/Library/Caches/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
```

This PR resolves this by not using the cache.
