### PR TITLE
commands: vm redeploy

### DIFF
--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/generated.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/generated.py
@@ -63,6 +63,7 @@ cli_command('vm list-sizes', VirtualMachinesOperations.list_available_sizes, fac
 cli_command('vm power-off', VirtualMachinesOperations.power_off, factory)
 cli_command('vm restart', VirtualMachinesOperations.restart, factory)
 cli_command('vm start', VirtualMachinesOperations.start, factory)
+cli_command('vm redeploy', VirtualMachinesOperations.redeploy, factory)
 cli_command('vm list-ip-addresses', list_ip_addresses)
 cli_command('vm list', list_vm)
 cli_command('vm resize', resize_vm)


### PR DESCRIPTION
Due to the simplicity of the auto-command (plus, no aliasing), and with my manual verification, I am skipping the VCR test for this one, which consumes time and nothing really to guard for regression.

``` bash
az vm redeploy -g myrg -n myvm
```
