### PR TITLE
[Install] Prevent pip cache warnings

### DIFF
--- a/scripts/install/install.py
+++ b/scripts/install/install.py
@@ -154,6 +154,10 @@ def main():
     tmp_dir = create_tmp_dir()
     install_dir = get_install_dir()
     exec_dir = get_exec_dir()
+    exec_path = os.path.join(exec_dir, EXECUTABLE_NAME)
+    if install_dir == exec_path:
+        print("ERROR: The executable file '{}' would clash with the install directory of '{}'. Choose either a different install directory or directory to place the executable.".format(exec_path, install_dir), file=sys.stderr)
+        sys.exit(1)
     environment_name = get_environment_name()
     env_dir = os.path.join(install_dir, ENVS_DIR_NAME, environment_name)
     create_dir(env_dir)


### PR DESCRIPTION
The warnings would happen when you try to install using sudo as root user does not have access to ~/... cache that pip uses.

Now, we specify pip cache as temp dir that the current user has access to.
