### PR TITLE
Case insensitive choices

### DIFF
--- a/src/azure/cli/application.py
+++ b/src/azure/cli/application.py
@@ -166,7 +166,8 @@ class Application(object):
         global_group.add_argument('--output', '-o', dest='_output_format',
                                   choices=['json', 'tsv', 'list'],
                                   default='json',
-                                  help='Output format')
+                                  help='Output format',
+                                  type=str.lower)
         # The arguments for verbosity don't get parsed by argparse but we add it here for help.
         global_group.add_argument('--verbose', dest='_log_verbosity_verbose', action='store_true',
                                   help='Increase logging verbosity. Use --debug for full debug logs.') #pylint: disable=line-too-long

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -51,7 +51,7 @@ register_cli_argument('network public-ip', 'name', name_arg_type, completer=get_
 register_cli_argument('network public-ip create', 'name', completer=None)
 register_cli_argument('network public-ip create', 'dns_name', CliArgumentType(action=PublicIpDnsNameAction))
 register_cli_argument('network public-ip create', 'public_ip_address_type', CliArgumentType(help=argparse.SUPPRESS))
-register_cli_argument('network public-ip create', 'allocation_method', CliArgumentType(choices=['dynamic', 'static'], default='dynamic'))
+register_cli_argument('network public-ip create', 'allocation_method', CliArgumentType(choices=['dynamic', 'static'], default='dynamic', type=str.lower))
 
 register_cli_argument('network route-operation', 'route_name', name_arg_type)
 
@@ -73,9 +73,9 @@ register_cli_argument('network lb', 'load_balancer_name', name_arg_type, complet
 
 register_cli_argument('network lb create', 'dns_name_for_public_ip', CliArgumentType(action=LBDNSNameAction))
 register_cli_argument('network lb create', 'dns_name_type', CliArgumentType(help=argparse.SUPPRESS))
-register_cli_argument('network lb create', 'private_ip_address_allocation', CliArgumentType(help='', choices=['dynamic', 'static'], default='dynamic'))
-register_cli_argument('network lb create', 'public_ip_address_allocation', CliArgumentType(help='', choices=['dynamic', 'static'], default='dynamic'))
-register_cli_argument('network lb create', 'public_ip_address_type', CliArgumentType(help='', choices=['new', 'existing', 'none'], default='new'))
+register_cli_argument('network lb create', 'private_ip_address_allocation', CliArgumentType(help='', choices=['dynamic', 'static'], default='dynamic', type=str.lower))
+register_cli_argument('network lb create', 'public_ip_address_allocation', CliArgumentType(help='', choices=['dynamic', 'static'], default='dynamic', type=str.lower))
+register_cli_argument('network lb create', 'public_ip_address_type', CliArgumentType(help='', choices=['new', 'existing', 'none'], default='new', type=str.lower))
 register_cli_argument('network lb create', 'subnet_name', CliArgumentType(options_list=('--subnet-name',)))
 
 register_cli_argument('network nsg create', 'name', name_arg_type)

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
@@ -28,7 +28,7 @@ register_cli_argument('resource', 'tag', tag_type)
 register_cli_argument('resource', 'tags', tags_type)
 
 register_cli_argument('resource deploy', 'mode', CliArgumentType(
-    choices=['incremental', 'complete'], default='incremental',
+    choices=['incremental', 'complete'], default='incremental', type=str.lower,
     help='Incremental (only add resources to resource group) or Complete (remove extra resources from resource group)'))
 register_cli_argument('resource deploy', 'resource_group', completer=get_resource_group_completion_list)
 register_cli_argument('resource deploy', 'parameters_file_path', completer=FilesCompleter())

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
@@ -54,7 +54,8 @@ blob_name_type = CliArgumentType(
 
 blob_type_type = CliArgumentType(
     options_list=('--blob-type',),
-    choices=list(blob_types.keys())
+    choices=list(blob_types.keys()),
+    type=str.lower
 )
 
 container_name_type = CliArgumentType(
@@ -101,7 +102,8 @@ ip_type = CliArgumentType(
 
 key_type = CliArgumentType(
     help='the key to renew (omit to renew both)',
-    choices=list(storage_account_key_options.keys())
+    choices=list(storage_account_key_options.keys()),
+    type=str.lower
 )
 
 lease_break_period_type = CliArgumentType(
@@ -140,7 +142,8 @@ policy_name_type = CliArgumentType(
 )
 
 public_access_type = CliArgumentType(
-    choices=list(public_access_types.keys())
+    choices=list(public_access_types.keys()),
+    type=str.lower
 )
 
 quota_type = CliArgumentType(

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -55,7 +55,7 @@ register_cli_argument('vm availability-set', 'availability_set_name', name_arg_t
 register_cli_argument('vm access', 'username', CliArgumentType(options_list=('--username', '-u'), help='The user name'))
 register_cli_argument('vm access', 'password', CliArgumentType(options_list=('--password', '-p'), help='The user password'))
 
-register_cli_argument('vm container', 'orchestrator_type', CliArgumentType(choices=['docs', 'swarm']))
+register_cli_argument('vm container', 'orchestrator_type', CliArgumentType(choices=['docs', 'swarm'], type=str.lower))
 register_cli_argument('vm container', 'admin_username', admin_username_type)
 register_cli_argument(
     'vm container', 'ssh_key_value', CliArgumentType(
@@ -89,15 +89,17 @@ register_cli_argument('vm image list', 'image_location', location_type)
 
 authentication_type = CliArgumentType(
     choices=['ssh', 'password'], default=None,
-    help='Password or SSH public key authentication. Defaults to password for Windows and SSH public key for Linux.'
+    help='Password or SSH public key authentication. Defaults to password for Windows and SSH public key for Linux.',
+    type=str.lower
 )
 
 nsg_rule_type = CliArgumentType(
     choices=['RDP', 'SSH'], default=None,
-    help='Network security group rule to create. Defaults to RDP for Windows and SSH for Linux'
+    help='Network security group rule to create. Defaults to RDP for Windows and SSH for Linux',
+    type=str.upper
 )
 
-register_cli_argument('vm create', 'network_interface_type', choices=['new', 'existing'], help=None)
+register_cli_argument('vm create', 'network_interface_type', choices=['new', 'existing'], help=None, type=str.lower)
 register_cli_argument('vm create', 'network_interface_ids', options_list=('--network-interfaces',), nargs='+',
                       help='Names or IDs of existing NICs to reference.  The first NIC will be the primary NIC.',
                       validator=_handle_vm_nics)
@@ -106,12 +108,12 @@ for scope in ['vm create', 'vm scaleset create']:
     register_cli_argument(scope, 'name', name_arg_type)
     register_cli_argument(scope, 'location', CliArgumentType(completer=get_location_completion_list))
     register_cli_argument(scope, 'custom_os_disk_uri', CliArgumentType(help=argparse.SUPPRESS))
-    register_cli_argument(scope, 'custom_os_disk_type', CliArgumentType(choices=['windows', 'linux']))
+    register_cli_argument(scope, 'custom_os_disk_type', CliArgumentType(choices=['windows', 'linux'], type=str.lower))
     register_cli_argument(scope, 'os_disk_type', CliArgumentType(help=argparse.SUPPRESS))
     register_cli_argument(scope, 'overprovision', CliArgumentType(action='store_false', default=None, options_list=('--disable-overprovision',)))
-    register_cli_argument(scope, 'load_balancer_type', CliArgumentType(choices=['new', 'existing', 'none']))
+    register_cli_argument(scope, 'load_balancer_type', CliArgumentType(choices=['new', 'existing', 'none'], type=str.lower))
     register_cli_argument(scope, 'storage_caching', CliArgumentType(choices=['ReadOnly', 'ReadWrite']))
-    register_cli_argument(scope, 'upgrade_policy_mode', CliArgumentType(choices=['manual', 'automatic'], default='manual', help=None))
+    register_cli_argument(scope, 'upgrade_policy_mode', CliArgumentType(choices=['manual', 'automatic'], default='manual', help=None, type=str.lower))
     register_cli_argument(scope, 'nat_backend_port', CliArgumentType(help='Backend NAT port to map.  Defaults to 22 for Linux and 3389 for Windows.', default=None))
     register_cli_argument(scope, 'os_disk_uri', CliArgumentType(help=argparse.SUPPRESS))
     register_cli_argument(scope, 'os_offer', CliArgumentType(help=argparse.SUPPRESS))
@@ -125,12 +127,12 @@ for scope in ['vm create', 'vm scaleset create']:
     register_cli_argument(scope, 'ssh_dest_key_path', completer=FilesCompleter())
     register_cli_argument(scope, 'dns_name_for_public_ip', CliArgumentType(action=VMDNSNameAction))
     register_cli_argument(scope, 'authentication_type', authentication_type)
-    register_cli_argument(scope, 'availability_set_type', CliArgumentType(choices=['none', 'existing'], help='', default='none'))
-    register_cli_argument(scope, 'private_ip_address_allocation', CliArgumentType(choices=['dynamic', 'static'], help='', default='dynamic'))
-    register_cli_argument(scope, 'public_ip_address_allocation', CliArgumentType(choices=['dynamic', 'static'], help='', default='dynamic'))
-    register_cli_argument(scope, 'public_ip_address_type', CliArgumentType(choices=['none', 'new', 'existing'], help='', default='new'))
-    register_cli_argument(scope, 'storage_account_type', CliArgumentType(choices=['new', 'existing'], help='', default='new'))
-    register_cli_argument(scope, 'virtual_network_type', CliArgumentType(choices=['new', 'existing'], help='', default='new'))
+    register_cli_argument(scope, 'availability_set_type', CliArgumentType(choices=['none', 'existing'], help='', default='none', type=str.lower))
+    register_cli_argument(scope, 'private_ip_address_allocation', CliArgumentType(choices=['dynamic', 'static'], help='', default='dynamic', type=str.lower))
+    register_cli_argument(scope, 'public_ip_address_allocation', CliArgumentType(choices=['dynamic', 'static'], help='', default='dynamic', type=str.lower))
+    register_cli_argument(scope, 'public_ip_address_type', CliArgumentType(choices=['none', 'new', 'existing'], help='', default='new', type=str.lower))
+    register_cli_argument(scope, 'storage_account_type', CliArgumentType(choices=['new', 'existing'], help='', default='new', type=str.lower))
+    register_cli_argument(scope, 'virtual_network_type', CliArgumentType(choices=['new', 'existing'], help='', default='new', type=str.lower))
     register_cli_argument(scope, 'network_security_group_rule', nsg_rule_type)
-    register_cli_argument(scope, 'network_security_group_type', CliArgumentType(choices=['new', 'existing', 'none'], help='', default='new'))
+    register_cli_argument(scope, 'network_security_group_type', CliArgumentType(choices=['new', 'existing', 'none'], help='', default='new', type=str.lower))
     register_extra_cli_argument(scope, 'image', options_list=('--image',), action=VMImageFieldAction, completer=get_urn_aliases_completion_list, default='Win2012R2Datacenter')


### PR DESCRIPTION
This PR addresses choice values that are entered with a different case.
e.g.:
--auth-type SSH
--auth-type ssh
--auth-type SsH

There are a couple of places where choices are still case sensitive:
1. Caching policies `'None', 'ReadOnly', 'ReadWrite'`
2. Storage account types `'Standard_LRS', 'Standard_ZRS', 'Standard_GRS', 'Standard_RAGRS', 'Premium_LRS'`

I believe these should still be case sensitive.

@tjprescott, @yugangw-msft 
