### PR TITLE
Remove 'vpn-gateway reset' command that was commented out after rc4 update

### DIFF
--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/generated.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/generated.py
@@ -169,8 +169,6 @@ factory = lambda _: _network_client_factory().virtual_network_gateways
 cli_command('network vpn-gateway delete', VirtualNetworkGatewaysOperations.delete, factory)
 cli_command('network vpn-gateway show', VirtualNetworkGatewaysOperations.get, factory)
 cli_command('network vpn-gateway list', VirtualNetworkGatewaysOperations.list, factory)
-# TODO Convert to a convenience command as we can't use the SDK method directly due to complex param
-# cli_command('network vpn-gateway reset', VirtualNetworkGatewaysOperations.reset, factory)
 
 # VirtualNetworksOperations
 factory = lambda _: _network_client_factory().virtual_networks

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/test_network_commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/test_network_commands.py
@@ -546,9 +546,6 @@ class NetworkVpnGatewayScenarioTest(VCRTestBase):
         self.run_command_and_verify('network vpn-gateway list --resource-group {0}'.format(self.resource_group), None)
         self.run_command_and_verify('network vpn-gateway show --resource-group {0} --name {1}'.format(
             self.resource_group, self.placeholder_value), None)
-        # TODO Add this once the command is updated.
-        # self.run_command_and_verify('network vpn-gateway reset --resource-group {0} --name {1} --parameters {1}'.format(
-        #     self.resource_group, self.placeholder_value), None)
 
 class NetworkVpnConnectionScenarioTest(VCRTestBase):
 


### PR DESCRIPTION
The command is a complex command that works similarly to 'vpn-gateway create' which we also have not implemented.

So remove for now.
