### PR TITLE
Case insensitive ChoicesCompleter (argcomplete)

### DIFF
--- a/src/azure/cli/parser.py
+++ b/src/azure/cli/parser.py
@@ -9,6 +9,13 @@ class IncorrectUsageError(CLIError):
     '''
     pass
 
+class CaseInsensitiveChoicesCompleter(argcomplete.completers.ChoicesCompleter): #pylint: disable=too-few-public-methods
+    def __call__(self, prefix, **kwargs):
+        return (c for c in self.choices if c.lower().startswith(prefix.lower()))
+
+# Override the choices completer with one that is case insensitive
+argcomplete.completers.ChoicesCompleter = CaseInsensitiveChoicesCompleter
+
 class EmptyDefaultCompletionFinder(argcomplete.CompletionFinder):
     def __init__(self, *args, **kwargs):
         super(EmptyDefaultCompletionFinder, self).__init__(*args, default_completer=lambda _: (),


### PR DESCRIPTION
The ChoicesComplete in argcomplete is case sensitive (https://github.com/kislyuk/argcomplete/blob/master/argcomplete/completers.py#L27).

We override this to make it case insensitive.

We do `argcomplete.completers.ChoicesCompleter = CaseInsensitiveChoicesCompleter` because of [L381 in argcomplete](https://github.com/kislyuk/argcomplete/blob/master/argcomplete/__init__.py#L381).
