### PR TITLE
vm command: support to update nics

### DIFF
--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -19,7 +19,7 @@ def get_urn_aliases_completion_list(prefix, **kwargs):#pylint: disable=unused-ar
 
 # BASIC PARAMETER CONFIGURATION
 name_arg_type = CliArgumentType(options_list=('--name', '-n'), metavar='NAME')
-instance_ids_type = CliArgumentType(
+multi_ids_type = CliArgumentType(
     nargs='+'
 )
 
@@ -28,7 +28,7 @@ admin_username_type = CliArgumentType(options_list=('--admin-username',), defaul
 register_cli_argument('vm', 'vm_name', name_arg_type, help='The name of the virtual machine')
 register_cli_argument('vm scaleset', 'vm_scale_set_name', name_arg_type)
 register_cli_argument('vm scaleset', 'virtual_machine_scale_set_name', name_arg_type)
-register_cli_argument('vm scaleset', 'instance_ids', instance_ids_type)
+register_cli_argument('vm scaleset', 'instance_ids', multi_ids_type)
 register_cli_argument('vm', 'diskname', CliArgumentType(options_list=('--name', '-n')))
 register_cli_argument('vm', 'disksize', CliArgumentType(help='Size of disk (Gb)', default=1023, type=MinMaxValue(1, 1023)))
 register_cli_argument('vm', 'lun', CliArgumentType(
@@ -51,7 +51,8 @@ register_cli_argument(
 )
 
 register_cli_argument('vm capture', 'overwrite', CliArgumentType(action='store_true'))
-
+register_cli_argument('vm nic', 'nic_ids', multi_ids_type)
+register_cli_argument('vm nic', 'nic_names', multi_ids_type)
 register_cli_argument('vm diagnostics', 'vm_name', CliArgumentType(options_list=('--vm-name',)))
 
 register_cli_argument('vm extension', 'vm_extension_name', name_arg_type)

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -519,6 +519,97 @@ def show_default_diagnostics_configuration():
     '''show the default config file which defines data to be collected'''
     return get_default_linux_diag_config()
 
+def vm_add_nics(resource_group_name, vm_name, nic_ids=None, nic_names=None, primary_nic=None):
+    '''add network interface configurations to the virtual machine
+    :param str nic_ids: NIC resource IDs
+    :param str nic_names: NIC names, assuming under the same resource group
+    :param str primary_nic: name or id of the primary NIC. If missing, the first of the
+    NIC list will be the primary
+    '''
+    vm = _vm_get(resource_group_name, vm_name)
+    new_nics = _build_nic_list(resource_group_name, nic_ids or [], nic_names or [])
+    existing_nics = _get_existing_nics(vm)
+    return _update_vm_nics(vm, existing_nics + new_nics, primary_nic)
+
+def vm_delete_nics(resource_group_name, vm_name, nic_ids=None, nic_names=None, primary_nic=None):
+    '''remove network interface configurations from the virtual machine
+    :param str nic_ids: NIC resource IDs
+    :param str nic_names: NIC names, assuming under the same resource group
+    :param str primary_nic: name or id of the primary NIC. If missing, the first of the
+    NIC list will be the primary
+    '''
+    def to_delete(nic_id):
+        return [n for n in nics_to_delete if n.id.lower() == nic_id.lower()]
+    vm = _vm_get(resource_group_name, vm_name)
+    nics_to_delete = _build_nic_list(resource_group_name, nic_ids or [], nic_names or [])
+    existing_nics = _get_existing_nics(vm)
+    survived = [x for x in existing_nics if not to_delete(x.id)]
+    return _update_vm_nics(vm, survived, primary_nic)
+
+def vm_update_nics(resource_group_name, vm_name, nic_ids=None, nic_names=None, primary_nic=None):
+    '''update network interface configurations of the virtual machine
+    :param str nic_ids: NIC resource IDs
+    :param str nic_names: NIC names, assuming under the same resource group
+    :param str primary_nic: name or id of the primary nic. If missing, the first element of
+    nic list will be set to the primary
+    '''
+    vm = _vm_get(resource_group_name, vm_name)
+    nics = _build_nic_list(resource_group_name, nic_ids or [], nic_names or [])
+    return _update_vm_nics(vm, nics, primary_nic)
+
+def _build_nic_list(resource_group_name, nic_ids, nic_names):
+    from azure.mgmt.network import NetworkManagementClient, NetworkManagementClientConfiguration
+    from azure.mgmt.compute.models import NetworkInterfaceReference
+    nics = []
+    if nic_names or nic_ids:
+        #pylint: disable=no-member
+        network_client = get_mgmt_service_client(NetworkManagementClient,
+                                                 NetworkManagementClientConfiguration)
+        for n in nic_names:
+            nic = network_client.network_interfaces.get(resource_group_name, n)
+            nics.append(NetworkInterfaceReference(nic.id, False))
+
+        for n in nic_ids:
+            rg, name = _parse_rg_name(n)
+            nic = network_client.network_interfaces.get(rg, name)
+            nics.append(NetworkInterfaceReference(nic.id, False))
+    return nics
+
+def _get_existing_nics(vm):
+    network_profile = getattr(vm, 'network_profile', None)
+    nics = []
+    if network_profile is not None:
+        nics = network_profile.network_interfaces or []
+    return nics
+
+def _update_vm_nics(vm, nics, primary_nic):
+    from azure.mgmt.compute.models import NetworkProfile
+
+    if primary_nic:
+        try:
+            _, primary_nic_name = _parse_rg_name(primary_nic)
+        except IndexError:
+            primary_nic_name = primary_nic
+
+        matched = [n for n in nics if _parse_rg_name(n.id)[1].lower() == primary_nic_name.lower()]
+        if not matched:
+            raise CLIError('Primary Nic {} is not found'.format(primary_nic))
+        if len(matched) > 1:
+            raise CLIError('Duplicate Nic entries with name {}'.format(primary_nic))
+        for n in nics:
+            n.primary = False
+        matched[0].primary = True
+    elif nics:
+        if not [n for n in nics if n.primary]:
+            nics[0].primary = True
+
+    network_profile = getattr(vm, 'network_profile', None)
+    if network_profile is None:
+        vm.network_profile = NetworkProfile(nics)
+    else:
+        network_profile.network_interfaces = nics
+
+    return _vm_set(vm)
 
 def vmss_scale(resource_group_name, vm_scale_set_name, new_capacity):
     '''change the number of VMs in an virtual machine scale set

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/generated.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/generated.py
@@ -30,6 +30,7 @@ from azure.cli.command_modules.vm.mgmt_acs.lib.operations import ACSOperations
 from .custom import (
     list_vm, resize_vm, list_vm_images, list_vm_extension_images, list_ip_addresses,
     attach_new_disk, attach_existing_disk, detach_disk, list_disks, capture_vm,
+    vm_update_nics, vm_delete_nics, vm_add_nics,
     set_windows_user_password, set_linux_user, delete_linux_user,
     disable_boot_diagnostics, enable_boot_diagnostics, get_boot_log,
     list_extensions, set_extension, set_diagnostics_extension,
@@ -66,6 +67,9 @@ cli_command('vm list-ip-addresses', list_ip_addresses)
 cli_command('vm list', list_vm)
 cli_command('vm resize', resize_vm)
 cli_command('vm capture', capture_vm)
+cli_command('vm nic add', vm_add_nics)
+cli_command('vm nic delete', vm_delete_nics)
+cli_command('vm nic update', vm_update_nics)
 
 # VM Access
 cli_command('vm access set-linux-user', set_linux_user)

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_custom_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_custom_vm_commands.py
@@ -5,6 +5,8 @@ from azure.cli.command_modules.vm.custom import enable_boot_diagnostics, disable
 from azure.cli.command_modules.vm.custom import (_get_access_extension_upgrade_info,
                                                  _LINUX_ACCESS_EXT,
                                                  _WINDOWS_ACCESS_EXT)
+from azure.cli.command_modules.vm.custom import (vm_add_nics, vm_delete_nics, vm_update_nics)
+from azure.mgmt.compute.models import NetworkProfile, NetworkInterfaceReference
 
 class Test_Vm_Custom(unittest.TestCase):
 
@@ -104,6 +106,153 @@ class Test_Vm_Custom(unittest.TestCase):
         self.assertIsNone(vm_fake.diagnostics_profile.boot_diagnostics.storage_uri)
         self.assertTrue(mock_vm_get.called)
         mock_vm_set.assert_called_once_with(vm_fake)
+
+    @mock.patch('azure.cli.command_modules.vm.custom._vm_get', autospec=True)
+    @mock.patch('azure.cli.command_modules.vm.custom._vm_set', autospec=True)
+    @mock.patch('azure.cli.command_modules.vm.custom.get_mgmt_service_client', autospec=True)
+    def test_add_single_nic_on_vm(self, client_mock, mock_vm_set, mock_vm_get):
+        #pylint: disable=line-too-long
+        new_nic_name = 'new_nic'
+        new_nic_id = '/subscriptions/123/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/' + new_nic_name
+        new_nic = NetworkInterfaceReference(new_nic_id, False)
+
+        #stub to get the vm which has no nic
+        vm = FakedVM(None)
+        vm.network_profile = None
+        mock_vm_get.return_value = vm
+
+        #stub to return nic on 'get'
+        network_client_fake = mock.MagicMock()
+        network_client_fake.network_interfaces.get.return_value = new_nic
+        client_mock.return_value = network_client_fake
+
+        #execute
+        vm_add_nics('rg1', 'vm1', [new_nic_id], [])
+
+        #assert
+        self.assertTrue(mock_vm_get.called)
+        mock_vm_set.assert_called_once_with(vm)
+        network_client_fake.network_interfaces.get.assert_called_once_with('rg1', new_nic_name)
+        self.assertEqual(len(vm.network_profile.network_interfaces), 1)
+        self.assertEqual(vm.network_profile.network_interfaces[0].id, new_nic_id)
+        self.assertTrue(vm.network_profile.network_interfaces[0].primary)
+
+
+    @mock.patch('azure.cli.command_modules.vm.custom._vm_get', autospec=True)
+    @mock.patch('azure.cli.command_modules.vm.custom._vm_set', autospec=True)
+    @mock.patch('azure.cli.command_modules.vm.custom.get_mgmt_service_client', autospec=True)
+    def test_add_nics_on_vm(self, client_mock, mock_vm_set, mock_vm_get):
+        #pylint: disable=line-too-long
+        new_nic_name = 'new_nic'
+        new_nic_id = '/subscriptions/123/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/' + new_nic_name
+        new_nic = NetworkInterfaceReference(new_nic_id, False)
+        existing_nic_id = '/subscriptions/123/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/existing_nic'
+        existing_nic = NetworkInterfaceReference(existing_nic_id, True)
+        existing_nic_name2 = 'existing_nic2'
+        existing_nic_id2 = '/subscriptions/123/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/' + existing_nic_name2
+        existing_nic2 = NetworkInterfaceReference(existing_nic_id2, False)
+
+        #stub to get the vm
+        vm = FakedVM([existing_nic, existing_nic2])
+        mock_vm_get.return_value = vm
+
+        #stub to return nic on 'get'
+        network_client_fake = mock.MagicMock()
+        network_client_fake.network_interfaces.get.return_value = new_nic
+        client_mock.return_value = network_client_fake
+
+        #execute
+        vm_add_nics('rg1', 'vm1', [new_nic_id], [], existing_nic_name2)
+
+        #assert
+        self.assertTrue(mock_vm_get.called)
+        mock_vm_set.assert_called_once_with(vm)
+        network_client_fake.network_interfaces.get.assert_called_once_with('rg1', new_nic_name)
+        self.assertEqual(len(vm.network_profile.network_interfaces), 3)
+        self.assertEqual(vm.network_profile.network_interfaces[0].id, existing_nic_id)
+        self.assertEqual(vm.network_profile.network_interfaces[1].id, existing_nic_id2)
+        self.assertEqual(vm.network_profile.network_interfaces[2].id, new_nic_id)
+        self.assertFalse(vm.network_profile.network_interfaces[0].primary)
+        self.assertTrue(vm.network_profile.network_interfaces[1].primary)
+        self.assertFalse(vm.network_profile.network_interfaces[2].primary)
+
+    @mock.patch('azure.cli.command_modules.vm.custom._vm_get', autospec=True)
+    @mock.patch('azure.cli.command_modules.vm.custom._vm_set', autospec=True)
+    @mock.patch('azure.cli.command_modules.vm.custom.get_mgmt_service_client', autospec=True)
+    def test_remove_nics_on_vm(self, client_mock, mock_vm_set, mock_vm_get):
+        #pylint: disable=line-too-long
+        existing_nic_name = 'existing_nic'
+        existing_nic_id = '/subscriptions/123/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/' + existing_nic_name
+        existing_nic = NetworkInterfaceReference(existing_nic_id, True)
+        existing_nic_name2 = 'existing_nic2'
+        existing_nic_id2 = '/subscriptions/123/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/' + existing_nic_name2
+        existing_nic2 = NetworkInterfaceReference(existing_nic_id2, False)
+        existing_nic_name3 = 'existing_nic3'
+        existing_nic_id3 = '/subscriptions/123/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/' + existing_nic_name3
+        existing_nic3 = NetworkInterfaceReference(existing_nic_id3, False)
+
+        #stub to get the vm
+        vm = FakedVM([existing_nic, existing_nic2, existing_nic3])
+        mock_vm_get.return_value = vm
+
+        #stub to return nic on 'get'
+        network_client_fake = mock.MagicMock()
+        network_client_fake.network_interfaces.get.return_value = existing_nic
+        client_mock.return_value = network_client_fake
+
+        #execute
+        vm_delete_nics('rg1', 'vm1', [], [existing_nic_name], existing_nic_name2)
+
+        #assert
+        self.assertTrue(mock_vm_get.called)
+        mock_vm_set.assert_called_once_with(vm)
+        network_client_fake.network_interfaces.get.assert_called_once_with('rg1', existing_nic_name)
+        self.assertEqual(len(vm.network_profile.network_interfaces), 2)
+        self.assertEqual(vm.network_profile.network_interfaces[0].id, existing_nic_id2)
+        self.assertEqual(vm.network_profile.network_interfaces[1].id, existing_nic_id3)
+        self.assertTrue(vm.network_profile.network_interfaces[0].primary)
+        self.assertFalse(vm.network_profile.network_interfaces[1].primary)
+
+    @mock.patch('azure.cli.command_modules.vm.custom._vm_get', autospec=True)
+    @mock.patch('azure.cli.command_modules.vm.custom._vm_set', autospec=True)
+    @mock.patch('azure.cli.command_modules.vm.custom.get_mgmt_service_client', autospec=True)
+    def test_update_nics_on_vm(self, client_mock, mock_vm_set, mock_vm_get):
+        #pylint: disable=line-too-long
+        existing_nic_name = 'existing_nic'
+        existing_nic_id = '/subscriptions/123/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/' + existing_nic_name
+        existing_nic = NetworkInterfaceReference(existing_nic_id, True)
+        existing_nic_name2 = 'existing_nic2'
+        existing_nic_id2 = '/subscriptions/123/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/' + existing_nic_name2
+        existing_nic2 = NetworkInterfaceReference(existing_nic_id2, False)
+        new_nic_name = 'existing_nic3'
+        new_nic_id = '/subscriptions/123/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/' + new_nic_name
+        new_nic = NetworkInterfaceReference(new_nic_id, False)
+
+        #stub to get the vm
+        vm = FakedVM([existing_nic, existing_nic2])
+        mock_vm_get.return_value = vm
+
+        #stub to return nic on 'get'
+        network_client_fake = mock.MagicMock()
+        network_client_fake.network_interfaces.get.side_effect = [existing_nic2, new_nic]
+        client_mock.return_value = network_client_fake
+
+        #execute
+        vm_update_nics('rg1', 'vm1', [], [existing_nic_name2, new_nic_name], new_nic_id)
+
+        #assert
+        self.assertTrue(mock_vm_get.called)
+        mock_vm_set.assert_called_once_with(vm)
+        self.assertEqual(network_client_fake.network_interfaces.get.call_count, 2)
+        self.assertEqual(len(vm.network_profile.network_interfaces), 2)
+        self.assertEqual(vm.network_profile.network_interfaces[0].id, existing_nic_id2)
+        self.assertEqual(vm.network_profile.network_interfaces[1].id, new_nic_id)
+        self.assertFalse(vm.network_profile.network_interfaces[0].primary)
+        self.assertTrue(vm.network_profile.network_interfaces[1].primary)
+
+class FakedVM:#pylint: disable=too-few-public-methods,old-style-class
+    def __init__(self, nics):
+        self.network_profile = NetworkProfile(nics)
 
 class FakedAccessExtensionEntity:#pylint: disable=too-few-public-methods,old-style-class
     def __init__(self, is_linux, version):


### PR DESCRIPTION
Commands look like:

``` bash
az vm nic add -g rg1 -n vm1 --nic-names nic1 nic2 --primary-nic nic2
az vm nic delete -g rg1 -n vm1 --nic-ids /subscriptions/123/resourceGroups/rg1/providers/Microsoft.Network/networkInterfaces/nic1
az vm nic update -g rg1 -n vm1 --nic-names nic3
```

The e2e will be completed once we address the #387
/CC:@burtbiel, @tjprescott , @jasonrshaver, @johanste
