### PR TITLE
command: service principal for login

### DIFF
--- a/src/azure/cli/_azure_env.py
+++ b/src/azure/cli/_azure_env.py
@@ -10,19 +10,23 @@ COMMON_TENANT = 'common'
 class ENDPOINT_URLS: #pylint: disable=too-few-public-methods,old-style-class,no-init
     MANAGEMENT = 'management'
     ACTIVE_DIRECTORY_AUTHORITY = 'active_directory_authority'
+    ACTIVE_DIRECTORY_GRAPH_RESOURCE_ID = 'active_directory_graph_resource_id'
 
 _environments = {
     ENV_DEFAULT: {
         ENDPOINT_URLS.MANAGEMENT: 'https://management.core.windows.net/',
-        ENDPOINT_URLS.ACTIVE_DIRECTORY_AUTHORITY : 'https://login.microsoftonline.com'
+        ENDPOINT_URLS.ACTIVE_DIRECTORY_AUTHORITY : 'https://login.microsoftonline.com',
+        ENDPOINT_URLS.ACTIVE_DIRECTORY_GRAPH_RESOURCE_ID: 'https://graph.windows.net/'
         },
     ENV_CHINA: {
         ENDPOINT_URLS.MANAGEMENT: 'https://management.core.chinacloudapi.cn/',
-        ENDPOINT_URLS.ACTIVE_DIRECTORY_AUTHORITY: 'https://login.chinacloudapi.cn'
+        ENDPOINT_URLS.ACTIVE_DIRECTORY_AUTHORITY: 'https://login.chinacloudapi.cn',
+        ENDPOINT_URLS.ACTIVE_DIRECTORY_GRAPH_RESOURCE_ID: 'https://graph.chinacloudapi.cn/'
         },
     ENV_US_GOVERNMENT: {
         ENDPOINT_URLS.MANAGEMENT: 'https://management.core.usgovcloudapi.net/',
-        ENDPOINT_URLS.ACTIVE_DIRECTORY_AUTHORITY: 'https://login.microsoftonline.com'
+        ENDPOINT_URLS.ACTIVE_DIRECTORY_AUTHORITY: 'https://login.microsoftonline.com',
+        ENDPOINT_URLS.ACTIVE_DIRECTORY_GRAPH_RESOURCE_ID: 'https://graph.windows.net/'
         }
 }
 
@@ -36,8 +40,3 @@ def get_env(env_name=None):
 def get_authority_url(tenant=None, env_name=None):
     env = get_env(env_name)
     return env[ENDPOINT_URLS.ACTIVE_DIRECTORY_AUTHORITY] + '/' + (tenant or COMMON_TENANT)
-
-def get_management_endpoint_url(env_name=None):
-    env = get_env(env_name)
-    return env[ENDPOINT_URLS.MANAGEMENT]
-

--- a/src/azure/cli/commands/client_factory.py
+++ b/src/azure/cli/commands/client_factory.py
@@ -16,7 +16,7 @@ def get_subscription_service_client(client_type):
 def _get_mgmt_service_client(client_type, subscription_bound=True):
     logger.info('Getting management service client client_type=%s', client_type.__name__)
     profile = Profile()
-    cred, subscription_id = profile.get_login_credentials()
+    cred, subscription_id, _ = profile.get_login_credentials()
     if subscription_bound:
         client = client_type(cred, subscription_id)
     else:

--- a/src/azure/cli/utils/vcr_test_base.py
+++ b/src/azure/cli/utils/vcr_test_base.py
@@ -30,7 +30,7 @@ COMMAND_COVERAGE_FILENAME = 'command_coverage.txt'
 def _mock_get_mgmt_service_client(client_type, subscription_bound=True):
     # version of _get_mgmt_service_client to use when recording or playing tests
     profile = Profile()
-    cred, subscription_id = profile.get_login_credentials()
+    cred, subscription_id, _ = profile.get_login_credentials()
     if subscription_bound:
         client = client_type(cred, subscription_id)
     else:
@@ -60,7 +60,7 @@ def _mock_subscriptions(self): #pylint: disable=unused-argument
         "tenantId": "123",
         "isDefault": True}]
 
