### PR TITLE
help: introduce subgroups

### DIFF
--- a/src/azure/cli/parser.py
+++ b/src/azure/cli/parser.py
@@ -73,10 +73,13 @@ class AzCliCommandParser(argparse.ArgumentParser):
         return parent_subparser
 
     def format_help(self):
-        is_group = not self._defaults.get('func')
+        is_group = self.is_group()
         _help.show_help(self.prog.split()[1:],
                         (self._actions[-1]
                          if is_group
                          else self),
                         is_group)
         self.exit()
+
+    def is_group(self):
+        return getattr(self, '_subparsers', None) is not None

--- a/src/azure/cli/tests/test_help.py
+++ b/src/azure/cli/tests/test_help.py
@@ -410,7 +410,7 @@ Global Arguments
 
         with self.assertRaises(SystemExit):
             app.execute('group1 -h'.split())
-        s = '\nGroup\n    az group1\n\nSub-Commands\n    group2\n    group3\n\n'
+        s = '\nGroup\n    az group1\n\nSubgroups:\n    group2\n    group3\n\n'
         self.assertEqual(s, io.getvalue())
 
     @redirect_io
@@ -502,7 +502,7 @@ Group
         This module.... kjsdflkj... klsfkj paragraph1
         this module.... kjsdflkj... klsfkj paragraph2.
 
-Sub-Commands
+Commands:
     n1: This module does xyz one-line or so.
 
 


### PR DESCRIPTION
The goal is to get help text clearer and easier to explore, particular for "vm" which has 20+ sub items. Mixing command and groups hurts the discovering. 
GCloud does the same thing.

Here is the snapshot after the change
![image](https://cloud.githubusercontent.com/assets/6014209/15727325/93499e06-280a-11e6-9513-e587d5881397.png)
