### PR TITLE
Command modules should import azure.cli.commands.parameters

### DIFF
--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
@@ -1,5 +1,7 @@
 from azure.mgmt.authorization import AuthorizationManagementClient
 
+import azure.cli.commands.parameters #pylint: disable=unused-import
+
 from azure.cli.commands.client_factory import get_mgmt_service_client
 
 # FACTORIES

--- a/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/_params.py
+++ b/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/_params.py
@@ -1,7 +1,5 @@
-#pylint: disable=unused-import
-import argparse
-
 from azure.cli.commands import CliArgumentType, register_cli_argument
+import azure.cli.commands.parameters #pylint: disable=unused-import
 
 from azure.mgmt.web import WebSiteManagementClient
 from azure.cli.commands.client_factory import get_mgmt_service_client


### PR DESCRIPTION
Command modules must import azure.cli.commands.parameters in order to get the global resource group param

i.e. register_cli_argument('', 'resource_group_name', resource_group_name_type) in parameters.py
