### PR TITLE
uncomment out VM tests (introduced by a local changes got merged by mistake)

### DIFF
--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/command_specs.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/command_specs.py
@@ -718,104 +718,104 @@ class VMDiagnosticsTest(CommandTestScript):
 ENV_VAR = {}
 
 TEST_DEF = [
-    ##{
-    ##    'test_name': 'vm_usage_list_westus',
-    ##    'command': VMUsageScenarioTest()
-    ##},
-    ##{
-    ##    'test_name': 'vm_images_list_by_aliases',
-    ##    'command': VMImageListByAliasesScenarioTest()
-    ##},
-    ##{
-    ##    'test_name': 'vm_images_list_thru_services',
-    ##    'command': VMImageListThruServiceScenarioTest()
-    ##},
-    ##{
-    ##    'test_name': 'vm_size_list',
-    ##    'command': VMSizeListScenarioTest()
-    ##},
-    ##{
-    ##    'test_name': 'vm_image_list_offers',
-    ##    'command': VMImageListOffersScenarioTest()
-    ##},
-    ##{
-    ##    'test_name': 'vm_image_list_publishers',
-    ##    'command': VMImageListPublishersScenarioTest()
-    ##},
-    ##{
-    ##    'test_name': 'vm_image_list_skus',
-    ##    'command': VMImageListSkusScenarioTest()
-    ##},
-    ##{
-    ##    'test_name': 'vm_image_show',
-    ##    'command': VMImageShowScenarioTest()
-    ##},
-    ##{
-    ##    'test_name': 'vm_generalize',
-    ##    'command': VMGeneralizeScenarioTest()
-    ##},
-    ##{
-    ##    'test_name': 'vm_availset',
-    ##    'command': VMAvailSetScenarioTest()
-    ##},
-    ##{
-    ##    'test_name': 'vm_extension',
-    ##    'command': VMExtensionsScenarioTest()
-    ##},
-    ##{
-    ##    'test_name': 'vm_machine_extension_image',
-    ##    'command': VMMachineExtensionImageScenarioTest()
-    ##},
-    ##{
-    ##    'test_name': 'vm_extension_image_search',
-    ##    'command': VMExtensionImageSearchScenarioTest()
-    ##},
-    ##{
-    ##    'test_name': 'vm_combined_list',
-    ##    'command': VMListFoldedScenarioTest()
-    ##},
-    #{
-    #    'test_name': 'vm_scaleset_gets',
-    #    'command': VMScaleSetGetsScenarioTest()
-    #},
-    ##{
-    ##    'test_name': 'vm_scaleset_states',
-    ##    'command': VMScaleSetStatesScenarioTest()
-    ##},
+    {
+        'test_name': 'vm_usage_list_westus',
+        'command': VMUsageScenarioTest()
+    },
+    {
+        'test_name': 'vm_images_list_by_aliases',
+        'command': VMImageListByAliasesScenarioTest()
+    },
+    {
+        'test_name': 'vm_images_list_thru_services',
+        'command': VMImageListThruServiceScenarioTest()
+    },
+    {
+        'test_name': 'vm_size_list',
+        'command': VMSizeListScenarioTest()
+    },
+    {
+        'test_name': 'vm_image_list_offers',
+        'command': VMImageListOffersScenarioTest()
+    },
+    {
+        'test_name': 'vm_image_list_publishers',
+        'command': VMImageListPublishersScenarioTest()
+    },
+    {
+        'test_name': 'vm_image_list_skus',
+        'command': VMImageListSkusScenarioTest()
+    },
+    {
+        'test_name': 'vm_image_show',
+        'command': VMImageShowScenarioTest()
+    },
+    {
+        'test_name': 'vm_generalize',
+        'command': VMGeneralizeScenarioTest()
+    },
+    {
+        'test_name': 'vm_availset',
+        'command': VMAvailSetScenarioTest()
+    },
+    {
+        'test_name': 'vm_extension',
+        'command': VMExtensionsScenarioTest()
+    },
+    {
+        'test_name': 'vm_machine_extension_image',
+        'command': VMMachineExtensionImageScenarioTest()
+    },
+    {
+        'test_name': 'vm_extension_image_search',
+        'command': VMExtensionImageSearchScenarioTest()
+    },
+    {
+        'test_name': 'vm_combined_list',
+        'command': VMListFoldedScenarioTest()
+    },
+    {
+        'test_name': 'vm_scaleset_gets',
+        'command': VMScaleSetGetsScenarioTest()
+    },
+    {
+        'test_name': 'vm_scaleset_states',
+        'command': VMScaleSetStatesScenarioTest()
+    },
     {
         'test_name': 'vm_scaleset_delete',
         'command': VMScaleSetDeleteScenarioTest()
     },
-    ##{
-    ##    'test_name': 'vm_scaleset_vms',
-    ##    'command': VMScaleSetVMsScenarioTest()
-    ##},
-    #{
-    #    'test_name': 'vm_scaleset-scaleup',
-    #    'command': VMScaleSetScaleUpScenarioTest()
-    #},
-    ##{
-    ##    'test_name': 'vm_add_remove_linux_user',
-    ##    'command': VMAccessAddRemoveLinuxUser()
-    ##},
-    ##{
-    ##    'test_name': 'vm_create_ubuntu',
-    ##    'command': VMCreateUbuntuScenarioTest()
-    ##},
-    ##{
-    ##    'test_name': 'vm_enable_disable_boot_diagnostic',
-    ##    'command': VMBootDiagnostics()
-    ##},
-    ##{
-    ##    'test_name': 'vm_extension_install',
-    ##    'command': VMExtensionInstallTest()
-    ##},
-    ##{
-    ##    'test_name': 'vm_diagnostics_install',
-    ##    'command': VMDiagnosticsTest()
-    ##},
-    ##{
-    ##    'test_name': 'vm_create_state_modifications',
-    ##    'command': VMCreateAndStateModificationsScenarioTest()
-    ##},
+    {
+        'test_name': 'vm_scaleset_vms',
+        'command': VMScaleSetVMsScenarioTest()
+    },
+    {
+        'test_name': 'vm_scaleset-scaleup',
+        'command': VMScaleSetScaleUpScenarioTest()
+    },
+    {
+        'test_name': 'vm_add_remove_linux_user',
+        'command': VMAccessAddRemoveLinuxUser()
+    },
+    {
+        'test_name': 'vm_create_ubuntu',
+        'command': VMCreateUbuntuScenarioTest()
+    },
+    {
+        'test_name': 'vm_enable_disable_boot_diagnostic',
+        'command': VMBootDiagnostics()
+    },
+    {
+        'test_name': 'vm_extension_install',
+        'command': VMExtensionInstallTest()
+    },
+    {
+        'test_name': 'vm_diagnostics_install',
+        'command': VMDiagnosticsTest()
+    },
+    {
+        'test_name': 'vm_create_state_modifications',
+        'command': VMCreateAndStateModificationsScenarioTest()
+    },
 ]


### PR DESCRIPTION
/CC @johanste, @tjprescott 
Note, local commenting won't be necessary once i rework the VCR test infrastructure next week so we can leverage python test driver to run any individual test you like..
