### PR TITLE
Remove 'x-ms-client-request-id' during automated tests

### DIFF
--- a/src/azure/cli/commands/client_factory.py
+++ b/src/azure/cli/commands/client_factory.py
@@ -13,22 +13,6 @@ def get_mgmt_service_client(client_type):
 def get_subscription_service_client(client_type):
     return _get_mgmt_service_client(client_type, False)
 
-def _mock_get_mgmt_service_client(client_type, subscription_bound=True):
-    # version of _get_mgmt_service_client to use when recording or playing tests
-    logger.info('Getting management service client client_type=%s', client_type.__name__)
-    profile = Profile()
-    cred, subscription_id = profile.get_login_credentials()
-    if subscription_bound:
-        client = client_type(cred, subscription_id)
-    else:
-        client = client_type(cred)
-
-    _debug.allow_debug_connection(client)
-
-    client.config.add_user_agent("AZURECLI/TEST/{}".format(cli.__version__))
-
-    return (client, subscription_id)
-
 def _get_mgmt_service_client(client_type, subscription_bound=True):
     logger.info('Getting management service client client_type=%s', client_type.__name__)
     profile = Profile()


### PR DESCRIPTION
PR #414 added the 'x-ms-client-request-id' header for telemetry purposes. This ensures that a single command sends the same request ID with all API calls for that invocation. However, when recording tests this results in all requests from all commands sending the same request ID.

If the same call is made multiple times (for example, to add multiple NAT rules) only the first update is applied. The server apparently thinks the subsequent calls are the same request and ignores them. Not including the request id ensures that these calls are processed correctly.

Additionally, we send a different user agent string in order to distinguish between rest calls made for testing and those made by actually using the CLI to do stuff. 
