### PR TITLE
hide deployment name from create commands.  Add back time to deployme…

### DIFF
--- a/src/azure/cli/commands/__init__.py
+++ b/src/azure/cli/commands/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import argparse
 import copy
 import json
 import time
@@ -27,8 +28,8 @@ COMMON_PARAMETERS = {
     'deployment_name': {
         'name': '--deployment-name',
         'metavar': 'DEPLOYMENTNAME',
-        'help': 'Name of the resource deployment',
-        'default': 'azurecli' + str(random.randint(0, 10000000)),
+        'help': argparse.SUPPRESS,
+        'default': 'azurecli' + str(time.time()) + str(random.randint(0, 100000)),
         'required': False
     },
     'location': {

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
@@ -71,7 +71,7 @@ helps['vm availability-set create'] = """
 helps['vm extension set'] = """
             type: command
             examples:
-                - name: Add a new linux user:
+                - name: Add a new linux user
                   text: 
                     az vm extension set -n VMAccessForLinux --publisher Microsoft.OSTCExtensions --version 1.4 --vm-name myvm --resource-group yugangw --private-config "{\\"username\\":\\"user1\\", \\"ssh_key\\":\\"ssh_rsa ....\\"}"
             """


### PR DESCRIPTION
…nt name so collision is much less likely.

Unique naming
Current way: 1/10,000,000 chance of collision, but 1,000 users with 1,000 concurrent deployments is 1/10 chance that one of those users will have a collision.  With the change back to include time, the chances of collision are ~1/10^20
