### PR TITLE
vm access: rename set-windows-user-password to reset-windows-admin

### DIFF
--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -243,7 +243,7 @@ def capture_vm(resource_group_name, vm_name, vhd_name_prefix,
     result = LongRunningOperation()(poller)
     print(json.dumps(result.output, indent=2)) # pylint: disable=no-member
 
-def set_windows_user_password(
+def reset_windows_admin(
         resource_group_name, vm_name, username, password):
     '''Update the password.
     You can only change the password. Adding a new user is not supported.

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/generated.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/generated.py
@@ -23,7 +23,7 @@ from .custom import (
     list_vm, resize_vm, list_vm_images, list_vm_extension_images, list_ip_addresses,
     attach_new_disk, attach_existing_disk, detach_disk, list_disks, capture_vm,
     vm_update_nics, vm_delete_nics, vm_add_nics,
-    set_windows_user_password, set_linux_user, delete_linux_user,
+    reset_windows_admin, set_linux_user, delete_linux_user,
     disable_boot_diagnostics, enable_boot_diagnostics, get_boot_log,
     list_extensions, set_extension, set_diagnostics_extension,
     show_default_diagnostics_configuration,
@@ -67,7 +67,7 @@ cli_command('vm nic update', vm_update_nics)
 # VM Access
 cli_command('vm access set-linux-user', set_linux_user)
 cli_command('vm access delete-linux-user', delete_linux_user)
-cli_command('vm access set-windows-user-password', set_windows_user_password)
+cli_command('vm access reset-windows-admin', reset_windows_admin)
 
 # VM Availability Set
 factory = lambda _: get_mgmt_service_client(AvailSetClient).avail_set


### PR DESCRIPTION
After the conversation with VM extension owner, I am renaming the command to be more accurate that is `Vmaccess today is to recover your admin account only`. So you can update both admin user name and password, but you just can't add new user