-def _mock_user_access_token(_, _1, _2): #pylint: disable=unused-argument
+def _mock_user_access_token(_, _1, _2, _3): #pylint: disable=unused-argument
     return ('Bearer', 'top-secret-token-for-you')
 
 def _mock_operation_delay(_):

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_param_folding.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_param_folding.py
@@ -66,5 +66,5 @@ def _name_id_fold(base_name, resource_type, type_field, #pylint: disable=too-man
 def get_subscription_id():
     from azure.cli.commands.client_factory import Profile
     profile = Profile()
-    _, subscription_id = profile.get_login_credentials()
+    _, subscription_id, _ = profile.get_login_credentials()
     return subscription_id

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
@@ -37,6 +37,10 @@ username_type = CliArgumentType(
     help='Organization id or service principal'
 )
 
+sp_name_type = CliArgumentType(
+    options_list=('--name', '-n')
+)
+
 register_cli_argument('login', 'password', password_type)
 register_cli_argument('login', 'service_principal', service_principal_type)
 register_cli_argument('login', 'username', username_type)
@@ -45,3 +49,6 @@ register_cli_argument('login', 'tenant', tenant_type)
 register_cli_argument('logout', 'username', username_type)
 
 register_cli_argument('account', 'subscription_name_or_id', subscription_name_or_id_type)
+
+register_cli_argument('account create-sp', 'name', sp_name_type)
+register_cli_argument('account reset-sp-credentials', 'name', sp_name_type)

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
@@ -1,7 +1,16 @@
-# pylint: disable=too-few-public-methods,too-many-arguments,no-self-use
+﻿# pylint: disable=too-few-public-methods,too-many-arguments,no-self-use
 #TODO: update adal-python to support it
 #from azure.cli._debug import should_disable_connection_verify
+import datetime
+import uuid
+from dateutil.relativedelta import relativedelta
+
 from adal.adal_error import AdalError
+
+from azure.graphrbac.models import (ApplicationCreateParameters,
+                                    ApplicationUpdateParameters,
+                                    PasswordCredential)
+from azure.graphrbac import GraphRbacManagementClient
 
 from azure.cli._profile import Profile
 from azure.cli._util import CLIError
@@ -64,4 +73,86 @@ def logout(username):
 def list_location():
     from azure.cli.commands.parameters import get_subscription_locations
     return get_subscription_locations()
+
+def create_service_principal(name=None, secret=None, years=1):
+    '''create a service principal you can use with login command
+
+    :param str name: an unique uri. If missing, the command will generate one.
+    :param str secret: the secret used to login. If missing, command will generate one.
+    :param str years: Years the secret will be valid.
+    '''
+    start_date = datetime.datetime.now()
+    app_display_name = 'azure-cli-' + start_date.strftime('%Y-%m-%d-%H-%M-%S')
+    if name is None:
+        name = 'http://' + app_display_name
+
+    key_id = str(uuid.uuid4())
+    end_date = start_date + relativedelta(years=years)
+    secret = secret or str(uuid.uuid4())
+    app_cred = PasswordCredential(start_date, end_date, key_id, secret)
+    app_create_param = ApplicationCreateParameters(False, app_display_name,
+                                                   'http://'+app_display_name, [name],
+                                                   password_credentials=[app_cred])
+
+    profile = Profile()
+    cred, _, tenant = profile.get_login_credentials(for_graph_client=True)
+
+    client = GraphRbacManagementClient(cred, tenant)
+
+    #pylint: disable=no-member
+    aad_application = client.applications.create(app_create_param)
+    aad_sp = client.service_principals.create(aad_application.app_id, True)
+
+    _build_output_content(name, aad_sp.object_id, secret, tenant)
+
+def reset_service_principal_credential(name, secret=None, years=1):
+    '''reset credential, on expiration or you forget it.
+
+    :param str name: the uri representing the name of the service principal
+    :param str secret: the secret used to login. If missing, command will generate one.
+    :param str years: Years the secret will be valid.
+    '''
+    profile = Profile()
+    cred, _, tenant = profile.get_login_credentials(for_graph_client=True)
+    client = GraphRbacManagementClient(cred, tenant)
+
+    #pylint: disable=no-member
+
+    #look for the existing application
+    query_exp = 'identifierUris/any(x:x eq \'{}\')'.format(name)
+    aad_apps = list(client.applications.list(filter=query_exp))
+    if not aad_apps:
+        raise CLIError('can\'t find a graph application matching \'{}\''.format(name))
+    #no need to check 2+ matches, as app id uri is unique
+    app = aad_apps[0]
+
+    #look for the existing service principal
+    query_exp = 'servicePrincipalNames/any(x:x eq \'{}\')'.format(name)
+    aad_sps = list(client.service_principals.list(filter=query_exp))
+    if not aad_sps:
+        raise CLIError('can\'t find an service principal matching \'{}\''.format(name))
+    sp_object_id = aad_sps[0].object_id
+
+    #build a new password credential and patch it
+    secret = secret or str(uuid.uuid4())
+    start_date = datetime.datetime.now()
+    end_date = start_date + relativedelta(years=years)
+    key_id = str(uuid.uuid4())
+    app_cred = PasswordCredential(start_date, end_date, key_id, secret)
+    app_create_param = ApplicationUpdateParameters(password_credentials=[app_cred])
+
+    client.applications.patch(app.object_id, app_create_param)
+
+    _build_output_content(name, sp_object_id, secret, tenant)
+
+def _build_output_content(sp_name, sp_object_id, secret, tenant):
+    logger.warning("Service principal has been configured with name: '%s', secret: '%s'",
+                   sp_name, secret)
+    logger.warning('Useful commands to manage azure:')
+    logger.warning('  Assign a role: "az role assignment create --object-id %s --role Contributor"',
+                   sp_object_id)
+    logger.warning('  Log in: "az login --service-principal -u %s -p %s --tenant %s"',
+                   sp_name, secret, tenant)
+    logger.warning('  Reset credentials: "az account reset-sp-credentials --name %s"',
+                   sp_name)
 

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/generated.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/generated.py
@@ -2,8 +2,14 @@
 
 from azure.cli.commands import cli_command
 
-from .custom import (login, logout, list_subscriptions, set_active_subscription, account_clear,
-                     list_location)
+from .custom import (login,
+                     logout,
+                     list_location,
+                     list_subscriptions,
+                     set_active_subscription,
+                     account_clear,
+                     create_service_principal,
+                     reset_service_principal_credential)
 
 cli_command('login', login)
 cli_command('logout', logout)
@@ -12,4 +18,7 @@ cli_command('account list', list_subscriptions)
 cli_command('account set', set_active_subscription)
 cli_command('account clear', account_clear)
 cli_command('account list-location', list_location)
+
+cli_command('account create-sp', create_service_principal)
+cli_command('account reset-sp-credentials', reset_service_principal_credential)
 

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
@@ -1,0 +1,25 @@
+import uuid
+import re
+
+from azure.cli._util import CLIError
+from azure.mgmt.authorization.models import RoleAssignmentProperties
+from ._params import _auth_client_factory
+
+#TODO: expand the support to be in parity with node cli
+def create_role_assignment(role, object_id, scope=None):
+    assignments_client = _auth_client_factory().role_assignments
+    definitions_client = _auth_client_factory().role_definitions
+    role_id = role
+    scope = scope or '/subscriptions/' + definitions_client.config.subscription_id
+    if not re.match(r'[0-9a-f]{32}\Z', role, re.I): #retrieve role id
+        role_defs = list(definitions_client.list(scope, "roleName eq '{}'".format(role)))
+        if not role_defs:
+            raise CLIError('Role {} doesn\'t exist.'.format(role))
+        elif len(role_defs) > 1:
+            raise CLIError('More than one roles match the given name {}'.format(role))
+        role_id = role_defs[0].id
+
+    properties = RoleAssignmentProperties(role_id, object_id)
+    assignment_name = uuid.uuid4()
+    return assignments_client.create(scope, assignment_name, properties)
+

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/generated.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/generated.py
@@ -1,4 +1,4 @@
-# pylint: disable=line-too-long
+﻿# pylint: disable=line-too-long
 from __future__ import print_function
 
 from azure.mgmt.authorization.operations import RoleAssignmentsOperations, RoleDefinitionsOperations
@@ -6,6 +6,7 @@ from azure.mgmt.authorization.operations import RoleAssignmentsOperations, RoleD
 from azure.cli.commands import cli_command
 
 from ._params import _auth_client_factory
+from .custom import create_role_assignment
 
 factory = lambda _: _auth_client_factory().role_definitions
 cli_command('role list', RoleDefinitionsOperations.list, factory)
@@ -22,3 +23,4 @@ cli_command('role assignment list', RoleAssignmentsOperations.list, factory)
 cli_command('role assignment list-for-resource', RoleAssignmentsOperations.list_for_resource, factory)
 cli_command('role assignment list-for-resource-group', RoleAssignmentsOperations.list_for_resource_group, factory)
 cli_command('role assignment list-for-scope', RoleAssignmentsOperations.list_for_scope, factory)
+cli_command('role assignment create', create_role_assignment)

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_actions.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_actions.py
@@ -257,5 +257,5 @@ APPLICATION.register(APPLICATION.COMMAND_PARSER_PARSED, _handle_container_ssh_fi
 def _get_subscription_id():
     from azure.cli.commands.client_factory import Profile
     profile = Profile()
-    _, subscription_id = profile.get_login_credentials()
+    _, subscription_id, _ = profile.get_login_credentials()
     return subscription_id

--- a/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/_param_folding.py
+++ b/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/_param_folding.py
@@ -66,5 +66,5 @@ def _name_id_fold(base_name, resource_type, type_field, #pylint: disable=too-man
 def get_subscription_id():
     from azure.cli.commands.client_factory import Profile
     profile = Profile()
-    _, subscription_id = profile.get_login_credentials()
+    _, subscription_id, _ = profile.get_login_credentials()
     return subscription_id


### PR DESCRIPTION
Notes:
1. We put 2 commands under  `account` group for the reason that they are for login, not dealing with general service principal. In future, the placement might change.
2. `role assignment create` command contains the minimum, and it is not the final version. We will get to it when we are done with the network set commands
3. The new commands don't follow the default output format, as it means to output the credentials information as clear as possible for people to write down.
4. The access token acquired for management endpoint (our default case) will not work for the graph endpoint, so the profile management code gets updated to handle the new situation.
