### PR TITLE
Client requests made by completers should be identifiable in CommandName header

### DIFF
--- a/src/azure/cli/application.py
+++ b/src/azure/cli/application.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from datetime import datetime
 import sys
+import os
 import re
 import uuid
 import argparse
@@ -11,6 +12,8 @@ import azure.cli._help as _help
 import azure.cli._logging as _logging
 
 logger = _logging.get_az_logger(__name__)
+
+ARGCOMPLETE_ENV_NAME = '_ARGCOMPLETE'
 
 class Configuration(object): # pylint: disable=too-few-public-methods
     """The configuration object tracks session specific data such
@@ -47,7 +50,8 @@ class Application(object):
             'headers': {
                 'x-ms-client-request-id': str(uuid.uuid1())
                 },
-            'command': 'unknown'
+            'command': 'unknown',
+            'completer_active': ARGCOMPLETE_ENV_NAME in os.environ
             }
 
 

--- a/src/azure/cli/commands/client_factory.py
+++ b/src/azure/cli/commands/client_factory.py
@@ -32,7 +32,9 @@ def _get_mgmt_service_client(client_type, subscription_bound=True):
         # private members
         client._client.add_header(header, value) #pylint: disable=protected-access
 
-    client._client.add_header('CommandName', APPLICATION.session['command']) #pylint: disable=protected-access
+    command_name_suffix = ';completer-request' if APPLICATION.session['completer_active'] else ''
+    client._client.add_header('CommandName', #pylint: disable=protected-access
+                              "{}{}".format(APPLICATION.session['command'], command_name_suffix))
     client.config.generate_client_request_id = \
         'x-ms-client-request-id' not in APPLICATION.session['headers']
 


### PR DESCRIPTION
When sending CommandName in the client header, differentiate requests that were initiated by completers.

Check for the _ARGCOMPLETE env var as this indicates that we are in completer mode.
