### PR TITLE
Improve Error Message with NIC Create ID Lists

### DIFF
--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
@@ -1,4 +1,5 @@
 from azure.cli.commands.azure_resource_id import AzureResourceId
+from azure.cli._util import CLIError
 
 def _convert_id_list_to_object(data):
     if not data:
@@ -9,7 +10,10 @@ def _convert_id_list_to_object(data):
     data_list = []
     for val in data:
         # currently only supports accepting ids, not names
-        data_list.append({'id': str(AzureResourceId(val))})
+        try:
+            data_list.append({'id': str(AzureResourceId(val))})
+        except ValueError:
+            raise CLIError('Please supply a space-separated list of well-formed IDs.')
     return data_list
 
 def process_nic_namespace(namespace):


### PR DESCRIPTION
Since NIC create only supports lists of IDs for address-pool and NAT rules, the default error that is given if a malformed ID is passed is incorrect (the default implementation supports names as well). This catches the error and re-wraps it with a CLIError and an accurate message.
