### PR TITLE
Bug fixes for #472 #213

### DIFF
--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
@@ -135,7 +135,7 @@ def list_resources(
 
 def deploy_arm_template(
         resource_group_name, deployment_name, template_file_path,
-        parameters_file_path, mode='incremental'):
+        parameters_file_path=None, mode='incremental'):
     ''' Deploy resources with an ARM template.
         :param str resource_group_name:resource group for deployment
         :param str location:location for deployment
@@ -148,7 +148,7 @@ def deploy_arm_template(
                                      parameters_file_path, mode)
 
 def validate_arm_template(resource_group_name, template_file_path,
-                          parameters_file_path, mode='incremental'):
+                          parameters_file_path=None, mode='incremental'):
     ''' Validate an ARM template.
         :param str resource_group_name:resource group for deployment
         :param str location:location for deployment
@@ -160,11 +160,14 @@ def validate_arm_template(resource_group_name, template_file_path,
                                      parameters_file_path, mode, validate_only=True)
 
 def _deploy_arm_template_core(resource_group_name, deployment_name, template_file_path,
-                              parameters_file_path, mode, validate_only=False):
+                              parameters_file_path=None, mode='incremental', validate_only=False):
     from azure.mgmt.resource.resources.models import DeploymentProperties
 
-    parameters = _get_file_json(parameters_file_path)
-    parameters = parameters.get('parameters', parameters)
+    parameters = None
+    if parameters_file_path:
+        parameters = _get_file_json(parameters_file_path)
+        if parameters:
+            parameters = parameters.get('parameters', parameters)
 
     template = _get_file_json(template_file_path)
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -158,8 +158,8 @@ def list_ip_addresses(resource_group_name=None, vm_name=None):
 
         # If provided, make sure that resource group name and vm name match the NIC we are
         # looking at before adding it to the result...
-        if (resource_group_name in (None, nic_resource_group)
-                and vm_name in (None, nic_vm_name)):
+        if ((resource_group_name is None or resource_group_name.lower() == nic_resource_group.lower()) and #pylint: disable=line-too-long
+                (vm_name is None or vm_name.lower() == nic_vm_name.lower())):
 
             network_info = {
                 'privateIpAddresses': [],

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
@@ -115,7 +115,8 @@ class VMShowListSizesListIPAddressesScenarioTest(ResourceGroupVCRTestBase):
             self.resource_group, self.vm_name), checks=JMESPathCheck('type(@)', 'array'))
 
         # Expecting the one we just added
-        self.cmd('vm list-ip-addresses --resource-group {}'.format(self.resource_group), checks=[
+        rg_name_all_upper = self.resource_group.upper() #test the command handles name with casing diff.
+        self.cmd('vm list-ip-addresses --resource-group {}'.format(rg_name_all_upper), checks=[
             JMESPathCheck('length(@)', 1),
             JMESPathCheck('[0].virtualMachine.name', self.vm_name),
             JMESPathCheck('[0].virtualMachine.resourceGroup', self.resource_group),


### PR DESCRIPTION
#472: make `resource group deployment create` treat `template parameter file` as optional
#213: make `vm list-ip-addresses` handles group name as case insensitive

/CC: @burtbiel, @tjprescott , @derekbekoe
