### PR TITLE
First iteration of portal-style defaults for VM Create

### DIFF
--- a/src/azure/cli/commands/template_create.py
+++ b/src/azure/cli/commands/template_create.py
@@ -12,22 +12,32 @@ from azure.cli.commands.arm import (
 def register_folded_cli_argument(scope, base_name, resource_type, parent_name=None, # pylint: disable=too-many-arguments
                                  parent_type=None, type_field=None,
                                  existing_id_flag_value='existingId', new_flag_value='new',
-                                 none_flag_value='none', post_validator=None, **kwargs):
+                                 none_flag_value='none', **kwargs):
     type_field_name = type_field or base_name + '_type'
-    register_cli_argument(scope, base_name, validator=_name_id_fold(base_name,
-                                                                    resource_type,
-                                                                    type_field_name,
-                                                                    existing_id_flag_value,
-                                                                    new_flag_value,
-                                                                    none_flag_value,
-                                                                    parent_name,
-                                                                    parent_type,
-                                                                    post_validator), **kwargs)
+
+    fold_validator = _name_id_fold(base_name,
+                                   resource_type,
+                                   type_field_name,
+                                   existing_id_flag_value,
+                                   new_flag_value,
+                                   none_flag_value,
+                                   parent_name,
+                                   parent_type)
+    custom_validator = kwargs.pop('validator', None)
+    if custom_validator:
+        def wrapped(namespace):
+            fold_validator(namespace)
+            custom_validator(namespace)
+        validator = wrapped
+    else:
+        validator = fold_validator
+
+    register_cli_argument(scope, base_name, validator=validator, **kwargs)
     register_cli_argument(scope, type_field_name, help=argparse.SUPPRESS, default=None)
 
 def _name_id_fold(base_name, resource_type, type_field, #pylint: disable=too-many-arguments
                   existing_id_flag_value, new_flag_value, none_flag_value, parent_name=None,
-                  parent_type=None, post_validator=None):
+                  parent_type=None):
     def handle_folding(namespace):
         base_name_val = getattr(namespace, base_name)
         type_field_val = getattr(namespace, type_field)
@@ -72,9 +82,6 @@ def _name_id_fold(base_name, resource_type, type_field, #pylint: disable=too-man
                                'a name to create a new resource.'.format(resource_id))
             else:
                 setattr(namespace, type_field, new_flag_value)
-
-        if post_validator:
-            post_validator(namespace)
 
     return handle_folding
 

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -96,7 +96,7 @@ register_cli_argument('network lb create', 'public_ip_dns_name', validator=proce
 register_cli_argument('network lb create', 'dns_name_type', help=argparse.SUPPRESS)
 register_cli_argument('network lb create', 'private_ip_address_allocation', help=argparse.SUPPRESS)
 register_cli_argument('network lb create', 'public_ip_address_allocation', choices=choices_ip_allocation_method, default='dynamic', type=str.lower)
-register_folded_cli_argument('network lb create', 'public_ip_address', 'Microsoft.Network/publicIPAddresses', post_validator=validate_public_ip_type)
+register_folded_cli_argument('network lb create', 'public_ip_address', 'Microsoft.Network/publicIPAddresses', validator=validate_public_ip_type)
 register_folded_cli_argument('network lb create', 'subnet', 'subnets', parent_name='virtual_network_name', parent_type='Microsoft.Network/virtualNetworks')
 
 register_cli_argument('network lb inbound-nat-rule', 'item_name', options_list=('--name', '-n'), help='The name of the inbound NAT rule.')

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_load_balancer.yaml
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_load_balancer.yaml
@@ -1,40 +1,35 @@
 interactions:
 - request:
-    body: !!binary |
-      eyJwcm9wZXJ0aWVzIjogeyJwYXJhbWV0ZXJzIjogeyJ2bmV0QWRkcmVzc1ByZWZpeCI6IHsidmFs
-      dWUiOiAiMTAuMC4wLjAvMTYifSwgImRuc05hbWVUeXBlIjogeyJ2YWx1ZSI6ICJub25lIn0sICJw
-      cml2YXRlSXBBZGRyZXNzQWxsb2NhdGlvbiI6IHsidmFsdWUiOiAiZHluYW1pYyJ9LCAic3VibmV0
-      QWRkcmVzc1ByZWZpeCI6IHsidmFsdWUiOiAiMTAuMC4wLjAvMjQifSwgIl9hcnRpZmFjdHNMb2Nh
-      dGlvbiI6IHsidmFsdWUiOiAiaHR0cHM6Ly9henVyZXNka2NpLmJsb2IuY29yZS53aW5kb3dzLm5l
-      dC90ZW1wbGF0ZWhvc3QvQ3JlYXRlTGJfMjAxNi0wNi0yMCJ9LCAicHVibGljSXBBZGRyZXNzQWxs
-      b2NhdGlvbiI6IHsidmFsdWUiOiAiZHluYW1pYyJ9LCAibG9hZEJhbGFuY2VyTmFtZSI6IHsidmFs
-      dWUiOiAibGIxIn19LCAidGVtcGxhdGVMaW5rIjogeyJ1cmkiOiAiaHR0cHM6Ly9henVyZXNka2Np
-      LmJsb2IuY29yZS53aW5kb3dzLm5ldC90ZW1wbGF0ZWhvc3QvQ3JlYXRlTGJfMjAxNi0wNi0yMC9h
-      enVyZWRlcGxveS5qc29uIn0sICJtb2RlIjogIkluY3JlbWVudGFsIn19
+    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-06-20/azuredeploy.json"},
+      "mode": "Incremental", "parameters": {"dnsNameType": {"value": "none"}, "publicIpAddressAllocation":
+      {"value": "dynamic"}, "loadBalancerName": {"value": "lb1"}, "privateIpAddressAllocation":
+      {"value": "dynamic"}, "_artifactsLocation": {"value": "https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-06-20"},
+      "vnetAddressPrefix": {"value": "10.0.0.0/16"}, "subnetAddressPrefix": {"value":
+      "10.0.0.0/24"}}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3NzMzOTMzLCJuYmYiOjE0Njc3MzM5MzMsImV4cCI6MTQ2NzczNzgzMywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.BUDdfJ1dId87f2nq-tcfBimD9x9tzkoqBw1mzP7QLokzQj_kNi-M-jGa8mASe6Uovd8xqpZrmTzosIQ7WumM3yhrtZ-q4NyvuPswzhb2dwl3Bb3-MlaLDa1g3Uu4HDDquR_KoQREWI6FEghmlGi3UcmoVdX9ODWlLl89FiSp_fJlDNvgzD0kDhGWq8lO9AgcsNexZR6DOthAfcCYLLatsYcZqxL3Ax0t2QMvY5CXvS8GXsnoIupcAwghPfCg0yqtw7_1RSMEXSXTLiyHKJI149R7wqmaVFvG42x3b09pvW9p9X2qCOhfF7rEohqv1u29NaQMJHYanY0kGjvsw9IRww]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY4MDA1NTg0LCJuYmYiOjE0NjgwMDU1ODQsImV4cCI6MTQ2ODAwOTQ4NCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.t9b-B1_IK7NClFfXkGsEL-eUnIKdzD3jA8BuOul0S-aQAuyjiDup1OE6HuIBWH7bEFdqa-kLA7tQ4TxT_TYs5Es2Ocmij2O66Ppq4dmZfMCMAuFIJ6UEdnj67OFk1Z4zsPJbsaE4btRXsz-DOl3gEisQ--xbYjXmZlgz_cY1FihQpLUPLcStSYkSnReQ6QbUME2IL_TMHk6poiC_vK8u7qwvvVdXWALeSOr4zSeVpvW33X3WFz4_Ryy3nMd9nyoMF7tgSHn-O1wqQWk-K5fda9zYH4QiawN-bp0hCmQbFOSETlbddm_E_ZuCcc2ZPi3q242Qy7R1ivSJl_sxU69Big]
       Connection: [keep-alive]
       Content-Length: ['555']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 lbcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [f09404ae-42c9-11e6-819b-a0b3ccf7272a]
+      x-ms-client-request-id: [75da9c9e-4545-11e6-8cdc-001dd8b7c0ad]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/lbrg/providers/Microsoft.Resources/deployments/azurecli1467734577.339084477722","name":"azurecli1467734577.339084477722","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-06-20/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-06-20"},"backendPoolName":{"type":"String","value":"lb1bepool"},"dnsNameType":{"type":"String","value":"none"},"loadBalancerName":{"type":"String","value":"lb1"},"location":{"type":"String","value":"westus"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddress":{"type":"String","value":"PublicIPlb1"},"publicIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddressType":{"type":"String","value":"new"},"publicIpDnsName":{"type":"String","value":""},"subnet":{"type":"String","value":""},"subnetAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetType":{"type":"String","value":"none"},"virtualNetworkName":{"type":"String","value":""},"vnetAddressPrefix":{"type":"String","value":"10.0.0.0/16"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-05T16:02:59.6296191Z","duration":"PT1.0994299S","correlationId":"6646e1e8-0955-4bc2-8f7d-44f6947b7293","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/lbrg/providers/Microsoft.Resources/deployments/IPlb1","resourceType":"Microsoft.Resources/deployments","resourceName":"IPlb1"},{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/lbrg/providers/Microsoft.Resources/deployments/Subnetlb1","resourceType":"Microsoft.Resources/deployments","resourceName":"Subnetlb1"}],"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/lbrg/providers/Microsoft.Network/loadBalancers/lb1","resourceType":"Microsoft.Network/loadBalancers","resourceName":"lb1"}]}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/lbrg/providers/Microsoft.Resources/deployments/azurecli1468007531.3692123","name":"azurecli1468007531.3692123","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-06-20/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-06-20"},"backendPoolName":{"type":"String","value":"lb1bepool"},"dnsNameType":{"type":"String","value":"none"},"loadBalancerName":{"type":"String","value":"lb1"},"location":{"type":"String","value":"westus"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddress":{"type":"String","value":"PublicIPlb1"},"publicIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddressType":{"type":"String","value":"new"},"publicIpDnsName":{"type":"String","value":""},"subnet":{"type":"String","value":""},"subnetAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetType":{"type":"String","value":"none"},"virtualNetworkName":{"type":"String","value":""},"vnetAddressPrefix":{"type":"String","value":"10.0.0.0/16"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-08T19:52:12.1738841Z","duration":"PT0.2408087S","correlationId":"9b22d89d-9090-4b1e-806c-2587109970ea","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/lbrg/providers/Microsoft.Resources/deployments/IPlb1","resourceType":"Microsoft.Resources/deployments","resourceName":"IPlb1"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/lbrg/providers/Microsoft.Resources/deployments/Subnetlb1","resourceType":"Microsoft.Resources/deployments","resourceName":"Subnetlb1"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/lbrg/providers/Microsoft.Network/loadBalancers/lb1","resourceType":"Microsoft.Network/loadBalancers","resourceName":"lb1"}]}}'}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/azurecli1467734577.339084477722/operationStatuses/08587338723069474742?api-version=2015-11-01']
-      Cache-Control: [no-cache]
-      Content-Length: ['2323']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 05 Jul 2016 16:02:59 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/azurecli1468007531.3692123/operationStatuses/08587335993535445794?api-version=2015-11-01']
+      cache-control: [no-cache]
+      content-length: ['2313']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Jul 2016 19:52:11 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
       x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
@@ -42,46 +37,15 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3NzMzOTMzLCJuYmYiOjE0Njc3MzM5MzMsImV4cCI6MTQ2NzczNzgzMywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.BUDdfJ1dId87f2nq-tcfBimD9x9tzkoqBw1mzP7QLokzQj_kNi-M-jGa8mASe6Uovd8xqpZrmTzosIQ7WumM3yhrtZ-q4NyvuPswzhb2dwl3Bb3-MlaLDa1g3Uu4HDDquR_KoQREWI6FEghmlGi3UcmoVdX9ODWlLl89FiSp_fJlDNvgzD0kDhGWq8lO9AgcsNexZR6DOthAfcCYLLatsYcZqxL3Ax0t2QMvY5CXvS8GXsnoIupcAwghPfCg0yqtw7_1RSMEXSXTLiyHKJI149R7wqmaVFvG42x3b09pvW9p9X2qCOhfF7rEohqv1u29NaQMJHYanY0kGjvsw9IRww]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY4MDA1NTg0LCJuYmYiOjE0NjgwMDU1ODQsImV4cCI6MTQ2ODAwOTQ4NCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.t9b-B1_IK7NClFfXkGsEL-eUnIKdzD3jA8BuOul0S-aQAuyjiDup1OE6HuIBWH7bEFdqa-kLA7tQ4TxT_TYs5Es2Ocmij2O66Ppq4dmZfMCMAuFIJ6UEdnj67OFk1Z4zsPJbsaE4btRXsz-DOl3gEisQ--xbYjXmZlgz_cY1FihQpLUPLcStSYkSnReQ6QbUME2IL_TMHk6poiC_vK8u7qwvvVdXWALeSOr4zSeVpvW33X3WFz4_Ryy3nMd9nyoMF7tgSHn-O1wqQWk-K5fda9zYH4QiawN-bp0hCmQbFOSETlbddm_E_ZuCcc2ZPi3q242Qy7R1ivSJl_sxU69Big]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 lbcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [f09404ae-42c9-11e6-819b-a0b3ccf7272a]
+      x-ms-client-request-id: [75da9c9e-4545-11e6-8cdc-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587338723069474742?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Length: ['140']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 05 Jul 2016 16:03:29 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3NzMzOTMzLCJuYmYiOjE0Njc3MzM5MzMsImV4cCI6MTQ2NzczNzgzMywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.BUDdfJ1dId87f2nq-tcfBimD9x9tzkoqBw1mzP7QLokzQj_kNi-M-jGa8mASe6Uovd8xqpZrmTzosIQ7WumM3yhrtZ-q4NyvuPswzhb2dwl3Bb3-MlaLDa1g3Uu4HDDquR_KoQREWI6FEghmlGi3UcmoVdX9ODWlLl89FiSp_fJlDNvgzD0kDhGWq8lO9AgcsNexZR6DOthAfcCYLLatsYcZqxL3Ax0t2QMvY5CXvS8GXsnoIupcAwghPfCg0yqtw7_1RSMEXSXTLiyHKJI149R7wqmaVFvG42x3b09pvW9p9X2qCOhfF7rEohqv1u29NaQMJHYanY0kGjvsw9IRww]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 lbcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [f09404ae-42c9-11e6-819b-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587338723069474742?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587335993535445794?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -89,28 +53,28 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
     headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Length: ['141']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 05 Jul 2016 16:04:00 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['141']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Jul 2016 19:52:41 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3NzMzOTMzLCJuYmYiOjE0Njc3MzM5MzMsImV4cCI6MTQ2NzczNzgzMywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.BUDdfJ1dId87f2nq-tcfBimD9x9tzkoqBw1mzP7QLokzQj_kNi-M-jGa8mASe6Uovd8xqpZrmTzosIQ7WumM3yhrtZ-q4NyvuPswzhb2dwl3Bb3-MlaLDa1g3Uu4HDDquR_KoQREWI6FEghmlGi3UcmoVdX9ODWlLl89FiSp_fJlDNvgzD0kDhGWq8lO9AgcsNexZR6DOthAfcCYLLatsYcZqxL3Ax0t2QMvY5CXvS8GXsnoIupcAwghPfCg0yqtw7_1RSMEXSXTLiyHKJI149R7wqmaVFvG42x3b09pvW9p9X2qCOhfF7rEohqv1u29NaQMJHYanY0kGjvsw9IRww]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY4MDA1NTg0LCJuYmYiOjE0NjgwMDU1ODQsImV4cCI6MTQ2ODAwOTQ4NCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.t9b-B1_IK7NClFfXkGsEL-eUnIKdzD3jA8BuOul0S-aQAuyjiDup1OE6HuIBWH7bEFdqa-kLA7tQ4TxT_TYs5Es2Ocmij2O66Ppq4dmZfMCMAuFIJ6UEdnj67OFk1Z4zsPJbsaE4btRXsz-DOl3gEisQ--xbYjXmZlgz_cY1FihQpLUPLcStSYkSnReQ6QbUME2IL_TMHk6poiC_vK8u7qwvvVdXWALeSOr4zSeVpvW33X3WFz4_Ryy3nMd9nyoMF7tgSHn-O1wqQWk-K5fda9zYH4QiawN-bp0hCmQbFOSETlbddm_E_ZuCcc2ZPi3q242Qy7R1ivSJl_sxU69Big]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 lbcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [f09404ae-42c9-11e6-819b-a0b3ccf7272a]
+      x-ms-client-request-id: [75da9c9e-4545-11e6-8cdc-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
@@ -118,89 +82,84 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXfLSX1xd1VXl8Usr5u7XxTTumqq83b8Sts1d2f5qqyuF/mybe5mP1jX+bQsdvc/ffDg
-        3v79Bw/G9+493DnY33/w4MHe3kejj5bZIifUbm5Ina7yui3y5qNHv/ijNl+syqzNnxfLt/h7XRcE
-        Zd62q+bRXem2mb2dFuNJWU3G06rOx1fFclZdNeNl3t41r8+rpr17Uuf06/PJ77+3s/vp9s6n23s7
-        AkFGMv7pploSAtNq2dKgfpLGTeSj3nbHO/jvo19CyGU1jaOlr4DM758RnufZtG2eV9MMxMan7fUK
-        I33d1sXyguBdZuUaH3xjSAORSTZ9my9nL6uqfJGBssP9lpPdSb6ihnhvtmzQ/g23HX5nWS1zNC+r
-        bPYkK7PlNK/x3qZ3qB955WZSXOVNu27QelUXlzS+s9XxbEZUYbIOvRVrf1zepr/ZNbFfMWUA60lZ
-        TO37m956KU1f6sA6b35ozzdOQX7lv/VUJm7TG2hOkk8sdLtWisjLOj8v3m16ZZe4H//d3dt3b9+I
-        v7LQZVG366x8kbdXVf32NmO4JOjvj9vupx/9Enp5Uc3w8dlyWufQTVlJjUmnXBaQZnr3dUv8Qy1e
-        r6fTnER/Rt+3xYI4Mlus6HORswfbO/ff7H76aOfeo3s743ufPtj5dPf+T1HT2brWSf/o5Zt7u+OD
-        e58ePNi795q+IkGucxJc+vYMavjTT/c/zXfzg23SsPe39yfTve2D8wez7f39808f7j+YPNh7eI9e
-        Y+SgZT969L1fzHqyWWVToOi0rlKPWhNVWP+C/PKG/wm95ItsQy8YLkVjI3jf/yXf/yWjob6shqeX
-        fdgA0OtNVCcIjeZ+X8t1WaKf7xPN8hXpqnw5ZaVOQOSD5kuiIv31c2SzRLDDMRIiN7zmvSC8/JHA
-        AT1/jgbymuURSDjcvu5gHCxM3M/6gJSv7wZMS803DiX6kveCDgVQMIhq3a7WNFZSIv4b+FuVypeT
-        n86nLUFQpfKLRSY3KAzT1edrJlH28B5R49Nse//hp59u708n59vZfv5wezb59MH9+w/ou3v36a3z
-        ml2L2dnLk2p5XlyoKiHUSAogjATquYfiM7Q/XaJD7ubuz8VM3B3C+u4AqnmbXRCy3737+360l8+m
-        O5/eO9+e7k8OtvfPd/e3Dz6dfbo9u0d/35/Mpvfv57/vR/QOYeQ5ffTXRuobJ+Cls8Ff5O28Ao2e
-        qsGlVmI5X6opAeAfGhU7fZPUBc7ELwFfqgunTeDJEY6OEaihum0/p7MfwRKfW9R+tmebSeXQojav
-        1iVe/B59Tq9OzO/FclKtl7MXWes1INmPfOqa8njwIU0JtyZNYTUlfa4scwtCOQPQb3wDN3z/l/yS
-        /we3oPesuQ0AAA==
+        o0cf3W3Wk2ZaF6u2qJbN3Xs7+/nBw4efbj94cD7Z3v80P9ieZLNs+/79B5/u7N5/uD/J9+/WeVOt
+        62n+eV2tV83dclJf3F3V1WUxy+vm7hfFtK6a6rwdv9J2zd1Zviqr60W+bJu72Q/WdT4ti939Tw92
+        dh7cv7c7vvfpw73dvXsfjT5aZoucsNrYhrpa5XVb5M1Hj37xR22+WJVZmz8vlm/x97ouCMC8bVfN
+        o7vSWTN7Oy3Gk7KajKdVnY+viuWsumrGy7y9a16fV01796TO6dfnk99/b2f30+2dT7f3dgSC4D/+
+        6aZaEgLTatnSUH6SRktEo952xzv476NfQshlNQ2hpa+AzO+fEZ7n2bRtnlfTDCTGp+31CoN83dbF
+        8oLgXWblGh98Y0gDkUk2fZsvZy+rqnyRgajD/ZaT3Um+ooZ4b7Zs0P4Ntx1+Z1ktczQvq2z2JCuz
+        5TSv8d6md6gfeeVmUlzlTbtu0HpVF5c0vrPV8WxGVGGyDr0Va39c3qa/2TVxXjFlAOtJWUzt+5ve
+        eilNX+rAOm9+aM83TkF+5b/1VCZu0xtoTvJOLHS7VorIyzo/L95temWXuB//3d3bd2/fiL+y0GVR
+        t+usfJG3V1X99jZjuCTo74/b7qcf/RJ6eVHN8PHZclrn0EhZSY1Jp1wWkGZ693VL/EMtXq+n05xE
+        f0bft8WCODJbrOhzkbMH2zsHb3YfPrq/92iftNO9nfuf7j34KWo6W9c66R+9fLP3cHzv4YP9gwf3
+        XtNXJMh1ToJL355B+T6c7O3NDh7Oth/uPNzZ3p/s5tsHO59Ot/fuHzzY3Xn48MFOntFrjBx060eP
+        vveLWUU2q2wKFJ2uVepRa6IKa12QX97wP6GXfJFt6AXDpWhsBO/7v+T7v2Q01JfV6/SyDxsAer2J
+        6gSh0dzva7kuS/TzfaJZviJdlS+nrNQJiHzQfElUpL9+jiyVCHY4RkLkhte8F4SXPxI4oOfP0UBe
+        szwCCYfb1x2Mg4WJ+1kfkPL13YBpqfnGoURf8l7QoQAKBlGt29WaxkpKxH8Df6tS+XLy0/m0JQiq
+        VH6xyOQGhWG6+nzNJDp4eP7p7OHOzvb9g+mD7f0H+afbk/3797Yf7s4e3ps+fJgdfPopvXVes2sx
+        O3t5Ui3PiwtVJYQaSQGEkUA991B8hvanS3TI3dz9uZiJu0NY3x1ANW+zC0L2u3d/34+m98/3P73/
+        6f72vf3JlOjyYLad3dvb3b63M50c3H+wP927t/v7fkTvEEae00d/baS+cQJeOhv8Rd7OK9DoqRpc
+        aiWW86WaEgD+oVGx0zdJXeBM/BLwpbpw2gSeHOHoGIEaqtv2czr7ESzxuUXtZ3u2mVQOLWrzal3i
+        xe/R5/TqxPxeLCfVejl7kbVeA5L9yKeuKY8HH9KUcGvSFFZT0ufKMrcglDMA/cY3cMP3f8kv+X8A
+        XsZNJ68NAAA=
     headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Length: ['1207']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 05 Jul 2016 16:04:00 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['1205']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Jul 2016 19:52:42 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!binary |
-      eyJwcm9wZXJ0aWVzIjogeyJwYXJhbWV0ZXJzIjogeyJ2bmV0QWRkcmVzc1ByZWZpeCI6IHsidmFs
-      dWUiOiAiMTAuMC4wLjAvMTYifSwgImRuc05hbWVUeXBlIjogeyJ2YWx1ZSI6ICJub25lIn0sICJw
-      cml2YXRlSXBBZGRyZXNzQWxsb2NhdGlvbiI6IHsidmFsdWUiOiAiZHluYW1pYyJ9LCAic3VibmV0
-      QWRkcmVzc1ByZWZpeCI6IHsidmFsdWUiOiAiMTAuMC4wLjAvMjQifSwgIl9hcnRpZmFjdHNMb2Nh
-      dGlvbiI6IHsidmFsdWUiOiAiaHR0cHM6Ly9henVyZXNka2NpLmJsb2IuY29yZS53aW5kb3dzLm5l
-      dC90ZW1wbGF0ZWhvc3QvQ3JlYXRlTGJfMjAxNi0wNi0yMCJ9LCAicHVibGljSXBBZGRyZXNzQWxs
-      b2NhdGlvbiI6IHsidmFsdWUiOiAic3RhdGljIn0sICJsb2FkQmFsYW5jZXJOYW1lIjogeyJ2YWx1
-      ZSI6ICJsYjIifX0sICJ0ZW1wbGF0ZUxpbmsiOiB7InVyaSI6ICJodHRwczovL2F6dXJlc2RrY2ku
-      YmxvYi5jb3JlLndpbmRvd3MubmV0L3RlbXBsYXRlaG9zdC9DcmVhdGVMYl8yMDE2LTA2LTIwL2F6
-      dXJlZGVwbG95Lmpzb24ifSwgIm1vZGUiOiAiSW5jcmVtZW50YWwifX0=
+    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-06-20/azuredeploy.json"},
+      "mode": "Incremental", "parameters": {"dnsNameType": {"value": "none"}, "publicIpAddressAllocation":
+      {"value": "static"}, "loadBalancerName": {"value": "lb2"}, "privateIpAddressAllocation":
+      {"value": "dynamic"}, "_artifactsLocation": {"value": "https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-06-20"},
+      "vnetAddressPrefix": {"value": "10.0.0.0/16"}, "subnetAddressPrefix": {"value":
+      "10.0.0.0/24"}}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3NzMzOTMzLCJuYmYiOjE0Njc3MzM5MzMsImV4cCI6MTQ2NzczNzgzMywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.BUDdfJ1dId87f2nq-tcfBimD9x9tzkoqBw1mzP7QLokzQj_kNi-M-jGa8mASe6Uovd8xqpZrmTzosIQ7WumM3yhrtZ-q4NyvuPswzhb2dwl3Bb3-MlaLDa1g3Uu4HDDquR_KoQREWI6FEghmlGi3UcmoVdX9ODWlLl89FiSp_fJlDNvgzD0kDhGWq8lO9AgcsNexZR6DOthAfcCYLLatsYcZqxL3Ax0t2QMvY5CXvS8GXsnoIupcAwghPfCg0yqtw7_1RSMEXSXTLiyHKJI149R7wqmaVFvG42x3b09pvW9p9X2qCOhfF7rEohqv1u29NaQMJHYanY0kGjvsw9IRww]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY4MDA1NTg0LCJuYmYiOjE0NjgwMDU1ODQsImV4cCI6MTQ2ODAwOTQ4NCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.t9b-B1_IK7NClFfXkGsEL-eUnIKdzD3jA8BuOul0S-aQAuyjiDup1OE6HuIBWH7bEFdqa-kLA7tQ4TxT_TYs5Es2Ocmij2O66Ppq4dmZfMCMAuFIJ6UEdnj67OFk1Z4zsPJbsaE4btRXsz-DOl3gEisQ--xbYjXmZlgz_cY1FihQpLUPLcStSYkSnReQ6QbUME2IL_TMHk6poiC_vK8u7qwvvVdXWALeSOr4zSeVpvW33X3WFz4_Ryy3nMd9nyoMF7tgSHn-O1wqQWk-K5fda9zYH4QiawN-bp0hCmQbFOSETlbddm_E_ZuCcc2ZPi3q242Qy7R1ivSJl_sxU69Big]
       Connection: [keep-alive]
       Content-Length: ['554']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 lbcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [16ca3b90-42ca-11e6-af23-a0b3ccf7272a]
+      x-ms-client-request-id: [88ff1fe1-4545-11e6-a2af-001dd8b7c0ad]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/lbrg/providers/Microsoft.Resources/deployments/azurecli1467734641.447804293788","name":"azurecli1467734641.447804293788","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-06-20/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-06-20"},"backendPoolName":{"type":"String","value":"lb2bepool"},"dnsNameType":{"type":"String","value":"none"},"loadBalancerName":{"type":"String","value":"lb2"},"location":{"type":"String","value":"westus"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddress":{"type":"String","value":"PublicIPlb2"},"publicIpAddressAllocation":{"type":"String","value":"static"},"publicIpAddressType":{"type":"String","value":"new"},"publicIpDnsName":{"type":"String","value":""},"subnet":{"type":"String","value":""},"subnetAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetType":{"type":"String","value":"none"},"virtualNetworkName":{"type":"String","value":""},"vnetAddressPrefix":{"type":"String","value":"10.0.0.0/16"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-05T16:04:03.5226504Z","duration":"PT0.8429604S","correlationId":"d7036b29-352e-458a-9aa2-340b65217eeb","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/lbrg/providers/Microsoft.Resources/deployments/IPlb2","resourceType":"Microsoft.Resources/deployments","resourceName":"IPlb2"},{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/lbrg/providers/Microsoft.Resources/deployments/Subnetlb2","resourceType":"Microsoft.Resources/deployments","resourceName":"Subnetlb2"}],"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/lbrg/providers/Microsoft.Network/loadBalancers/lb2","resourceType":"Microsoft.Network/loadBalancers","resourceName":"lb2"}]}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/lbrg/providers/Microsoft.Resources/deployments/azurecli1468007563.4897079","name":"azurecli1468007563.4897079","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-06-20/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-06-20"},"backendPoolName":{"type":"String","value":"lb2bepool"},"dnsNameType":{"type":"String","value":"none"},"loadBalancerName":{"type":"String","value":"lb2"},"location":{"type":"String","value":"westus"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddress":{"type":"String","value":"PublicIPlb2"},"publicIpAddressAllocation":{"type":"String","value":"static"},"publicIpAddressType":{"type":"String","value":"new"},"publicIpDnsName":{"type":"String","value":""},"subnet":{"type":"String","value":""},"subnetAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetType":{"type":"String","value":"none"},"virtualNetworkName":{"type":"String","value":""},"vnetAddressPrefix":{"type":"String","value":"10.0.0.0/16"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-08T19:52:44.3579812Z","duration":"PT0.2837283S","correlationId":"a081a8e3-4633-49f3-9688-236dc32ea35d","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/lbrg/providers/Microsoft.Resources/deployments/IPlb2","resourceType":"Microsoft.Resources/deployments","resourceName":"IPlb2"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/lbrg/providers/Microsoft.Resources/deployments/Subnetlb2","resourceType":"Microsoft.Resources/deployments","resourceName":"Subnetlb2"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/lbrg/providers/Microsoft.Network/loadBalancers/lb2","resourceType":"Microsoft.Network/loadBalancers","resourceName":"lb2"}]}}'}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/azurecli1467734641.447804293788/operationStatuses/08587338722427979730?api-version=2015-11-01']
-      Cache-Control: [no-cache]
-      Content-Length: ['2322']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 05 Jul 2016 16:04:03 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/azurecli1468007563.4897079/operationStatuses/08587335993214034117?api-version=2015-11-01']
+      cache-control: [no-cache]
+      content-length: ['2312']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Jul 2016 19:52:43 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3NzMzOTMzLCJuYmYiOjE0Njc3MzM5MzMsImV4cCI6MTQ2NzczNzgzMywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.BUDdfJ1dId87f2nq-tcfBimD9x9tzkoqBw1mzP7QLokzQj_kNi-M-jGa8mASe6Uovd8xqpZrmTzosIQ7WumM3yhrtZ-q4NyvuPswzhb2dwl3Bb3-MlaLDa1g3Uu4HDDquR_KoQREWI6FEghmlGi3UcmoVdX9ODWlLl89FiSp_fJlDNvgzD0kDhGWq8lO9AgcsNexZR6DOthAfcCYLLatsYcZqxL3Ax0t2QMvY5CXvS8GXsnoIupcAwghPfCg0yqtw7_1RSMEXSXTLiyHKJI149R7wqmaVFvG42x3b09pvW9p9X2qCOhfF7rEohqv1u29NaQMJHYanY0kGjvsw9IRww]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY4MDA1NTg0LCJuYmYiOjE0NjgwMDU1ODQsImV4cCI6MTQ2ODAwOTQ4NCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.t9b-B1_IK7NClFfXkGsEL-eUnIKdzD3jA8BuOul0S-aQAuyjiDup1OE6HuIBWH7bEFdqa-kLA7tQ4TxT_TYs5Es2Ocmij2O66Ppq4dmZfMCMAuFIJ6UEdnj67OFk1Z4zsPJbsaE4btRXsz-DOl3gEisQ--xbYjXmZlgz_cY1FihQpLUPLcStSYkSnReQ6QbUME2IL_TMHk6poiC_vK8u7qwvvVdXWALeSOr4zSeVpvW33X3WFz4_Ryy3nMd9nyoMF7tgSHn-O1wqQWk-K5fda9zYH4QiawN-bp0hCmQbFOSETlbddm_E_ZuCcc2ZPi3q242Qy7R1ivSJl_sxU69Big]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 lbcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [16ca3b90-42ca-11e6-af23-a0b3ccf7272a]
+      x-ms-client-request-id: [88ff1fe1-4545-11e6-a2af-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587338722427979730?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587335993214034117?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -208,28 +167,28 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
     headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Length: ['141']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 05 Jul 2016 16:04:33 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['141']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Jul 2016 19:53:13 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3NzMzOTMzLCJuYmYiOjE0Njc3MzM5MzMsImV4cCI6MTQ2NzczNzgzMywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.BUDdfJ1dId87f2nq-tcfBimD9x9tzkoqBw1mzP7QLokzQj_kNi-M-jGa8mASe6Uovd8xqpZrmTzosIQ7WumM3yhrtZ-q4NyvuPswzhb2dwl3Bb3-MlaLDa1g3Uu4HDDquR_KoQREWI6FEghmlGi3UcmoVdX9ODWlLl89FiSp_fJlDNvgzD0kDhGWq8lO9AgcsNexZR6DOthAfcCYLLatsYcZqxL3Ax0t2QMvY5CXvS8GXsnoIupcAwghPfCg0yqtw7_1RSMEXSXTLiyHKJI149R7wqmaVFvG42x3b09pvW9p9X2qCOhfF7rEohqv1u29NaQMJHYanY0kGjvsw9IRww]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY4MDA1NTg0LCJuYmYiOjE0NjgwMDU1ODQsImV4cCI6MTQ2ODAwOTQ4NCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.t9b-B1_IK7NClFfXkGsEL-eUnIKdzD3jA8BuOul0S-aQAuyjiDup1OE6HuIBWH7bEFdqa-kLA7tQ4TxT_TYs5Es2Ocmij2O66Ppq4dmZfMCMAuFIJ6UEdnj67OFk1Z4zsPJbsaE4btRXsz-DOl3gEisQ--xbYjXmZlgz_cY1FihQpLUPLcStSYkSnReQ6QbUME2IL_TMHk6poiC_vK8u7qwvvVdXWALeSOr4zSeVpvW33X3WFz4_Ryy3nMd9nyoMF7tgSHn-O1wqQWk-K5fda9zYH4QiawN-bp0hCmQbFOSETlbddm_E_ZuCcc2ZPi3q242Qy7R1ivSJl_sxU69Big]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 lbcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [16ca3b90-42ca-11e6-af23-a0b3ccf7272a]
+      x-ms-client-request-id: [88ff1fe1-4545-11e6-a2af-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
@@ -237,50 +196,50 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXfLSX1xd1VXl8Usr5u7XxTTumqq83b8Sts1d2f5qqyuF/mybe5mP1jX+bQsdvc/ffDg
-        3v6n+7vj/f0HBzv7ew/vPTg4+Gj00TJb5ITazQ2p01Vet0XefPToF3/U5otVmbX582L5Fn+v64Kg
-        zNt21Ty6K902s7fTYjwpq8l4WtX5+KpYzqqrZrzM27vm9XnVtHdP6px+fT75/fd2dj/d3vl0e29H
-        IMhIxj/dVEtCYFotWxrUT9K4iXzU2+54B/999EsIuaymcbT0FZD5/TPC8zybts3zapqB2Pi0vV5h
-        pK/bulheELzLrFzjg28MaSAyyaZv8+XsZVWVLzJQdrjfcrI3yVfUEO/Nlg3av+G2w+8sq2WO5mWV
-        zZ5kZbac5jXe2/QO9SOv3EyKq7xp1w1ar+riksZ3tjqezYgqTNaht2Ltj8vb9De7JvYrpgxgPSmL
-        qX1/01svpelLHVjnzdv13LTUJNbxjTOQX/lvPZV52/QGmpPgEwfdrpUi8rLOz4t3m17ZJebHf3f3
-        9t3bN+KvHHRZ1O06K1/k7VVVv73NGC4J+vvjtvvpR7+EXl5UM3x8tpzWOVRTVlJjUimXBYSZ3n1N
-        E4IWr9fTaU6SP6Pv22JBDJktVvS5iNmD7Z37b3Y/fbSz/2jv4fjeg3v3Dj7d+ylqOlvXNKGY849e
-        vtn7dPzpw3ufPvx07zV9RXJc5yS39O0ZtPDswc69Tyd7D7fv3d/Lt/fvH2TbD7Nsb/ve/s7k0/t7
-        uw/yfEKvMXJQsh89+t4vZjXZrLIpUHRKV6lHrYkqrH5BfnnD/4Re8iW2oRcMk6Kxkbvv/5Lv/5LR
-        UF9WwdPLPmwA6PUmmhOERnO/r+W6LNHP94lm+YpUVb6csk4nIPJB8yVRkf76OTJZItfhGAmRG17z
-        XhBe/kjggJ4/RwN5zfIIJBxuX3cwDhYm7md9QMrXdwOmpeYbhxJ9yXtBhwIoGES1bldrGispEf8N
-        /K1K5cvJT+fTliCoUvnFIpMbFIbp6vM1k2i68/De+fnBve17D2cPtvd37uXbk9396fbDBw8/nU52
-        D+7n5zm9dV6zZzE7e3lSLc+LC1UlhBpJAYSRQD33UHyG9qdLdMjd3P25mIm7Q1jfHUA1b7MLQva7
-        d3/fjz59uDu7f2/3YHt3D3TJM6LL/b1Ptyf5+e7DycHu/mzn3u/7Eb1DGHk+H/21kfrGB3jpTPAX
-        eTuvQKOnaumplVjOl2pKAPiHRsVO3yR1gS/xS8CX6sFpEzhyhKNjBGqoXtvP6exHsMTnFrWf7dlm
-        Ujm0qM2rdYkXv0ef06sT83uxnFTr5exF1noNSPYjn7qmPB58SFPCrUlTWE1JnyvL3IJQzgD0G9/A
-        Dd//Jb/k/wHVPeV2uA0AAA==
+        o0cf3W3Wk2ZaF6u2qJbN3Xs7+/nBw4efbj94cD7Z3v80P9ieZLNs+/79B5/u7N5/uD/J9+/WeVOt
+        62n+eV2tV83dclJf3F3V1WUxy+vm7hfFtK6a6rwdv9J2zd1Zviqr60W+bJu72Q/WdT4ti939Tw92
+        dh7c//TeeP/g4YOdBw8/Gn20zBY5YbWxDXW1yuu2yJuPHv3ij9p8sSqzNn9eLN/i73VdEIB5266a
+        R3els2b2dlqMJ2U1GU+rOh9fFctZddWMl3l717w+r5r27kmd06/PJ7//3s7up9s7n27v7QgEwX/8
+        0021JASm1bKlofwkjZaIRr3tjnfw30e/hJDLahpCS18Bmd8/IzzPs2nbPK+mGUiMT9vrFQb5uq2L
+        5QXBu8zKNT74xpAGIpNs+jZfzl5WVfkiA1GH+y0ne5N8RQ3x3mzZoP0bbjv8zrJa5mheVtnsSVZm
+        y2le471N71A/8srNpLjKm3bdoPWqLi5pfGer49mMqMJkHXor1v64vE1/s2vivGLKANaTspja9ze9
+        9VKavtSBdd68Xc9NS01iHd84A/mV/9ZTmbdNb6A5iTtx0O1aKSIv6/y8eLfplV1ifvx3d2/fvX0j
+        /spBl0XdrrPyRd5eVfXb24zhkqC/P267n370S+jlRTXDx2fLaZ1DIWUlNSaVcllAmOnd1zQhaPF6
+        PZ3mJPkz+r4tFsSQ2WJFn4uYPdjeOXiz+/DR/XuPqIfdnYOd/Xu7P0VNZ+uaJhRz/tHLN3ufjnfu
+        3XvwcGfvNX1FclznJLf07Rl0b7ZzsJsd5PdIz96jfx6e39t++OnBwfbevU9n03t7eXbvPjpn5KBa
+        P3r0vV/MGrJZZVOg6FStUo9aE1VY6YL88ob/Cb3kS2xDLxgmRWMjd9//Jd//JaOhvqxap5d92ADQ
+        6000JwiN5n5fy3VZop/vE83yFamqfDllnU5A5IPmS6Ii/fVzZKhErsMxEiI3vOa9ILz8kcABPX+O
+        BvKa5RFIONy+7mAcLEzcz/qAlK/vBkxLzTcOJfqS94IOBVAwiGrdrtY0VlIi/hv4W5XKl5Ofzqct
+        QVCl8otFJjcoDNPV52sm0W42ffjwfP/hdnZ+b3d7f7I32z54sDPZvrf/6d7up9PZw/vZPXrrvGbP
+        Ynb28qRanhcXqkoINZICCCOBeu6h+AztT5fokLu5+3MxE3eHsL47gGreZheE7Hfv/r4fPcwePLz/
+        YH+yPZncy4gu02w7+zTf2549/HT3wf7e3v1PHz78fT+idwgjz+ejvzZS3/gAL50J/iJv5xVo9FQt
+        PbUSy/lSTQkA/9Co2OmbpC7wJX4J+FI9OG0CR45wdIxADdVr+zmd/QiW+Nyi9rM920wqhxa1ebUu
+        8eL36HN6dWJ+L5aTar2cvcharwHJfuRT15THgw9pSrg1aQqrKelzZZlbEMoZgH7jG7jh+7/kl/w/
+        we79qa4NAAA=
     headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Length: ['1213']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 05 Jul 2016 16:04:34 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['1205']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Jul 2016 19:53:14 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3NzMzOTMzLCJuYmYiOjE0Njc3MzM5MzMsImV4cCI6MTQ2NzczNzgzMywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.BUDdfJ1dId87f2nq-tcfBimD9x9tzkoqBw1mzP7QLokzQj_kNi-M-jGa8mASe6Uovd8xqpZrmTzosIQ7WumM3yhrtZ-q4NyvuPswzhb2dwl3Bb3-MlaLDa1g3Uu4HDDquR_KoQREWI6FEghmlGi3UcmoVdX9ODWlLl89FiSp_fJlDNvgzD0kDhGWq8lO9AgcsNexZR6DOthAfcCYLLatsYcZqxL3Ax0t2QMvY5CXvS8GXsnoIupcAwghPfCg0yqtw7_1RSMEXSXTLiyHKJI149R7wqmaVFvG42x3b09pvW9p9X2qCOhfF7rEohqv1u29NaQMJHYanY0kGjvsw9IRww]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY4MDA1NTg0LCJuYmYiOjE0NjgwMDU1ODQsImV4cCI6MTQ2ODAwOTQ4NCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.t9b-B1_IK7NClFfXkGsEL-eUnIKdzD3jA8BuOul0S-aQAuyjiDup1OE6HuIBWH7bEFdqa-kLA7tQ4TxT_TYs5Es2Ocmij2O66Ppq4dmZfMCMAuFIJ6UEdnj67OFk1Z4zsPJbsaE4btRXsz-DOl3gEisQ--xbYjXmZlgz_cY1FihQpLUPLcStSYkSnReQ6QbUME2IL_TMHk6poiC_vK8u7qwvvVdXWALeSOr4zSeVpvW33X3WFz4_Ryy3nMd9nyoMF7tgSHn-O1wqQWk-K5fda9zYH4QiawN-bp0hCmQbFOSETlbddm_E_ZuCcc2ZPi3q242Qy7R1ivSJl_sxU69Big]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b1b1e1c-42ca-11e6-ae43-a0b3ccf7272a]
+      x-ms-client-request-id: [9c280ff0-4545-11e6-a8e2-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbrg/providers/Microsoft.Network/publicIPAddresses/PublicIPlb2?api-version=2016-03-30
   response:
@@ -288,76 +247,73 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj96OV6UhbTs5flZO+jEX9TzPD53WY9aaZ1sWqLatnc3Znsnn+6/2B3e3dyvrO9P5tl
-        21k+vbc9nTzce7B3vvPw/sOdu3XeVOt6mn9eV+tVc7ec1Bd3V3V1Wczyurn7RTGtq6Y6b8cv8vaq
-        qt/eXWnfx7MZvdrkzd0+NnmbXQCf7979fT+6P8vuT7OH97d3dyf3t/f3d863Dx48yLZ388lsZ/fh
-        /vl0/+Hv+5G+2F6veIC36FbfKKtphtHirau8adfmCxrDKq/bglo+Spl88uFl0VDzYnnxus1a7uz1
-        ejrN81k+kzepGfUgNFkLXe8/zA7yg3ufbh+c53vb+9P9yXb2YG9/e/dg796n59nDT6eZe7lYKY54
-        c3dnf7x/f7y39+l498Gntk1nND9JpCak8MLZy8v9frPSDPOLvJ1XjBPQL6a2aTEr8zfFIq/W7dny
-        i2K5bnng+/b71Um1PC8u1jW9xl0pTfAdA7z7Q2CesspmT7IyW07xPTHM3fO6Wrb5cnb2MsCvufvc
-        a/oMjU6Xs48E5V+CH/TPL/l/AGzE+SoWAwAA
+        6UfLbJF/9Cj96OV6UhbTs5flZO+jEX9TzPD53WY9aaZ1sWqLatncvbeznx88fPjp9oMH55Pt/U/z
+        g+1JNsu2799/8OnO7v2H+5N8/26dN9W6nuaf19V61dwtJ/XF3VVdXRazvG7uflFM66qpztvxi7y9
+        quq3d1fa9/FsRq82eXO3j03eZhfA57t3f9+P9qYH9yfTnU+3J/fyT7f36c/tLJ/d2374YJpP7z88
+        +HR2cP77fqQvttcrHuAtutU3ymqaYbR46ypv2rX5gsawyuu2oJaPUiaffHhZNNS8WF68brOWO3u9
+        nk7zfJbP5E1qRj0ITdZC1wd7072D83v3t7PJ7OH2/v396fbDycPZ9r2D7GF+MJ3cm366a18uVooj
+        3ty9Nz44GO8+HB88sA06Q/lJojNhhNZnLy/3+81KM8Yv8nZeMULAvZjapsWszN8Ui7xat2fLL4rl
+        uuVR79vvVyfV8ry4WNf0GnelBMF3DPDuD4FzyiqbPcnKbDnF98Qtd8/ratnmy9nZywC/5u5zr+kz
+        NDpdzj4SlH8JftA/v+T/AVPJOVATAwAA
     headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 05 Jul 2016 16:04:36 GMT']
-      ETag: [W/"5da5ca95-11b5-440f-877a-1ebd0194fc49"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Jul 2016 19:53:15 GMT']
+      etag: [W/"2c85bc06-b3e6-42c8-aed3-97cec5986d8f"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!binary |
-      eyJwcm9wZXJ0aWVzIjogeyJwYXJhbWV0ZXJzIjogeyJ2aXJ0dWFsTmV0d29ya1ByZWZpeCI6IHsi
-      dmFsdWUiOiAiMTAuMC4wLjAvMTYifSwgInZpcnR1YWxOZXR3b3JrTmFtZSI6IHsidmFsdWUiOiAi
-      bXl0ZXN0dm5ldCJ9LCAic3VibmV0UHJlZml4IjogeyJ2YWx1ZSI6ICIxMC4wLjAuMC8yNCJ9LCAi
-      c3VibmV0TmFtZSI6IHsidmFsdWUiOiAiU3VibmV0MSJ9fSwgInRlbXBsYXRlTGluayI6IHsidXJp
-      IjogImh0dHBzOi8vYXp1cmVzZGtjaS5ibG9iLmNvcmUud2luZG93cy5uZXQvdGVtcGxhdGVob3N0
-      L0NyZWF0ZVZOZXQvYXp1cmVkZXBsb3kuanNvbiJ9LCAibW9kZSI6ICJJbmNyZW1lbnRhbCJ9fQ==
+    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateVNet/azuredeploy.json"},
+      "mode": "Incremental", "parameters": {"subnetName": {"value": "Subnet1"}, "virtualNetworkPrefix":
+      {"value": "10.0.0.0/16"}, "virtualNetworkName": {"value": "mytestvnet"}, "subnetPrefix":
+      {"value": "10.0.0.0/24"}}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3NzMzOTMzLCJuYmYiOjE0Njc3MzM5MzMsImV4cCI6MTQ2NzczNzgzMywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.BUDdfJ1dId87f2nq-tcfBimD9x9tzkoqBw1mzP7QLokzQj_kNi-M-jGa8mASe6Uovd8xqpZrmTzosIQ7WumM3yhrtZ-q4NyvuPswzhb2dwl3Bb3-MlaLDa1g3Uu4HDDquR_KoQREWI6FEghmlGi3UcmoVdX9ODWlLl89FiSp_fJlDNvgzD0kDhGWq8lO9AgcsNexZR6DOthAfcCYLLatsYcZqxL3Ax0t2QMvY5CXvS8GXsnoIupcAwghPfCg0yqtw7_1RSMEXSXTLiyHKJI149R7wqmaVFvG42x3b09pvW9p9X2qCOhfF7rEohqv1u29NaQMJHYanY0kGjvsw9IRww]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY4MDA1NTg0LCJuYmYiOjE0NjgwMDU1ODQsImV4cCI6MTQ2ODAwOTQ4NCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.t9b-B1_IK7NClFfXkGsEL-eUnIKdzD3jA8BuOul0S-aQAuyjiDup1OE6HuIBWH7bEFdqa-kLA7tQ4TxT_TYs5Es2Ocmij2O66Ppq4dmZfMCMAuFIJ6UEdnj67OFk1Z4zsPJbsaE4btRXsz-DOl3gEisQ--xbYjXmZlgz_cY1FihQpLUPLcStSYkSnReQ6QbUME2IL_TMHk6poiC_vK8u7qwvvVdXWALeSOr4zSeVpvW33X3WFz4_Ryy3nMd9nyoMF7tgSHn-O1wqQWk-K5fda9zYH4QiawN-bp0hCmQbFOSETlbddm_E_ZuCcc2ZPi3q242Qy7R1ivSJl_sxU69Big]
       Connection: [keep-alive]
       Content-Length: ['340']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 resourcemanagementclient/2015-11-01 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b5fd680-42ca-11e6-8143-a0b3ccf7272a]
+      x-ms-client-request-id: [9c662a61-4545-11e6-b619-001dd8b7c0ad]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/lbrg/providers/Microsoft.Resources/deployments/azurecli1467734675.981689248528","name":"azurecli1467734675.981689248528","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVNet/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"virtualNetworkName":{"type":"String","value":"mytestvnet"},"virtualNetworkPrefix":{"type":"String","value":"10.0.0.0/16"},"subnetName":{"type":"String","value":"Subnet1"},"subnetPrefix":{"type":"String","value":"10.0.0.0/24"},"location":{"type":"String","value":"westus"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-05T16:04:38.0135031Z","duration":"PT0.651998S","correlationId":"b093d02f-f99d-4905-a7bd-ad319e5ed8d5","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]}]}],"dependencies":[]}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/lbrg/providers/Microsoft.Resources/deployments/azurecli1468007596.0314715","name":"azurecli1468007596.0314715","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVNet/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"virtualNetworkName":{"type":"String","value":"mytestvnet"},"virtualNetworkPrefix":{"type":"String","value":"10.0.0.0/16"},"subnetName":{"type":"String","value":"Subnet1"},"subnetPrefix":{"type":"String","value":"10.0.0.0/24"},"location":{"type":"String","value":"westus"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-08T19:53:16.9691648Z","duration":"PT0.1832049S","correlationId":"f8c2a1eb-c7a2-4c12-b66b-0a82c6856ad4","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]}]}],"dependencies":[]}}'}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/azurecli1467734675.981689248528/operationStatuses/08587338722081161338?api-version=2015-11-01']
-      Cache-Control: [no-cache]
-      Content-Length: ['949']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 05 Jul 2016 16:04:38 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/azurecli1468007596.0314715/operationStatuses/08587335992886916679?api-version=2015-11-01']
+      cache-control: [no-cache]
+      content-length: ['940']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Jul 2016 19:53:16 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3NzMzOTMzLCJuYmYiOjE0Njc3MzM5MzMsImV4cCI6MTQ2NzczNzgzMywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.BUDdfJ1dId87f2nq-tcfBimD9x9tzkoqBw1mzP7QLokzQj_kNi-M-jGa8mASe6Uovd8xqpZrmTzosIQ7WumM3yhrtZ-q4NyvuPswzhb2dwl3Bb3-MlaLDa1g3Uu4HDDquR_KoQREWI6FEghmlGi3UcmoVdX9ODWlLl89FiSp_fJlDNvgzD0kDhGWq8lO9AgcsNexZR6DOthAfcCYLLatsYcZqxL3Ax0t2QMvY5CXvS8GXsnoIupcAwghPfCg0yqtw7_1RSMEXSXTLiyHKJI149R7wqmaVFvG42x3b09pvW9p9X2qCOhfF7rEohqv1u29NaQMJHYanY0kGjvsw9IRww]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY4MDA1NTg0LCJuYmYiOjE0NjgwMDU1ODQsImV4cCI6MTQ2ODAwOTQ4NCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.t9b-B1_IK7NClFfXkGsEL-eUnIKdzD3jA8BuOul0S-aQAuyjiDup1OE6HuIBWH7bEFdqa-kLA7tQ4TxT_TYs5Es2Ocmij2O66Ppq4dmZfMCMAuFIJ6UEdnj67OFk1Z4zsPJbsaE4btRXsz-DOl3gEisQ--xbYjXmZlgz_cY1FihQpLUPLcStSYkSnReQ6QbUME2IL_TMHk6poiC_vK8u7qwvvVdXWALeSOr4zSeVpvW33X3WFz4_Ryy3nMd9nyoMF7tgSHn-O1wqQWk-K5fda9zYH4QiawN-bp0hCmQbFOSETlbddm_E_ZuCcc2ZPi3q242Qy7R1ivSJl_sxU69Big]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 resourcemanagementclient/2015-11-01 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b5fd680-42ca-11e6-8143-a0b3ccf7272a]
+      x-ms-client-request-id: [9c662a61-4545-11e6-b619-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587338722081161338?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587335992886916679?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -365,29 +321,29 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
     headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Length: ['141']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 05 Jul 2016 16:05:07 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['141']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Jul 2016 19:53:47 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3NzMzOTMzLCJuYmYiOjE0Njc3MzM5MzMsImV4cCI6MTQ2NzczNzgzMywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.BUDdfJ1dId87f2nq-tcfBimD9x9tzkoqBw1mzP7QLokzQj_kNi-M-jGa8mASe6Uovd8xqpZrmTzosIQ7WumM3yhrtZ-q4NyvuPswzhb2dwl3Bb3-MlaLDa1g3Uu4HDDquR_KoQREWI6FEghmlGi3UcmoVdX9ODWlLl89FiSp_fJlDNvgzD0kDhGWq8lO9AgcsNexZR6DOthAfcCYLLatsYcZqxL3Ax0t2QMvY5CXvS8GXsnoIupcAwghPfCg0yqtw7_1RSMEXSXTLiyHKJI149R7wqmaVFvG42x3b09pvW9p9X2qCOhfF7rEohqv1u29NaQMJHYanY0kGjvsw9IRww]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY4MDA1NTg0LCJuYmYiOjE0NjgwMDU1ODQsImV4cCI6MTQ2ODAwOTQ4NCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.t9b-B1_IK7NClFfXkGsEL-eUnIKdzD3jA8BuOul0S-aQAuyjiDup1OE6HuIBWH7bEFdqa-kLA7tQ4TxT_TYs5Es2Ocmij2O66Ppq4dmZfMCMAuFIJ6UEdnj67OFk1Z4zsPJbsaE4btRXsz-DOl3gEisQ--xbYjXmZlgz_cY1FihQpLUPLcStSYkSnReQ6QbUME2IL_TMHk6poiC_vK8u7qwvvVdXWALeSOr4zSeVpvW33X3WFz4_Ryy3nMd9nyoMF7tgSHn-O1wqQWk-K5fda9zYH4QiawN-bp0hCmQbFOSETlbddm_E_ZuCcc2ZPi3q242Qy7R1ivSJl_sxU69Big]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 resourcemanagementclient/2015-11-01 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [2b5fd680-42ca-11e6-8143-a0b3ccf7272a]
+      x-ms-client-request-id: [9c662a61-4545-11e6-b619-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
@@ -395,44 +351,44 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXfLSX1xd1VXl8Usr5u7XxTTumqq83b8Sts1d2f5qqyuF/mybe5mP1jX+bQsdvc/ffDg
-        Hv1zf/zwYPfTg4d7+wf39w4+Gn20zBY5oXZzQ+p0lddtkTcfPfrFH7X5YlVmbf68WL7F3+u6ICjz
-        tl01j+5Kt83s7bQYT8pqMp5WdT6+Kpaz6qoZL/P2rnl9XjXt3ZM6p19/8gV9zi/KAMY/3VRL6nda
-        LVsay0/ScIlq1MnueAf/ffRLCKesJvRb+go4XBZ1u85KgnNV1W9f0Df4tL1e0c+PXrd1sbwgeJdZ
-        ucYHi+s2b9pLwgaQwndf1vl58W7T27uEAf67u/spXqeJJUA3dfmaW+26F96jn719vFZW0wzMs+mV
-        KxrWuvnol1DzRTXDJ2fLaZ2DIbKS2tFEXhagJb32uiXKU4vX6+k0J8LP6Pu2WBCEbLGiz/d2dj/d
-        3nmwvXP/ze6nj3buP9rZHe/t3N/d3dn/KWo6W9eKzkcv3+zdGx/s3/t05/691/QVTXmd0xTTt2fg
-        /cnOw3uznb3z7fOHD2fb+w937m9nDyaz7Wx2b/dhfj+fHczu02uMHFj7o0ff+8XMnM0qmwJFx+o6
-        SdSamIyZ/g2RQt7wP6GXwmlt6BVDQTQ3pPr+L6H/aDT5Kl/O8uWUefx79Em1blfrlv4gVPIrcCh+
-        VcJ/OfnpfNoSSCX8LxbkN1DWIPf5mtXB7D4J+UE+3Z4+nH66vb/zcH/74Sz/dPv+zv38wd6n9yb3
-        dyb0Vjab0YvNa6HDLzZ/C+8wpo5LiBu/T/Mu3IWvCPEMTEl44KNdgsd936UmP1uqiMgEat/tEP+u
-        k7i71Dv9aO46rPI2uyC8vnv39/1osn9+fnAv39ve+zQ72N4/ODggukzOt6ez+59OZw/3z+/vTX7f
-        j+gd6txTSfTXRuoHdKPvLNEgWsQBEBiZcKtLmYBMr/cZ3UcA9v8A50njkPMFAAA=
+        o0cf3W3Wk2ZaF6u2qJbN3Xs7+/nBw4efbj94cD7Z3v80P9ieZLNs+/79B5/u7N5/uD/J9+/WeVOt
+        62n+eV2tV83dclJf3F3V1WUxy+vm7hfFtK6a6rwdv9J2zd1Zviqr60W+bJu72Q/WdT4ti939Tw92
+        dh7cf/jpeOfe7v6D3fsfjT5aZoucsNrYhrpa5XVb5M1Hj37xR22+WJVZmz8vlm/x97ouCMC8bVfN
+        o7vSWTN7Oy3Gk7KajKdVnY+viuWsumrGy7y9a16fV01796TO6deffEGf84uC9vinm2pJ/U6rZUsj
+        +EkaJNGKOtkd7+C/j34J4ZTVhHlLXwGHy6Ju11lJcK6q+u0L+gafttcr+vnR67YulhcE7zIr1/hg
+        cd3mTXtJ2ABS+O7LOj8v3m16e5cwwH93dz/F6zSdBOimLl9zq133wnv0s7eP18pqmoFlNr1yRcNa
+        Nx/9Emq+qGb45Gw5rXOwQVZSO5rIywK0pNdet0R5avF6PZ3mRPgZfd8WC4KQLVb0+d7O7qfbOw+2
+        dw7e7D58dP/eo3v3xw/u7+/s797/KWo6W9eKzkcv3+wejB8S3xzsfvqavqIpr3OaYvr2DBx/fjDd
+        y3bzyfb0Qba3vT/d3duefPrpZHsnO9ibfnpw/9Nstk+vMXJg6I8efe8XM182q2wKFB2D6yRRa2Iy
+        ZvU3RAp5w/+EXgqntaFXDAXR3JDq+7+E/qPR5Kt8OcuXU+bx79En1bpdrVv6g1DJr8Ch+FUJ/+Xk
+        p/NpSyCV8L9YkN9AWYPc52tWAjt79+4fTKa727uf7uxv7+8fPNyePHjw6fZ0crB7kGeTe7NP79Fb
+        2WxGLzavhQ6/2PwtvMOYOi4hbvw+zbtwF74ixDMwJeGBj3YJHvd9l5r8bCkgIhOofbdD/LtO4u5S
+        7/SjueuwytvsgvD67t3f96O9h7OD8+n+wfaDew+JVXbvz7YPHtx7sJ0d5Puf7u7tP9yb7Py+H9E7
+        1LmnkuivjdQP6EbfWaJBtIgDIDAy4VaDMgGZXu8zuo8A7P8BjeIF+OkFAAA=
     headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Length: ['902']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 05 Jul 2016 16:05:08 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['899']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Jul 2016 19:53:47 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3NzMzOTMzLCJuYmYiOjE0Njc3MzM5MzMsImV4cCI6MTQ2NzczNzgzMywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.BUDdfJ1dId87f2nq-tcfBimD9x9tzkoqBw1mzP7QLokzQj_kNi-M-jGa8mASe6Uovd8xqpZrmTzosIQ7WumM3yhrtZ-q4NyvuPswzhb2dwl3Bb3-MlaLDa1g3Uu4HDDquR_KoQREWI6FEghmlGi3UcmoVdX9ODWlLl89FiSp_fJlDNvgzD0kDhGWq8lO9AgcsNexZR6DOthAfcCYLLatsYcZqxL3Ax0t2QMvY5CXvS8GXsnoIupcAwghPfCg0yqtw7_1RSMEXSXTLiyHKJI149R7wqmaVFvG42x3b09pvW9p9X2qCOhfF7rEohqv1u29NaQMJHYanY0kGjvsw9IRww]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY4MDA1NTg0LCJuYmYiOjE0NjgwMDU1ODQsImV4cCI6MTQ2ODAwOTQ4NCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.t9b-B1_IK7NClFfXkGsEL-eUnIKdzD3jA8BuOul0S-aQAuyjiDup1OE6HuIBWH7bEFdqa-kLA7tQ4TxT_TYs5Es2Ocmij2O66Ppq4dmZfMCMAuFIJ6UEdnj67OFk1Z4zsPJbsaE4btRXsz-DOl3gEisQ--xbYjXmZlgz_cY1FihQpLUPLcStSYkSnReQ6QbUME2IL_TMHk6poiC_vK8u7qwvvVdXWALeSOr4zSeVpvW33X3WFz4_Ryy3nMd9nyoMF7tgSHn-O1wqQWk-K5fda9zYH4QiawN-bp0hCmQbFOSETlbddm_E_ZuCcc2ZPi3q242Qy7R1ivSJl_sxU69Big]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 resourcemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [3f19f4d0-42ca-11e6-9423-a0b3ccf7272a]
+      x-ms-client-request-id: [af892700-4545-11e6-8568-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27lbrg%27%20and%20name%20eq%20%27mytestvnet%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FvirtualNetworks%27
   response:
@@ -440,79 +396,71 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
-        zsP7D3fu1nlTretp/nldrVfN3XJSX9xd1dVlMcvr5u4XxbSumuq8Hb/I26uqfnv3sqjbdVbqn83d
-        xXWbN+3lMm8/Gn20zBaEzkfBZ+31Cp/dCImaltU0A+rU/IoArPFZm100Hz36xR/NimZVZtcvpIcX
-        +dVP0osf/ZJf8v1f8v8AoEyCIwcBAAA=
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXP33s5+fvDw4afbDx6cT7b3P80PtifZLNu+f//Bpzu7
+        9x/uT/L9u3XeVOt6mn9eV+tVc7ec1Bd3V3V1Wczyurn7RTGtq6Y6b8cv8vaqqt/evSzqdp2V+mdz
+        d3Hd5k17uczbj0YfLbMFofNR8Fl7vcJnN0KipmU1zYA6Nb8iAGt81mYXzUePfvFHs6JZldn1C+nh
+        RX71k/TiR7/kl3z/l/w/61FLZAcBAAA=
     headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Length: ['308']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 05 Jul 2016 16:05:09 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['308']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Jul 2016 19:53:47 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!binary |
-      eyJwcm9wZXJ0aWVzIjogeyJwYXJhbWV0ZXJzIjogeyJkbnNOYW1lVHlwZSI6IHsidmFsdWUiOiAi
-      bm9uZSJ9LCAicHVibGljSXBBZGRyZXNzVHlwZSI6IHsidmFsdWUiOiAibm9uZSJ9LCAidmlydHVh
-      bE5ldHdvcmtOYW1lIjogeyJ2YWx1ZSI6ICJteXRlc3R2bmV0In0sICJfYXJ0aWZhY3RzTG9jYXRp
-      b24iOiB7InZhbHVlIjogImh0dHBzOi8vYXp1cmVzZGtjaS5ibG9iLmNvcmUud2luZG93cy5uZXQv
-      dGVtcGxhdGVob3N0L0NyZWF0ZUxiXzIwMTYtMDYtMjAifSwgInN1Ym5ldCI6IHsidmFsdWUiOiAi
-      L3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291
-      cmNlR3JvdXBzL2xicmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3ZpcnR1YWxOZXR3b3Jr
-      cy9teXRlc3R2bmV0L3N1Ym5ldHMvU3VibmV0MSJ9LCAic3VibmV0VHlwZSI6IHsidmFsdWUiOiAi
-      ZXhpc3RpbmdJZCJ9LCAibG9hZEJhbGFuY2VyTmFtZSI6IHsidmFsdWUiOiAibGIzIn0sICJ2bmV0
-      QWRkcmVzc1ByZWZpeCI6IHsidmFsdWUiOiAiMTAuMC4wLjAvMTYifSwgInByaXZhdGVJcEFkZHJl
-      c3NBbGxvY2F0aW9uIjogeyJ2YWx1ZSI6ICJzdGF0aWMifSwgInB1YmxpY0lwQWRkcmVzc0FsbG9j
-      YXRpb24iOiB7InZhbHVlIjogImR5bmFtaWMifSwgInByaXZhdGVJcEFkZHJlc3MiOiB7InZhbHVl
-      IjogIjEwLjAuMC4xNSJ9LCAic3VibmV0QWRkcmVzc1ByZWZpeCI6IHsidmFsdWUiOiAiMTAuMC4w
-      LjAvMjQifX0sICJ0ZW1wbGF0ZUxpbmsiOiB7InVyaSI6ICJodHRwczovL2F6dXJlc2RrY2kuYmxv
-      Yi5jb3JlLndpbmRvd3MubmV0L3RlbXBsYXRlaG9zdC9DcmVhdGVMYl8yMDE2LTA2LTIwL2F6dXJl
-      ZGVwbG95Lmpzb24ifSwgIm1vZGUiOiAiSW5jcmVtZW50YWwifX0=
+    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-06-20/azuredeploy.json"},
+      "mode": "Incremental", "parameters": {"subnet": {"value": "/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/lbrg/providers/Microsoft.Network/virtualNetworks/mytestvnet/subnets/Subnet1"},
+      "publicIpAddressAllocation": {"value": "dynamic"}, "_artifactsLocation": {"value":
+      "https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-06-20"},
+      "subnetAddressPrefix": {"value": "10.0.0.0/24"}, "loadBalancerName": {"value":
+      "lb3"}, "publicIpAddressType": {"value": "none"}, "subnetType": {"value": "existingId"},
+      "dnsNameType": {"value": "none"}, "virtualNetworkName": {"value": "mytestvnet"},
+      "vnetAddressPrefix": {"value": "10.0.0.0/16"}, "privateIpAddressAllocation":
+      {"value": "static"}, "privateIpAddress": {"value": "10.0.0.15"}}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3NzMzOTMzLCJuYmYiOjE0Njc3MzM5MzMsImV4cCI6MTQ2NzczNzgzMywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.BUDdfJ1dId87f2nq-tcfBimD9x9tzkoqBw1mzP7QLokzQj_kNi-M-jGa8mASe6Uovd8xqpZrmTzosIQ7WumM3yhrtZ-q4NyvuPswzhb2dwl3Bb3-MlaLDa1g3Uu4HDDquR_KoQREWI6FEghmlGi3UcmoVdX9ODWlLl89FiSp_fJlDNvgzD0kDhGWq8lO9AgcsNexZR6DOthAfcCYLLatsYcZqxL3Ax0t2QMvY5CXvS8GXsnoIupcAwghPfCg0yqtw7_1RSMEXSXTLiyHKJI149R7wqmaVFvG42x3b09pvW9p9X2qCOhfF7rEohqv1u29NaQMJHYanY0kGjvsw9IRww]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY4MDA1NTg0LCJuYmYiOjE0NjgwMDU1ODQsImV4cCI6MTQ2ODAwOTQ4NCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.t9b-B1_IK7NClFfXkGsEL-eUnIKdzD3jA8BuOul0S-aQAuyjiDup1OE6HuIBWH7bEFdqa-kLA7tQ4TxT_TYs5Es2Ocmij2O66Ppq4dmZfMCMAuFIJ6UEdnj67OFk1Z4zsPJbsaE4btRXsz-DOl3gEisQ--xbYjXmZlgz_cY1FihQpLUPLcStSYkSnReQ6QbUME2IL_TMHk6poiC_vK8u7qwvvVdXWALeSOr4zSeVpvW33X3WFz4_Ryy3nMd9nyoMF7tgSHn-O1wqQWk-K5fda9zYH4QiawN-bp0hCmQbFOSETlbddm_E_ZuCcc2ZPi3q242Qy7R1ivSJl_sxU69Big]
       Connection: [keep-alive]
       Content-Length: ['893']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 lbcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [3f6cdfdc-42ca-11e6-a235-a0b3ccf7272a]
+      x-ms-client-request-id: [afc5e1e1-4545-11e6-b872-001dd8b7c0ad]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/lbrg/providers/Microsoft.Resources/deployments/azurecli1467734709.077144172638","name":"azurecli1467734709.077144172638","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-06-20/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-06-20"},"backendPoolName":{"type":"String","value":"lb3bepool"},"dnsNameType":{"type":"String","value":"none"},"loadBalancerName":{"type":"String","value":"lb3"},"location":{"type":"String","value":"westus"},"privateIpAddress":{"type":"String","value":"10.0.0.15"},"privateIpAddressAllocation":{"type":"String","value":"static"},"publicIpAddress":{"type":"String","value":"PublicIPlb3"},"publicIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddressType":{"type":"String","value":"none"},"publicIpDnsName":{"type":"String","value":""},"subnet":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/lbrg/providers/Microsoft.Network/virtualNetworks/mytestvnet/subnets/Subnet1"},"subnetAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetType":{"type":"String","value":"existingId"},"virtualNetworkName":{"type":"String","value":"mytestvnet"},"vnetAddressPrefix":{"type":"String","value":"10.0.0.0/16"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-05T16:05:11.8836089Z","duration":"PT0.7634579S","correlationId":"71c5f764-1611-4018-83f5-68e629ec357b","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/lbrg/providers/Microsoft.Resources/deployments/IPlb3","resourceType":"Microsoft.Resources/deployments","resourceName":"IPlb3"},{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/lbrg/providers/Microsoft.Resources/deployments/Subnetlb3","resourceType":"Microsoft.Resources/deployments","resourceName":"Subnetlb3"}],"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/lbrg/providers/Microsoft.Network/loadBalancers/lb3","resourceType":"Microsoft.Network/loadBalancers","resourceName":"lb3"}]}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/lbrg/providers/Microsoft.Resources/deployments/azurecli1468007628.1432765","name":"azurecli1468007628.1432765","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-06-20/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-06-20"},"backendPoolName":{"type":"String","value":"lb3bepool"},"dnsNameType":{"type":"String","value":"none"},"loadBalancerName":{"type":"String","value":"lb3"},"location":{"type":"String","value":"westus"},"privateIpAddress":{"type":"String","value":"10.0.0.15"},"privateIpAddressAllocation":{"type":"String","value":"static"},"publicIpAddress":{"type":"String","value":"PublicIPlb3"},"publicIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddressType":{"type":"String","value":"none"},"publicIpDnsName":{"type":"String","value":""},"subnet":{"type":"String","value":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/lbrg/providers/Microsoft.Network/virtualNetworks/mytestvnet/subnets/Subnet1"},"subnetAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetType":{"type":"String","value":"existingId"},"virtualNetworkName":{"type":"String","value":"mytestvnet"},"vnetAddressPrefix":{"type":"String","value":"10.0.0.0/16"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-08T19:53:49.3668639Z","duration":"PT0.2115155S","correlationId":"8e93a3f3-f1b4-43cc-a573-a7311dcae2c9","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/lbrg/providers/Microsoft.Resources/deployments/IPlb3","resourceType":"Microsoft.Resources/deployments","resourceName":"IPlb3"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/lbrg/providers/Microsoft.Resources/deployments/Subnetlb3","resourceType":"Microsoft.Resources/deployments","resourceName":"Subnetlb3"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/lbrg/providers/Microsoft.Network/loadBalancers/lb3","resourceType":"Microsoft.Network/loadBalancers","resourceName":"lb3"}]}}'}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/azurecli1467734709.077144172638/operationStatuses/08587338721743575154?api-version=2015-11-01']
-      Cache-Control: [no-cache]
-      Content-Length: ['2490']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 05 Jul 2016 16:05:11 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/azurecli1468007628.1432765/operationStatuses/08587335992563223092?api-version=2015-11-01']
+      cache-control: [no-cache]
+      content-length: ['2480']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Jul 2016 19:53:48 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3NzMzOTMzLCJuYmYiOjE0Njc3MzM5MzMsImV4cCI6MTQ2NzczNzgzMywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.BUDdfJ1dId87f2nq-tcfBimD9x9tzkoqBw1mzP7QLokzQj_kNi-M-jGa8mASe6Uovd8xqpZrmTzosIQ7WumM3yhrtZ-q4NyvuPswzhb2dwl3Bb3-MlaLDa1g3Uu4HDDquR_KoQREWI6FEghmlGi3UcmoVdX9ODWlLl89FiSp_fJlDNvgzD0kDhGWq8lO9AgcsNexZR6DOthAfcCYLLatsYcZqxL3Ax0t2QMvY5CXvS8GXsnoIupcAwghPfCg0yqtw7_1RSMEXSXTLiyHKJI149R7wqmaVFvG42x3b09pvW9p9X2qCOhfF7rEohqv1u29NaQMJHYanY0kGjvsw9IRww]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY4MDA1NTg0LCJuYmYiOjE0NjgwMDU1ODQsImV4cCI6MTQ2ODAwOTQ4NCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.t9b-B1_IK7NClFfXkGsEL-eUnIKdzD3jA8BuOul0S-aQAuyjiDup1OE6HuIBWH7bEFdqa-kLA7tQ4TxT_TYs5Es2Ocmij2O66Ppq4dmZfMCMAuFIJ6UEdnj67OFk1Z4zsPJbsaE4btRXsz-DOl3gEisQ--xbYjXmZlgz_cY1FihQpLUPLcStSYkSnReQ6QbUME2IL_TMHk6poiC_vK8u7qwvvVdXWALeSOr4zSeVpvW33X3WFz4_Ryy3nMd9nyoMF7tgSHn-O1wqQWk-K5fda9zYH4QiawN-bp0hCmQbFOSETlbddm_E_ZuCcc2ZPi3q242Qy7R1ivSJl_sxU69Big]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 lbcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [3f6cdfdc-42ca-11e6-a235-a0b3ccf7272a]
+      x-ms-client-request-id: [afc5e1e1-4545-11e6-b872-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587338721743575154?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587335992563223092?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -520,28 +468,28 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
     headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Length: ['141']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 05 Jul 2016 16:05:42 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['141']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Jul 2016 19:54:18 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3NzMzOTMzLCJuYmYiOjE0Njc3MzM5MzMsImV4cCI6MTQ2NzczNzgzMywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.BUDdfJ1dId87f2nq-tcfBimD9x9tzkoqBw1mzP7QLokzQj_kNi-M-jGa8mASe6Uovd8xqpZrmTzosIQ7WumM3yhrtZ-q4NyvuPswzhb2dwl3Bb3-MlaLDa1g3Uu4HDDquR_KoQREWI6FEghmlGi3UcmoVdX9ODWlLl89FiSp_fJlDNvgzD0kDhGWq8lO9AgcsNexZR6DOthAfcCYLLatsYcZqxL3Ax0t2QMvY5CXvS8GXsnoIupcAwghPfCg0yqtw7_1RSMEXSXTLiyHKJI149R7wqmaVFvG42x3b09pvW9p9X2qCOhfF7rEohqv1u29NaQMJHYanY0kGjvsw9IRww]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY4MDA1NTg0LCJuYmYiOjE0NjgwMDU1ODQsImV4cCI6MTQ2ODAwOTQ4NCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.t9b-B1_IK7NClFfXkGsEL-eUnIKdzD3jA8BuOul0S-aQAuyjiDup1OE6HuIBWH7bEFdqa-kLA7tQ4TxT_TYs5Es2Ocmij2O66Ppq4dmZfMCMAuFIJ6UEdnj67OFk1Z4zsPJbsaE4btRXsz-DOl3gEisQ--xbYjXmZlgz_cY1FihQpLUPLcStSYkSnReQ6QbUME2IL_TMHk6poiC_vK8u7qwvvVdXWALeSOr4zSeVpvW33X3WFz4_Ryy3nMd9nyoMF7tgSHn-O1wqQWk-K5fda9zYH4QiawN-bp0hCmQbFOSETlbddm_E_ZuCcc2ZPi3q242Qy7R1ivSJl_sxU69Big]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 lbcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [3f6cdfdc-42ca-11e6-a235-a0b3ccf7272a]
+      x-ms-client-request-id: [afc5e1e1-4545-11e6-b872-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
@@ -549,90 +497,84 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXfLSX1xd1VXl8Usr5u7XxTTumqq83b8Sts1d2f5qqyuF/mybe5mP1jX+bQsdvc/ffDg
-        3v6DnYfjnQcPdvf3dx/sfXrv4KPRR8tskRNqNzekTld53RZ589GjX/xRmy9WZdbmz4vlW/y9rguC
-        Mm/bVfPornTbzN5Oi/GkrCbjaVXn46tiOauumvEyb++a1+dV0949qXP69fnk99/b2f10e+fT7b0d
-        gSAjGf90Uy0JgWm1bGlQP0njJvJRb7vjHfz30S8h5LKaxtHSV0Dm988Iz/Ns2jbPq2kGYuPT9nqF
-        kb5u62J5QfAus3KND74xpIHIJJu+zZezl1VVvshA2eF+y8m9Sb6ihnhvtmzQ/g23HX5nWS1zNC+r
-        bPYkK7PlNK/x3qZ3qB955WZSXOVNu27QelUXlzS+s9XxbEZUYbIOvbVLk0D/7d6PvXhc3qbjpqUm
-        U35/PSmLqX1900svpelLHWDnzdt1PLsmAYj2fNupMK89lRnc9AqakwogXtrU6i41+dnSEi/y9qqq
-        3969LOp2nZX6Z3N3cd3S1F8SZnepd/rR3H3NP3cdzkqXl3V+XrzbNADlh527e/vu7ZvImb8rmpY+
-        OpvhnRC/m+jqsOd36ef747r76Ue/hF5eVDN8fLac1jlUaFZSY6YklA69+5o4FS1er6fTnDTUjL5v
-        iwX1ny1W9LmogwfbO/ff7H76aOf+o3v3xvceHOztPbj3U9R0tq6VJz96+WZvb7x3/2Dnwaf3XtNX
-        pG/qnPQLfUtEePTRg93p/fMHn+5v7366u7u9v7N7sH1w7/z+9qcH+ad7D4kF7j+Y0GuMHKb5o0ff
-        +8WszptVNgWKvWmn1kQVZhRMh7zhf0Iv+ZqloReMEKGx0Q/f/yXf/yWjob6sIaKXfdgA0OtNNDwI
-        jeZ+X8t1WaKf7xPN8hWp1Hw5ZdtDQOSD5kuiIv31c2RaRe+EYyREbnjNe0G4+iOBA3r+HA3kNcsn
-        kHC4fd3BOFiYuJ/1ASlf3w2YlppvHEr0Je8FHQqgYBDVul2taaykRPw38LcqlS8nP51PW4KgSuUX
-        i0xuUBimq8/XTKKDew/2Z/mns21qcH97f/rg3vbB/YPd7fPJ/sPz6cOH5/cenNNb5zV7QLOzlyfV
-        8ry4UFVCqJEUQBgJ1HMPxWdof7pEh9zN3Z+Lmbg7hPXdAVTzNrsgZL979/f9aLp/b3f30wc72zv7
-        O/uE4acPtyf7+f72/Xs7Dz99ON3LD7LJ7/sRvUMYeb4p/bWR+sZFealWgr5WM0AujP+19SC+yNt5
-        BRICHHkLxqihtx8aaUObuNlm/xJwrvqiOkq4pDRUxyo0Oep//pzyRwRLfG5R+9nmByaVQ4vavFqX
-        ePF79Dm9OjG/F8tJtV7OXmSt14C0Q+RT15THgw9pSrg16RKrS+lz5Z9bEIqU0S/5Jf8PuOCeg0kO
-        AAA=
+        o0cf3W3Wk2ZaF6u2qJbN3Xs7+/nBw4efbj94cD7Z3v80P9ieZLNs+/79B5/u7N5/uD/J9+/WeVOt
+        62n+eV2tV83dclJf3F3V1WUxy+vm7hfFtK6a6rwdv9J2zd1Zviqr60W+bJu72Q/WdT4ti939Tw92
+        dh58uncw3t2/t/fg0/sfjT5aZoucsNrYhrpa5XVb5M1Hj37xR22+WJVZmz8vlm/x97ouCMC8bVfN
+        o7vSWTN7Oy3Gk7KajKdVnY+viuWsumrGy7y9a16fV01796TO6dfnk99/b2f30+2dT7f3dgSC4D/+
+        6aZaEgLTatnSUH6SRktEo952xzv476NfQshlNQ2hpa+AzO+fEZ7n2bRtnlfTDCTGp+31CoN83dbF
+        8oLgXWblGh98Y0gDkUk2fZsvZy+rqnyRgajD/ZaTe5N8RQ3x3mzZoP0bbjv8zrJa5mheVtnsSVZm
+        y2le471N71A/8srNpLjKm3bdoPWqLi5pfGer49mMqMJkHXprlyaB/tu9H3vxuLxNx01LTab8/npS
+        FlP7+qaXXkrTlzrAzpu363h2Tbwf7fm2U2FeeyozuOkVNCfBJ17a1OouNfnZ0g0v8vaqqt/evSzq
+        dp2V+mdzd3Hd0tRfEmZ3qXf60dx9zT93Hc5Kl5d1fl682zQA5Yedu3v77u2byJm/K5qWPjqb4Z0Q
+        v5vo6rDnd+nn++O6++lHv4ReXlQzfHy2nNY5FGdWUmOmJJQOvfuaOBUtXq+n05w01Iy+b4sF9Z8t
+        VvS5qIMH2zsHb3YfPrq//2h3f3xw7979nd3dn6Kms3WtPPnRyzd798efPjjYvb/34DV9Rfqmzkm/
+        0LdEhEcfHeQP72X3zu9tn+9O9rf3702n29n9B/e2swf3dndn0yzfmz6k1xg5TPNHj773i1mTN6ts
+        ChR7006tiSrMKJgOecP/hF7yNUtDLxghQmOjH77/S77/S0ZDfVnzQy/7sAGg15toeBAazf2+luuy
+        RD/fJ5rlK1Kp+XLKtoeAyAfNl0RF+uvnyKCK3gnHSIjc8Jr3gnD1RwIH9Pw5Gshrlk8g4XD7uoNx
+        sDBxP+sDUr6+GzAtNd84lOhL3gs6FEDBIKp1u1rTWEmJ+G/gb1UqX05+Op+2BEGVyi8WmdygMExX
+        n6+ZROezg92d3QPI9wFJ+sPpwXaWTfe2H+7sne8/uL97cP/eAb11XrMHNDt7eVItz4sLVSWEGkkB
+        hJFAPfdQfIb2p0t0yN3c/bmYibtDWN8dQDVvswtC9rt3f9+P9u7tffrw/ODT7YN7ewfb+/mDh9uT
+        /Yfn259OHhxMZzuTnYf5zu/7Eb1DGHm+Kf21kfrGRXmpVoK+VjNALoz/tfUgvsjbeQUSAhx5C8ao
+        obcfGmlDm7jZZv8ScK76ojpKuKQ0VMcqNDnqf/6c8kcES3xuUfvZ5gcmlUOL2rxal3jxe/Q5vTox
+        vxfLSbVezl5krdeAtEPkU9eUx4MPaUq4NekSq0vpc+WfWxCKlNEv+SX/D5VYA6A/DgAA
     headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Length: ['1256']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 05 Jul 2016 16:05:41 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['1248']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Jul 2016 19:54:19 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!binary |
-      eyJwcm9wZXJ0aWVzIjogeyJwYXJhbWV0ZXJzIjogeyJfYXJ0aWZhY3RzTG9jYXRpb24iOiB7InZh
-      bHVlIjogImh0dHBzOi8vYXp1cmVzZGtjaS5ibG9iLmNvcmUud2luZG93cy5uZXQvdGVtcGxhdGVo
-      b3N0L0NyZWF0ZXB1YmxpY19pcF8yMDE2LTA2LTA2In0sICJhbGxvY2F0aW9uTWV0aG9kIjogeyJ2
-      YWx1ZSI6ICJkeW5hbWljIn0sICJwdWJsaWNJcEFkZHJlc3NUeXBlIjogeyJ2YWx1ZSI6ICJub0Ru
-      cyJ9LCAibmFtZSI6IHsidmFsdWUiOiAicHVibGljaXA0In19LCAidGVtcGxhdGVMaW5rIjogeyJ1
-      cmkiOiAiaHR0cHM6Ly9henVyZXNka2NpLmJsb2IuY29yZS53aW5kb3dzLm5ldC90ZW1wbGF0ZWhv
-      c3QvQ3JlYXRlUHVibGljSXBfMjAxNi0wNi0wNi9henVyZWRlcGxveS5qc29uIn0sICJtb2RlIjog
-      IkluY3JlbWVudGFsIn19
+    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreatePublicIp_2016-06-06/azuredeploy.json"},
+      "mode": "Incremental", "parameters": {"allocationMethod": {"value": "dynamic"},
+      "publicIpAddressType": {"value": "noDns"}, "name": {"value": "publicip4"}, "_artifactsLocation":
+      {"value": "https://azuresdkci.blob.core.windows.net/templatehost/Createpublic_ip_2016-06-06"}}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3NzMzOTMzLCJuYmYiOjE0Njc3MzM5MzMsImV4cCI6MTQ2NzczNzgzMywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.BUDdfJ1dId87f2nq-tcfBimD9x9tzkoqBw1mzP7QLokzQj_kNi-M-jGa8mASe6Uovd8xqpZrmTzosIQ7WumM3yhrtZ-q4NyvuPswzhb2dwl3Bb3-MlaLDa1g3Uu4HDDquR_KoQREWI6FEghmlGi3UcmoVdX9ODWlLl89FiSp_fJlDNvgzD0kDhGWq8lO9AgcsNexZR6DOthAfcCYLLatsYcZqxL3Ax0t2QMvY5CXvS8GXsnoIupcAwghPfCg0yqtw7_1RSMEXSXTLiyHKJI149R7wqmaVFvG42x3b09pvW9p9X2qCOhfF7rEohqv1u29NaQMJHYanY0kGjvsw9IRww]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY4MDA1NTg0LCJuYmYiOjE0NjgwMDU1ODQsImV4cCI6MTQ2ODAwOTQ4NCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.t9b-B1_IK7NClFfXkGsEL-eUnIKdzD3jA8BuOul0S-aQAuyjiDup1OE6HuIBWH7bEFdqa-kLA7tQ4TxT_TYs5Es2Ocmij2O66Ppq4dmZfMCMAuFIJ6UEdnj67OFk1Z4zsPJbsaE4btRXsz-DOl3gEisQ--xbYjXmZlgz_cY1FihQpLUPLcStSYkSnReQ6QbUME2IL_TMHk6poiC_vK8u7qwvvVdXWALeSOr4zSeVpvW33X3WFz4_Ryy3nMd9nyoMF7tgSHn-O1wqQWk-K5fda9zYH4QiawN-bp0hCmQbFOSETlbddm_E_ZuCcc2ZPi3q242Qy7R1ivSJl_sxU69Big]
       Connection: [keep-alive]
       Content-Length: ['414']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 publicipcreationclient/2015-11-01 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [532591cc-42ca-11e6-af68-a0b3ccf7272a]
+      x-ms-client-request-id: [c2eb4f80-4545-11e6-99bc-001dd8b7c0ad]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/lbrg/providers/Microsoft.Resources/deployments/azurecli1467734742.709685689644","name":"azurecli1467734742.709685689644","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreatePublicIp_2016-06-06/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/Createpublic_ip_2016-06-06"},"allocationMethod":{"type":"String","value":"dynamic"},"dnsName":{"type":"String","value":""},"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"publicip4"},"publicIpAddressType":{"type":"String","value":"noDns"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-05T16:05:43.8571197Z","duration":"PT0.2050018S","correlationId":"ba490f71-6cab-4cce-a08d-0045ffa34f2b","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]}]}],"dependencies":[]}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/lbrg/providers/Microsoft.Resources/deployments/azurecli1468007660.6667339","name":"azurecli1468007660.6667339","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreatePublicIp_2016-06-06/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/Createpublic_ip_2016-06-06"},"allocationMethod":{"type":"String","value":"dynamic"},"dnsName":{"type":"String","value":""},"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"publicip4"},"publicIpAddressType":{"type":"String","value":"noDns"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-08T19:54:21.7798814Z","duration":"PT0.145723S","correlationId":"9fbd5ec1-338d-4e9e-8761-c85e3eda7a03","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]}]}],"dependencies":[]}}'}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/azurecli1467734742.709685689644/operationStatuses/08587338721418255231?api-version=2015-11-01']
-      Cache-Control: [no-cache]
-      Content-Length: ['1065']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 05 Jul 2016 16:05:43 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/azurecli1468007660.6667339/operationStatuses/08587335992238434765?api-version=2015-11-01']
+      cache-control: [no-cache]
+      content-length: ['1054']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Jul 2016 19:54:21 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3NzMzOTMzLCJuYmYiOjE0Njc3MzM5MzMsImV4cCI6MTQ2NzczNzgzMywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.BUDdfJ1dId87f2nq-tcfBimD9x9tzkoqBw1mzP7QLokzQj_kNi-M-jGa8mASe6Uovd8xqpZrmTzosIQ7WumM3yhrtZ-q4NyvuPswzhb2dwl3Bb3-MlaLDa1g3Uu4HDDquR_KoQREWI6FEghmlGi3UcmoVdX9ODWlLl89FiSp_fJlDNvgzD0kDhGWq8lO9AgcsNexZR6DOthAfcCYLLatsYcZqxL3Ax0t2QMvY5CXvS8GXsnoIupcAwghPfCg0yqtw7_1RSMEXSXTLiyHKJI149R7wqmaVFvG42x3b09pvW9p9X2qCOhfF7rEohqv1u29NaQMJHYanY0kGjvsw9IRww]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY4MDA1NTg0LCJuYmYiOjE0NjgwMDU1ODQsImV4cCI6MTQ2ODAwOTQ4NCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.t9b-B1_IK7NClFfXkGsEL-eUnIKdzD3jA8BuOul0S-aQAuyjiDup1OE6HuIBWH7bEFdqa-kLA7tQ4TxT_TYs5Es2Ocmij2O66Ppq4dmZfMCMAuFIJ6UEdnj67OFk1Z4zsPJbsaE4btRXsz-DOl3gEisQ--xbYjXmZlgz_cY1FihQpLUPLcStSYkSnReQ6QbUME2IL_TMHk6poiC_vK8u7qwvvVdXWALeSOr4zSeVpvW33X3WFz4_Ryy3nMd9nyoMF7tgSHn-O1wqQWk-K5fda9zYH4QiawN-bp0hCmQbFOSETlbddm_E_ZuCcc2ZPi3q242Qy7R1ivSJl_sxU69Big]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 publicipcreationclient/2015-11-01 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [532591cc-42ca-11e6-af68-a0b3ccf7272a]
+      x-ms-client-request-id: [c2eb4f80-4545-11e6-99bc-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587338721418255231?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587335992238434765?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -640,29 +582,29 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
     headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Length: ['141']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 05 Jul 2016 16:06:13 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['141']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Jul 2016 19:54:51 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3NzMzOTMzLCJuYmYiOjE0Njc3MzM5MzMsImV4cCI6MTQ2NzczNzgzMywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.BUDdfJ1dId87f2nq-tcfBimD9x9tzkoqBw1mzP7QLokzQj_kNi-M-jGa8mASe6Uovd8xqpZrmTzosIQ7WumM3yhrtZ-q4NyvuPswzhb2dwl3Bb3-MlaLDa1g3Uu4HDDquR_KoQREWI6FEghmlGi3UcmoVdX9ODWlLl89FiSp_fJlDNvgzD0kDhGWq8lO9AgcsNexZR6DOthAfcCYLLatsYcZqxL3Ax0t2QMvY5CXvS8GXsnoIupcAwghPfCg0yqtw7_1RSMEXSXTLiyHKJI149R7wqmaVFvG42x3b09pvW9p9X2qCOhfF7rEohqv1u29NaQMJHYanY0kGjvsw9IRww]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY4MDA1NTg0LCJuYmYiOjE0NjgwMDU1ODQsImV4cCI6MTQ2ODAwOTQ4NCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.t9b-B1_IK7NClFfXkGsEL-eUnIKdzD3jA8BuOul0S-aQAuyjiDup1OE6HuIBWH7bEFdqa-kLA7tQ4TxT_TYs5Es2Ocmij2O66Ppq4dmZfMCMAuFIJ6UEdnj67OFk1Z4zsPJbsaE4btRXsz-DOl3gEisQ--xbYjXmZlgz_cY1FihQpLUPLcStSYkSnReQ6QbUME2IL_TMHk6poiC_vK8u7qwvvVdXWALeSOr4zSeVpvW33X3WFz4_Ryy3nMd9nyoMF7tgSHn-O1wqQWk-K5fda9zYH4QiawN-bp0hCmQbFOSETlbddm_E_ZuCcc2ZPi3q242Qy7R1ivSJl_sxU69Big]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 publicipcreationclient/2015-11-01 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [532591cc-42ca-11e6-af68-a0b3ccf7272a]
+      x-ms-client-request-id: [c2eb4f80-4545-11e6-99bc-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
@@ -670,43 +612,43 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXfLSX1xd1VXl8Usr5u7XxTTumqq83b8Sts1d2f5qqyuF/mybe5mP1jX+bQsdvc/ffDg
-        3v6D/b3xg52Hnx7c//Tg4af7+x+NPlpmi5xQu7khdbrK67bIm48e/eKP2nyxKrM2f14s3+LvdV0Q
-        lHnbrppHd6XbZvZ2WownZTUZT6s6H18Vy1l11YyXeXvXvD6vmvbuSZ3Try/Xk7KYnq1+/72d3U+3
-        d/A/gSPjGf90Uy0JjWm1bGloP0mjJyJSn7vjHfz30S8hFLOaRtPSV0Dp988I2/Ns2jbPq2kGkuPT
-        9nqF8b5u62J5QfAus3KNDz4E9RWj/vsXPu7AJytL7fmLvJ1XxALD/c+uaSaKKV6bLZsXGWZluDWa
-        Gdib2l3lTbtu0Jqg0wfDLWUMxWofjeWPs9XxbEbEaN7wO8PvLqunS+qEXlxUM3xwtpzWOTgwK6kZ
-        cc5lgdmit163RC9q8Xo9neY0tTP6vi0WhGa2WNHnQsAH2zv33+x++mgH/xvfPzj49P6D/Z+iprN1
-        rWP+6OWbvb3xw3uf3r/38P5r+oomqs5pYujbM6L0R5Ns/+HOOUnXp9Nssr1P3W1nOwez7Z2d/fvn
-        59m9/fO9Cb3GyEGWPnr0vV/MVGpW2RQoOtl6kbdXVf2WWhM1WMpAEXnD/4ReUsq9VMpRIzdReMHM
-        yPd/Cf1H48lX+XKWL6csVt+jT6p1u1q39McvNrCILJb0X05+Op+2BFNJT42A/wbiEhaM3+drVkH3
-        988P9u7dz4jAB0SV3enO9sO96R4pnux8ejB98ODBwS69pV2/PO5x8EdPlVFHHxWzMn9Dc0cony2/
-        KJbrFoPY/yVgBPqMhmGVEo1NdWCPqndtX4Zk+gnz4vd/yS/5fwBxUxH8PQUAAA==
+        o0cf3W3Wk2ZaF6u2qJbN3Xs7+/nBw4efbj94cD7Z3v80P9ieZLNs+/79B5/u7N5/uD/J9+/WeVOt
+        62n+eV2tV83dclJf3F3V1WUxy+vm7hfFtK6a6rwdv9J2zd1Zviqr60W+bJu72Q/WdT4ti939Tw92
+        dh58+unO+NNPP31w797Dj0YfLbNFTlhtbENdrfK6LfLmo0e/+KM2X6zKrM2fF8u3+HtdFwRg3rar
+        5tFd6ayZvZ0W40lZTcbTqs7HV8VyVl0142Xe3jWvz6umvXtS5/Try/WkLKZnq99/b2f30+0d/E/g
+        yCjGP91US0JjWi1bGtBP0piJdNTn7ngH/330SwjFrKaBtPQVUPr9M8L2PJu2zfNqmoHQ+LS9XmGo
+        r9u6WF4QvMusXOODD0F9xaj//oWPO/DJylJ7/iJv5xVN/HD/s2uahGKK12bL5kWGCRlujWYG9qZ2
+        V3nTrhu0Juj0wXBLGUOx2kdj+eNsdTybETGaN/zO8LvL6umSOqEXF9UMH5wtp3UOvstKakacc1lg
+        tuit1y3Ri1q8Xk+nOU3tjL5viwWhmS1W9LkQ8MH2zsGb3YeP7u8/2t8d793bP9g9+PSnqOlsXeuY
+        P3pJDcaf7uwQl+69pq9oouqcJoa+PSNKf/TwfDK7n093t+/dO5ht7+cP8+2DB5/ubk8P7uf38ln2
+        INu5R68xcpCgjx597xczlZpVNgWKTqJe5O1VVb+l1kQNli1QRN7wP6GXlHIvlXLUyE0UXjAz8v1f
+        Qv/RePJVvpzlyymL1ffok2rdrtYt/fGLDSwiiyX9l5OfzqctwVTSUyPgv4G4hAXj9/maFc/+7oNP
+        96YPPt3ev5/tbu/v3P90O9t/ONt++PA+Sfy9+/sP85ze0q5fHvc4+KOnyqijj4pZmb+huSOUz5Zf
+        FMt1i0Hs/xIwAn1Gw7CqiMammq9H1bu2L0My/YR58fu/5Jf8PwgOPO4zBQAA
     headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Length: ['844']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 05 Jul 2016 16:06:14 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['843']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Jul 2016 19:54:53 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3NzMzOTMzLCJuYmYiOjE0Njc3MzM5MzMsImV4cCI6MTQ2NzczNzgzMywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.BUDdfJ1dId87f2nq-tcfBimD9x9tzkoqBw1mzP7QLokzQj_kNi-M-jGa8mASe6Uovd8xqpZrmTzosIQ7WumM3yhrtZ-q4NyvuPswzhb2dwl3Bb3-MlaLDa1g3Uu4HDDquR_KoQREWI6FEghmlGi3UcmoVdX9ODWlLl89FiSp_fJlDNvgzD0kDhGWq8lO9AgcsNexZR6DOthAfcCYLLatsYcZqxL3Ax0t2QMvY5CXvS8GXsnoIupcAwghPfCg0yqtw7_1RSMEXSXTLiyHKJI149R7wqmaVFvG42x3b09pvW9p9X2qCOhfF7rEohqv1u29NaQMJHYanY0kGjvsw9IRww]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY4MDA1NTg0LCJuYmYiOjE0NjgwMDU1ODQsImV4cCI6MTQ2ODAwOTQ4NCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.t9b-B1_IK7NClFfXkGsEL-eUnIKdzD3jA8BuOul0S-aQAuyjiDup1OE6HuIBWH7bEFdqa-kLA7tQ4TxT_TYs5Es2Ocmij2O66Ppq4dmZfMCMAuFIJ6UEdnj67OFk1Z4zsPJbsaE4btRXsz-DOl3gEisQ--xbYjXmZlgz_cY1FihQpLUPLcStSYkSnReQ6QbUME2IL_TMHk6poiC_vK8u7qwvvVdXWALeSOr4zSeVpvW33X3WFz4_Ryy3nMd9nyoMF7tgSHn-O1wqQWk-K5fda9zYH4QiawN-bp0hCmQbFOSETlbddm_E_ZuCcc2ZPi3q242Qy7R1ivSJl_sxU69Big]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 resourcemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [6644f3b8-42ca-11e6-b63e-a0b3ccf7272a]
+      x-ms-client-request-id: [d6b00a5e-4545-11e6-b735-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27lbrg%27%20and%20name%20eq%20%27publicip4%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FpublicIPAddresses%27
   response:
@@ -714,76 +656,69 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
-        zsP7D3fu1nlTretp/nldrVfN3XJSX9xd1dVlMcvr5u4XxbSumuq8Hb/I26uqfnt3tZ6UxfTs5fFs
-        Rq82eaOfFKv9j0YfLbMF4fOR/1F7vcJHt4BEjctqmgF5euEqb9p189Ev+f4v+X8AVK91PugAAAA=
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXP33s5+fvDw4afbDx6cT7b3P80PtifZLNu+f//Bpzu7
+        9x/uT/L9u3XeVOt6mn9eV+tVc7ec1Bd3V3V1Wczyurn7RTGtq6Y6b8cv8vaqqt/eXa0nZTE9e3k8
+        m9GrTd7oJ8Vq/6PRR8tsQfh85H/UXq/w0S0gUeOymmZAnl64ypt23Xz0S77/S/4fcakK2+gAAAA=
     headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Length: ['284']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 05 Jul 2016 16:06:14 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['284']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Jul 2016 19:54:53 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!binary |
-      eyJwcm9wZXJ0aWVzIjogeyJwYXJhbWV0ZXJzIjogeyJ2bmV0QWRkcmVzc1ByZWZpeCI6IHsidmFs
-      dWUiOiAiMTAuMC4wLjAvMTYifSwgImRuc05hbWVUeXBlIjogeyJ2YWx1ZSI6ICJub25lIn0sICJw
-      dWJsaWNJcEFkZHJlc3NBbGxvY2F0aW9uIjogeyJ2YWx1ZSI6ICJkeW5hbWljIn0sICJwdWJsaWNJ
-      cEFkZHJlc3NUeXBlIjogeyJ2YWx1ZSI6ICJleGlzdGluZ0lkIn0sICJzdWJuZXRBZGRyZXNzUHJl
-      Zml4IjogeyJ2YWx1ZSI6ICIxMC4wLjAuMC8yNCJ9LCAiX2FydGlmYWN0c0xvY2F0aW9uIjogeyJ2
-      YWx1ZSI6ICJodHRwczovL2F6dXJlc2RrY2kuYmxvYi5jb3JlLndpbmRvd3MubmV0L3RlbXBsYXRl
-      aG9zdC9DcmVhdGVMYl8yMDE2LTA2LTIwIn0sICJwcml2YXRlSXBBZGRyZXNzQWxsb2NhdGlvbiI6
-      IHsidmFsdWUiOiAiZHluYW1pYyJ9LCAicHVibGljSXBBZGRyZXNzIjogeyJ2YWx1ZSI6ICIvc3Vi
-      c2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VH
-      cm91cHMvbGJyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvcHVibGljSVBBZGRyZXNzZXMv
-      cHVibGljaXA0In0sICJsb2FkQmFsYW5jZXJOYW1lIjogeyJ2YWx1ZSI6ICJsYjQifX0sICJ0ZW1w
-      bGF0ZUxpbmsiOiB7InVyaSI6ICJodHRwczovL2F6dXJlc2RrY2kuYmxvYi5jb3JlLndpbmRvd3Mu
-      bmV0L3RlbXBsYXRlaG9zdC9DcmVhdGVMYl8yMDE2LTA2LTIwL2F6dXJlZGVwbG95Lmpzb24ifSwg
-      Im1vZGUiOiAiSW5jcmVtZW50YWwifX0=
+    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-06-20/azuredeploy.json"},
+      "mode": "Incremental", "parameters": {"dnsNameType": {"value": "none"}, "publicIpAddressAllocation":
+      {"value": "dynamic"}, "publicIpAddressType": {"value": "existingId"}, "loadBalancerName":
+      {"value": "lb4"}, "_artifactsLocation": {"value": "https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-06-20"},
+      "privateIpAddressAllocation": {"value": "dynamic"}, "publicIpAddress": {"value":
+      "/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/lbrg/providers/Microsoft.Network/publicIPAddresses/publicip4"},
+      "vnetAddressPrefix": {"value": "10.0.0.0/16"}, "subnetAddressPrefix": {"value":
+      "10.0.0.0/24"}}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3NzMzOTMzLCJuYmYiOjE0Njc3MzM5MzMsImV4cCI6MTQ2NzczNzgzMywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.BUDdfJ1dId87f2nq-tcfBimD9x9tzkoqBw1mzP7QLokzQj_kNi-M-jGa8mASe6Uovd8xqpZrmTzosIQ7WumM3yhrtZ-q4NyvuPswzhb2dwl3Bb3-MlaLDa1g3Uu4HDDquR_KoQREWI6FEghmlGi3UcmoVdX9ODWlLl89FiSp_fJlDNvgzD0kDhGWq8lO9AgcsNexZR6DOthAfcCYLLatsYcZqxL3Ax0t2QMvY5CXvS8GXsnoIupcAwghPfCg0yqtw7_1RSMEXSXTLiyHKJI149R7wqmaVFvG42x3b09pvW9p9X2qCOhfF7rEohqv1u29NaQMJHYanY0kGjvsw9IRww]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY4MDA1NTg0LCJuYmYiOjE0NjgwMDU1ODQsImV4cCI6MTQ2ODAwOTQ4NCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.t9b-B1_IK7NClFfXkGsEL-eUnIKdzD3jA8BuOul0S-aQAuyjiDup1OE6HuIBWH7bEFdqa-kLA7tQ4TxT_TYs5Es2Ocmij2O66Ppq4dmZfMCMAuFIJ6UEdnj67OFk1Z4zsPJbsaE4btRXsz-DOl3gEisQ--xbYjXmZlgz_cY1FihQpLUPLcStSYkSnReQ6QbUME2IL_TMHk6poiC_vK8u7qwvvVdXWALeSOr4zSeVpvW33X3WFz4_Ryy3nMd9nyoMF7tgSHn-O1wqQWk-K5fda9zYH4QiawN-bp0hCmQbFOSETlbddm_E_ZuCcc2ZPi3q242Qy7R1ivSJl_sxU69Big]
       Connection: [keep-alive]
       Content-Length: ['764']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 lbcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [6687bf7a-42ca-11e6-b43c-a0b3ccf7272a]
+      x-ms-client-request-id: [d71582ee-4545-11e6-ab1e-001dd8b7c0ad]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/lbrg/providers/Microsoft.Resources/deployments/azurecli1467734774.792064216813","name":"azurecli1467734774.792064216813","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-06-20/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-06-20"},"backendPoolName":{"type":"String","value":"lb4bepool"},"dnsNameType":{"type":"String","value":"none"},"loadBalancerName":{"type":"String","value":"lb4"},"location":{"type":"String","value":"westus"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddress":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/lbrg/providers/Microsoft.Network/publicIPAddresses/publicip4"},"publicIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddressType":{"type":"String","value":"existingId"},"publicIpDnsName":{"type":"String","value":""},"subnet":{"type":"String","value":""},"subnetAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetType":{"type":"String","value":"none"},"virtualNetworkName":{"type":"String","value":""},"vnetAddressPrefix":{"type":"String","value":"10.0.0.0/16"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-05T16:06:16.3829522Z","duration":"PT0.2253614S","correlationId":"7865196f-56f1-4f01-ac9d-7faa5a7e7d0b","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/lbrg/providers/Microsoft.Resources/deployments/IPlb4","resourceType":"Microsoft.Resources/deployments","resourceName":"IPlb4"},{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/lbrg/providers/Microsoft.Resources/deployments/Subnetlb4","resourceType":"Microsoft.Resources/deployments","resourceName":"Subnetlb4"}],"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/lbrg/providers/Microsoft.Network/loadBalancers/lb4","resourceType":"Microsoft.Network/loadBalancers","resourceName":"lb4"}]}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/lbrg/providers/Microsoft.Resources/deployments/azurecli1468007694.4956385","name":"azurecli1468007694.4956385","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-06-20/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-06-20"},"backendPoolName":{"type":"String","value":"lb4bepool"},"dnsNameType":{"type":"String","value":"none"},"loadBalancerName":{"type":"String","value":"lb4"},"location":{"type":"String","value":"westus"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddress":{"type":"String","value":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/lbrg/providers/Microsoft.Network/publicIPAddresses/publicip4"},"publicIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddressType":{"type":"String","value":"existingId"},"publicIpDnsName":{"type":"String","value":""},"subnet":{"type":"String","value":""},"subnetAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetType":{"type":"String","value":"none"},"virtualNetworkName":{"type":"String","value":""},"vnetAddressPrefix":{"type":"String","value":"10.0.0.0/16"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-08T19:54:55.7580528Z","duration":"PT0.4971059S","correlationId":"bed58308-4d2e-4b78-ab54-8b5f9f5ffc83","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/lbrg/providers/Microsoft.Resources/deployments/IPlb4","resourceType":"Microsoft.Resources/deployments","resourceName":"IPlb4"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/lbrg/providers/Microsoft.Resources/deployments/Subnetlb4","resourceType":"Microsoft.Resources/deployments","resourceName":"Subnetlb4"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/lbrg/providers/Microsoft.Network/loadBalancers/lb4","resourceType":"Microsoft.Network/loadBalancers","resourceName":"lb4"}]}}'}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/azurecli1467734774.792064216813/operationStatuses/08587338721093200655?api-version=2015-11-01']
-      Cache-Control: [no-cache]
-      Content-Length: ['2446']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 05 Jul 2016 16:06:15 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/azurecli1468007694.4956385/operationStatuses/08587335991902167127?api-version=2015-11-01']
+      cache-control: [no-cache]
+      content-length: ['2436']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Jul 2016 19:54:55 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3NzMzOTMzLCJuYmYiOjE0Njc3MzM5MzMsImV4cCI6MTQ2NzczNzgzMywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.BUDdfJ1dId87f2nq-tcfBimD9x9tzkoqBw1mzP7QLokzQj_kNi-M-jGa8mASe6Uovd8xqpZrmTzosIQ7WumM3yhrtZ-q4NyvuPswzhb2dwl3Bb3-MlaLDa1g3Uu4HDDquR_KoQREWI6FEghmlGi3UcmoVdX9ODWlLl89FiSp_fJlDNvgzD0kDhGWq8lO9AgcsNexZR6DOthAfcCYLLatsYcZqxL3Ax0t2QMvY5CXvS8GXsnoIupcAwghPfCg0yqtw7_1RSMEXSXTLiyHKJI149R7wqmaVFvG42x3b09pvW9p9X2qCOhfF7rEohqv1u29NaQMJHYanY0kGjvsw9IRww]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY4MDA1NTg0LCJuYmYiOjE0NjgwMDU1ODQsImV4cCI6MTQ2ODAwOTQ4NCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.t9b-B1_IK7NClFfXkGsEL-eUnIKdzD3jA8BuOul0S-aQAuyjiDup1OE6HuIBWH7bEFdqa-kLA7tQ4TxT_TYs5Es2Ocmij2O66Ppq4dmZfMCMAuFIJ6UEdnj67OFk1Z4zsPJbsaE4btRXsz-DOl3gEisQ--xbYjXmZlgz_cY1FihQpLUPLcStSYkSnReQ6QbUME2IL_TMHk6poiC_vK8u7qwvvVdXWALeSOr4zSeVpvW33X3WFz4_Ryy3nMd9nyoMF7tgSHn-O1wqQWk-K5fda9zYH4QiawN-bp0hCmQbFOSETlbddm_E_ZuCcc2ZPi3q242Qy7R1ivSJl_sxU69Big]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 lbcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [6687bf7a-42ca-11e6-b43c-a0b3ccf7272a]
+      x-ms-client-request-id: [d71582ee-4545-11e6-ab1e-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587338721093200655?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587335991902167127?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -791,28 +726,28 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
     headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Length: ['141']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 05 Jul 2016 16:06:46 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['141']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Jul 2016 19:55:25 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3NzMzOTMzLCJuYmYiOjE0Njc3MzM5MzMsImV4cCI6MTQ2NzczNzgzMywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.BUDdfJ1dId87f2nq-tcfBimD9x9tzkoqBw1mzP7QLokzQj_kNi-M-jGa8mASe6Uovd8xqpZrmTzosIQ7WumM3yhrtZ-q4NyvuPswzhb2dwl3Bb3-MlaLDa1g3Uu4HDDquR_KoQREWI6FEghmlGi3UcmoVdX9ODWlLl89FiSp_fJlDNvgzD0kDhGWq8lO9AgcsNexZR6DOthAfcCYLLatsYcZqxL3Ax0t2QMvY5CXvS8GXsnoIupcAwghPfCg0yqtw7_1RSMEXSXTLiyHKJI149R7wqmaVFvG42x3b09pvW9p9X2qCOhfF7rEohqv1u29NaQMJHYanY0kGjvsw9IRww]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY4MDA1NTg0LCJuYmYiOjE0NjgwMDU1ODQsImV4cCI6MTQ2ODAwOTQ4NCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.t9b-B1_IK7NClFfXkGsEL-eUnIKdzD3jA8BuOul0S-aQAuyjiDup1OE6HuIBWH7bEFdqa-kLA7tQ4TxT_TYs5Es2Ocmij2O66Ppq4dmZfMCMAuFIJ6UEdnj67OFk1Z4zsPJbsaE4btRXsz-DOl3gEisQ--xbYjXmZlgz_cY1FihQpLUPLcStSYkSnReQ6QbUME2IL_TMHk6poiC_vK8u7qwvvVdXWALeSOr4zSeVpvW33X3WFz4_Ryy3nMd9nyoMF7tgSHn-O1wqQWk-K5fda9zYH4QiawN-bp0hCmQbFOSETlbddm_E_ZuCcc2ZPi3q242Qy7R1ivSJl_sxU69Big]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 lbcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [6687bf7a-42ca-11e6-b43c-a0b3ccf7272a]
+      x-ms-client-request-id: [d71582ee-4545-11e6-ab1e-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/lbrg/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
@@ -820,50 +755,50 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXfLSX1xd1VXl8Usr5u7XxTTumqq83b8Sts1d2f5qqyuF/mybe5mP1jX+bQsdvc/ffDg
-        3v6DB/vjBw/3dj7d39v99GD33kejj5bZIifUbm5Ina7yui3y5qNHv/ijNl+syqzNnxfLt/h7XRcE
-        Zd62q+bRXem2mb2dFuNJWU3G06rOx1fFclZdNeNl3t41r8+rpr17Uuf06/PJ77+3s/vp9s6n23s7
-        AkFGMv7pploSAtNq2dKgfpLGTeSj3nbHO/jvo19CyGU1jaOlr4DM758RnufZtG2eV9MMxMan7fUK
-        I33d1sXyguBdZuUaH3xjSAORSTZ9my9nL6uqfJGBssP9lpP9Sb6ihnhvtmzQ/g23HX5nWS1zNC+r
-        bPYkK7PlNK/x3qZ3qB955WZSXOVNu27QelUXlzS+s9XxbEZUYbIOvRVrf1zepr/ZNbFfMWUA60lZ
-        TO37m966+7MoRi/y9qqq395VdF4qOiRW8kmxYmLKHxbbDx3tTdOevyualj46m/kvPxWe2fQimhO1
-        iHtv10rxeVnn58W7Ta/skuDhv7t7TA95+6ZhGO69LOp2nZVK69uM4ZKgvz9uu59+9Evo5UU1w8dn
-        y2mdQy1mJTXmyYcioXdft8S61OL1ejrNSevM6Pu2WJAwZIsVfS4i/mB75/6b3U8f7Xz66N7++OD+
-        wwc7Bw9/iprO1rXO/Ucv3+wejB/s7O3uHuy+pq9Ih9Q56Qz6lubu0UcPDj69v/vw0/Pt+5+e727v
-        n+/sbmfTh7PtB+dZdj97kD+Y7UzoNUYOnPnRo+/9YlbRzSqbAsUep1JrogrzNsgvb/if0Eu+tmjo
-        BcOsaGxk/vu/5Pu/ZDTUlzUu9LIPGwB6vYnWBqHR3O9ruS5L9PN9olm+IjWZL6dsTwiIfNB8SVSk
-        v36OzOXZSyjLcIyEyA2veS8IL38kcEDPn6OBvGZ5BBIOt687GAcLE/ezPiDl67sB01LzjUOJvuS9
-        oEMBFAyiWrerNY2VlIj/Bv5WpfLl5KfzaUsQVKn8YpHJDQrDdPX5mkl08GBv596DycF2fpBl2/t7
-        oMns/P72w92D6c6DfH//wXSP3jqv2auZnb08qZbnxYWqEkKNpADCSKCeeyg+Q/vTJTrkbu7+XMzE
-        3SGs7w6gmrfZBSH73bu/70fZ3r3dvZ2D/e2H5GNu79/P729P8gf3tx98erA3+3TvQTadPfx9P6J3
-        CCPP36S/NlLf+B8vnSn+Im/nFWj0VO0utRLLaaw6AP/QqNjpm6ROPmGP4peAK9V31AZwIQlDxwZE
-        ePUXf07nPoIlPreo/WzPNZPKoUVtXq1LvPg9+pxenZjfi+WkWi9nL7LWa0CSH/nUNeXx4EOaEm5N
-        esLqSfpcGeYWhCJF80t+yf8DFUVGRvkNAAA=
+        o0cf3W3Wk2ZaF6u2qJbN3Xs7+/nBw4efbj94cD7Z3v80P9ieZLNs+/79B5/u7N5/uD/J9+/WeVOt
+        62n+eV2tV83dclJf3F3V1WUxy+vm7hfFtK6a6rwdv9J2zd1Zviqr60W+bJu72Q/WdT4ti939Tw92
+        dh58+nB/vP/w/qf3Du5/NPpomS1ywmpjG+pqlddtkTcfPfrFH7X5YlVmbf68WL7F3+u6IADztl01
+        j+5KZ83s7bQYT8pqMp5WdT6+Kpaz6qoZL/P2rnl9XjXt3ZM6p1+fT37/vZ3dT7d3Pt3e2xEIgv/4
+        p5tqSQhMq2VLQ/lJGi0RjXrbHe/gv49+CSGX1TSElr4CMr9/RnieZ9O2eV5NM5AYn7bXKwzydVsX
+        ywuCd5mVa3zwjSENRCbZ9G2+nL2sqvJFBqIO91tOaFpX1BDvzZYN2r/htsPvLKtljuZllc2eZGW2
+        nOY13tv0DvUjr9xMiqu8adcNWq/q4pLGd7Y6ns2IKkzWobdi7Y/L2/Q3uybOK6YMYD0pi6l9f9Nb
+        d38WhedF3l5V9du7is5LRYeEST4pVkxM+cNi+6GjvWna83dF09JHZzP/5afCM5teRHOiFnHv7Vop
+        Pi/r/Lx4t+mVXRI8/Hd3j+khb980DMO9l0XdrrNSaX2bMVwS9PfHbffTj34JvbyoZvj4bDmtcyjD
+        rKTGPPlQJPTu65ZYl1q8Xk+nOWmdGX3fFgsShmyxos9FxB9s7xy82X346P79RzsPx/f3P929d++n
+        qOVsXevUf/Tyze7+eO/g/u7Bp7uv6StSIXVOKoO+pal79NEkn90/uLdzsL0/28u39ycPDrazyf39
+        7YPJ/fOH5/fPz6cH9+g1xg2M+dGj7/1iVs7NKpsCwx6jUmsiCrM2qC9v+J/QS76yaOgFw6tobET+
+        +7/k+79kNNSXtSj0sg8bAHq9idIGndHc72u5Lkv0832iWb4iLZkvp2xOCIh80HxJVKS/fo5s5NlL
+        6MpwjITIDa95LwgrfyRwQM+fo4G8ZnEEEg63rzsYBwsT97M+IOXruwHTUvONQ4m+5L2gQwEUDKJa
+        t6s1jZV0iP8G/lad8uXkp/NpSxBUp/xikckN+sJ09fmaSXRvujedTQ92t+/vPyRJvze5tz2Z3vt0
+        e3Ivm356f0rC/iCjt85rdmpmZy9PquV5caGqhFAjKYAwEqjnHorP0P50iQ65m7s/FzNxdwjruwOo
+        5m12Qch+9+7vS7p55yDL7z3Yzqazh9v72QMiyYPpve2dyb1P78327k/2z3d+34/oHcLIczfpr43U
+        N+7HS2eJv8jbeQUaPVWzS63EcBqjDsA/NCp2+iapk0/Yofgl4Ep1HbUBPEjC0LEBEV7dxZ/TuY9g
+        ic8taj/bc82kcmhRm1frEi9+jz6nVyfm92I5qdbL2Yus9RqQ5Ec+dU15PPiQpoRbk56wepI+V4a5
+        BaFI0fySX/L/AF1EkaHuDQAA
     headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Length: ['1223']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 05 Jul 2016 16:06:46 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['1215']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Jul 2016 19:55:26 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3NzMzOTMzLCJuYmYiOjE0Njc3MzM5MzMsImV4cCI6MTQ2NzczNzgzMywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.BUDdfJ1dId87f2nq-tcfBimD9x9tzkoqBw1mzP7QLokzQj_kNi-M-jGa8mASe6Uovd8xqpZrmTzosIQ7WumM3yhrtZ-q4NyvuPswzhb2dwl3Bb3-MlaLDa1g3Uu4HDDquR_KoQREWI6FEghmlGi3UcmoVdX9ODWlLl89FiSp_fJlDNvgzD0kDhGWq8lO9AgcsNexZR6DOthAfcCYLLatsYcZqxL3Ax0t2QMvY5CXvS8GXsnoIupcAwghPfCg0yqtw7_1RSMEXSXTLiyHKJI149R7wqmaVFvG42x3b09pvW9p9X2qCOhfF7rEohqv1u29NaQMJHYanY0kGjvsw9IRww]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY4MDA1NTg0LCJuYmYiOjE0NjgwMDU1ODQsImV4cCI6MTQ2ODAwOTQ4NCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.t9b-B1_IK7NClFfXkGsEL-eUnIKdzD3jA8BuOul0S-aQAuyjiDup1OE6HuIBWH7bEFdqa-kLA7tQ4TxT_TYs5Es2Ocmij2O66Ppq4dmZfMCMAuFIJ6UEdnj67OFk1Z4zsPJbsaE4btRXsz-DOl3gEisQ--xbYjXmZlgz_cY1FihQpLUPLcStSYkSnReQ6QbUME2IL_TMHk6poiC_vK8u7qwvvVdXWALeSOr4zSeVpvW33X3WFz4_Ryy3nMd9nyoMF7tgSHn-O1wqQWk-K5fda9zYH4QiawN-bp0hCmQbFOSETlbddm_E_ZuCcc2ZPi3q242Qy7R1ivSJl_sxU69Big]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [79a6fa1e-42ca-11e6-a6ad-a0b3ccf7272a]
+      x-ms-client-request-id: [ea421c80-4545-11e6-a8fe-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/loadBalancers?api-version=2016-03-30
   response:
@@ -871,100 +806,138 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UeXWbnOP3qUfg9/pSl/iOejZbbA5x8106zMm7zdLScfjey3xQzf3W3Wk2ZaF6u2qJbN3Z3J7vmn
-        +w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWup/nndbVeNXenZfEmb9pXF7//a3T0
-        mjq6u6qry2KW183dL4ppXTXVeTt+kbdXVf32blllsydZmS2n+D6OXN5mF0Dvu3d/349m57u7Owe7
-        D7ZnD+7d296f3N/ZJiz3tx9kO9n0wfneg/3zT3/fj7yX2+sVj/uGrr03ymqagQB464rGsva/pLGs
-        8rot8oa+ttSVLy6Lhl4rlhev26zlTl+vp9M8n+UzB4GaWpKthexZNst28/uT7ft7ewfb+/n5wfbB
-        /v75dvbpZDo5P3g4O7h/EAA4r6tlmy9nZy9PquV5cbGuGWGgpPMuj4cfHssDz72RPwOs02WAIZ7/
-        F7LE3aFx373VgD6EjeTBJEdnXx58fUsekIdeKC6p2dnL49Jw3Rd5O6+Y9E+vab6Kaey19aQspvTW
-        bEa0juJCrX7OJrCDXu5N4qpYfdRF9Zf0B1gsJ9V6OXuRtS+rqsQAA76WJzJmvPpzNephtu2Mxn23
-        zNoVfdKjCNGk+9H3ww+C770/vu/R8qNJNn1L0qLTwH0TbQJKdmhoNYRFcZIzhh5YPP9vpHJktO77
-        gWH8nKuEsL03kcEfwaw6ChDIV2saH4H8XtCEOp1EPnZ8GH+tWrebGzgATF587769BTMZfvdg4vl/
-        Izd1huq+GxrDzzkrdaDRC8Zcvqzq9lW2vMjprbqlt+7v0HOL9rCi3Prhw35rlTc0pkb37h1E2hDK
-        bTUlahGmb6arDTh2TDq90CMAtf5/IaMMDGDAJ+mOyRNyPMGf3h9W++tnxmRaGvVkbS/woH8W6bb3
-        NegWIudLDvHl+V6+s7e9c//TXXKFP51sP5xk+9v39vf2Hh7s7ezvZru+5Px/wb3fz+5/uref7ZJ7
-        P51s7+98urd9sLPzYDt7mGV7+b3dg51P///l3n9NlnhPUeoO6EPYSB5McnT25cHXt+QBeeiF/2+6
-        95snsIOe597v/X/avd886mG27YzGfWdchf5AVI27xyp4eYLvvT8Cb0wNsE4D9020CSjZoaHVEBbF
-        Ab/4/4VUjozWfT8wjJ9zlRC29yYy+COYVUcBAhl3w6nT/ze695bfPZh4/t/ITZ2huu+GxvBzzkod
-        aPSCMZfwwNldp7fYFyeH/Ufu/TfEKAMDGPBJumPyhBxP8Kf3h9X++pkxmZZGVtbKya6j8jdHr3JS
-        X7wHgUIsfNHYy2fTnU/vnW9P9yeUyj7f3d8++HT26fbsHv19fzKb3r+f+6Lx/wX/PXt4j0j5aba9
-        //DTT7f3KSW/ne3nD7dnk08f3L//gL67dz8AMMQzBOxWCjXKWl4HeH4u5/49haKL+YfwizyYzeg0
-        y4OvbznZ8tAL/19w1G+cqQ4+5Jm/1E9o1r62cvLGbayCdsC2kwZ3K64mFAbctB8egfqsHBkQPh/A
-        9OecdcP23iwFfwRT5sZMIOOOH3U6iXzsnKT4a1/HoXwfU7fniPdzyCM+Fv78f/pwd3afsjfbu3uz
-        B+QFZvn25P7ep9uT/Hz34eRgd3+2c8+f/59tU0dd8IPZ3MRCFiFqammjpm668/De+fnBve17DzGm
-        nXs0pt396fbDBw8/nU52D+7n53kAYMgSELBbKYVbGQzB7e7Pxdx/g6bufflFHszmB+iLDjR+4f/3
-        pm6voyZJy4QfBH96fwTKK2IZaHC34mpCYcCA/PAI1GflyIDw+QCmP+esG7b3Zin4I5gyN2YCGTdJ
-        1On/G03dPUe8n0Me8bHw53+6f29399MHO9s7+zv71PmnD7cn+/n+9v17Ow8/fTjdyw+yiT///18w
-        dQf3HuzP8k9n29T2PkV1D+5tH9w/2N0+n+w/PJ8+fHh+78F5AGDIEhCwWymFWxkMwe3uz8Xcf4Om
-        7n35RR7MZnSa5cHXt5xseegFY+pE5aH97s4Y/+0GEbs8XvuIaUSPUctIc7XMkSPrYUxf/vDm87Ko
-        23VW6p/N3cV1S2J0Sajdpd7pR3P3Nf/8f0EgeG/A5vzwqNXn/siA8PkApj/n3B6292Yp+COYMjdm
-        Ahm3YtTp/xut474j3s8hj/hY+POf7d3b3ds52Kco6QHN/30yJ5P8wf3tB58e7M0+3XuQTWcP/fn/
-        /4R1fLC3c+8B5TWIeSnxuQeCzs7vbz/cPZjuPMj39x9MvbiYAAwZDwJ2K6VwKxsjuN39uZj7b9A6
-        vi+/yIPZjE6zPPj6lpMtD72wwdr9fzkQlE+K1X5HSZKOCT8I/vT+CFRXxC7Q0G7F08Q2A+bjh0ee
-        PiNHBoTPBzD9OWfcsL03S8EfwZS5MRPIuEGiTv/fZ+hm06rZzi7yZbtd0pLy7v6T3Z1TT81+c2xz
-        vb6gBeCrbErSAvLfinluRC/glfOd+/dm+WR7Z++ADMinsx3KJD6Ybd+7d+/TT/cOZp/m+ac+r/x/
-        wSje3589IHO4sz0jC7i9f29nl9Ig93e3Hz6cTrJsdy+j5YAAwJDNIGC3UiABxY1tiVBenv9Xssew
-        3Qza3zy4D2EueTD1UZ6QB1/fkjPkoRf+v2BBbzmZHazIjnoTVKy2HZhd/qxxU9XF3mg495CsGlYh
-        4lrV2W3WkwR5fui0cNjie48OPmO7RmZId58/wc9vv3nzskeTGFX+/zPc1z+PxvuyqtuDnYOd2JC7
-        H1nbL0/wvfdH4EJE/DMiTyArHTLG7AWcOTuYrhL6fyfFIwP3m24e0f8LzYOOp2v46LVgMuXp9Yfn
-        hzZPJ9VitW5zk0T8IpvOi2X+epqV+WtkDv1pYDthJ2L7ctE0O50XCce7lGnE1J+R8a/Psyl9xu+/
-        qGb5i2J6t1iFVLm7RMg25c9uJVl9ejsmoxmCpP6/ktTvJRKuUbGUIakSgtLtkIkG8f9bnYvh/sjG
-        8NOXhPCD4HvvD19gbiEqHSpaEyP4YT66Gu//YySODuH/hVZkIH6i13rAqfX/K+dgYAid9v0QsDu+
-        vrRb6kBgaOQHO/0maoY3tMiX2aTMn9FYWpqVs5fU7Dwrm7zfspiV+ZtikVMe6Gz5RbEkm4lpvt9v
-        SURrqykl1Gg63kxXkYml7mZPi6ati8ka5EDLp/l5ti7bSGsdheccUfv/z3BAH/ugaejadQcVmXZC
-        aALJ+f8MAQgA5RvvttMV9M5L/NUfZ/hB8GdIg86wI8r5dZeF/t9JFteIBA+4+9q5P4YfqeefjUkY
-        GEKn/Tehnvf37/XbqG7Y1ORHCvpnmwf62AdNf74p6Nc/uxoavM7uffAONft/JWlcIxI+oG+U9OAw
-        fqSnfzbmYWAInfbfhJ7GpPYbqY7Y2OZHmvpnmwv62AdNfz5panAi2PBrKGv3R5AXEdg06FvlQggF
-        GAvp3gOD5//ttBtG/P+FypteuEEDrIgV6NuYSipIs9WXWXm2fJ1TfnkGnCJaZrleTPL6y3MmCtrs
-        9ds4GhPmsIBoF7CKPL0h4/l/J0e4RmZIatzBID2ZCiRHno3px4CEHap0xUh9ruAVavX/SqoRAGIS
-        I0cDmP9/WZCiYdiPJGkTT7hGZkieJEUXL7offSOiFBrF4C1q+P9KyhEAYhRI02bk/78sUBhV/8sf
-        SdQmvnCNzJBUogybfLBQuT8CN7BYTqr1cvYia9EbEzL4nmKWzQ0cAHbQ+XvztXZqBNrOhxVipsYi
-        a4g1fHI43vp/w2xtxM8XVJLS84OD2Wx7eg5B3TvY2X44e/hg+2C2M83v7+58em9y7gvqR+31islw
-        AxreG2U1pXBTwr6rvGnX/pc0rqjE44tbyvpHlmproTy12P303u5k+9Pdyd72/sP84XZ2/+Hu9oMH
-        n04e7Ow8eDjbmwYATHzdDd0JWCCiHn54BliiH+KjL2pvnv93MsgNCQz7ws3D+xD+kgezH2ULefD1
-        LZlDHnqhuKRmZy+PS8OOX+TtvOKJeHpNE1kELCHPR6v1pCym9NaMw3lq3MOFWv2wp7ODFeldf4aK
-        1baDs7u4WLRuprrIGy3nHk83Wt3ZbdMTBHl+6HS4HVt3BnT39etvb/ttTcPtnzV7FckJEaECsnYI
-        GtUsYe7I6wDP/0uJHxl60HbzmP5fqEh0QF0dSa8F8ylPrz88P/SZWsrPM1Lu9Xk2JRHwZ8AQf3tZ
-        TLd37harcGD2gxfVrJ/EC3henq8jII6XaBpYSolCoctGAxTfOvy4I9z43n3bmwArVht0gAcdzw99
-        thwt8L2PpC9XnXFvUmrdAf2/UKgGPA96rQecWv+/c0YGxtB9oe89dUcYsckGNgIrGvve3k4kWFXN
-        ZNv0W3zw6s9+vyUR7oYIW/Hq0IXa/79hbn8WdaOn7PAEf3p/BOqM6B3INRFjSN+xLeXvzdcK1PCP
-        Ja/VekqTy0XTbO+WEzdX3zjZ0cVGuhMPejLlvdVBzFdWlDp6MN2dnW8/PPj04fb+zsGn29nB/sH2
-        OeWY7uf7k2xvZ+orq/8vhKqT6XTvwb2He9uzg73Z9n52vr89yR+eb0/2Hjzc+fTBw4PJJAsAGFXQ
-        ESegdCvL99wbudFFfgd4/l/GDsOq9VaD+RAWkgcTHJ15efD1LedfHnrh/0PRKKZh4+R10CId6r25
-        vftSv+4ryP4InXqz6q/bpsfa8vzwh72ZZzsjCb9fZi0Cn3E04uxR5f9PI96Njbj7kW/x5PEYw9q9
-        bpv/z5GJRxJ+r2S6FZHCD4LvvT98WhpXTAWV+yfaBJTs0NDajQDNSc5YeqDx/L+N0pHRhm0GhvH/
-        QoOhQ+kaQHotmDx5ev3h+eFNzkm1WFG8cPeyqNt1Vn6RTefFMn89zcr8dd4G72/vdloRRhGX3L5B
-        brj1uQ0N3LfFitbo6JuY9PRI+v9xMu3+7JCp+9HXUTJOKIm72RQQRcMohujxDSZz7MhAKdWgZFo9
-        yHh+eDN7O+3UGWz4/fAo/l+onAbcc3qtB5xa/79sGgaQH4gtuuPp6xVLDc3D3N+hp99KFbo2+lGy
-        xk5KdCo/TFf+bJgUT/nhCf4MmaJDuM1aa7c7JT88Gt9OXG6ltfqj+P+B1vrQafhGp8EomY6cfqNa
-        a7ffSrWDNvqR1rKTEp3KD9NaPxseXqCmOn96fwROGc1PIPJEvCGvjUMsfO++fT/9153aH95c3U7s
-        OkMNvx8aw/+LdR8E+RWNIKe3WKQh9xFvpdceWoVbP3zYb63SiMbUKKYlCOEbJNr0+P8ykb4dmwwg
-        f1vtHH4Q/On9YUMz/Yx/0Ie/5P8BnyXufGmGAAA=
+        6UeXWbnOP3qUfg9/pSl/iOejZbbA5x+Vk92PRvbTYobP7jbrSTOti1VbVMvm7r2d/fzg4cNPtx88
+        OJ9s73+aH2xPslm2ff/+g093du8/3J/k+3frvKnW9TT/vK7Wq+ZuOakv7q7q6rKY5XVz94tiWldN
+        dd6OX+TtVVW/vVtW2exJVmbLKb4Pscjb7AJ4fPfu7/vR9P75/qf3P93fvrc/mW7vP3gw287u7e1u
+        39uZTg7uP9if7t3b/X0/8l5ur1c8sBu69N4oq2mGkeKtq7xp1/6XNIZVXrdF3tDXlnzyxWXR0GvF
+        8uJ1m7Xc6ev1dJrns3zmIFBTS5u10Pfg4fmns4c7O9v3D6YPaEz5p9uT/fv3th/uzh7emz58mB18
+        +mkA4Lyulm2+nJ29PKmW58XFumaEgZJOrDwefnjsJD/3Rv4MsE6XAYZ4fi7n/u7QAO/eCvMP4Rd5
+        MJvRaZYHX99ysuWhF4pLanb28rg07PVF3s4rpvHTa5qYYhp7bT0piym9NZsRUaO4UKsf3kx18Mmb
+        uy/1E5q1j7qo/ZLwg+BP74/ve+P+aJJN39LEawcvq6rEqG/F1YTCJF/RG11C/hAJ1GflyIDw+QCm
+        P+esG7b3Zin4I5gyN2YC+WpdcsffC5pQp5PIx8VyUq2XsxdZG3+tWrebGzgATFj+3nyt6P4SbW8p
+        4fHLniPezyGP+Fj48/8we/CQpnmyPZncy7aJB7Lt7NN8b3v28NPdB/t7e/c/ffjQn///L5i63Yzs
+        2fn+w+3s/N4ujWlvtn3wYGdCLP7p3u6n09nD+9m9AMCQJSBgt1IKtzIYgtvdn4u5/wZN3fvyizyY
+        zeg0y4OvbznZ8tAL/783dXsdNUlaJvwg+NP7I1BeEctAg7sVVxMKAwbkh0egPitHBoTPBzD9OWfd
+        sL03S8EfwZS5MRPIuEmiTv/faOo8rfpzyCM+Fv78793b+/Th+cGn2wf39g629/MHDykCeni+/enk
+        wcF0tjPZeZjv+PP//wVTdz472N3ZPZhuZ/cP9rf3H04PtrNsurf9cGfvfP/B/d2D+/cOAgBDloCA
+        3Uop3MpgCG53fy7m/hs0de/LL/JgNqPTLA++vuVky0MvGFMnKg/td3fG+G/3/sb2EdOIHqOWkeZq
+        mbfUpIcxffnDm8/Lom7XWal/NncX1y2J0SWhdpd6px/N3df88/8FgeC9AZvzw6NWn/sjA8LnA5j+
+        nHN72N6bpeCPYMrcmAlk3IpRp/9vtI77jng/hzziY+HP/+7OzkGW33uwnVGAtL2fPaD84IPpve2d
+        yb1P78327k/2z4P5//+Cdbw33ZvOpge72/f3H+bb+/cm97Yn03s0sHvZ9NP704fn9x9kAYAh40HA
+        bqUUbmVjBLe7Pxdz/w1ax/flF3kwm9Fplgdf33Ky5aEXNli7/y8HgvJJsdrvKEnSMeEHwZ/eH4Hq
+        itgFGtqteJrYZsB8/PDI02fkyIDw+QCmP+eMG7b3Zin4I5gyN2YCGTdI1On/+wzdIluSB3e5aMqJ
+        I+I3xysWfPNePGNfC7Dy+WJGPLGbPSS+yA7IAXpIrlC2MznfPqDQ6tPJvel5thPwxf8XDOB0fza7
+        f75LFL33kDKhB7T8l+1N9igxujPJ792nFcF9zx8gAEP2gYDdSlncyowIbnf/38AL36BBfF/+kQez
+        G512efD1LSdfHnrh59AgfvMzJ2bQN4z21VWx6uhVp5bc4ykzq+y6bXr8LM//qxi1Mwz33TJrYfPG
+        /Yg4Ro7/Xwy1nxqnoXY/8i2aPB4rWLvWbfP/LfrwMNx3Sp9bUSf8IPje+8Mn4oc4kRbFAQft/03k
+        jQzTfT+A//8LDYEOo2vY6LVgxuTp9YfnhzgrJ9VitW5zk//7IpvOi2X+epqV+Wsk/SyATovm7u5d
+        ygZiRs/Ijtfn2ZQ+s62XxfRusQoJ4L4tVlP+JiYvPXr+f5lGez87NOp+9HV0ihND4mtW90TOMBoh
+        WtwyynHf9marr4lUWZLd9KDi+SFO6c3KqDNK990w+v8v1EUDXja91gNOrf/fRP8BzAfig+5g+mrE
+        kuJlVWO55f7Ozs5uv5Uqb210797Bw36bfJlNyvwZ4d7SPJy9pIbnWdnk/ZbFrMzfFIucAv+z5RfF
+        krQIJna/35KI1FZTMnA0AW+mq8hUKmYdelD7n9uZ/PrK8WfDgHjaDk/wZ8gTHaoNq6m97lz8EIl7
+        s5jcqKb66P9ITX2D9B/A/BtVU3v9VqoMtNGP1JSdkqGZ/Ppq6mfDhwv0UudP74/A7aLJCUSdKDfk
+        l3HohO/dt7dXeN05/SFO0s3i1hmj+24I+f8XKzsI76tseZHTWyzGkPWdW7SHJuHWDyNSr/KHxtQo
+        rhkI5Ruk2PT5/zYxvplDBjC/rUIOPwj+9P6wAZd+ZvS4JY6Trutg3eObo9R1fbH3PiQK8fDF4v7B
+        g3uz/Xu72zuf7pBY3NvPt7PdGUnJ9N7O9ODgIJ/c2/fF4v8L6y97D2b397IHk+3Z7r397f29ewfb
+        D7O9T7enROnJvb37ew/3Pg0ADLENAbuVFo1yl9cBnp/b2X9Pyeji/iEcIw/mMzrR8uDrW063PPTC
+        /ydWXG6cqw5C8C+u6bPbrbK4iSayWceg26zHuPL8MEfpEMX3zJHuI4P73fPsbX5d068fvtTAAGl4
+        /x8hRgfxu00z/3/LytI3NJzbTWn4QfC994c/88bnUflhz5CGHsx7h0RWbwPXgaWFn1v6RcbEXwwg
+        +3OunsP23kzRH0FPHcjeTGQ9T/T/lXMQQfNnnfo3Ub+DEKGkuHeNPZEzkAt5OnMizw+T+P0Qu5xs
+        U3C9uz3J+wG2iav/P6Mfh4a39/7D637kK0J5fp67BOEHwffeHz7ZbkGwDqms0vJw8wDi+X81Hbu4
+        /r9Qfw1EK/RaDzi1/rkl9gCuA5FVF/2+xrKD1yzOHj39RqrhN7b5uckBU3ezp0XT1sVkDUKg5dP8
+        PFuXbaS1jsOzstT+/32T3EcTX5Az0MU0Mp/U1QQc//++UVFzWuNn3cC/9nWspzTxBH96fwQKlUGB
+        fW6tRPmNvmL6fxtxuvj9v1Bx0gs3iOdqk8YoSPHUl1l5tnydkxsyA1a79/vtluvFJK+/PH8JwqBR
+        BJYjKSHPRojaBSwhT2/UeH6O5959ZHBnPlAD2kfYEwV5vo4j0gmaafwBtTp0sgJEsfVud55/jsnX
+        GQnC/z6K/y+UHmN5O6acXusBp9Y/tzQewPWbczt2+03UCpoWEaH/uXE5FK8OKaj9z/G0DUV+7xvY
+        ehoDT/BnOJOdAftKom+/foiUIIawTIn2xMARJdFH8UdK4oNoPIDrN6ck7vWbqDCaFj9SEjdM25CS
+        eN/0UKAVOn96fwQuB9E1EEIa9PeCBk5IOebh783XCtRwiSWjVTqLa1qVb3Y/zYPV52+QtADfbCQu
+        8Zjlc/NGFyFfx2QPdu7N9s53t+9PDz7d3p/ukKreub+7fZ59+iCf7E+nu59OfR3z/4Xl8E/3Pj3f
+        m9ybbu/SUvj2/u69e9sHDx7sbN+7v/fpwWz28ODBnkcOAmCEvCMqQOlWHmlUuXgd4Pl/CRu8p4bs
+        DuJDWEceTGx0xuXB17ecd3nohf9vrItjCjZPWgclUozyFk3cS/2qrwT7I3MqzKq4bpseK8vzwx3u
+        MI92RuC+W2Yt1gPHOz06xCjx//VR9k0ejbL7kW+95PEYwNqwbpv/z5CGR+C+U9LcijDhB8H33h8+
+        /YzLpALIfRM9Aup16GZtgEVxYMn6/yWUjYzQfT+A+v8Llb4Oo2vE6LVgsuTp9YfnhzMhJ9ViRT78
+        3cuibtdZ+UU2nRfL/PU0K/PXeWveJdJ3WjR3dyJ+sm1N3jI5xuHY3bfGZY5JSY+U/18kD5Fi92eH
+        PN2Pvo4SccJH3MyqnRgtjDKIVSSNHH7s1J59zX3bm6i+6lHtSObRg4rnh8PsN2ufzgDdd8OY/79Q
+        +Qy40PRaDzi1/n8J6QeQHvD7u+Po6w1LBc173N+hp99KFbU2+lFyBBMSn8L/d5kKT7nhCf4MmaFD
+        sGGt1F8R+aHQ9WbRuFEr9TH/kVb6Zkg/gPQ3qpV+tK7zAVP49bXSz4aHFqihzp/eH4FTRfMSiDcR
+        bcjr4nAI37tvb6/futP5w5mfm0WsMzz33RDe/y/WbRDYV9nyIqe3WHQh3xGvo9ce2oNbP3zYb61S
+        h8bUKKYNCOEbJNf0+P8i0b2ZNQaQvq32DT8I/vT+sCGUfmaUtqVLT6KKYLXi/wW0ChHy5eNhvr/z
+        6ezhbHvvwXm2vf9g+mB78nB/Z3s22dnf29t5+ODT84e+fPx/YflkZzp7mO1++mB7594+0TbfnWxP
+        PqU1lOzhwwfZTnbw8N55HgAYYiMCditNGuU2rwM8/y9hg/cUme4gPoR15MHERmdcHnx9y3mXh174
+        ///ySfHzZ/kEPNoZgftOLT7FM330+5T4//oo92Kj7H7ke4LyeAzADhMN9v+7DMAjcN8paW5FmPCD
+        4HvvD59+xpFSAeS+iR4B9Tp0szbAojiwBvH/EspGRui+H0D9/4VKX4fRNWL0WjBZ8vT6w/PDmZDb
+        Rp9Fp8Xm6LPYGH0Wg9EnMX6PlP8fJc/ezw55uh99HSXihI+4mVU7UTKM2IkWPwvLJ0Y7knn0oOL5
+        4czmzdqnM0D33TDm/y9UPgMuNL3WA06t/19C+gGkB/z+7jj6esNSQbMOlJr4UaLyQ6bw6+vCnw1T
+        4Sk3PMGfITN0CDaslfa60/DDoevNonGjVuph/qFaCYMnXH+klQaQ/ka1UkTnqPRrox9pJUxIfAq/
+        vlb62fDQAjXU+dP7I3CqaF4C8SaiDXldHA7he/ft7fVbdzp/OPNzs4h1hue+G8L7/8UeFwSWl0Po
+        LRZdyPePlk++LmsMIH1b7Rt+EPzp/WFDKP3MKG1Ll55E/XSwWvH/AlqFCPnycf/Bvfv5bH+6fe/T
+        /fPt/fvnD7cfZnu00PjwfLY33dvb37+/68vH/xeWT/KH+7v37mcPtmfTHaLtvd0dWjk5J5nfPd+9
+        t5fvTqefPggADLERAbuVJo1ym9cBnv+XsMF7ikx3EB/COvJgYqMzLg++vuW8y0Mv/P9/+eSnf/4s
+        n4BHOyNw36nFH+/06BCjxP/XRxldJOp+5HuC8ngMwA4TDfb/uwzAI3DfKWluRZjwg+B77w+ffsaR
+        UgHkvokeAfU6dLM2wKI4sAbx/xLKRkbovh9A/f+FSl+H0TVi9FowWfL0+sPzw5mQ20afP91p0dzd
+        2RB9/vTG6POnB6NPYvweKf8/Sp5NKcMPIE/3o6+jRJzwETezaidKhhE70eJnYfnEaEcyjx5UPD+c
+        2bxZ+3QG6L4bxvz/hcpnwIWm13rAqfX/S0g/gPSA398dR19vWCpo1oFSE7FEhipqbXTv3kEkffGj
+        VKVM4tfXhj8bxsJTb3iCP0N26BBsWC/1F0d/KHS9WThu1Et9zH+kl74Z0g8g/Y3qpRuXdX+kl2RK
+        4pP49fXSz4aXFiiizp/eH4FjRfMSCDgRbcjz4pAI37tvb6/hutP5w5mfm4WsMzz33RDe/y/WbhBZ
+        XhKht1h4IeERz6PXHvqDW9+8hBLXB4TyDbJr+vx/kfDezBwDSG/UwIS+Pp7I4Qn+9P6wgZR+ZhS3
+        pUtXpnazYM3im6bV3vsTq4ORLyL5/v6ne5N7s+2dh/dplXE3f7h9sLNDEpPNZp8enOfT+w9yX0T+
+        v7CKMt3/9N7D8wf3th9OJvdp5XTy6fZkOvt0m+R9unP/ILu3e74fABjiIwJ2K2UaNfheB3j+38IH
+        7yk03VF8CO/Ig5mNTrk8+PqWEy8PvfD/oWWUzbPWwcn5HLvZ/0fXUTaPd5hLO0Nw36ndp7imj3+f
+        FP+fH+ZebJjdj3yHUB6PBdhvotH+f5gFeAjuO6XNrSgTfhB87/3hE9A4VCqD3DcRJCBfh3DWEFgU
+        B9Yj/t9C2sgQ3fcDuP+/UPPrMLqWjF4LZkueXn94fkgzcss4dDfrtNgYh5IgbIhDd7PBOJRYv0fL
+        /6/SZ+9nhz7dj76OHnHiR/zM6p1IGQbvRItvfjWFxi0KkmykBxXPD2k6b1ZAnRG674ZR/3+h/hlw
+        pem1HnBq/f8W2g9gPRAAdAfSVx2WDJqCoDzFzXnLvb1+i5+HWcv4HH59dfizYS48/YYn+DPkhg7F
+        hhXTXncefkiEvVk4blRMfdR/pJi+IdoPYP2NKqaI2lEFoI1+pJgwIQNz+PUV08+GnxZoos6f3h+B
+        a0UTEwg4UW3I9+KwCN+7b2+v4rrz+UOaoJuFrDM+990Q4v8vVm8QWV4gobdYeCHh3/CCSkwfEMI3
+        yK7p8f9NwnszbwxgfVsFHH4Q/On9YUMp/czobUsYK1NXz5840n5zRHrx6uWrz9+DQiEavjjcn+T3
+        Jvd2P90m7r9Hq4oP729PDiYPt2f3pp8e7H2azw5mB744/H9h8eTTg08fTnfye9uf7u4+oDXTvYPt
+        h7tE4L3dh7N8dyd/kB3kAYAhpiFgt9KcUd7yOsDzczr57ykWXdQ/hGHkwXRG51kefH3L2ZaHXvj/
+        worJzVPVQYhcCrNKQtPW10/9EXWMISEesKw8kUHi1R/eMPsc2cEbnxnz3UdW9ax7rAaWJ/je+yNw
+        i9QoKqW5Vxp/QK0OnayAE3IDKeUYDX+2aWhpGBkRPh9A9edcisP23jQFfwRz5viGQMa9Xer0lgnI
+        4PufLS+a6G/42IOG5+eWVzrDwWdDeP6cM0oHGr1g7Bc8WnZ/6S32bckB/nntLn8dVhhAdcAZ6GLv
+        iSqe4E/vD6uh9TNjuiw1rMRkM79fR9pvjkh1db27d4/yGO17UGoQLV88dvcP8k8nGbmaD/f2t/f3
+        HuxuHzyYTbfz8+nO3qf3Dib39gLx+P+C+5yf7xx8mj/It+/PaDj7n073tg/29u9vfzr9dG/nPon8
+        w51JAGCInwjYrVTm8yfPTn2AeP5fNfkbJCaG+ocwiDyYvui8yoOvbzm78tAL/19wl285VR2syGfO
+        ZsZr7qur/qicKbSWv9umx6zy/NCHupErO+Ogr1897ROASND9yOpmeYLvvT8Cd0htpNKcfQgiRUC4
+        Dsk8+X7SF5L/V1EyMjgS7QjW/y8UbcW9q5rotWBy5On1h+eHPhf9PHo2exFLoJu8+e7PFlc7riBy
+        sxQRJcI4gAYyiXzcET58777tEdrKgsioBwjPD30C3LDxfUcYOiOjr2Mo/79QEgasNL3WA06t/19F
+        8wHUoYXIwehiH7FpBoDGMPfuHdwY58Tb/HxaKLzlzH0D6srTP3iCP70/Ag1DdA0EkQY9pILYYvH3
+        5msFajjFktEqosv6vPTc+G+OqA2WUpu8/f2ndU5C+/vn74oGrPT7VwL0968v7m0kN7GeFYzmbhdP
+        X+/MznfOD3bOKTTZowzF/s5+tv1w797+9u69nd392f75ZHY/8/XO/xeiLyL4gwez+0To3cnB9n5O
+        i5ST80+z7Qe7+58+nNw/OD+////lxYufDe7YoD29xoNj+xCOkgfzHWUEefD1LdlBHnrh/wvh2gfP
+        ZQff3C1+8Lx+I1pULYt2YRWlazEsGYzEQDL9/z1EjAlEZNDyzcBofs5FIGzvzWXwRzCxbtwEMm4g
+        qdNJ5GNnN+Ov/ewaXrgbl4um2SUG10b07TfGT1f5BD28B8ugeR8hnyU+3c3zh/nD2fb04c5se39K
+        S+sPsx3652D3/vQgO5jO8n2fJb5pO0uogMiWlvTRrGhWZXb9QonqK3rLTGYOqDlRI8qd+GITX1oI
+        1NQSWi11tjeZHUwPKEV6b3a+vU8LJBT1TKfbe/fuZ3s72ae7k/uBkv7/mKX+IEb6Bk3y+zKfPJjY
+        6IzLg69vOe/y0Av/XzDJt5m0Dkq5N3GrYmWlxzxOiswT03/dNj0ulueHO9Jh9uyMwH1n1kT7yKti
+        d49V+fIE33t/BJYjYpiJHgH1OnSz0m9RnMRt+P9LKBsZofv+Fu7Hz4m4h+29yQv+CGbSUYBAxt0E
+        6vSH5X64b2/BQIbHPZh4/t/CQZ3hue+G8P45Z58ONHrBmD+k2l5ly4uc3uKk2/0dem7RHlaRWz+M
+        5OhUxtCYGsXzeITyDTk302fHRNMLPQJQ6/+XMMcA0gN+RXccnjDjCf70/rCaXT/jH/ThL/l/ALk7
+        QeJ65QAA
     headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 05 Jul 2016 16:06:47 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Jul 2016 19:55:26 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3NzMzOTMzLCJuYmYiOjE0Njc3MzM5MzMsImV4cCI6MTQ2NzczNzgzMywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.BUDdfJ1dId87f2nq-tcfBimD9x9tzkoqBw1mzP7QLokzQj_kNi-M-jGa8mASe6Uovd8xqpZrmTzosIQ7WumM3yhrtZ-q4NyvuPswzhb2dwl3Bb3-MlaLDa1g3Uu4HDDquR_KoQREWI6FEghmlGi3UcmoVdX9ODWlLl89FiSp_fJlDNvgzD0kDhGWq8lO9AgcsNexZR6DOthAfcCYLLatsYcZqxL3Ax0t2QMvY5CXvS8GXsnoIupcAwghPfCg0yqtw7_1RSMEXSXTLiyHKJI149R7wqmaVFvG42x3b09pvW9p9X2qCOhfF7rEohqv1u29NaQMJHYanY0kGjvsw9IRww]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY4MDA1NTg0LCJuYmYiOjE0NjgwMDU1ODQsImV4cCI6MTQ2ODAwOTQ4NCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.t9b-B1_IK7NClFfXkGsEL-eUnIKdzD3jA8BuOul0S-aQAuyjiDup1OE6HuIBWH7bEFdqa-kLA7tQ4TxT_TYs5Es2Ocmij2O66Ppq4dmZfMCMAuFIJ6UEdnj67OFk1Z4zsPJbsaE4btRXsz-DOl3gEisQ--xbYjXmZlgz_cY1FihQpLUPLcStSYkSnReQ6QbUME2IL_TMHk6poiC_vK8u7qwvvVdXWALeSOr4zSeVpvW33X3WFz4_Ryy3nMd9nyoMF7tgSHn-O1wqQWk-K5fda9zYH4QiawN-bp0hCmQbFOSETlbddm_E_ZuCcc2ZPi3q242Qy7R1ivSJl_sxU69Big]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [7a49d826-42ca-11e6-9cb3-a0b3ccf7272a]
+      x-ms-client-request-id: [edad820f-4545-11e6-9631-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbrg/providers/Microsoft.Network/loadBalancers?api-version=2016-03-30
   response:
@@ -972,51 +945,51 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UeXWbnOP3qUfg9/pSl/iOejZbbA5x+Vk92PRvbTYobP7jbrSTOti1VbVMvm7s5k9/zT/Qe727uT
-        853t/dks287y6b3t6eTh3oO9852H9x/u3K3zplrX0/zzulqvmrvlpL64u6qry2KW183dL4ppXTXV
-        eTt+kbdXVf32blllsydZmS2n+D7EIm+zC+Dx3bu/70d7+Wy68+m98+3p/uRge/98d3/74NPZp9uz
-        e/T3/clsev9+/vt+5L3cXq94YDd06b1RVtMMI8VbV3nTrv0vaQyrvG6LvKGvLfnki8uiodeK5cXr
-        Nmu509fr6TTPZ/nMQaCmljZroW/28B6R8tNse//hp59u708n59vZfv5wezb59MH9+w/ou3v3AwDn
-        dbVs8+Xs7OVJtTwvLtY1IwyUdGLl8fDDYyf5uTfyZ4B1ugwwxPNzOfd3hwZ491aYfwi/yIPZjE6z
-        PPj6lpMtD71QXFKzs5fHpWGvL/J2XjGNn17TxBTT2GvrSVlM6a3ZjIgaxYVa/fBmqoNP3tx9qZ/Q
-        rH3URe2XhB8Ef3p/fN8b90eTbPqWJl47eFlVJUZ9K64mFCb5it7oEvKHSKA+K0cGhM8HMP05Z92w
-        vTdLwR/BlLkxE8hX65I7/l7QhDqdRD4ulpNqvZy9yNr4a9W63dzAAWDC8vfma0X3l2h7SwmPX/Yc
-        8X4OecTHwp//Tx/uzu7f2z3Y3t2bPdjez7N8e3J/79PtSX6++3BysLs/27nnz///F0zddOfhvfPz
-        g3vb9x5iTDv3aEy7+9Pthw8efjqd7B7cz8/zAMCQJSBgt1IKtzIYgtvdn4u5/wZN3fvyizyYzeg0
-        y4OvbznZ8tAL/783dXsdNUlaJvwg+NP7I1BeEctAg7sVVxMKAwbkh0egPitHBoTPBzD9OWfdsL03
-        S8EfwZS5MRPIuEmiTv/faOruOeL9HPKIj4U//9P9e7u7nz7Y2d7Z39mnzj99uD3Zz/e379/befjp
-        w+lefpBN/Pn//4KpO7j3YH+Wfzrbprb3Kap7cG/74P7B7vb5ZP/h+fThw/N7D84DAEOWgIDdSinc
-        ymAIbnd/Lub+GzR178sv8mA2o9MsD76+5WTLQy8YUycqD+13d8b4bzeI2OXx2kdMI3qMWkaaq2Xe
-        UpMexvTlD28+L4u6XWel/tncXVy3JEaXhNpd6p1+NHdf88//FwSC9wZszg+PWn3ujwwInw9g+nPO
-        7WF7b5aCP4Ipc2MmkHErRp3+v9E67jvi/RzyiI+FP//Z3r3dvZ2DfYqSHtD83ydzMskf3N9+8OnB
-        3uzTvQfZdPbQn///T1jHB3s79x5QXoOYlxKfeyDo7Pz+9sPdg+nOg3x//8HUi4sJwJDxIGC3Ugq3
-        sjGC292fi7n/Bq3j+/KLPJjN6DTLg69vOdny0AsbrN3/lwNB+aRY7XeUJOmY8IPgT++PQHVF7AIN
-        7VY8TWwzYD5+eOTpM3JkQPh8ANOfc8YN23uzFPwRTJkbM4GMGyTq9OfM0OEHffhL/h98iW8e8xsA
-        AA==
+        6UeXWbnOP3qUfg9/pSl/iOejZbbA5x+Vk92PRvbTYobP7jbrSTOti1VbVMvm7r2d/fzg4cNPtx88
+        OJ9s73+aH2xPslm2ff/+g093du8/3J/k+3frvKnW9TT/vK7Wq+ZuOakv7q7q6rKY5XVz94tiWldN
+        dd6OX+TtVVW/vVtW2exJVmbLKb4Pscjb7AJ4fPfu7/vR9P75/qf3P93fvrc/mW7vP3gw287u7e1u
+        39uZTg7uP9if7t3b/X0/8l5ur1c8sBu69N4oq2mGkeKtq7xp1/6XNIZVXrdF3tDXlnzyxWXR0GvF
+        8uJ1m7Xc6ev1dJrns3zmIFBTS5u10Pfg4fmns4c7O9v3D6YPaEz5p9uT/fv3th/uzh7emz58mB18
+        +mkA4Lyulm2+nJ29PKmW58XFumaEgZJOrDwefnjsJD/3Rv4MsE6XAYZ4fi7n/u7QAO/eCvMP4Rd5
+        MJvRaZYHX99ysuWhF4pLanb28rg07PVF3s4rpvHTa5qYYhp7bT0piym9NZsRUaO4UKsf3kx18Mmb
+        uy/1E5q1j7qo/ZLwg+BP74/ve+P+aJJN39LEawcvq6rEqG/F1YTCJF/RG11C/hAJ1GflyIDw+QCm
+        P+esG7b3Zin4I5gyN2YC+WpdcsffC5pQp5PIx8VyUq2XsxdZG3+tWrebGzgATFj+3nyt6P4SbW8p
+        4fHLniPezyGP+Fj48/8we/CQpnmyPZncy7aJB7Lt7NN8b3v28NPdB/t7e/c/ffjQn///L5i63Yzs
+        2fn+w+3s/N4ujWlvtn3wYGdCLP7p3u6n09nD+9m9AMCQJSBgt1IKtzIYgtvdn4u5/wZN3fvyizyY
+        zeg0y4OvbznZ8tAL/783dXsdNUlaJvwg+NP7I1BeEctAg7sVVxMKAwbkh0egPitHBoTPBzD9OWfd
+        sL03S8EfwZS5MRPIuEmiTv/faOo8rfpzyCM+Fv78793b+/Th+cGn2wf39g629/MHDykCeni+/enk
+        wcF0tjPZeZjv+PP//wVTdz472N3ZPZhuZ/cP9rf3H04PtrNsurf9cGfvfP/B/d2D+/cOAgBDloCA
+        3Uop3MpgCG53fy7m/hs0de/LL/JgNqPTLA++vuVky0MvGFMnKg/td3fG+G/3/sb2EdOIHqOWkeZq
+        mbfUpIcxffnDm8/Lom7XWal/NncX1y2J0SWhdpd6px/N3df88/8FgeC9AZvzw6NWn/sjA8LnA5j+
+        nHN72N6bpeCPYMrcmAlk3IpRp/9vtI77jng/hzziY+HP/+7OzkGW33uwnVGAtL2fPaD84IPpve2d
+        yb1P78327k/2z4P5//+Cdbw33ZvOpge72/f3H+bb+/cm97Yn03s0sHvZ9NP704fn9x9kAYAh40HA
+        bqUUbmVjBLe7Pxdz/w1ax/flF3kwm9Fplgdf33Ky5aEXNli7/y8HgvJJsdrvKEnSMeEHwZ/eH4Hq
+        itgFGtqteJrYZsB8/PDI02fkyIDw+QCmP+eMG7b3Zin4I5gyN2YCGTdI1OnPmaHDD/rwl/w/e9y7
+        W/MbAAA=
     headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 05 Jul 2016 16:06:48 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Jul 2016 19:55:31 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3NzMzOTMzLCJuYmYiOjE0Njc3MzM5MzMsImV4cCI6MTQ2NzczNzgzMywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.BUDdfJ1dId87f2nq-tcfBimD9x9tzkoqBw1mzP7QLokzQj_kNi-M-jGa8mASe6Uovd8xqpZrmTzosIQ7WumM3yhrtZ-q4NyvuPswzhb2dwl3Bb3-MlaLDa1g3Uu4HDDquR_KoQREWI6FEghmlGi3UcmoVdX9ODWlLl89FiSp_fJlDNvgzD0kDhGWq8lO9AgcsNexZR6DOthAfcCYLLatsYcZqxL3Ax0t2QMvY5CXvS8GXsnoIupcAwghPfCg0yqtw7_1RSMEXSXTLiyHKJI149R7wqmaVFvG42x3b09pvW9p9X2qCOhfF7rEohqv1u29NaQMJHYanY0kGjvsw9IRww]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY4MDA1NTg0LCJuYmYiOjE0NjgwMDU1ODQsImV4cCI6MTQ2ODAwOTQ4NCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.t9b-B1_IK7NClFfXkGsEL-eUnIKdzD3jA8BuOul0S-aQAuyjiDup1OE6HuIBWH7bEFdqa-kLA7tQ4TxT_TYs5Es2Ocmij2O66Ppq4dmZfMCMAuFIJ6UEdnj67OFk1Z4zsPJbsaE4btRXsz-DOl3gEisQ--xbYjXmZlgz_cY1FihQpLUPLcStSYkSnReQ6QbUME2IL_TMHk6poiC_vK8u7qwvvVdXWALeSOr4zSeVpvW33X3WFz4_Ryy3nMd9nyoMF7tgSHn-O1wqQWk-K5fda9zYH4QiawN-bp0hCmQbFOSETlbddm_E_ZuCcc2ZPi3q242Qy7R1ivSJl_sxU69Big]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [7a8ba764-42ca-11e6-8daa-a0b3ccf7272a]
+      x-ms-client-request-id: [ee46dbde-4545-11e6-8351-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -1024,73 +997,73 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpP64u6qri6LWV43d78opnXVVOft+EXeXlX127tllc2e
-        ZGW2nOJ7h0HeZhfA4bt3f9+P9vLZdOfTe+fb0/3Jwfb++e7+9sGns0+3Z/fo7/uT2fT+/fz3/Uhf
-        bK9XPJgbutLWZTXNMDq8cZU37dp8QTiv8rot8oa+YjLJh5dFQ82L5cXrNmu5o9fr6TTPZ/lM3qRm
-        lgZroWP28B6R7NNse//hp59u708n59vZfv5wezb59MH9+w/ou3v37cvndbVs8+Xs7OVJtTwvLtY1
-        Iwg0vidNUoMPHjt5z73RPQOM06XFCM/P5ZzeHRrU3Rux/rp8IA9mrDeN8uCrW0ymPNS4uKQmZy+P
-        S8MyX+TtvGKaPr2mSSim3VfWk7KY0huzGRGw1z+1+OHNSAeXvLn7Uj+h2fnIR+uXuD/sr/rL93V8
-        H02y6VuaTAX2sqpKjG4jd1I3k3xFLX0i/RAJ0GfJyCDweQTLnzMWdG11BuwvdircuAjEq3XJnXzP
-        fk0dTDofFctJtV7OXmRtv3m1boe/dC8ysfg7fEUo/ZL/B7fGAthIBgAA
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7v3dvbzg4cPP91+8OB8sr3/aX6wPclm2fb9
+        +w8+3dm9/3B/ku/frfOmWtfT/PO6Wq+au+Wkvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43mGQt9kFcPju3d/3o+n98/1P73+6v31vfzLd3n/wYLad3dvb3b63M50c3H+wP927t/v7
+        fqQvttcrHswNXWnrsppmGB3euMqbdm2+IJxXed0WeUNfMZnkw8uioebF8uJ1m7Xc0ev1dJrns3wm
+        b1IzS4O10PHg4fmns4c7O9v3D6YPCP/80+3J/v172w93Zw/vTR8+zA4+/dS+fF5XyzZfzs5enlTL
+        8+JiXTOCQON70iQ1+OCxk/fcG90zwDhdWozw/FzO6d2hQd29EeuvywfyYMZ60ygPvrrFZMpDjYtL
+        anL28rg0LPNF3s4rpunTa5qEYtp9ZT0piym9MZsRAXv9U4sf3ox0cMmbuy/1E5qdj3y0fon7w/6q
+        v3xfx/fRJJu+pclUYC+rqsToNnIndTPJV9TSJ9IPkQB9lowMAp9HsPw5Y0HXVmfA/mKnwo2LQLxa
+        l9zJ9+zX1MGk81GxnFTr5exF1vabV+t2+Ev3IhOLv8NXhNIv+X8Akghm0UgGAAA=
     headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 05 Jul 2016 16:06:50 GMT']
-      ETag: [W/"2edc063f-c4b8-4f14-86d6-d34b85bdc55e"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Jul 2016 19:55:33 GMT']
+      etag: [W/"c5f46564-34bc-477d-a321-30cb8574c231"]
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3NzMzOTMzLCJuYmYiOjE0Njc3MzM5MzMsImV4cCI6MTQ2NzczNzgzMywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.BUDdfJ1dId87f2nq-tcfBimD9x9tzkoqBw1mzP7QLokzQj_kNi-M-jGa8mASe6Uovd8xqpZrmTzosIQ7WumM3yhrtZ-q4NyvuPswzhb2dwl3Bb3-MlaLDa1g3Uu4HDDquR_KoQREWI6FEghmlGi3UcmoVdX9ODWlLl89FiSp_fJlDNvgzD0kDhGWq8lO9AgcsNexZR6DOthAfcCYLLatsYcZqxL3Ax0t2QMvY5CXvS8GXsnoIupcAwghPfCg0yqtw7_1RSMEXSXTLiyHKJI149R7wqmaVFvG42x3b09pvW9p9X2qCOhfF7rEohqv1u29NaQMJHYanY0kGjvsw9IRww]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY4MDA1NTg0LCJuYmYiOjE0NjgwMDU1ODQsImV4cCI6MTQ2ODAwOTQ4NCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.t9b-B1_IK7NClFfXkGsEL-eUnIKdzD3jA8BuOul0S-aQAuyjiDup1OE6HuIBWH7bEFdqa-kLA7tQ4TxT_TYs5Es2Ocmij2O66Ppq4dmZfMCMAuFIJ6UEdnj67OFk1Z4zsPJbsaE4btRXsz-DOl3gEisQ--xbYjXmZlgz_cY1FihQpLUPLcStSYkSnReQ6QbUME2IL_TMHk6poiC_vK8u7qwvvVdXWALeSOr4zSeVpvW33X3WFz4_Ryy3nMd9nyoMF7tgSHn-O1wqQWk-K5fda9zYH4QiawN-bp0hCmQbFOSETlbddm_E_ZuCcc2ZPi3q242Qy7R1ivSJl_sxU69Big]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [7b6405ee-42ca-11e6-99a3-a0b3ccf7272a]
+      x-ms-client-request-id: [ee83bdd1-4545-11e6-85d6-001dd8b7c0ad]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/006c6770-aab5-4caa-a93e-22b7958124db?api-version=2016-03-30']
-      Cache-Control: [no-cache]
-      Content-Length: ['0']
-      Date: ['Tue, 05 Jul 2016 16:06:50 GMT']
-      Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/006c6770-aab5-4caa-a93e-22b7958124db?api-version=2016-03-30']
-      Pragma: [no-cache]
-      Retry-After: ['10']
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Network/locations/westus/operations/703a35ba-69d7-49e9-8130-93cccd0158cc?api-version=2016-03-30']
+      cache-control: [no-cache]
+      content-length: ['0']
+      date: ['Fri, 08 Jul 2016 19:55:34 GMT']
+      expires: ['-1']
+      location: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Network/locations/westus/operationResults/703a35ba-69d7-49e9-8130-93cccd0158cc?api-version=2016-03-30']
+      pragma: [no-cache]
+      retry-after: ['10']
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 202, message: Accepted}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3NzMzOTMzLCJuYmYiOjE0Njc3MzM5MzMsImV4cCI6MTQ2NzczNzgzMywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.BUDdfJ1dId87f2nq-tcfBimD9x9tzkoqBw1mzP7QLokzQj_kNi-M-jGa8mASe6Uovd8xqpZrmTzosIQ7WumM3yhrtZ-q4NyvuPswzhb2dwl3Bb3-MlaLDa1g3Uu4HDDquR_KoQREWI6FEghmlGi3UcmoVdX9ODWlLl89FiSp_fJlDNvgzD0kDhGWq8lO9AgcsNexZR6DOthAfcCYLLatsYcZqxL3Ax0t2QMvY5CXvS8GXsnoIupcAwghPfCg0yqtw7_1RSMEXSXTLiyHKJI149R7wqmaVFvG42x3b09pvW9p9X2qCOhfF7rEohqv1u29NaQMJHYanY0kGjvsw9IRww]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY4MDA1NTg0LCJuYmYiOjE0NjgwMDU1ODQsImV4cCI6MTQ2ODAwOTQ4NCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.t9b-B1_IK7NClFfXkGsEL-eUnIKdzD3jA8BuOul0S-aQAuyjiDup1OE6HuIBWH7bEFdqa-kLA7tQ4TxT_TYs5Es2Ocmij2O66Ppq4dmZfMCMAuFIJ6UEdnj67OFk1Z4zsPJbsaE4btRXsz-DOl3gEisQ--xbYjXmZlgz_cY1FihQpLUPLcStSYkSnReQ6QbUME2IL_TMHk6poiC_vK8u7qwvvVdXWALeSOr4zSeVpvW33X3WFz4_Ryy3nMd9nyoMF7tgSHn-O1wqQWk-K5fda9zYH4QiawN-bp0hCmQbFOSETlbddm_E_ZuCcc2ZPi3q242Qy7R1ivSJl_sxU69Big]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [7b6405ee-42ca-11e6-99a3-a0b3ccf7272a]
+      x-ms-client-request-id: [ee83bdd1-4545-11e6-85d6-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/006c6770-aab5-4caa-a93e-22b7958124db?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/703a35ba-69d7-49e9-8130-93cccd0158cc?api-version=2016-03-30
   response:
     body:
       string: !!binary |
@@ -1098,29 +1071,29 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UdNm7Xr5qNH6Uev19Npns/y2Ue/cfJL/h9PlJBHHQAAAA==
     headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 05 Jul 2016 16:07:00 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Jul 2016 19:55:44 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3NzMzOTMzLCJuYmYiOjE0Njc3MzM5MzMsImV4cCI6MTQ2NzczNzgzMywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.BUDdfJ1dId87f2nq-tcfBimD9x9tzkoqBw1mzP7QLokzQj_kNi-M-jGa8mASe6Uovd8xqpZrmTzosIQ7WumM3yhrtZ-q4NyvuPswzhb2dwl3Bb3-MlaLDa1g3Uu4HDDquR_KoQREWI6FEghmlGi3UcmoVdX9ODWlLl89FiSp_fJlDNvgzD0kDhGWq8lO9AgcsNexZR6DOthAfcCYLLatsYcZqxL3Ax0t2QMvY5CXvS8GXsnoIupcAwghPfCg0yqtw7_1RSMEXSXTLiyHKJI149R7wqmaVFvG42x3b09pvW9p9X2qCOhfF7rEohqv1u29NaQMJHYanY0kGjvsw9IRww]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY4MDA1NTg0LCJuYmYiOjE0NjgwMDU1ODQsImV4cCI6MTQ2ODAwOTQ4NCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.t9b-B1_IK7NClFfXkGsEL-eUnIKdzD3jA8BuOul0S-aQAuyjiDup1OE6HuIBWH7bEFdqa-kLA7tQ4TxT_TYs5Es2Ocmij2O66Ppq4dmZfMCMAuFIJ6UEdnj67OFk1Z4zsPJbsaE4btRXsz-DOl3gEisQ--xbYjXmZlgz_cY1FihQpLUPLcStSYkSnReQ6QbUME2IL_TMHk6poiC_vK8u7qwvvVdXWALeSOr4zSeVpvW33X3WFz4_Ryy3nMd9nyoMF7tgSHn-O1wqQWk-K5fda9zYH4QiawN-bp0hCmQbFOSETlbddm_E_ZuCcc2ZPi3q242Qy7R1ivSJl_sxU69Big]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [81fcc1a2-42ca-11e6-a590-a0b3ccf7272a]
+      x-ms-client-request-id: [f51e4340-4545-11e6-b688-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbrg/providers/Microsoft.Network/loadBalancers?api-version=2016-03-30
   response:
@@ -1128,32 +1101,33 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UeXWbnOP3qUfg9/pSl/iOejZbbA5x+Vk72PRvbTYobP7jbrSTOti1VbVMvm7s5k9/zT/Qe727uT
-        853t/dks287y6b3t6eTh3oO9852H9x/u3K3zplrX0/zzulqvmrvlpL64u6qry2KW183dL4ppXTXV
-        eTt+kbdXVf32blllsydZmS2n+D7EIm+zC+Dx3bu/70efPtyd3b+3e7C9uzd7sL2fZ/n25P7ep9uT
-        /Hz34eRgd3+2c+/3/ch7ub1e8cBu6NJ7o6ymGUaKt67ypl37X9IYVnndFnlDX1vyyReXRUOvFcuL
-        123Wcqev19Npns/ymYNATS1t1kLf6c7De+fnB/e27z3EmHbu0Zh296fbDx88/HQ62T24n5/nAYDz
-        ulq2+XJ29vKkWp4XF+uaEQZKOrHyePjhsZP83Bv5M8A6XQYY4vm5nPu7QwO8eyvMP4Rf5MFsRqdZ
-        Hnx9y8mWh14oLqnZ2cvj0rDXF3k7r5jGT69pYopp7LX1pCym9NZsRkSN4kKtfngz1cEnb+6+1E9o
-        1j7qovZLwg+CP70/vu+N+6NJNn1LE68dvKyqEqO+FVcTCpN8RW90CflDJFCflSMDwucDmP6cs27Y
-        3pul4I9gytyYCeSrdckdfy9oQp1OIh8Xy0m1Xs5eZG38tWrdbm7gADBh+XvztaL7S7S9pYTHL/cc
-        8X4OecTHwp//6f693d1PH+xs7+zv7FPnnz7cnuzn+9v37+08/PThdC8/yCb+/P9/wdQd3HuwP8s/
-        nW1T2/vb+9MH97YP7h/sbp9P9h+eTx8+PL/34DwAMGQJCNitlMKtDIbgdvfnYu6/QVP3vvwiD2Yz
-        Os3y4OtbTrY89IIxdaLy0H53Z4z/du9vbB8xjegxahlprpZ5S016GNOXP7z5vCzqdp2V+mdzd3Hd
-        khhdEmp3qXf60dx9zT93O5qVFFP4QfCn90eg7yLGhEZ6K0EgXhuwOT88avW5PzIgfD6A6c85t4ft
-        vVkK/gimzI2ZQMatGHX6/0bruO+I93PIIz4W/vxne/d293YO9ilKekDzf5/MySR/cH/7wacHe7NP
-        9x5k09lDf/7/P2EdH+zt3HswOdgm5s229/dA0Nn5/e2HuwfTnQf5/v6DqRcXE4Ah40HAbqUUbmVj
-        BLe7Pxdz/w1ax/flF3kwm9Fplgdf33Ky5aEXNli7/y8HgvJJsdrvKEnSMeEHwZ/eH4HqitgFGtqt
-        eJrYZsB8/PDI02fkyIDw+QCmP+eMG7b3Zin4I5gyN2YCGTdI1OnPmaHDD/rwl/w/Qncd0ggVAAA=
+        6UeXWbnOP3qUfg9/pSl/iOejZbbA5x+Vk72PRvbTYobP7jbrSTOti1VbVMvm7r2d/fzg4cNPtx88
+        OJ9s73+aH2xPslm2ff/+g093du8/3J/k+3frvKnW9TT/vK7Wq+ZuOakv7q7q6rKY5XVz94tiWldN
+        dd6OX+TtVVW/vVtW2exJVmbLKb4Pscjb7AJ4fPfu7/vRw+zBw/sP9ifbk8m9bHt/Ms22s0/zve3Z
+        w093H+zv7d3/9OHD3/cj7+X2esUDu6FL742ymmYYKd66ypt27X9JY1jldVvkDX1tySdfXBYNvVYs
+        L163Wcudvl5Pp3k+y2cOAjW1tFkLfXez6cOH5/sPt7Pze7s0pr3Z9sGDncn2vf1P93Y/nc4e3s/u
+        BQDO62rZ5svZ2cuTanleXKxrRhgo6cTK4+GHx07yc2/kzwDrdBlgiOfncu7vDg3w7q0w/xB+kQez
+        GZ1mefD1LSdbHnqhuKRmZy+PS8NeX+TtvGIaP72miSmmsdfWk7KY0luzGRE1igu1+uHNVAefvLn7
+        Uj+hWfuoi9ovCT8I/vT++L437o8m2fQtTbx28LKqSoz6VlxNKEzyFb3RJeQPkUB9Vo4MCJ8PYPpz
+        zrphe2+Wgj+CKXNjJpCv1iV3/L2gCXU6iXxcLCfVejl7kbXx16p1u7mBA8CE5e/N14ruL9H2lhIe
+        v3ha9eeQR3ws/Pnfu7f36cPzg0+3D+7tHWzv5w8ebk/2H55vfzp5cDCd7Ux2HuY7/vz/f8HUnc8O
+        dnd2D6bb2f2D/e39h9OD7Syb7m0/3Nk7339wf/fg/r2DAMCQJSBgt1IKtzIYgtvdn4u5/wZN3fvy
+        izyYzeg0y4OvbznZ8tALxtSJykP73Z0x/tu9v7F9xDSix6hlpLla5i016WFMX/7w5vOyqNt1Vuqf
+        zd3FdUtidEmo3aXe6Udz9zX/3O1oVlJM4QfBn94fgb6LGBMa6a0EgXhtwOb88KjV5/7IgPD5AKY/
+        59wetvdmKfgjmDI3ZgIZt2LU6f8breO+I97PIY/4WPjzv7uzc5Dl9x5sZxQgbe9nDz7dnjyY3tve
+        mdz79N5s7/5k/zyY//8vWMd7073pbHqwu31//2G+vX9vcm97Mr1HA7uXTT+9P314fv9BFgAYMh4E
+        7FZK4VY2RnC7+3Mx99+gdXxffpEHsxmdZnnw9S0nWx56YYO1+/9yICifFKv9jpIkHRN+EPzp/RGo
+        rohdoKHdiqeJbQbMxw+PPH1GjgwInw9g+nPOuGF7b5aCP4Ipc2MmkHGDRJ3+nBk6/KAPf8n/Ay2L
+        EKsIFQAA
     headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 05 Jul 2016 16:07:01 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 08 Jul 2016 19:55:44 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/test_network_commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/test_network_commands.py
@@ -185,7 +185,7 @@ class NetworkLoadBalancerScenarioTest(ResourceGroupVCRTestBase):
 
     def body(self):
         # test lb create with min params (new ip)
-        self.cmd('network lb create -n {} -g {}'.format(self.lb_name, self.resource_group), checks=[
+        self.cmd('network lb create -n {}1 -g {}'.format(self.lb_name, self.resource_group), checks=[
             JMESPathCheck('loadBalancer.frontendIPConfigurations[0].properties.privateIPAllocationMethod', 'Dynamic'),
             JMESPathCheck('loadBalancer.frontendIPConfigurations[0].resourceGroup', self.resource_group)
         ])

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -18,7 +18,9 @@ from azure.cli.command_modules.vm._actions import (VMImageFieldAction,
                                                    _handle_vm_nics,
                                                    PrivateIpAction,
                                                    _resource_not_exists,
-                                                   _os_disk_default)
+                                                   _os_disk_default,
+                                                   _find_default_vnet,
+                                                   _find_default_storage_account)
 from azure.cli.commands.parameters import (location_type,
                                            get_location_completion_list,
                                            get_one_of_subscription_locations,
@@ -159,8 +161,8 @@ for scope in ['vm create', 'vm scaleset create']:
     register_cli_argument(scope, 'private_ip_address', help='Static private IP address (e.g. 10.0.0.5).', options_list=('--private-ip-address',), action=PrivateIpAction)
     register_cli_argument(scope, 'public_ip_address_allocation', CliArgumentType(choices=['dynamic', 'static'], help='', default='dynamic', type=str.lower))
     register_folded_cli_argument(scope, 'public_ip_address', 'Microsoft.Network/publicIPAddresses', help='Name or ID of public IP address (creates if doesn\'t exist)')
-    register_folded_cli_argument(scope, 'storage_account', 'Microsoft.Storage/storageAccounts', help='Name or ID of storage account (creates if doesn\'t exist)')
-    register_folded_cli_argument(scope, 'virtual_network', 'Microsoft.Network/virtualNetworks', help='Name or ID of virtual network (creates if doesn\'t exist)', options_list=('--vnet',))
+    register_folded_cli_argument(scope, 'storage_account', 'Microsoft.Storage/storageAccounts', help='Name or ID of storage account (creates if doesn\'t exist).  Chooses an existing storage account if none specified.', validator=_find_default_storage_account)
+    register_folded_cli_argument(scope, 'virtual_network', 'Microsoft.Network/virtualNetworks', help='Name or ID of virtual network (creates if doesn\'t exist).  Chooses an existing VNet if none specified.', options_list=('--vnet',), validator=_find_default_vnet)
     register_folded_cli_argument(scope, 'network_security_group', 'Microsoft.Network/networkSecurityGroups', help='Name or ID of network security group (creates if doesn\'t exist)', options_list=('--nsg',))
     register_cli_argument(scope, 'network_security_group_rule', nsg_rule_type, options_list=('--nsg-rule',))
     register_extra_cli_argument(scope, 'image', options_list=('--image',), action=VMImageFieldAction, completer=get_urn_aliases_completion_list, default='Win2012R2Datacenter')

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_create_custom_ip.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_create_custom_ip.yaml
@@ -4,11 +4,11 @@ interactions:
     headers:
       Connection: [close]
       Host: [raw.githubusercontent.com]
-      User-Agent: [Python-urllib/2.7]
+      User-Agent: [Python-urllib/3.5]
     method: GET
     uri: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json
   response:
-    body: {string: !!python/unicode "{\n  \"$schema\":\"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json\"\
+    body: {string: "{\n  \"$schema\":\"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json\"\
         ,\n  \"contentVersion\":\"1.0.0.0\",\n  \"parameters\":{},\n  \"variables\"\
         :{},\n  \"resources\":[],\n\n  \"outputs\":{\n    \"aliases\":{\n      \"\
         metadata\":{\n        \"description\":\"This list of aliases is used by Azure\
@@ -45,43 +45,107 @@ interactions:
         \     \"version\":\"latest\"\n          }\n        }\n      }\n    }\n  }\n\
         }\n"}
     headers:
-      accept-ranges: [bytes]
-      access-control-allow-origin: ['*']
-      cache-control: [max-age=300]
-      connection: [close]
-      content-length: ['2297']
-      content-security-policy: [default-src 'none'; style-src 'unsafe-inline']
-      content-type: [text/plain; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:28:19 GMT']
-      etag: ['"db78eb36618a060181b32ac2de91b1733f382e01"']
-      expires: ['Wed, 06 Jul 2016 18:33:19 GMT']
-      source-age: ['1']
-      strict-transport-security: [max-age=31536000]
-      vary: ['Authorization,Accept-Encoding']
-      via: [1.1 varnish]
-      x-cache: [HIT]
-      x-cache-hits: ['1']
-      x-content-type-options: [nosniff]
-      x-fastly-request-id: [83669b800fff1c52108805db11a7bdcd48db2bec]
-      x-frame-options: [deny]
-      x-geo-block-list: ['']
-      x-github-request-id: ['C71B4F14:5AD4:50AE121:577D4DC1']
-      x-served-by: [cache-lax1425-LAX]
-      x-xss-protection: [1; mode=block]
+      Accept-Ranges: [bytes]
+      Access-Control-Allow-Origin: ['*']
+      Cache-Control: [max-age=300]
+      Connection: [close]
+      Content-Length: ['2297']
+      Content-Security-Policy: [default-src 'none'; style-src 'unsafe-inline']
+      Content-Type: [text/plain; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:42:13 GMT']
+      ETag: ['"db78eb36618a060181b32ac2de91b1733f382e01"']
+      Expires: ['Thu, 07 Jul 2016 19:47:13 GMT']
+      Source-Age: ['104']
+      Strict-Transport-Security: [max-age=31536000]
+      Vary: ['Authorization,Accept-Encoding']
+      Via: [1.1 varnish]
+      X-Cache: [HIT]
+      X-Cache-Hits: ['1']
+      X-Content-Type-Options: [nosniff]
+      X-Fastly-Request-ID: [6cd705be2d944c72eda66bb6d292f70520a98163]
+      X-Frame-Options: [deny]
+      X-Geo-Block-List: ['']
+      X-GitHub-Request-Id: ['17EB2F14:5AD4:5836B6B:577EB02D']
+      X-Served-By: [cache-sjc3131-SJC]
+      X-XSS-Protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI2MTE1LCJuYmYiOjE0Njc4MjYxMTUsImV4cCI6MTQ2NzgzMDAxNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.BsXPjbpDDitiOiqCh89LqEkRNwGth9IsXslnNhFEHJBysUJjzEBeOZaEwQCAZtLOO2DLZkoTvDZ2ddXEfZ3XNXS4wSAj2Hf0L0-d3gbP7mvzGpcZIsAH4eUlfX8LoGuQt4MyBNPH1pfTfNJYTMOFAsnsy3vPjr6qVj8butsv2XpDhPrDGRTE7WrgCBF-I7OfWqeiej_zc3ZKEXneOgxc6IbWGBqmUfM8SyLh48O2a_hoEs1KciA4AKt77zbsCbqrnbHdNadvVTDvkM-ToYNzgjWXp6kcW13cwS_roFV3Afz3YNB61ICCYog45D3uATmoKVE9BCZkrwCGrljteh9djw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e73e6b8a-447a-11e6-b9d9-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Network/virtualnetworks?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS97/+S/wdC6kBEDAAAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['133']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:42:15 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 storagemanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e827a326-447a-11e6-92a3-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Storage/storageAccounts?api-version=2016-01-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS97/+S5P8BxWZBqg0AAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Thu, 07 Jul 2016 19:42:15 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 resourcemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [6974558f-43a7-11e6-8e08-001dd8b7c0ad]
+      x-ms-client-request-id: [e869b8b6-447a-11e6-add1-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27vm_create_custom_ip_rg3%27%20and%20name%20eq%20%27vrfvmz%27%20and%20resourceType%20eq%20%27Microsoft.Compute%2FvirtualMachines%27
   response:
@@ -91,74 +155,96 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
         uc4/evS97/+S/wdC6kBEDAAAAA==
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['133']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:28:18 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['133']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:42:17 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30/azuredeploy.json"},
-      "mode": "Incremental", "parameters": {"osSKU": {"value": "13.2"}, "publicIpAddressAllocation":
-      {"value": "static"}, "authenticationType": {"value": "ssh"}, "osDiskType": {"value":
-      "provided"}, "storageType": {"value": "Premium_LRS"}, "dnsNameType": {"value":
-      "new"}, "subnetIpAddressPrefix": {"value": "10.0.0.0/24"}, "adminUsername":
-      {"value": "burtbiel"}, "networkInterfaceType": {"value": "new"}, "privateIpAddress":
-      {"value": "10.0.0.5"}, "_artifactsLocation": {"value": "https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30"},
-      "osType": {"value": "Custom"}, "sshKeyValue": {"value": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
-      test@example.com\n"}, "osVersion": {"value": "latest"}, "customOsDiskType":
-      {"value": "windows"}, "virtualNetworkIpAddressPrefix": {"value": "10.0.0.0/16"},
-      "name": {"value": "vrfvmz"}, "dnsNameForPublicIP": {"value": "vrfmyvm00110011z"},
-      "storageCaching": {"value": "ReadWrite"}, "networkSecurityGroupRule": {"value":
-      "SSH"}, "storageContainerName": {"value": "vhds"}, "osOffer": {"value": "openSUSE"},
-      "osPublisher": {"value": "SUSE"}, "privateIpAddressAllocation": {"value": "static"},
-      "size": {"value": "Standard_DS1"}, "osDiskName": {"value": "osdisk1467829699"}}}}'
+    body: !!binary |
+      eyJwcm9wZXJ0aWVzIjogeyJ0ZW1wbGF0ZUxpbmsiOiB7InVyaSI6ICJodHRwczovL2F6dXJlc2Rr
+      Y2kuYmxvYi5jb3JlLndpbmRvd3MubmV0L3RlbXBsYXRlaG9zdC9DcmVhdGVWbV8yMDE2LTA2LTMw
+      L2F6dXJlZGVwbG95Lmpzb24ifSwgIm1vZGUiOiAiSW5jcmVtZW50YWwiLCAicGFyYW1ldGVycyI6
+      IHsiYXV0aGVudGljYXRpb25UeXBlIjogeyJ2YWx1ZSI6ICJzc2gifSwgIm5ldHdvcmtTZWN1cml0
+      eUdyb3VwUnVsZSI6IHsidmFsdWUiOiAiU1NIIn0sICJvc09mZmVyIjogeyJ2YWx1ZSI6ICJvcGVu
+      U1VTRSJ9LCAic3RvcmFnZUNhY2hpbmciOiB7InZhbHVlIjogIlJlYWRXcml0ZSJ9LCAibmV0d29y
+      a0ludGVyZmFjZVR5cGUiOiB7InZhbHVlIjogIm5ldyJ9LCAib3NEaXNrTmFtZSI6IHsidmFsdWUi
+      OiAib3NkaXNrMTQ2NzkyMDUzOCJ9LCAibmFtZSI6IHsidmFsdWUiOiAidnJmdm16In0sICJkbnNO
+      YW1lRm9yUHVibGljSVAiOiB7InZhbHVlIjogInZyZm15dm0wMDExMDAxMXoifSwgInB1YmxpY0lw
+      QWRkcmVzc0FsbG9jYXRpb24iOiB7InZhbHVlIjogInN0YXRpYyJ9LCAicHJpdmF0ZUlwQWRkcmVz
+      cyI6IHsidmFsdWUiOiAiMTAuMC4wLjUifSwgImFkbWluVXNlcm5hbWUiOiB7InZhbHVlIjogImJ1
+      cnRiaWVsIn0sICJ2aXJ0dWFsTmV0d29ya0lwQWRkcmVzc1ByZWZpeCI6IHsidmFsdWUiOiAiMTAu
+      MC4wLjAvMTYifSwgIm9zUHVibGlzaGVyIjogeyJ2YWx1ZSI6ICJTVVNFIn0sICJzdG9yYWdlVHlw
+      ZSI6IHsidmFsdWUiOiAiUHJlbWl1bV9MUlMifSwgInN0b3JhZ2VDb250YWluZXJOYW1lIjogeyJ2
+      YWx1ZSI6ICJ2aGRzIn0sICJwcml2YXRlSXBBZGRyZXNzQWxsb2NhdGlvbiI6IHsidmFsdWUiOiAi
+      c3RhdGljIn0sICJjdXN0b21Pc0Rpc2tUeXBlIjogeyJ2YWx1ZSI6ICJ3aW5kb3dzIn0sICJkbnNO
+      YW1lVHlwZSI6IHsidmFsdWUiOiAibmV3In0sICJzdWJuZXRJcEFkZHJlc3NQcmVmaXgiOiB7InZh
+      bHVlIjogIjEwLjAuMC4wLzI0In0sICJzaXplIjogeyJ2YWx1ZSI6ICJTdGFuZGFyZF9EUzEifSwg
+      Il9hcnRpZmFjdHNMb2NhdGlvbiI6IHsidmFsdWUiOiAiaHR0cHM6Ly9henVyZXNka2NpLmJsb2Iu
+      Y29yZS53aW5kb3dzLm5ldC90ZW1wbGF0ZWhvc3QvQ3JlYXRlVm1fMjAxNi0wNi0zMCJ9LCAib3NW
+      ZXJzaW9uIjogeyJ2YWx1ZSI6ICJsYXRlc3QifSwgIm9zVHlwZSI6IHsidmFsdWUiOiAiQ3VzdG9t
+      In0sICJzc2hLZXlWYWx1ZSI6IHsidmFsdWUiOiAic3NoLXJzYSBBQUFBQjNOemFDMXljMkVBQUFB
+      REFRQUJBQUFDQVFDYklnMWd1UkhiSTBsVjExd1dEdDFyMmNVZGNOZDI3Q0pzZytTZmdDN21pWmV1
+      YnR3VWhic1BkaE1Rc2ZEeWhPV0hxMStaTDBNK25KWlY2M2QvMWRobWh0Z3lPcWVqVXdyUGx6S2h5
+      ZHNicnNkVW9yK0ptTkpEZFcwMXY3QlhIeXV5bVQ4RzRzMDlqQ2FzTk93aXVmYlAvcXA3MnJ1dTBi
+      SUExbnlTc3ZsZjlwQ1FBdUZrQW5WbmYvckZoVWxPa2h0UnB3Y3E4U1VOWTJ6UkhSL0VLYi80TldZ
+      MUp6UjRzYTNxMmZXSUpkcnJYMER2TG9hNWc5YklFZDREZjc5YmE3dit5aVVCT1MwelQybGwrejRn
+      OWl6SEszRU81ZDhoTDRqWXhjaktzK3djc2xTWVJXcmFzY2ZzY0xnTWxNR2gwQ2RLZU5URGpIcEdQ
+      bmNhZjNaK0Z3d3dqV2V1aU5CeHY3YkpvMTMvOEIvMDk4S2xWRGw0R1pxc29CQ0VqUHlKZlY2aE8w
+      eS9Ma1JHa2s3b0hXS2dlV0FmS3RmTEl0UnAwMGVaNGZjSk5LOWtDYVNNbUV1Z29aV2NJN05HYlpY
+      enFGV3FicFJJN05jRFA5K1dJUStpOVU1dnFXc3FkL3puZzRrYnVBSjZVdUtxSXpCMHVwWXJMU2hm
+      UUUzU0FjazhvYUxoSnFxcTU2VmZEdUFTTnBKS2lkVit6cTI3SGZTQm1iWG5rUi81QUszMzdkYzNN
+      WEtKeXBvSy9RUE1MS1VBUDVYTFBicytOZGRKUVY3RVpYZDI5RExncCtmUklnM2VkcEtkTzdaRXJX
+      aHY3ZCszS3dzK2UxWSt5cG1SMldJVlN3VnlCRVVmZ3YyQzhUczlnblRGNHBOY0VZL1MyYUJpY3o1
+      RXcyK2pkeUdOUVE9PSB0ZXN0QGV4YW1wbGUuY29tXG4ifSwgIm9zU0tVIjogeyJ2YWx1ZSI6ICIx
+      My4yIn0sICJvc0Rpc2tUeXBlIjogeyJ2YWx1ZSI6ICJwcm92aWRlZCJ9fX19
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI2MTE1LCJuYmYiOjE0Njc4MjYxMTUsImV4cCI6MTQ2NzgzMDAxNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.BsXPjbpDDitiOiqCh89LqEkRNwGth9IsXslnNhFEHJBysUJjzEBeOZaEwQCAZtLOO2DLZkoTvDZ2ddXEfZ3XNXS4wSAj2Hf0L0-d3gbP7mvzGpcZIsAH4eUlfX8LoGuQt4MyBNPH1pfTfNJYTMOFAsnsy3vPjr6qVj8butsv2XpDhPrDGRTE7WrgCBF-I7OfWqeiej_zc3ZKEXneOgxc6IbWGBqmUfM8SyLh48O2a_hoEs1KciA4AKt77zbsCbqrnbHdNadvVTDvkM-ToYNzgjWXp6kcW13cwS_roFV3Afz3YNB61ICCYog45D3uATmoKVE9BCZkrwCGrljteh9djw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Length: ['2040']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [699746e1-43a7-11e6-8e05-001dd8b7c0ad]
+      x-ms-client-request-id: [e9bf09ae-447a-11e6-a67c-001dd8b7c0ad]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/azurecli1467829698.9154663","name":"azurecli1467829698.9154663","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30"},"adminPassword":{"type":"SecureString"},"adminUsername":{"type":"String","value":"burtbiel"},"authenticationType":{"type":"String","value":"ssh"},"availabilitySet":{"type":"String","value":""},"availabilitySetType":{"type":"String","value":"none"},"customOsDiskType":{"type":"String","value":"windows"},"customOsDiskUri":{"type":"String","value":""},"dnsNameForPublicIP":{"type":"String","value":"vrfmyvm00110011z"},"dnsNameType":{"type":"String","value":"new"},"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"vrfvmz"},"networkSecurityGroup":{"type":"String","value":"vrfvmzNSG"},"networkSecurityGroupRule":{"type":"String","value":"SSH"},"networkSecurityGroupType":{"type":"String","value":"new"},"networkInterfaceIds":{"type":"Array","value":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Network/networkInterfaces/vrfvmzVMNic"}]},"networkInterfaceType":{"type":"String","value":"new"},"osDiskName":{"type":"String","value":"osdisk1467829699"},"osDiskType":{"type":"String","value":"provided"},"osDiskUri":{"type":"String","value":"https://vhdstoragelkpellvpldfzc.blob.core.windows.net/vhds/osdisk1467829699.vhd"},"osOffer":{"type":"String","value":"openSUSE"},"osPublisher":{"type":"String","value":"SUSE"},"osSKU":{"type":"String","value":"13.2"},"osType":{"type":"String","value":"Custom"},"osVersion":{"type":"String","value":"latest"},"privateIpAddress":{"type":"String","value":"10.0.0.5"},"privateIpAddressAllocation":{"type":"String","value":"static"},"publicIpAddressAllocation":{"type":"String","value":"static"},"publicIpAddress":{"type":"String","value":"vrfvmzPublicIP"},"publicIpAddressType":{"type":"String","value":"new"},"size":{"type":"String","value":"Standard_DS1"},"sshDestKeyPath":{"type":"String","value":"/home/burtbiel/.ssh/authorized_keys"},"sshKeyValue":{"type":"String","value":"ssh-rsa
+    body: {string: '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/azurecli1467920537.96001431173","name":"azurecli1467920537.96001431173","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30"},"adminPassword":{"type":"SecureString"},"adminUsername":{"type":"String","value":"burtbiel"},"authenticationType":{"type":"String","value":"ssh"},"availabilitySet":{"type":"String","value":""},"availabilitySetType":{"type":"String","value":"none"},"customOsDiskType":{"type":"String","value":"windows"},"customOsDiskUri":{"type":"String","value":""},"dnsNameForPublicIP":{"type":"String","value":"vrfmyvm00110011z"},"dnsNameType":{"type":"String","value":"new"},"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"vrfvmz"},"networkSecurityGroup":{"type":"String","value":"vrfvmzNSG"},"networkSecurityGroupRule":{"type":"String","value":"SSH"},"networkSecurityGroupType":{"type":"String","value":"new"},"networkInterfaceIds":{"type":"Array","value":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Network/networkInterfaces/vrfvmzVMNic"}]},"networkInterfaceType":{"type":"String","value":"new"},"osDiskName":{"type":"String","value":"osdisk1467920538"},"osDiskType":{"type":"String","value":"provided"},"osDiskUri":{"type":"String","value":"https://vhdstoragelkpellvpldfzc.blob.core.windows.net/vhds/osdisk1467920538.vhd"},"osOffer":{"type":"String","value":"openSUSE"},"osPublisher":{"type":"String","value":"SUSE"},"osSKU":{"type":"String","value":"13.2"},"osType":{"type":"String","value":"Custom"},"osVersion":{"type":"String","value":"latest"},"privateIpAddress":{"type":"String","value":"10.0.0.5"},"privateIpAddressAllocation":{"type":"String","value":"static"},"publicIpAddressAllocation":{"type":"String","value":"static"},"publicIpAddress":{"type":"String","value":"vrfvmzPublicIP"},"publicIpAddressType":{"type":"String","value":"new"},"size":{"type":"String","value":"Standard_DS1"},"sshDestKeyPath":{"type":"String","value":"/home/burtbiel/.ssh/authorized_keys"},"sshKeyValue":{"type":"String","value":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
-        test@example.com\n"},"storageAccount":{"type":"String","value":"vhdstoragelkpellvpldfzc"},"storageAccountType":{"type":"String","value":"new"},"storageCaching":{"type":"String","value":"ReadWrite"},"storageContainerName":{"type":"String","value":"vhds"},"storageType":{"type":"String","value":"Premium_LRS"},"subnetIpAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetName":{"type":"String","value":"vrfvmzSubnet"},"virtualNetworkIpAddressPrefix":{"type":"String","value":"10.0.0.0/16"},"virtualNetwork":{"type":"String","value":"vrfvmzVNET"},"virtualNetworkType":{"type":"String","value":"new"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-06T18:28:20.0319892Z","duration":"PT0.1739035S","correlationId":"0e4b5345-1d22-4c96-a1bb-a61cbb6c77c4","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/vrfvmzVNet","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmzVNet"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/vrfvmzNSG","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmzNSG"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/vrfvmzNicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmzNicIp"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/vrfvmzq6cn6odec2yoi","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmzq6cn6odec2yoi"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/vrfvmzNicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmzNicIp"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/vrfvmzVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmzVM"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/vrfvmzVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmzVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/vrfvmzdjjp67rc4jb2unew","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmzdjjp67rc4jb2unew"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/vrfvmzVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmzVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/vrfvmzdjjp67rc4jb2unewfqdn","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmzdjjp67rc4jb2unewfqdn"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/vrfvmzVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmzVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/vrfvmzvrfvmzVMNicmac","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmzvrfvmzVMNicmac"}]}}'}
+        test@example.com\n"},"storageAccount":{"type":"String","value":"vhdstoragelkpellvpldfzc"},"storageAccountType":{"type":"String","value":"new"},"storageCaching":{"type":"String","value":"ReadWrite"},"storageContainerName":{"type":"String","value":"vhds"},"storageType":{"type":"String","value":"Premium_LRS"},"subnetIpAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetName":{"type":"String","value":"vrfvmzSubnet"},"virtualNetworkIpAddressPrefix":{"type":"String","value":"10.0.0.0/16"},"virtualNetwork":{"type":"String","value":"vrfvmzVNET"},"virtualNetworkType":{"type":"String","value":"new"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-07T19:42:18.7069627Z","duration":"PT0.1113489S","correlationId":"71b879d1-2633-4c74-9f44-a2643cee403b","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/vrfvmzVNet","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmzVNet"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/vrfvmzNSG","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmzNSG"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/vrfvmzNicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmzNicIp"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/vrfvmzq6cn6odec2yoi","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmzq6cn6odec2yoi"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/vrfvmzNicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmzNicIp"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/vrfvmzVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmzVM"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/vrfvmzVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmzVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/vrfvmzdjjp67rc4jb2unew","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmzdjjp67rc4jb2unew"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/vrfvmzVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmzVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/vrfvmzdjjp67rc4jb2unewfqdn","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmzdjjp67rc4jb2unewfqdn"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/vrfvmzVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmzVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/vrfvmzvrfvmzVMNicmac","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmzvrfvmzVMNicmac"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/azurecli1467829698.9154663/operationStatuses/08587337771856196244?api-version=2015-11-01']
-      cache-control: [no-cache]
-      content-length: ['6965']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:28:19 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/azurecli1467920537.96001431173/operationStatuses/08587336863468820835?api-version=2015-11-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['6973']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:42:18 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1192']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [699746e1-43a7-11e6-8e05-001dd8b7c0ad]
+      x-ms-client-request-id: [e9bf09ae-447a-11e6-a67c-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771856196244?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863468820835?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -166,30 +252,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:28:51 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:42:48 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [699746e1-43a7-11e6-8e05-001dd8b7c0ad]
+      x-ms-client-request-id: [e9bf09ae-447a-11e6-a67c-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771856196244?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863468820835?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -197,30 +283,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:29:22 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:43:18 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [699746e1-43a7-11e6-8e05-001dd8b7c0ad]
+      x-ms-client-request-id: [e9bf09ae-447a-11e6-a67c-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771856196244?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863468820835?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -228,30 +314,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:29:52 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:43:48 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [699746e1-43a7-11e6-8e05-001dd8b7c0ad]
+      x-ms-client-request-id: [e9bf09ae-447a-11e6-a67c-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771856196244?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863468820835?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -259,30 +345,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:30:22 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:44:18 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [699746e1-43a7-11e6-8e05-001dd8b7c0ad]
+      x-ms-client-request-id: [e9bf09ae-447a-11e6-a67c-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771856196244?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863468820835?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -290,30 +376,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:30:52 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:44:48 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [699746e1-43a7-11e6-8e05-001dd8b7c0ad]
+      x-ms-client-request-id: [e9bf09ae-447a-11e6-a67c-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771856196244?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863468820835?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -321,30 +407,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:31:22 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:45:19 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [699746e1-43a7-11e6-8e05-001dd8b7c0ad]
+      x-ms-client-request-id: [e9bf09ae-447a-11e6-a67c-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771856196244?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863468820835?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -352,30 +438,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:31:53 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:45:49 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [699746e1-43a7-11e6-8e05-001dd8b7c0ad]
+      x-ms-client-request-id: [e9bf09ae-447a-11e6-a67c-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771856196244?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863468820835?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -383,30 +469,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:32:23 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:46:20 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [699746e1-43a7-11e6-8e05-001dd8b7c0ad]
+      x-ms-client-request-id: [e9bf09ae-447a-11e6-a67c-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771856196244?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863468820835?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -414,30 +500,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:32:54 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:46:49 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [699746e1-43a7-11e6-8e05-001dd8b7c0ad]
+      x-ms-client-request-id: [e9bf09ae-447a-11e6-a67c-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771856196244?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863468820835?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -445,30 +531,61 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:33:24 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:47:19 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [699746e1-43a7-11e6-8e05-001dd8b7c0ad]
+      x-ms-client-request-id: [e9bf09ae-447a-11e6-a67c-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771856196244?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863468820835?api-version=2015-11-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
+        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:47:50 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e9bf09ae-447a-11e6-a67c-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863468820835?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -476,28 +593,28 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['141']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:33:55 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['141']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:48:21 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [699746e1-43a7-11e6-8e05-001dd8b7c0ad]
+      x-ms-client-request-id: [e9bf09ae-447a-11e6-a67c-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_custom_ip_rg3/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
@@ -507,69 +624,69 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
         o0cf3W3Wk2ZaF6u2qJbN3Xs7+/nBw4efbj94cD7Z3v80P9ieZLNs+/79B5/u7N5/uD/J9+/WeVOt
         62n+eV2tV83dy8XvP63zrM1//+m6aavF71+sfv/64t7dVV1dFrO8bu5+UUzrqqnO2/ErfbW5O8tX
-        ZXW9yJdtczf7wbrOp2Wxu//pg4O9h58+PBg/3L2//+mn9z4afbTMFjkhurENdbXK67bIm48e/eKP
-        2nyxKgmf58XyLf5e1wUBmLftqnl0VzprZm+nxXhSVpPxtKrz8VWxnFVXzXiZt3fN6/Oqae+e8Mh+
-        cvH77+3sfrq98+n2vR2BIPiPf7qploTAtFq2NJSfpNESHam33fEO/vvolxByWU1DaOkrIPP7Z4Tn
-        eTZtm+fVNAPV8Wl7vcIgX7d1sbwgeJdZucYH3xjSQCSbLYrly6xprqqa5t71mk8JuvZt2n3V5LWQ
-        3rWTFg67ybpuJ0Ve8kvrdk4UKGRMb/iN4TebZs4vXWZFmU2KsmivX+ftpjcizW/qZFktc7wmbPll
-        87Ro3t70jtK0+9pXYKHht9B8tmxeZIv8WVW/XE/KYnr2ctMbl/X54vpysbOzu4v//8CDcBOKy/wK
-        rctbsM9V3rRrHsxNU0n4XC4YC+Im4o+3zBREZxbym9988frzoZdfrUtqNwzg9etvD716S1Loq2ck
-        gzWJVn42Y1HTt47rOrt2L33v50bzvRAc73ZxJShMwJ/84kUx/eiXfD8ynFtSoWJOBQdtalw1M2pl
-        tehD9+ZN3eioZu6NG6TCKK/L+YyoU2cXefl2lZfl5aqcnf9gOqDJ0PpuF8sxfSr9fnl+ntebeiVL
-        sHz91etTac6y2Mw3v+Kav/69vtrUcPfeeE8a3kSsE2YIaWutwnBzqO6mRfNVXVzSH2er49mM2M1n
-        5N5bu2Rh6L/7sfeOy9soiKalJsR29D4INf2mXt/0kvA7TwyUZP/lm2ir/N4UP6C/hpu9brPlLKtn
-        v//T17vcvpk/JSL/Xvn1y6ydb3rz7rxa5HeNdbs7pjfvwr5VNXU5+/3f5tesU+ljAvaT8tIwNGq2
-        XTdZekzPk3svfpCd7F5P907pr+Onxz9x/IR+nhz/xMnk7GL3Yv3q25OznfInd3evvvu03a33pl/N
-        pi9mew9OvtNcfPL6/OLkwaL4qXw9aa++mk+al7P5Fz/RnD+9nn/53W//ot1Pfur5zhefLL/zUz/5
-        6b3Z3d3ZfDFvL66//EX5T391Vb8sf/B7za9nzaRuZl9V9SffWbz4ztPZd3d2Lx88+b2/fb2+Xrw5
-        +Hy/2Xn40ydZ8+LLq2J9Pnl59xetHuzV6/XO5Ox4d3n9urkszx+uTn7ieP3s7fHyJ5fnd+tn86/K
-        L9/O21erq+kvOnj91YvfZ+8Hr7796u7p7zW5u//iu7/P7nd+8Gq/ye79or3z7559Z1bXv/fO08vn
-        VXb/4uHk7HS2//T8wcNJ9uDyk+viqydfvt75wZu9svzkB/sXD4sffPv3unf65f3Zwfz5/k//Pu+m
-        P/17NZ9cTZvy9e/z6rt11kzPm+nziy/KLz6f75zMfq/8xZunP/3t1ecvl9Ps/N5PffLs6urqp7+b
-        r4sXT95dPph8p9q9d/fgyd2dhwe/V/mTT8v9z3/qFzXVk5PTn355/Z3zn/x0/uXO9d3nb199/vbt
-        g+rb3/29LvLvHp//Xu358zMa2s5O/lP759PvvPi9Hr49yV5/sThdX1Q/9d3p2YMXn09+6vf+wS96
-        9t1fNFm9oj+nT18+/OS7Zz/xSfHwq/uXv+i7zS+a3f3B8mL/7WR9/J1Pv1r/Xr/o7AdPdtar36d+
-        /np+/hOn914fT98eVNnz+Xd+0S/6Rfc//cnzp+vj1y9W3/m9itlPfvKDX7T34Nvnr58sJr/38u2r
-        u/ePf6979x7Mpve++L1/r+9cr6rf6+5PvPzi+e/11fHL+7/385eT5pMXs9l3fuInH5z+1O8923v4
-        9PnF6pPzV2cX9/LZ6veaffngp07r784vH8w+ufd7XTWf5Lu/zyfXq8Wrve+e/eTrq5+8fnL61fnF
-        5d7JwZvm4cXyzbP91Yvp6e9z9/Ve9qSY/uD+6dXeJz89u/78xU/8xGefpVBXv2f+LiOvMycdvvh9
-        lywRouaPp9NqvdzozpE+18aBTegDua0ykJdOsukc32944VWezb5LHga7huY1ct+zYpnXN1lPoO29
-        dxNyL+t8UawXv//zV6/5rfWELJzVc/TtefFu0/uq4Hfu7u2792/EkfXra26Lty6Lul1n5Qv1Kr5G
-        77uf9uFselEw+MkXp2/6791EMp5PemtRzfDn2ZI8LESJWUmN2AWBLaV3SL3THBKE9XSaUzg2o+/b
-        YkF8SUxJn0vs84DCnze7B4/u3Xu0/3C8++nB/sPdez9FTWfrmmwXzNtHL9/c/2Lv4fje7s7+zv1P
-        X9OX5JTUOdlk+v4MvuJOvj+5f2///vbubG9ve39KbmK2O5lsZ5/uTieTT6cPHkz36TVGD34fe5lw
-        uZsV+W8EwPmBNgKm9jQN/DtoIu/4n9BrEmRi+GhuLDKaLtdl+X3yFr9PI8nJ45nlyymHvwREPmi+
-        pLHRXz8Xzq4dZBDmG7YgtgzHTgje8K73grC/5TEC9ktG/+8bJeIhh/OHDRKwMNH/rxsjfDYP6Q8c
-        JUPDXFLj/xfz7y/6dLr8lJTTdO+6KrzBfNjoQ6igwv/bxi3z49D/sPEKtP83cvVPfuHh/GGDJFCY
-        SWr5/2J+JiQd+h8+3v8Xzujsp3969emDerr/05O9NfwLh/6HjbcH+Eez/XM/wu6knP+iGTL0prcP
-        G3MU+I9m/ed+hPIvJ1EX2dRD/sNGK/9asBh5tW5Xa3qDYhgQYTiSufvDpc5JtSC88rsabn3BkTCN
-        UoZATNpNs23CnRKdBwfj3fvjhwd4k9l8Q3PqI1jNGMvCw3haVutZtlqNef0KeQJA66YqN0HWGJRT
-        nDQDt3hjZ2d75+n2vePte/vbO3vbn1Luj96VWbNz76T0PQjYe4OCD4S0N+X0b3wxWPMwL7PXP/yq
-        TuZLpYjt08urDr6rI9Q/zZsar/feei25jrvEgPipeRl6i3Ih8lEnhfP9X/JL/h84TvxtXh4AAA==
+        ZXW9yJdtczf7wbrOp2Wxu//pg4d7O/fvPRg//HRnZ3f/3u7ug3sfjT5aZouckL2xHXW5yuu2yJuP
+        Hv3ij9p8sSoJr+fF8i3+XtcFAZm37ap5dFc6bWZvp8V4UlaT8bSq8/FVsZxVV814mbd3zevzqmnv
+        nvAIf3Lx++/t7H66vfPp9r0dgSDjGP90Uy0JgWm1bGlIP0mjJnpSb7vjHfz30S8h5LKahtHSV0Dm
+        988Iz/Ns2jbPq2kG6uPT9nqFgb5u62J5QfAus3KND74xpIFINlsUy5dZ01xVNfGA6zWfEnTt27T7
+        qslrIb9rJy0cdpN13U6KvOSX1u2cKFDImN7wG8NvNs2cX7rMijKbFGXRXr/O201vRJrf1MmyWuZ4
+        Tdjzy+Zp0by96R2lafe1r8BCw2+h+WzZvMgW+bOqfrmelMX07OWmNy7r88X15YKYeBf//4EH4SYU
+        l/kVWpe3YJ+rvGnXPJibppLwuVwwFsRNxB9vmSmIzizsN7/54vXnQy+/WpfUbhjA69ffHnr1lqTQ
+        V89IBmsSrfxsxqKmbx3XdXbtXvrez40GfCE43u3iSlCYgD/5xYti+tEv+X5kOLekQsWcCg7a1Lhq
+        ZtTKatID9+ZN3eioZu6NG6TCKK/L+YyoU2cXefl2lZfl5aqcnf9gOqDJ0PpuF8sxfSr9fnl+nteb
+        eiVLsHz91etTac6y2Mw3v+Kav/69vtrUcPfeeE8a3kSsE2YIaWutwnBzqO6mRfNVXVzSH2er49mM
+        2M1n5N5bu2Rh6L/7sfeOy9soiKalJsR29D4INf2mXt/0kvA7TwyUZP/lm2ir/N4UP6C/hpu9brPl
+        LKtnv//T17vcvpk/JSL/Xvn1y6ydb3rz7rxa5HeNdbs7pjfvwr5VNXU5+/3f5tesU+ljAvaT8tIw
+        NGq2XTdZekzPk3svfpCd7F5P907pr+Onxz9x/IR+nhz/xMnk7GL3Yv3q25OznfInd3evvvu03a33
+        pl/Npi9mew9OvtNcfPL6/OLkwaL4qXw9aa++mk+al7P5Fz/RnD+9nn/53W//ot1Pfur5zhefLL/z
+        Uz/56b3Z3d3ZfDFvL66//EX5T391Vb8sf/B7za9nzaRuZl9V9SffWbz4ztPZd3d2Lx88+b2/fb2+
+        Xrw5+Hy/2Xn40ydZ8+LLq2J9Pnl59xetHuzV6/XO5Ox4d3n9urkszx+uTn7ieP3s7fHyJ5fnd+tn
+        86/KL9/O21erq+kvOnj91YvfZ+8Hr7796u7p7zW5u//iu7/P7nd+8Gq/ye79or3z7559Z1bXv/fO
+        08vnVXb/4uHk7HS2//T8wcNJ9uDyk+viqydfvt75wZu9svzkB/sXD4sffPv3unf65f3Zwfz5/k//
+        Pu+mP/17NZ9cTZvy9e/z6rt11kzPm+nziy/KLz6f75zMfq/8xZunP/3t1ecvl9Ps/N5PffLs6urq
+        p7+br4sXT95dPph8p9q9d/fgyd2dhwe/V/mTT8v9z3/qFzXVk5PTn355/Z3zn/x0/uXO9d3nb199
+        /vbtg+rb3/29LvLvHp//Xu358zMa2s5O/lP759PvvPi9Hr49yV5/sThdX1Q/9d3p2YMXn09+6vf+
+        wS969t1fNFm9oj+nT18+/OS7Zz/xSfHwq/uXv+i7zS+a3f3B8mL/7WR9/J1Pv1r/Xr/o7AdPdtar
+        36d+/np+/hOn914fT98eVNnz+Xd+0S/6Rfc//cnzp+vj1y9W3/m9itlPfvKDX7T34Nvnr58sJr/3
+        8u2ru/ePf6979x7Mpve++L1/r+9cr6rf6+5PvPzi+e/11fHL+7/385eT5pMXs9l3fuInH5z+1O89
+        23v49PnF6pPzV2cX9/LZ6veaffngp07r784vH8w+ufd7XTWf5Lu/zyfXq8Wrve+e/eTrq5+8fnL6
+        1fnF5d7JwZvm4cXyzbP91Yvp6e9z9/Ve9qSY/uD+6dXeJz89u/78xU/8xGefpVBXv2f+LiOvMycd
+        vvh9lywRouaPp9NqvdzozpE+18aBTegDua0ykJdOsukc32944VWezb5LHga7huY1ct+zYpnXN1lP
+        oO29dxNyL+t8UawXv//zV6/5rfWELJzVc/TtefFu0/uq4Hfu7u2792/EkfXra26Lty6Lul1n5Qv1
+        Kr5G77uf9uFselEw+MkXp2/6791EMp5PemtRzfDn2ZI8LESLWUmN2AWBLaV3SL3THBKE9XSaUzg2
+        o+/bYkF8SUxJn0vs84D+92b34aP9g0e7B+OHe/v3H3568FPUdLauyXbBvH308s2nX+yM7+0dPDy4
+        95q+Ipekzski07dn8BQf7E4OHjyc7W7vfXrv3vb+9MH+9sPz/f3tbO/T/XvU9/7OvQm9xsjB62Mf
+        Ew53syLvjQA4L9DGwdSeJoF/B0XkHf8Tek1CTAwezY09RtPluiy/T77i92kcOfk7s3w55eCXgMgH
+        zZc0Mvrr58LVtYMMgn3DFMSU4dgJwRve9V4Q5rccRsB+yej/faNENORw/rBBAhYm+v91Y4TH5iH9
+        gaNkaJhLavz/Yv79RZ9Ol5+SapruXVeFN5gPG30IFVT4f9u4ZX4c+h82XoH2/0au/skvPJw/bJAE
+        CjNJLf9fzM+EpEP/w8f7/8IZnf30T68+fVBP9396sreGd+HQ/7Dx9gD/aLZ/7kfYnZTzXzRDft70
+        9mFjjgL/0az/3I9Q/uUU6iKbesh/2GjlXwsWI6/W7WpNb1AEAyIMxzF3f7jUOakWhFd+V4OtLzgO
+        plHKEIhJu0m2TbhTmvPgYLx7sD9+yPlh5vMN7amTYDFjLOsO42lZrWfZajXm5SukCQCtm6ncBFlD
+        UM5w0hTc4o2dne2dp9v3jrfv7W+fHGzvPeRoUqbNTr4T0/egYO8Nij4Q0d6U0r/xxWDJw7zMbv/w
+        qzqbL5Uitk8vrTr4ro5Q/zRvarjee+u1pDruEgfip6Zl6C1KhchHnQzO93/JL/l/AHsjkTRlHgAA
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['2449']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:33:54 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['2451']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:48:21 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [32a41680-43a8-11e6-a308-001dd8b7c0ad]
+      x-ms-client-request-id: [c2e6a4b4-447b-11e6-8806-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Network/publicIPAddresses/vrfvmzPublicIP?api-version=2016-03-30
   response:
@@ -579,39 +696,39 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj96LI+v1z84OV6UhbTs5cfjfjLYoav7jbrSTOti1VbVMvm7r2d/fzg4cNPtx88OJ9s
         73+aH2xPslm2ff/+g093du8/3J/k+3frvKnW9TT/vK7Wq+bu5eL3n9Z51ua//3TdtNXi9y9Wv399
-        ce/uqq4ui1leN3e/KKZ11VTn7fhF3l5V9du7K8XleDYjaE1OUGI45m12ASy/e/f3/Wh2vnuwf777
-        6fbe3oPp9v7B/v3tg+z+Q/rt4c79/ft7u/t59vt+pC+21yse+S161jfKapqBBnjrKm/atfmCUGjo
-        Q6Yo/TkrmlWZXb9Q0hqEFdxHaPVL5EUa/yqv24K6cK/Th5dFQ/0Uy4vXLRGNvvvo9Xo6zfNZPpMu
-        qRnBEhKvZZry/N75ZLab0eD3Mwx5dzu7/2m2Pdk5ODi/d/BpNpk9sC8XK4MNvbl7b3xwMN69P354
-        YBt0aPCTNEeEEVqfvbzc7zcrDXG+yNt5xQgB92JqmxazMn9TLPJq3Z4tvyiW65ZHvW++ny2b13nb
-        0qDxsRIDn1eLrFiCmM+zSV7Sd2DWxfXlYmdndxf//4Hpg1qf/6IZY9ltMpYJG0/Laj3LVqtx9oN1
-        nY+n1YLnw8wIQShWJ9XyvLhY14Q+D9nhIpS++3MjEEv5ebZs8/o8m1qB+MkvXhTTux20G/pgyh9I
-        IzNK/KB/fsn/A4T44vT+AwAA
+        ce/uqq4ui1leN3e/KKZ11VTn7fhF3l5V9du7K8XleDYjaE1OUGI45m12ASy/e/f3/Wh6f+/eLMvu
+        b2f53sH2/mySb2fne/vbk4ODbDfbuXdv52D/9/1IX2yvVzzyW/Ssb5TVNAMN8NZV3rRr8wWh0NCH
+        TFH6c1Y0qzK7fqGkNQgruI/Q6pfIizT+VV63BXXhXqcPL4uG+imWF69bIhp999Hr9XSa57N8Jl1S
+        M4IlJF7LNH2aHeztHkym29ODyc72/r3s0+3J/U+z7Qf39/ez2aezB3sPM/tysTLY0Ju798YHB+Pd
+        g/3xwwPbokOEn6RJIpTQ/Ozl5X6/WWmo80XezivGCMgXU9u0mJX5m2KRV+v2bPlFsVy3POx98/1s
+        2bzO25ZGjY+VGvi8WmTFEtR8nk3ykr4Dty6uLxc7O7u7+P8PTB/U+vwXzRjLbpOxzNh4WlbrWbZa
+        jbMfrOt8PK0WPCFmSghCsTqplufFxbom9HnIDhch9d2fG4lYys+zZZvX59nUSsRPfvGimN7toN3Q
+        B1P+QBqZUeIH/fNL/h+/rY0D/wMAAA==
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:33:57 GMT']
-      etag: [W/"df184f16-227c-4845-8a59-4890545214ea"]
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:48:22 GMT']
+      ETag: [W/"c523daa5-ae28-4dbe-af24-b88a1a033084"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [3375974f-43a8-11e6-9b74-001dd8b7c0ad]
+      x-ms-client-request-id: [c31cd90a-447b-11e6-a6de-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Network/networkInterfaces/vrfvmzVMNic?api-version=2016-03-30
   response:
@@ -621,28 +738,28 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj96LI+v1z84Ce/eFFMPxrxN8UMn99t1pNmWhertqiWzd17O/v5wcOHn24/eHA+2d7/
         ND/YnmSzbPv+/Qef7uzef7g/yffv1nlTretp/nldrVfN3cvF7z+t86zNf//pummrxe9frH7/+uLe
-        3VVdXRazvG7uflFM66qpztvxi7y9quq3d5fy82zZ5vV5Ns0JSg/BvM0ugOJ37/6+H+UPd+9N7s2m
-        27sP9h9s7x8QXtl0b2d7d2+S78zOP92fPDj4fT/SF8tqmmE4ePkqb9p1o18QwIY+ZMrQn7OiWZXZ
-        9QslkeJmcfoIzX6JvEljWeV1W+T++/ThZdFQR8Xy4nVLBKDvPnq9nk7zfJbPpE9qZsm1FpLf393b
-        2/t0L9s+nxBl9yf7+9vZpw/vbed797PJ5N6D++f3lQT0crE6qZbnxcW65iGh++/JV6nBA4+d52I1
-        5fZCTgMGz/+LJ/xud5T0weAwvi5byINJ682kPPjqFvMpDzUuLqnJ2cvj2YzoA2gf7e6M8d/9waal
-        Yc0v8nZe8XygI8Py5vlotZ6UxZResLADTKnFz+lkdtCzk/lSP2fJMY9IkHk+IoyJFwj5/1eN6LKo
-        23VW6p8Eg8fzky9O39wlhAhh89Fr/mvTAGm2F1l9TYNp63Xe+045QSj3k4QNjZPafnT28nLfA/tL
-        zK/6y/cV0EezZfM6b1ti0YAt5PP6kgDSx98zzemLbLUqi3z2dOj7AiK5zMqn1SIrllCGr9fn58U7
-        avbRsi2v5heXO5O9ybou71/tt9X52+ziqpqNZ+/G5s3xtKzWM+pn7EhjiPLRIpvqYAFwZ2d75+n2
-        vePte/vbO3vbn+4axv8oX2aTkijzrKqvsnpG46P251nZGBJ+RMAxOa/z6bou2muebWrjSPBzykEx
-        7AgSM82L1593yUKc0OeSj5QNv8im82IJ9fNzPLiTarFat7kRD8WLYPCwzJjwQwb2UXu9AtofORAd
-        +jgDQG//kv8Hs+Cq46QIAAA=
+        3VVdXRazvG7uflFM66qpztvxi7y9quq3d5fy82zZ5vV5Ns0JSg/BvM0ugOJ37/6+H2X3Hny6P5vu
+        bX96sPdwe386nW4/PJgScvn9B7u7s/u7+Xn++36kL5bVNMNw8PJV3rTrRr8ggA19yJShP2dFsyqz
+        6xdKIsXN4vQRmv0SeZPGssrrtsj99+nDy6KhjorlxeuWCEDfffR6PZ3m+SyfSZ/UzJJrLSTfz+9N
+        Hkwe7m3PDvam2/tZdm87u/fp/e0H9x/u3ptOHxzcm92zLxerk2p5Xlysax4Suv+efJUaPPDYeS5W
+        U24v5DRg8Py/eMLvdkdJHwwO4+uyhTyYtN5MyoOvbjGf8lDj4pKanL08ns2IPoD20e7OGP/dH2xa
+        Gtb8Im/nFc8HOjIsb56PVutJWUzpBQs7wJRa/JxOZgc9O5kv9XOWHPOIBJnnI8KYeIGQ/3/ViC6L
+        ul1npf5JMHg8P/ni9M1dQogQNh+95r82DZBme5HV1zSYtl7nve+UE4RyP0nY0Dip7UdnLy/3PbC/
+        xPyqv3xfAX00Wzav87YlFg3YQj6vLwkgffw905y+yFarsshnT4e+LyCSy6x8Wi2yYgll+Hp9fl68
+        o2Yf/WBV3MvvV4tf1N5f706K5bzMrt7trO+/m49n78bmzfG0rNYz6mfsSGOI8tEim+pgAXBnZ3vn
+        6fa94+17+9snB9t7Dw3jf5Qvs0lJlHlW1VdZPaPxUfvzrGwMCT8i4Jic1/l0XRftNc82tXEk+Dnl
+        oBh2BImZ5sXrz7tkIU7oc8lHyoZfZNN5sYT6+Tke3Em1WK3b3IiH4kUweFhmTPghA/uovV4B7Y8c
+        iA59nAGgt3/J/wMIKVh6pAgAAA==
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:33:57 GMT']
-      etag: [W/"e913b3dc-1747-48e8-ac20-12be0df64b78"]
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:48:23 GMT']
+      ETag: [W/"a3764dc2-6829-4ccc-98c8-be5711d51efe"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_create_existing_options.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_create_existing_options.yaml
@@ -1,140 +1,37 @@
 interactions:
 - request:
-    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateAvailSet/azuredeploy.json"},
-      "mode": "Incremental", "parameters": {"platformFaultDomainCount": {"value":
-      "1"}, "name": {"value": "vrfavailset"}, "platformUpdateDomainCount": {"value":
-      "1"}}}}'
+    body: !!binary |
+      eyJwcm9wZXJ0aWVzIjogeyJtb2RlIjogIkluY3JlbWVudGFsIiwgInRlbXBsYXRlTGluayI6IHsi
+      dXJpIjogImh0dHBzOi8vYXp1cmVzZGtjaS5ibG9iLmNvcmUud2luZG93cy5uZXQvdGVtcGxhdGVo
+      b3N0L0NyZWF0ZUF2YWlsU2V0L2F6dXJlZGVwbG95Lmpzb24ifSwgInBhcmFtZXRlcnMiOiB7Im5h
+      bWUiOiB7InZhbHVlIjogInZyZmF2YWlsc2V0In0sICJwbGF0Zm9ybUZhdWx0RG9tYWluQ291bnQi
+      OiB7InZhbHVlIjogIjEifSwgInBsYXRmb3JtVXBkYXRlRG9tYWluQ291bnQiOiB7InZhbHVlIjog
+      IjEifX19fQ==
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI2MTE1LCJuYmYiOjE0Njc4MjYxMTUsImV4cCI6MTQ2NzgzMDAxNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.BsXPjbpDDitiOiqCh89LqEkRNwGth9IsXslnNhFEHJBysUJjzEBeOZaEwQCAZtLOO2DLZkoTvDZ2ddXEfZ3XNXS4wSAj2Hf0L0-d3gbP7mvzGpcZIsAH4eUlfX8LoGuQt4MyBNPH1pfTfNJYTMOFAsnsy3vPjr6qVj8butsv2XpDhPrDGRTE7WrgCBF-I7OfWqeiej_zc3ZKEXneOgxc6IbWGBqmUfM8SyLh48O2a_hoEs1KciA4AKt77zbsCbqrnbHdNadvVTDvkM-ToYNzgjWXp6kcW13cwS_roFV3Afz3YNB61ICCYog45D3uATmoKVE9BCZkrwCGrljteh9djw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Length: ['292']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 availsetcreationclient/2015-11-01 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [68e42380-43a7-11e6-bf9c-001dd8b7c0ad]
+      x-ms-client-request-id: [e720f848-447a-11e6-97ec-001dd8b7c0ad]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/azurecli1467829697.9794400","name":"azurecli1467829697.9794400","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateAvailSet/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"name":{"type":"String","value":"vrfavailset"},"location":{"type":"String","value":"westus"},"platformUpdateDomainCount":{"type":"String","value":"1"},"platformFaultDomainCount":{"type":"String","value":"1"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-06T18:28:19.1192887Z","duration":"PT0.2086445S","correlationId":"3b8a2185-be0f-41fe-9fca-c69244df7281","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"availabilitySets","locations":["westus"]}]}],"dependencies":[]}}'}
+    body: {string: '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/azurecli1467920533.569533626643","name":"azurecli1467920533.569533626643","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateAvailSet/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"name":{"type":"String","value":"vrfavailset"},"location":{"type":"String","value":"westus"},"platformUpdateDomainCount":{"type":"String","value":"1"},"platformFaultDomainCount":{"type":"String","value":"1"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-07T19:42:15.9749637Z","duration":"PT0.1024594S","correlationId":"228871f4-9c19-4e9e-824b-f59d6a051872","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"availabilitySets","locations":["westus"]}]}],"dependencies":[]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/azurecli1467829697.9794400/operationStatuses/08587337771865669833?api-version=2015-11-01']
-      cache-control: [no-cache]
-      content-length: ['905']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:28:18 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 201, message: Created}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDI5LCJuYmYiOjE0Njc4Mjk0MjksImV4cCI6MTQ2NzgzMzMyOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.C_BLXWW9vN77qoGkyY5AVX9U09iN0QvGXfMxvcf1Bi9PjpOJELoOfofvbwbMO2YUS8DAjklRogeJH_XhWCDQN53amFX0sDSK3AshP4P_j3Tauuf6f7G0f6FBTdYd55Ny6yx6NtqzKRN5YfLAj-ozwKpdWoYtwkeHPQ6xXhM7RnASvqFNF08FNvmaTF9BgYsvm4xFb5lWL9HtBF2mAADQI87DGhGIPquyH7f5BN8VmVrbcnIbIK4VW7WBC_fWGzTOAq4H46RlY4v6QKv5sVOoT5bQAe9RPAQoKnR2vrUYQTuDyHoWOF5muTjJiJqwUj6eJ5gxobC2CoQyIB408pekMw]
-      Connection: [keep-alive]
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/azurecli1467920533.569533626643/operationStatuses/08587336863496051295?api-version=2015-11-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['915']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 availsetcreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [68e42380-43a7-11e6-bf9c-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771865669833?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['141']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:28:50 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDI5LCJuYmYiOjE0Njc4Mjk0MjksImV4cCI6MTQ2NzgzMzMyOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.C_BLXWW9vN77qoGkyY5AVX9U09iN0QvGXfMxvcf1Bi9PjpOJELoOfofvbwbMO2YUS8DAjklRogeJH_XhWCDQN53amFX0sDSK3AshP4P_j3Tauuf6f7G0f6FBTdYd55Ny6yx6NtqzKRN5YfLAj-ozwKpdWoYtwkeHPQ6xXhM7RnASvqFNF08FNvmaTF9BgYsvm4xFb5lWL9HtBF2mAADQI87DGhGIPquyH7f5BN8VmVrbcnIbIK4VW7WBC_fWGzTOAq4H46RlY4v6QKv5sVOoT5bQAe9RPAQoKnR2vrUYQTuDyHoWOF5muTjJiJqwUj6eJ5gxobC2CoQyIB408pekMw]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 availsetcreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [68e42380-43a7-11e6-bf9c-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3W3Wk2ZaF6u2qJbN3Xs7+/nBw4efbj94cD7Z3v80P9ieZLNs+/79B5/u7N5/uD/J9+/WeVOt
-        62n+eV2tV83dy8XvP63zrM1///xd0bTF8uL3rwTc719f3F3V1WUxy+vm7hfFtK6a6rwdv1IAzd1Z
-        viqr60W+bJu72Q/WdT4ti939Tx8c7D389OGD8cMHD/f3d3Y+Gn20zBY5obuxDXW1yuu2yJuPHv3i
-        j9p8sSoJq+fF8i3+XtcFAZi37ap5dFc6a2Zvp8V4UlaT8bSq8/FVsZxVV814mbd3zevzqmnvnvD4
-        ji+zonxN3/HLgvr4p5tqSX1Pq2VLo/hJGiiNnDraHe/gv49+CeGV1YR9S18BDxkJ4Xe9op8fvW5r
-        ohhBuMzKNT64rM8zdNTkLV4uq2kGYm565Spv2nWD1kD5vKoXX61mhPDTapEVy5NqvWw3vb7rv/ks
-        W5ft7V+kNxfVDH+cLYkLMJNZSU1oLi4LkILeeN0SLtTi9Xo6zYluM/q+LRaEdLZY0ed7O7ufbu88
-        2N759M3uwaM9+t+D8b2d+3t7Dw5+iprO1rVS4KOXbw7G9x7u3z+49+lr+oYmrc4Jb/ryDMx8b3KQ
-        7e0e3N+e5Dvn2/u75/n2w/Nptj399OHe/v7s/MHewS69xriBJT969D2Zj2aVTYGhY9GTarFaE9aj
-        j4hNmFnfEBHkDf8TeolnK5sUZdFeE3c09I6ZNLQ3s/P9X0L/0WjyVb6c5csps+n36JNq3VJX9Mcv
-        JmLKH1ZAqIUKag+1u91+7wac8/1f8kv+H88hbbrjAwAA
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['717']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:28:51 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreatePublicIp_2016-06-06/azuredeploy.json"},
-      "mode": "Incremental", "parameters": {"allocationMethod": {"value": "dynamic"},
-      "publicIpAddressType": {"value": "noDns"}, "name": {"value": "vrfpubip"}, "_artifactsLocation":
-      {"value": "https://azuresdkci.blob.core.windows.net/templatehost/Createpublic_ip_2016-06-06"}}}}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Length: ['413']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 publicipcreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7d451e5e-43a7-11e6-b661-001dd8b7c0ad]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
-  response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/azurecli1467829732.1699460","name":"azurecli1467829732.1699460","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreatePublicIp_2016-06-06/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/Createpublic_ip_2016-06-06"},"allocationMethod":{"type":"String","value":"dynamic"},"dnsName":{"type":"String","value":""},"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"vrfpubip"},"publicIpAddressType":{"type":"String","value":"noDns"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-06T18:28:53.1218565Z","duration":"PT0.188844S","correlationId":"85810107-81ad-4a2f-8046-e8c9e05433cb","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]}]}],"dependencies":[]}}'}
-    headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/azurecli1467829732.1699460/operationStatuses/08587337771525446216?api-version=2015-11-01']
-      cache-control: [no-cache]
-      content-length: ['1078']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:28:52 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
+      Date: ['Thu, 07 Jul 2016 19:42:15 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       x-ms-ratelimit-remaining-subscription-writes: ['1196']
     status: {code: 201, message: Created}
 - request:
@@ -142,16 +39,16 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 publicipcreationclient/2015-11-01 Azure-SDK-For-Python
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 availsetcreationclient/2015-11-01 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [7d451e5e-43a7-11e6-b661-001dd8b7c0ad]
+      x-ms-client-request-id: [e720f848-447a-11e6-97ec-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771525446216?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863496051295?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -159,29 +56,29 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['141']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:29:23 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['141']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:42:45 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 publicipcreationclient/2015-11-01 Azure-SDK-For-Python
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 availsetcreationclient/2015-11-01 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [7d451e5e-43a7-11e6-b661-001dd8b7c0ad]
+      x-ms-client-request-id: [e720f848-447a-11e6-97ec-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
@@ -191,74 +88,187 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
         o0cf3W3Wk2ZaF6u2qJbN3Xs7+/nBw4efbj94cD7Z3v80P9ieZLNs+/79B5/u7N5/uD/J9+/WeVOt
         62n+eV2tV83dy8XvP63zrM1///xd0bTF8uL3rwTc719f3F3V1WUxy+vm7hfFtK6a6rwdv1IAzd1Z
-        viqr60W+bJu72Q/WdT4ti939Tx8c7D18cG9vvPvpw4f7n+58NPpomS1yQndjG+pqlddtkTcfPfrF
-        H7X5YlUSVs+L5Vv8va4LAjBv21Xz6K501szeTovxpKwm42lV5+OrYjmrrprxMm/vmtfnVdPePeHx
-        vVxPymJ6tvr993Z2P93ewf8Ejoxi/NNNtSQ0ptWypQH9JI2ZiEB97o538N9Hv4RQzGoaSEtfAaXf
-        PyNsz7Np2zyvphlIhk/b6xWG+rqtiZQE7zIr1/jgQ1BfMeq/f+HjDnyystSev8jbeUUcMdz/7Jom
-        oZjitdmyeZFhQoZbo5mBvandVd606watCTp9MNzysj6nYRQrtKVfaDxnq+PZjGjRvOFXhl9dVk+X
-        1Ae9uKhm+OBsSSwLtstKakaMc1lgsuit1y2Ri1q8Xk+nOc3sjL5viwVhmS1W9LnQ7wHR783uwaO9
-        h492DsZ7e/ce7j28/1PUdLaudcgfvXyze3+893Dn4e6D1/QNTVOd07TQl2dE548O7h/s7uwSpIPd
-        bLa9n+2dbx/s7H+6nR9MH+Y79/fv3ZtO6DXGDfLz0aPv/WKmUbPKpsDQydOLvL2q6rfUmojBkgWC
-        yBv+J/SSEu6lEo4auWnCC2Y+vv9L6D8aTr7Kl7N8OWWh+h59Uq3b1bqlP36xgUVUsZT/cvLT+bQl
-        mEp5agT8N9CWsGD8Pl+zPpqd785m+7t729n9fHd7f/bgISmg8/3tyR6R5dN7e3ufTjN6S7t+edzj
-        34+eKpuOPipmZf6Gpo5QPlt+USzXLQax/0vAB/QZDcMqIhqbKsQeVe/avgzJ7jpO/P4v+SX/D0oA
-        dgVJBQAA
+        viqr60W+bJu72Q/WdT4ti939Tx883Nu5f+/e+P6nD+nHp3uffrp/76PRR8tskRPONzekTld53RZ5
+        89GjX/xRmy9WJeH3vFi+xd/ruiAo87ZdNY/uSrfN7O20GE/KajKeVnU+viqWs+qqGS/z9q55fV41
+        7d0THunxZVaUr+k7flkGMf7pplpS39Nq2dJ4fpKGTDSgjnbHO/jvo19CeGU1DaGlr4CHDIfwu17R
+        z49etzXRjiBcZuUaH1zW5xk6avIWL5fVNANZN71ylTftukFroHxe1YuvVjNC+Gm1yIrlSbVetpte
+        3/XffJaty/b2L9Kbi2qGP86WxA+Y06ykJjQXlwVIQW+8bgkXavF6PZ3mRLcZfd8WC0I6W6zo872d
+        3U+3dx7Q/97sPny0v/dob2+8f+/h/Qe7D36Kms7WtVLgo5dvPqVJf7Dz6YP91/QNTVqdE9705RnY
+        em/v4ODB7vn+9sPp7sPt/fxhvn2wtz/ZPr//cPZptnN/9+DBHr3GuIE5P3r0PZmPZpVNgaFj1pNq
+        sVoT1qOPiE2Ybd8QEeQN/xN6iWcrmxRl0V4TdzT0jpk0tDez8/1fQv/RaPJVvpzlyymz6ffok2rd
+        Ulf0xy8mYsofVlSohYpsD7W73X7vBpzz/V/yS/4fhD1Eie0DAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['861']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:29:22 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['722']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:42:45 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"sku": {"name": "Standard_LRS"}, "kind": "Storage", "location": "westus"}'
+    body: !!binary |
+      eyJwcm9wZXJ0aWVzIjogeyJwYXJhbWV0ZXJzIjogeyJfYXJ0aWZhY3RzTG9jYXRpb24iOiB7InZh
+      bHVlIjogImh0dHBzOi8vYXp1cmVzZGtjaS5ibG9iLmNvcmUud2luZG93cy5uZXQvdGVtcGxhdGVo
+      b3N0L0NyZWF0ZXB1YmxpY19pcF8yMDE2LTA2LTA2In0sICJwdWJsaWNJcEFkZHJlc3NUeXBlIjog
+      eyJ2YWx1ZSI6ICJub0RucyJ9LCAibmFtZSI6IHsidmFsdWUiOiAidnJmcHViaXAifSwgImFsbG9j
+      YXRpb25NZXRob2QiOiB7InZhbHVlIjogImR5bmFtaWMifX0sICJ0ZW1wbGF0ZUxpbmsiOiB7InVy
+      aSI6ICJodHRwczovL2F6dXJlc2RrY2kuYmxvYi5jb3JlLndpbmRvd3MubmV0L3RlbXBsYXRlaG9z
+      dC9DcmVhdGVQdWJsaWNJcF8yMDE2LTA2LTA2L2F6dXJlZGVwbG95Lmpzb24ifSwgIm1vZGUiOiAi
+      SW5jcmVtZW50YWwifX0=
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Length: ['413']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 publicipcreationclient/2015-11-01 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [faecf5f6-447a-11e6-8d2e-001dd8b7c0ad]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+  response:
+    body: {string: '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/azurecli1467920566.781115351109","name":"azurecli1467920566.781115351109","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreatePublicIp_2016-06-06/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/Createpublic_ip_2016-06-06"},"allocationMethod":{"type":"String","value":"dynamic"},"dnsName":{"type":"String","value":""},"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"vrfpubip"},"publicIpAddressType":{"type":"String","value":"noDns"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-07T19:42:47.6916032Z","duration":"PT0.3158708S","correlationId":"16f85545-d778-4a71-a8f1-d4fee3674136","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]}]}],"dependencies":[]}}'}
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/azurecli1467920566.781115351109/operationStatuses/08587336863181019008?api-version=2015-11-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['1089']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:42:47 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 publicipcreationclient/2015-11-01 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [faecf5f6-447a-11e6-8d2e-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863181019008?api-version=2015-11-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
+        tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['141']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:43:17 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 publicipcreationclient/2015-11-01 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [faecf5f6-447a-11e6-8d2e-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3Xs7+/nBw4efbj94cD7Z3v80P9ieZLNs+/79B5/u7N5/uD/J9+/WeVOt
+        62n+eV2tV83dy8XvP63zrM1///xd0bTF8uL3rwTc719f3F3V1WUxy+vm7hfFtK6a6rwdv1IAzd1Z
+        viqr60W+bJu72Q/WdT4ti939Tx883Nu5/+mn4wcHu7u79+/d393defjR6KNltsgJ55sbUqervG6L
+        vPno0S/+qM0Xq5Lwe14s3+LvdV0QlHnbrppHd6XbZvZ2WownZTUZT6s6H18Vy1l11YyXeXvXvD6v
+        mvbuCY/05XpSFtOz1e+/t7P76fYO/idwZDzjn26qJaExrZYtDe0nafREDupzd7yD/z76JYRiVtNo
+        WvoKKP3+GWF7nk3b5nk1zUA8fNperzDe121NRCV4l1m5xgcfgvqKUf/9Cx934JOVpfb8Rd7OK+KN
+        4f5n1zQTxRSvzZbNiwyzMtwazQzsTe2u8qZdN2hN0OmD4ZaX9TkNo1ihLf1C4zlbHc9mRIvmDb8y
+        /OqyerqkPujFRTXDB2dLYl4wYFZSM2KcywKTRW+9bolc1OL1ejrNaWZn9H1bLAjLbLGiz4V+D+h/
+        b3YfPtq/92jn/vj+3qef3jvY/SlqOlvXOuSPXr7ZPRjv3t95uHP/wWv6iuapzmle6NszIvRHu5+e
+        H9y/v39/e/bgwcH2fvZgdzs7ON/dnu2f5/m9Tx/s7977lF5j5CBKHz363i9mIjWrbAoUnWi9yNur
+        qn5LrYkaLGSgiLzhf0IvKeVeKuWokZsnvGAm5Pu/hP6j8eSrfDnLl1OWqu/RJ9W6Xa1b+uMXG1hE
+        Fkv6Lyc/nU9bgqmkp0bAfwNxCQvG7/M1q6aDh/mn0939B9sPs/397f2Hu9l2Np19up1PH+YH97LZ
+        ven0Hr2lXb887jHwR0+VT0cfFbMyf0NzRyifLb8olusWg9j/JWAE+oyGYXUSjU11Y4+qd21fhmR3
+        HSt+/5f8kv8HTYyof1QFAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['872']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:43:17 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAia2luZCI6ICJTdG9yYWdlIiwgInNrdSI6IHsibmFtZSI6
+      ICJTdGFuZGFyZF9MUlMifX0=
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Length: ['74']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 storagemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [907c1830-43a7-11e6-866a-001dd8b7c0ad]
+      x-ms-client-request-id: [0e27a758-447b-11e6-b245-001dd8b7c0ad]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Storage/storageAccounts/azureclivrfstorage0011?api-version=2016-01-01
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Wed, 06 Jul 2016 18:29:24 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Storage/operations/cc437382-76a4-4d4c-baf0-866a030ca900?monitor=true&api-version=2016-01-01']
-      pragma: [no-cache]
-      retry-after: ['25']
-      server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Thu, 07 Jul 2016 19:43:19 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Storage/operations/189b40e8-2767-46c9-a86f-dd77b5c44059?monitor=true&api-version=2016-01-01']
+      Pragma: [no-cache]
+      Retry-After: ['25']
+      Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1191']
     status: {code: 202, message: Accepted}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 storagemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [907c1830-43a7-11e6-866a-001dd8b7c0ad]
+      x-ms-client-request-id: [0e27a758-447b-11e6-b245-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/operations/cc437382-76a4-4d4c-baf0-866a030ca900?monitor=true&api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/operations/189b40e8-2767-46c9-a86f-dd77b5c44059?monitor=true&api-version=2016-01-01
   response:
     body:
       string: !!binary |
@@ -267,100 +277,71 @@ interactions:
         o0cf3W3Wk2ZaF6u2qJbN3Xs7+/nBw4efbj94cD7Z3v80P9ieZLNs+/79B5/u7N5/uD/J9+/WeVOt
         62n+eV2tV83dy8XvP63zrM1///xd0bTF8uL3rwTc719f3F3V1WUxy+vm7hfFtK6a6rwdv26rOrvI
         7zby83g6rdbLtrmb/WBd59OyuKzP9audnd3dj0YfvS2WQFbfow/KapqhC/rwKm/adUOfLbNFTn8P
-        AiFMVnndFnnz0aNf/BGjTBDeFPzW3s7up9s7D7Z3Pn2ze/Bo7+Gjvf3xwYOHuw8Odn6K3y0WWX19
-        upytqoJQBYRJWU3ozXnbrppHdweQH6PVeFrV+fiKBlFdNeNl3t4lkOdFiY5veB2toq//onW+vsX7
-        3CwKoM0mt0GAm0UA/BJLlOeRuSBaXxYNfUjc8Lol3qAvX6+n0zyf5TP6vqHP1s2X5y8FBH2bXWZF
-        ib4AuXm7BoV1RgnAcpbVs9//+avX9C7NYO19ivZtdoEpwW/XK7xyI6999EuS/wcj6VxKAgMAAA==
+        AiFMVnndFnnz0aNf/BGjTBDeFPzW3s7up9s7D+h/b3YfPtq/92j34fjew/sP7u0e/BS/Wyyy+vp0
+        OVtVBaEKCJOymtCb87ZdNY/uDiA/RqvxtKrz8RUNorpqxsu8vUsgz4sSHd/wOlpFX/9F63x9i/e5
+        WRRAm01ugwA3iwD4JZYozyNzQbS+LBr6kLjhdUu8QV++Xk+neT7LZ/R9Q5+tmy/PXwoI+ja7zIoS
+        fQFy83YNCuuMEoDlLKtnv//zV6/pXZrB2vsU7dvsAlOC365XeOVGXvvolyT/DwHE9aYCAwAA
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json]
-      date: ['Wed, 06 Jul 2016 18:29:50 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Thu, 07 Jul 2016 19:43:44 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateVNet/azuredeploy.json"},
-      "mode": "Incremental", "parameters": {"subnetName": {"value": "vrfsubnet"},
-      "virtualNetworkPrefix": {"value": "10.0.0.0/16"}, "virtualNetworkName": {"value":
-      "vrfvnet"}, "subnetPrefix": {"value": "10.0.0.0/24"}}}}'
+    body: !!binary |
+      eyJwcm9wZXJ0aWVzIjogeyJtb2RlIjogIkluY3JlbWVudGFsIiwgInRlbXBsYXRlTGluayI6IHsi
+      dXJpIjogImh0dHBzOi8vYXp1cmVzZGtjaS5ibG9iLmNvcmUud2luZG93cy5uZXQvdGVtcGxhdGVo
+      b3N0L0NyZWF0ZVZOZXQvYXp1cmVkZXBsb3kuanNvbiJ9LCAicGFyYW1ldGVycyI6IHsic3VibmV0
+      TmFtZSI6IHsidmFsdWUiOiAidnJmc3VibmV0In0sICJ2aXJ0dWFsTmV0d29ya1ByZWZpeCI6IHsi
+      dmFsdWUiOiAiMTAuMC4wLjAvMTYifSwgInN1Ym5ldFByZWZpeCI6IHsidmFsdWUiOiAiMTAuMC4w
+      LjAvMjQifSwgInZpcnR1YWxOZXR3b3JrTmFtZSI6IHsidmFsdWUiOiAidnJmdm5ldCJ9fX19
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Length: ['339']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 resourcemanagementclient/2015-11-01 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [a0ae848f-43a7-11e6-bace-001dd8b7c0ad]
+      x-ms-client-request-id: [1e5ae700-447b-11e6-8bf1-001dd8b7c0ad]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/azurecli1467829791.5712688","name":"azurecli1467829791.5712688","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVNet/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"virtualNetworkName":{"type":"String","value":"vrfvnet"},"virtualNetworkPrefix":{"type":"String","value":"10.0.0.0/16"},"subnetName":{"type":"String","value":"vrfsubnet"},"subnetPrefix":{"type":"String","value":"10.0.0.0/24"},"location":{"type":"String","value":"westus"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-06T18:29:52.7088328Z","duration":"PT0.1911387S","correlationId":"f060dd86-b01f-4b28-850e-735012622d98","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]}]}],"dependencies":[]}}'}
+    body: {string: '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/azurecli1467920626.222884270249","name":"azurecli1467920626.222884270249","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVNet/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"virtualNetworkName":{"type":"String","value":"vrfvnet"},"virtualNetworkPrefix":{"type":"String","value":"10.0.0.0/16"},"subnetName":{"type":"String","value":"vrfsubnet"},"subnetPrefix":{"type":"String","value":"10.0.0.0/24"},"location":{"type":"String","value":"westus"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-07T19:43:47.111926Z","duration":"PT0.2250774S","correlationId":"cda78675-d618-4dc7-b921-841d329ff57e","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]}]}],"dependencies":[]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/azurecli1467829791.5712688/operationStatuses/08587337770929599416?api-version=2015-11-01']
-      cache-control: [no-cache]
-      content-length: ['964']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:29:51 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/azurecli1467920626.222884270249/operationStatuses/08587336862585907881?api-version=2015-11-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['973']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:43:46 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 resourcemanagementclient/2015-11-01 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [a0ae848f-43a7-11e6-bace-001dd8b7c0ad]
+      x-ms-client-request-id: [1e5ae700-447b-11e6-8bf1-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337770929599416?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:30:22 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 resourcemanagementclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [a0ae848f-43a7-11e6-bace-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337770929599416?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336862585907881?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -368,29 +349,29 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['141']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:30:52 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['141']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:44:16 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 resourcemanagementclient/2015-11-01 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [a0ae848f-43a7-11e6-bace-001dd8b7c0ad]
+      x-ms-client-request-id: [1e5ae700-447b-11e6-8bf1-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
@@ -400,72 +381,76 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
         o0cf3W3Wk2ZaF6u2qJbN3Xs7+/nBw4efbj94cD7Z3v80P9ieZLNs+/79B5/u7N5/uD/J9+/WeVOt
         62n+eV2tV83dy8XvP63zrM1///xd0bTF8uL3rwTc719f3F3V1WUxy+vm7hfFtK6a6rwdv1IAzd1Z
-        viqr60W+bJu72Q/WdT4ti939Tx8c7D188HB3fP/B7t6nBwcfjT5aZouc0N3Yhrpa5XVb5M1Hj37x
-        R22+WJWE1fNi+RZ/r+uCAMzbdtU8uiudNbO302I8KavJeFrV+fiqWM6qq2a8zNu75vV51bR3T3h8
-        P/mCPucXBe3xTzfVkvqdVsuWRvCTNEgaNXWyO97Bfx/9EsIpqwnzlr4CDpdF3a6zkuBcVfXbF/QN
-        Pm2vV/Tzo9dtTbQjeJdZucYHl/X5JaECMOGLL+v8vHi36dVd6h7/3d39FK/TJBOgW/QnDd0r79HT
-        3j5eK6tphrnf9MpV3rTr5qNfQs0X1QyfnC2Jg8AFWUntaB4vC5CSXnvdEuGpxev1dJoT3Wf0fVss
-        CEK2WNHnezu7n27vPNje+fTN7sGjezuP7j0Yf7r/cOfe/v5PUdPZulZ0Pnr5Zv/+ePfe7r39nXuv
-        6Sua8TqnGaZvzyAJ5zuf7sxmB59uT3Z2z7f3J3sH2wf3d/LtB/fu7xCH7e3NHiqTCT9/9Oh7v5jZ
-        slllU6Do+FuniVoTjzGnvyFSyBv+J/RSOLENvWIoiOaGVN//JfQfjSZf5ctZvpwyi3+PPqnW7Wrd
-        0h+ESn4FBsWvSvgvJz+dT1sCqYT/xYL8Bsoa5D5fs3I4388eznb3ZttZdv/T7f17k2z74e75bPve
-        /iQ7uL+XfTrL8FY2m9GLzWuhwy82fwvvMKaOS4gfv0/zLtyFrwjxDGzpcd/oI+79Lv35Q1dNREFM
-        xN3OvNwl7CCLdwkn+sF/y6+Ebd5mF4Tvd+/+vh/tPpju3Jtl+fbD7P6D7f2dCTHR7u5kO79/Pj2f
-        Tia7Dw7u/74f0TvUt6er6K+N8xJQlL6z5ITQEW9AlIQVrGpl0jIdbz24jwDp/wGtGAyQGAYAAA==
+        viqr60W+bJu72Q/WdT4ti939Tx883Nv5dO/T8d7e3sHB/t6Dnb39hx+NPlpmi5xwvrkhdbrK67bI
+        m48e/eKP2nyxKgm/58XyLf5e1wVBmbftqnl0V7ptZm+nxXhSVpPxtKrz8VWxnFVXzXiZt3fN6/Oq
+        ae+e8Eh/8gV9zi/KAMY/3VRL6ndaLVsay0/ScGn81MnueAf/ffRLCKesJvRb+go4XBZ1u85KgnNV
+        1W9f0Df4tL1e0c+PXrc1UZHgXWblGh9c1ueXhArAhC++rPPz4t2mV3epe/x3d/dTvE7TTYBu0Z80
+        dK+8R097+3itrKYZuGDTK1d5066bj34JNV9UM3xytiReAj9kJbWjebwsQEp67XVLhKcWr9fTaU50
+        n9H3bbEgCNliRZ/v7ex+ur3zgP73Zvfho/17j+4/HD/Y2d3Zu3fwU9R0tq4VnY9evtndGx/s7u8+
+        uL/3mr6iGa9zmmH69gwyMZ1lDw4+fXB/e/bp7sH2/mz6YHvycG93+2B/d3Zv7+H5+f0HOb3GyIGz
+        P3r0vV/MvNmssilQdJyu00SticeY598QKeQN/xN6KZzYhl4xFERzQ6rv/xL6j0aTr/LlLF9OmcW/
+        R59U63a1bukPQiW/AoPiVyX8l5OfzqctgVTC/2JBfgNlDXKfr1lNzM4/3XuwO5ttf7r/IN/ef3Aw
+        2T6Yzna3J/fPdw6mew+zbP+c3spmM3qxeS10+MXmb+EdxtRxCfHj92nehbvwFSGegS097ht9xL3f
+        pT9/6EqKKIiJuNuZl7uEHWTxLuFEP/hv+ZWwzdvsgvD97t3f96ODg08/3f80u789+TS/t70/+fTe
+        9sP7D7Pt6fTe/b18P8um+7Pf9yN6h/r2dBX9tXFeAorSd5acEDriDYiSsIJVskxapuOtB/cRIP0/
+        LbwxdCIGAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['910']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:30:53 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['920']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:44:17 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateNSG_2016-06-06/azuredeploy.json"},
-      "mode": "Incremental", "parameters": {"name": {"value": "vrfnsg"}}}}'
+    body: !!binary |
+      eyJwcm9wZXJ0aWVzIjogeyJwYXJhbWV0ZXJzIjogeyJuYW1lIjogeyJ2YWx1ZSI6ICJ2cmZuc2ci
+      fX0sICJ0ZW1wbGF0ZUxpbmsiOiB7InVyaSI6ICJodHRwczovL2F6dXJlc2RrY2kuYmxvYi5jb3Jl
+      LndpbmRvd3MubmV0L3RlbXBsYXRlaG9zdC9DcmVhdGVOU0dfMjAxNi0wNi0wNi9henVyZWRlcGxv
+      eS5qc29uIn0sICJtb2RlIjogIkluY3JlbWVudGFsIn19
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Length: ['204']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 nsgcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [c658b300-43a7-11e6-841b-001dd8b7c0ad]
+      x-ms-client-request-id: [318fc238-447b-11e6-9d20-001dd8b7c0ad]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/azurecli1467829854.7685371","name":"azurecli1467829854.7685371","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateNSG_2016-06-06/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"vrfnsg"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-06T18:30:55.9817956Z","duration":"PT0.2175591S","correlationId":"25a11ea4-a812-42e4-b33f-4f0e1b70b230","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[]}}'}
+    body: {string: '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/azurecli1467920658.445991883333","name":"azurecli1467920658.445991883333","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateNSG_2016-06-06/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"vrfnsg"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-07T19:44:19.3081313Z","duration":"PT0.240013S","correlationId":"57ba34c6-5f09-4bb2-8647-e2ea6728c7bf","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/azurecli1467829854.7685371/operationStatuses/08587337770297133920?api-version=2015-11-01']
-      cache-control: [no-cache]
-      content-length: ['796']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:30:55 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/azurecli1467920658.445991883333/operationStatuses/08587336862264095088?api-version=2015-11-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['805']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:44:18 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1194']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 nsgcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [c658b300-43a7-11e6-841b-001dd8b7c0ad]
+      x-ms-client-request-id: [318fc238-447b-11e6-9d20-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337770297133920?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336862264095088?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -473,28 +458,28 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['141']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:31:25 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['141']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:44:48 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 nsgcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [c658b300-43a7-11e6-841b-001dd8b7c0ad]
+      x-ms-client-request-id: [318fc238-447b-11e6-9d20-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
@@ -504,45 +489,46 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
         o0cf3W3Wk2ZaF6u2qJbN3Xs7+/nBw4efbj94cD7Z3v80P9ieZLNs+/79B5/u7N5/uD/J9+/WeVOt
         62n+eV2tV83dy8XvP63zrM1///xd0bTF8uL3rwTc719f3F3V1WUxy+vm7hfFtK6a6rwdv1IAzd1Z
-        viqr60W+bJu72Q/WdT4ti939Tx8c7D08uL8/fvDpwf17D3Y/Gn20zBY5obuxDXW1yuu2yJuPHv3i
-        j9p8sSoJq+fF8i3+XtcFAZi37ap5dFc6a2Zvp8V4UlaT8bSq8/FVsZxVV814mbd3zevzqmnvnvD4
-        Xrz+/Pff29n9dHsH/xMQMoDxTzfVkjCYVsuWxvKTNFwaP3W3O97Bfx/9EsIuq2kMLX0FbMpqmoFG
-        +L29XmFsr9uaaEdQLrNyjQ+u8qZdN3hXRj/c8rI+XzYXH/0SarqoZvjkbElzArpmJbUjylwWQIle
-        e93SUKjF6/V0mhP+M/q+LRbUV7ZY0ecywgc0wje7B4/u7T7a3RvTZ7s/Re1m61qx/ujlm91Px/v3
-        Pj349N791/QVEbDOiWD07RkYa+9+trubZ/vb2cHu3vb+Xr6/Pbl373x7/3wn35082Jns3duh1xgz
-        sMdHj773i3mczSqbAj/HLi/y9qqq31JrmjJmnDdEB3nD/4ReoplD09f5lKa7vRYOpRcNufGSoev3
-        fwn9R2PKV/lyli+nzDffo0+qdbtat/QHIZRf0azjNyX9l5OfzqctQVTS/2IZwQbaGgw/X7PA5fmD
-        ezvTe7vb+9Nz+mf26XT74OHBbPv8fPLwwU5+nuUP79FbjY7g1bo0aM3oy3XZmrGZbwjJDNzx0XFZ
-        Vlc/SRQ4Wz6p1kv0zT3e/bkQcZ2zu4QOfhqkDTzmV5L+/ojuRoaRt9kFDeS7d3/fj/b2z/d29x9O
-        iT3zTwn7B59uH8wyYqtPD6b7s3t792e757/vR/QOIeUpA/pr4yTNcksh+oZRSIvlBP2nbZ2dnxfT
-        9LyuFmlWlulPftHQl+lPvjh9Q68S6LaaViW99y36U+j2sqrbV9nyAv3gU4JPVGMW7H4lLxzPZkTz
-        5mWdnxfv6JufLOp2nZVKRmrmQbixbUYDa2jcMhD6YFUXFSj80aNP7+/s7BC0gtQoYFGjMxkntEfI
-        S8dQcM+rbPYkK7PlNK/djPx/lrE2jOn/TVwGLNOS0Ewniie9TuB/FjitRxFq6QHpNgegG/hrlwDc
-        wF9P8+U1veyI//9FhuoN4ofNQUCANVIhJDZMRA0J0M8Cr+Ab76XY15Y3gBz97bMG8Qa9fwNrEEVF
-        /3+5bg1h/7/IHbFx/LAZhHFIyZ9hMhv2UB1DfANL1lb21/8fGTUiOo+5z1pn5KLX4bT8f5a9ImP5
-        fymLGUzpfYL/s8Bb+MZ7qfu11/8NjNSxXkRaHlnASNBt9DZ9Z8j+/0UW6o/ih808wIC5pMs/1JIg
-        /fDZBF9b/gB29LfPHsQf9H6cPb7/S4hFPqKRUPBoMxwcoDFzvN+MfQRw/w8buFKjpBEAAA==
+        viqr60W+bJu72Q/WdT4ti939Tx883Nv59P7BeH///sOHuwcH9+j5aPTRMlvkhPPNDanTVV63Rd58
+        9OgXf9Tmi1VJ+D0vlm/x97ouCMq8bVfNo7vSbTN7Oy3Gk7KajKdVnY+viuWsumrGy7y9a16fV017
+        94RH+uL157//3s7up9s7+J+AkKGMf7qploTBtFq2NKqfpIETJai73fEO/vvolxB2WU0DaekrYFNW
+        0wzUwu/t9QoDfN3WREWCcpmVa3xwlTftusG7QoLhlpf1+bK5+OiXUNNFNcMnZ0uaHVA4K6kdUeay
+        AEr02uuWhkItXq+n05zwn9H3bbGgvrLFij6XET6g/73Zffhof//RvZ3xwwf39g/u7f8UNZ2ta0X8
+        o5dvdnfHD3fu3/v0/u5r+opoWOdEM/r2DFx2/8Eku7c//XT7/vnOw+39yWRv++DT/Qfb+V6effpg
+        72D6YHJOrzFy4JWPHn3vF/NQm1U2BYqOd17k7VVVv6XWNGvMRW+IFPKG/wm9RJOHpq/zKc14ey3s
+        Si8aiuMlQ9rv/xL6j8aUr/LlLF9OmXW+R59U63a1bukPQii/oonHb0r9Lyc/nU9bgqjU/8Uygg3k
+        NRh+vmbpe7h3/jC/l+9uT6YP723v7+99uj3Zm3y6Pb0/u7cznd2/N8l26K1GR/BqXRq0Zvl5ti5b
+        MzbzDSGZgUE+Oi7L6uoniQJnyyfVeom+uce7PxfyrnN2l9DBT4O0gccsS6qgP6K7kWHkbXZBA/nu
+        3d/3oyyf7h98mt/fntybzIh80/3th/dmk+29hzv0Y//+wXn26e/7Eb1DSHn6gP7aOEmz3FKIvmEU
+        0mI5Qf9pW2fn58U0Pa+rRZqVZfqTXzT0ZfqTL07f0KsEuq2mVUnvfYv+FLq9rOr2Vba8QD/4lOAT
+        1ZgFu1/JC8ezGdG8eVnn58U7+uYni7pdZ6WSkZp5EG5sm9HAGhq3DIQ+WNVFBQp/9OjT+zs7OwSt
+        IHUKWNToTMYJBRLy0jF03PMqmz3Jymw5zWs3I/+fZawNY/p/E5cBy7QkNNOJ4kmvE/ifBU7rUYRa
+        ekC6zQHoBv7aJQA38NfTfHlNLzvi/3+RoXqD+GFzEBBgjVQIiQ0TUUMC9LPAK/jGeyn2teUNIEd/
+        +6xBvEHv38AaRFHR/1+uW0PY/y9yR2wcP2wGYRxS8meYzIY9VMcQ38CStZX99f9HRo2IzmPus9YZ
+        eel1OC3/n2WvyFj+X8piBlN6n+D/LPAWvvFe6n7t9X8DI3WsF5GWRxYwEnQbvU3fGbL/f5GF+qP4
+        YTMPMGAu6fIPtSRIP3w2wdeWP4Ad/e2zB/EHvR9nj+//EmKRj2gkFDzadAcHaMwc7zdjHwHc/wMr
+        i9c6sREAAA==
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['1249']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:31:25 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['1261']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:44:48 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [close]
       Host: [raw.githubusercontent.com]
-      User-Agent: [Python-urllib/2.7]
+      User-Agent: [Python-urllib/3.5]
     method: GET
     uri: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json
   response:
-    body: {string: !!python/unicode "{\n  \"$schema\":\"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json\"\
+    body: {string: "{\n  \"$schema\":\"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json\"\
         ,\n  \"contentVersion\":\"1.0.0.0\",\n  \"parameters\":{},\n  \"variables\"\
         :{},\n  \"resources\":[],\n\n  \"outputs\":{\n    \"aliases\":{\n      \"\
         metadata\":{\n        \"description\":\"This list of aliases is used by Azure\
@@ -579,43 +565,43 @@ interactions:
         \     \"version\":\"latest\"\n          }\n        }\n      }\n    }\n  }\n\
         }\n"}
     headers:
-      accept-ranges: [bytes]
-      access-control-allow-origin: ['*']
-      cache-control: [max-age=300]
-      connection: [close]
-      content-length: ['2297']
-      content-security-policy: [default-src 'none'; style-src 'unsafe-inline']
-      content-type: [text/plain; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:31:27 GMT']
-      etag: ['"db78eb36618a060181b32ac2de91b1733f382e01"']
-      expires: ['Wed, 06 Jul 2016 18:36:27 GMT']
-      source-age: ['155']
-      strict-transport-security: [max-age=31536000]
-      vary: ['Authorization,Accept-Encoding']
-      via: [1.1 varnish]
-      x-cache: [HIT]
-      x-cache-hits: ['1']
-      x-content-type-options: [nosniff]
-      x-fastly-request-id: [a4cb248c77a4e873ebe51a5924129fdad2b076f4]
-      x-frame-options: [deny]
-      x-geo-block-list: ['']
-      x-github-request-id: ['17EB2F14:5AD3:33797ED:577D4DE3']
-      x-served-by: [cache-sjc3625-SJC]
-      x-xss-protection: [1; mode=block]
+      Accept-Ranges: [bytes]
+      Access-Control-Allow-Origin: ['*']
+      Cache-Control: [max-age=300]
+      Connection: [close]
+      Content-Length: ['2297']
+      Content-Security-Policy: [default-src 'none'; style-src 'unsafe-inline']
+      Content-Type: [text/plain; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:44:51 GMT']
+      ETag: ['"db78eb36618a060181b32ac2de91b1733f382e01"']
+      Expires: ['Thu, 07 Jul 2016 19:49:51 GMT']
+      Source-Age: ['261']
+      Strict-Transport-Security: [max-age=31536000]
+      Vary: ['Authorization,Accept-Encoding']
+      Via: [1.1 varnish]
+      X-Cache: [HIT]
+      X-Cache-Hits: ['1']
+      X-Content-Type-Options: [nosniff]
+      X-Fastly-Request-ID: [60ab8c34d08feac276ee3744398c11821ca2b958]
+      X-Frame-Options: [deny]
+      X-Geo-Block-List: ['']
+      X-GitHub-Request-Id: ['17EB2F14:5AD4:5836B6B:577EB02D']
+      X-Served-By: [cache-sjc3624-SJC]
+      X-XSS-Protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 resourcemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [d9a7055e-43a7-11e6-bf32-001dd8b7c0ad]
+      x-ms-client-request-id: [44d5724a-447b-11e6-b8b7-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27vm_create_existing_options_rg%27%20and%20name%20eq%20%27vrfavailset%27%20and%20resourceType%20eq%20%27Microsoft.Compute%2FavailabilitySets%27
   response:
@@ -628,29 +614,29 @@ interactions:
         q6Y6b8cn1WK1bvO72WVWlNmkKIv2+nXeEqj6nD9r8vaj0UfLbEGYfhR+2F6v8OHNwKhtWU0zIELt
         r/KmXeOzNrtoPnr0iz+aFc2qzK5fSB/H4csf/ZJf8v1f8v8A5trdZSwBAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['329']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:31:26 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['329']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:44:50 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 resourcemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [d9f01c51-43a7-11e6-888b-001dd8b7c0ad]
+      x-ms-client-request-id: [4503f1f4-447b-11e6-a089-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27vm_create_existing_options_rg%27%20and%20name%20eq%20%27vrfvnet%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FvirtualNetworks%27
   response:
@@ -663,29 +649,64 @@ interactions:
         q6Y6b8cv8vaqqt/evSzqdp2V+idBqs8vl3n70eijZbYgJD9yH7TXK3xwIwxqWlbTDN1T86u8adf4
         rM0umo8e/eKPZkWzKrPrFwL+RX71k/TiR7/kl3z/l/w/Jim6mhoBAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['326']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:31:28 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['326']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:44:50 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 resourcemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [da67210f-43a7-11e6-94ed-001dd8b7c0ad]
+      x-ms-client-request-id: [452791d2-447b-11e6-acca-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27vm_create_existing_options_rg%27%20and%20name%20eq%20%27vrfnsg%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FnetworkSecurityGroups%27
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXP33s5+fvDw4afbDx6cT7b3P80PtifZLNu+f//Bpzu7
+        9x/uT/L9u3XeVOt6mn9eV+tVc/dy8ftP6zxr898/f1c0bbG8+P0rAff71xd3V3V1Wczyurn7RTGt
+        q6Y6b8cv8vaqqt/eXcrP1/l0XRfttYFXny+bi49GHy2zBWH6kf27vV7h71vCoRfKapoBEXrpKm/a
+        dfPRL/n+L/l/AJWxcnsDAQAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['303']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:44:50 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 resourcemanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [4551e67e-447b-11e6-b308-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27vm_create_existing_options_rg%27%20and%20name%20eq%20%27vrfpubip%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FpublicIPAddresses%27
   response:
@@ -698,29 +719,29 @@ interactions:
         q6Y6b8cv8vaqqt/eXa0nZTE9e3k8mxHMJidY9Tl9WKw+Gn20zBaE50feJ+31Cp/cAg41LqtpBiTo
         hau8adfNR7/k+7/k/wGP5fGw/wAAAA==
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['307']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:31:28 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['307']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:44:51 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 resourcemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [daaa4491-43a7-11e6-8f0a-001dd8b7c0ad]
+      x-ms-client-request-id: [4578c3a2-447b-11e6-b3d8-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27vm_create_existing_options_rg%27%20and%20name%20eq%20%27azureclivrfstorage0011%27%20and%20resourceType%20eq%20%27Microsoft.Storage%2FstorageAccounts%27
   response:
@@ -734,29 +755,29 @@ interactions:
         m7frjx79YgPxdZstZ1k9+/2fv3pNX7ZFXnuffvRLRh+9LZagkwKkNmU1zTA6+vAqb9o1gLbZRUNQ
         f8kv+f4v+X8ARaIWg2IBAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['359']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:31:29 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['359']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:44:51 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 resourcemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [dadced4f-43a7-11e6-8645-001dd8b7c0ad]
+      x-ms-client-request-id: [45a17664-447b-11e6-8777-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27vm_create_existing_options_rg%27%20and%20name%20eq%20%27vrfvm%27%20and%20resourceType%20eq%20%27Microsoft.Compute%2FvirtualMachines%27
   response:
@@ -766,117 +787,118 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
         uc4/evS97/+S/wdC6kBEDAAAAA==
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['133']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:31:29 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['133']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 resourcemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [db2a981e-43a7-11e6-a819-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27vm_create_existing_options_rg%27%20and%20name%20eq%20%27vrfnsg%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FnetworkSecurityGroups%27
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXP33s5+fvDw4afbDx6cT7b3P80PtifZLNu+f//Bpzu7
-        9x/uT/L9u3XeVOt6mn9eV+tVc/dy8ftP6zxr898/f1c0bbG8+P0rAff71xd3V3V1Wczyurn7RTGt
-        q6Y6b8cv8vaqqt/eXcrP1/l0XRfttYFXny+bi49GHy2zBWH6kf27vV7h71vCoRfKapoBEXrpKm/a
-        dfPRL/n+L/l/AJWxcnsDAQAA
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['303']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:31:29 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Date: ['Thu, 07 Jul 2016 19:44:52 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30/azuredeploy.json"},
-      "mode": "Incremental", "parameters": {"osSKU": {"value": "14.04.4-LTS"}, "publicIpAddressAllocation":
-      {"value": "dynamic"}, "virtualNetworkType": {"value": "existingId"}, "authenticationType":
-      {"value": "ssh"}, "osDiskType": {"value": "provided"}, "storageType": {"value":
-      "Premium_LRS"}, "_artifactsLocation": {"value": "https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30"},
-      "subnetIpAddressPrefix": {"value": "10.0.0.0/24"}, "adminUsername": {"value":
-      "burtbiel"}, "networkInterfaceType": {"value": "new"}, "dnsNameType": {"value":
-      "none"}, "osType": {"value": "Custom"}, "sshKeyValue": {"value": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
-      test@example.com\n"}, "osVersion": {"value": "latest"}, "customOsDiskType":
-      {"value": "windows"}, "size": {"value": "Standard_DS2"}, "availabilitySetType":
-      {"value": "existingId"}, "virtualNetwork": {"value": "/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Network/virtualNetworks/vrfvnet"},
-      "name": {"value": "vrfvm"}, "storageCaching": {"value": "ReadWrite"}, "storageAccountType":
-      {"value": "existingId"}, "osOffer": {"value": "UbuntuServer"}, "storageAccount":
-      {"value": "/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Storage/storageAccounts/azureclivrfstorage0011"},
-      "networkSecurityGroupRule": {"value": "SSH"}, "storageContainerName": {"value":
-      "vrfcontainer"}, "publicIpAddressType": {"value": "existingId"}, "availabilitySet":
-      {"value": "/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Compute/availabilitySets/vrfavailset"},
-      "osPublisher": {"value": "Canonical"}, "publicIpAddress": {"value": "/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Network/publicIPAddresses/vrfpubip"},
-      "subnetName": {"value": "vrfsubnet"}, "networkSecurityGroupType": {"value":
-      "existingId"}, "privateIpAddressAllocation": {"value": "dynamic"}, "virtualNetworkIpAddressPrefix":
-      {"value": "10.0.0.0/16"}, "networkSecurityGroup": {"value": "/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Network/networkSecurityGroups/vrfnsg"},
-      "osDiskName": {"value": "vrfosdisk"}, "location": {"value": "West US"}}}}'
+    body: !!binary |
+      eyJwcm9wZXJ0aWVzIjogeyJwYXJhbWV0ZXJzIjogeyJzaXplIjogeyJ2YWx1ZSI6ICJTdGFuZGFy
+      ZF9EUzIifSwgInN0b3JhZ2VBY2NvdW50VHlwZSI6IHsidmFsdWUiOiAiZXhpc3RpbmdJZCJ9LCAi
+      Y3VzdG9tT3NEaXNrVHlwZSI6IHsidmFsdWUiOiAid2luZG93cyJ9LCAibmV0d29ya1NlY3VyaXR5
+      R3JvdXBSdWxlIjogeyJ2YWx1ZSI6ICJTU0gifSwgInNzaEtleVZhbHVlIjogeyJ2YWx1ZSI6ICJz
+      c2gtcnNhIEFBQUFCM056YUMxeWMyRUFBQUFEQVFBQkFBQUNBUUNiSWcxZ3VSSGJJMGxWMTF3V0R0
+      MXIyY1VkY05kMjdDSnNnK1NmZ0M3bWlaZXVidHdVaGJzUGRoTVFzZkR5aE9XSHExK1pMME0rbkpa
+      VjYzZC8xZGhtaHRneU9xZWpVd3JQbHpLaHlkc2Jyc2RVb3IrSm1OSkRkVzAxdjdCWEh5dXltVDhH
+      NHMwOWpDYXNOT3dpdWZiUC9xcDcycnV1MGJJQTFueVNzdmxmOXBDUUF1RmtBblZuZi9yRmhVbE9r
+      aHRScHdjcThTVU5ZMnpSSFIvRUtiLzROV1kxSnpSNHNhM3EyZldJSmRyclgwRHZMb2E1ZzliSUVk
+      NERmNzliYTd2K3lpVUJPUzB6VDJsbCt6NGc5aXpISzNFTzVkOGhMNGpZeGNqS3Mrd2NzbFNZUldy
+      YXNjZnNjTGdNbE1HaDBDZEtlTlREakhwR1BuY2FmM1orRnd3d2pXZXVpTkJ4djdiSm8xMy84Qi8w
+      OThLbFZEbDRHWnFzb0JDRWpQeUpmVjZoTzB5L0xrUkdrazdvSFdLZ2VXQWZLdGZMSXRScDAwZVo0
+      ZmNKTks5a0NhU01tRXVnb1pXY0k3TkdiWlh6cUZXcWJwUkk3TmNEUDkrV0lRK2k5VTV2cVdzcWQv
+      em5nNGtidUFKNlV1S3FJekIwdXBZckxTaGZRRTNTQWNrOG9hTGhKcXFxNTZWZkR1QVNOcEpLaWRW
+      K3pxMjdIZlNCbWJYbmtSLzVBSzMzN2RjM01YS0p5cG9LL1FQTUxLVUFQNVhMUGJzK05kZEpRVjdF
+      WlhkMjlETGdwK2ZSSWczZWRwS2RPN1pFcldodjdkKzNLd3MrZTFZK3lwbVIyV0lWU3dWeUJFVWZn
+      djJDOFRzOWduVEY0cE5jRVkvUzJhQmljejVFdzIramR5R05RUT09IHRlc3RAZXhhbXBsZS5jb21c
+      biJ9LCAicHVibGljSXBBZGRyZXNzIjogeyJ2YWx1ZSI6ICIvc3Vic2NyaXB0aW9ucy8zMDRlODk5
+      Ni03N2ZiLTQ2ZTgtYmFkYS01NTc2MDE1OTRiZTQvcmVzb3VyY2VHcm91cHMvdm1fY3JlYXRlX2V4
+      aXN0aW5nX29wdGlvbnNfcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3B1YmxpY0lQQWRk
+      cmVzc2VzL3ZyZnB1YmlwIn0sICJuZXR3b3JrSW50ZXJmYWNlVHlwZSI6IHsidmFsdWUiOiAibmV3
+      In0sICJvc1B1Ymxpc2hlciI6IHsidmFsdWUiOiAiQ2Fub25pY2FsIn0sICJhZG1pblVzZXJuYW1l
+      IjogeyJ2YWx1ZSI6ICJidXJ0YmllbCJ9LCAibmFtZSI6IHsidmFsdWUiOiAidnJmdm0ifSwgInB1
+      YmxpY0lwQWRkcmVzc0FsbG9jYXRpb24iOiB7InZhbHVlIjogImR5bmFtaWMifSwgIm9zRGlza1R5
+      cGUiOiB7InZhbHVlIjogInByb3ZpZGVkIn0sICJfYXJ0aWZhY3RzTG9jYXRpb24iOiB7InZhbHVl
+      IjogImh0dHBzOi8vYXp1cmVzZGtjaS5ibG9iLmNvcmUud2luZG93cy5uZXQvdGVtcGxhdGVob3N0
+      L0NyZWF0ZVZtXzIwMTYtMDYtMzAifSwgIm9zRGlza05hbWUiOiB7InZhbHVlIjogInZyZm9zZGlz
+      ayJ9LCAiYXV0aGVudGljYXRpb25UeXBlIjogeyJ2YWx1ZSI6ICJzc2gifSwgInZpcnR1YWxOZXR3
+      b3JrIjogeyJ2YWx1ZSI6ICIvc3Vic2NyaXB0aW9ucy8zMDRlODk5Ni03N2ZiLTQ2ZTgtYmFkYS01
+      NTc2MDE1OTRiZTQvcmVzb3VyY2VHcm91cHMvdm1fY3JlYXRlX2V4aXN0aW5nX29wdGlvbnNfcmcv
+      cHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3ZpcnR1YWxOZXR3b3Jrcy92cmZ2bmV0In0sICJw
+      cml2YXRlSXBBZGRyZXNzQWxsb2NhdGlvbiI6IHsidmFsdWUiOiAiZHluYW1pYyJ9LCAiYXZhaWxh
+      YmlsaXR5U2V0VHlwZSI6IHsidmFsdWUiOiAiZXhpc3RpbmdJZCJ9LCAib3NTS1UiOiB7InZhbHVl
+      IjogIjE0LjA0LjQtTFRTIn0sICJkbnNOYW1lVHlwZSI6IHsidmFsdWUiOiAibm9uZSJ9LCAib3NW
+      ZXJzaW9uIjogeyJ2YWx1ZSI6ICJsYXRlc3QifSwgInZpcnR1YWxOZXR3b3JrSXBBZGRyZXNzUHJl
+      Zml4IjogeyJ2YWx1ZSI6ICIxMC4wLjAuMC8xNiJ9LCAibmV0d29ya1NlY3VyaXR5R3JvdXAiOiB7
+      InZhbHVlIjogIi9zdWJzY3JpcHRpb25zLzMwNGU4OTk2LTc3ZmItNDZlOC1iYWRhLTU1NzYwMTU5
+      NGJlNC9yZXNvdXJjZUdyb3Vwcy92bV9jcmVhdGVfZXhpc3Rpbmdfb3B0aW9uc19yZy9wcm92aWRl
+      cnMvTWljcm9zb2Z0Lk5ldHdvcmsvbmV0d29ya1NlY3VyaXR5R3JvdXBzL3ZyZm5zZyJ9LCAic3Vi
+      bmV0TmFtZSI6IHsidmFsdWUiOiAidnJmc3VibmV0In0sICJhdmFpbGFiaWxpdHlTZXQiOiB7InZh
+      bHVlIjogIi9zdWJzY3JpcHRpb25zLzMwNGU4OTk2LTc3ZmItNDZlOC1iYWRhLTU1NzYwMTU5NGJl
+      NC9yZXNvdXJjZUdyb3Vwcy92bV9jcmVhdGVfZXhpc3Rpbmdfb3B0aW9uc19yZy9wcm92aWRlcnMv
+      TWljcm9zb2Z0LkNvbXB1dGUvYXZhaWxhYmlsaXR5U2V0cy92cmZhdmFpbHNldCJ9LCAib3NUeXBl
+      IjogeyJ2YWx1ZSI6ICJDdXN0b20ifSwgInN0b3JhZ2VUeXBlIjogeyJ2YWx1ZSI6ICJQcmVtaXVt
+      X0xSUyJ9LCAib3NPZmZlciI6IHsidmFsdWUiOiAiVWJ1bnR1U2VydmVyIn0sICJsb2NhdGlvbiI6
+      IHsidmFsdWUiOiAiV2VzdCBVUyJ9LCAic3VibmV0SXBBZGRyZXNzUHJlZml4IjogeyJ2YWx1ZSI6
+      ICIxMC4wLjAuMC8yNCJ9LCAic3RvcmFnZUNhY2hpbmciOiB7InZhbHVlIjogIlJlYWRXcml0ZSJ9
+      LCAic3RvcmFnZUFjY291bnQiOiB7InZhbHVlIjogIi9zdWJzY3JpcHRpb25zLzMwNGU4OTk2LTc3
+      ZmItNDZlOC1iYWRhLTU1NzYwMTU5NGJlNC9yZXNvdXJjZUdyb3Vwcy92bV9jcmVhdGVfZXhpc3Rp
+      bmdfb3B0aW9uc19yZy9wcm92aWRlcnMvTWljcm9zb2Z0LlN0b3JhZ2Uvc3RvcmFnZUFjY291bnRz
+      L2F6dXJlY2xpdnJmc3RvcmFnZTAwMTEifSwgInZpcnR1YWxOZXR3b3JrVHlwZSI6IHsidmFsdWUi
+      OiAiZXhpc3RpbmdJZCJ9LCAibmV0d29ya1NlY3VyaXR5R3JvdXBUeXBlIjogeyJ2YWx1ZSI6ICJl
+      eGlzdGluZ0lkIn0sICJzdG9yYWdlQ29udGFpbmVyTmFtZSI6IHsidmFsdWUiOiAidnJmY29udGFp
+      bmVyIn0sICJwdWJsaWNJcEFkZHJlc3NUeXBlIjogeyJ2YWx1ZSI6ICJleGlzdGluZ0lkIn19LCAi
+      dGVtcGxhdGVMaW5rIjogeyJ1cmkiOiAiaHR0cHM6Ly9henVyZXNka2NpLmJsb2IuY29yZS53aW5k
+      b3dzLm5ldC90ZW1wbGF0ZWhvc3QvQ3JlYXRlVm1fMjAxNi0wNi0zMC9henVyZWRlcGxveS5qc29u
+      In0sICJtb2RlIjogIkluY3JlbWVudGFsIn19
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Length: ['3219']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [db8d2a80-43a7-11e6-9dbd-001dd8b7c0ad]
+      x-ms-client-request-id: [45d47aee-447b-11e6-a757-001dd8b7c0ad]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/azurecli1467829887.1535752","name":"azurecli1467829887.1535752","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30"},"adminPassword":{"type":"SecureString"},"adminUsername":{"type":"String","value":"burtbiel"},"authenticationType":{"type":"String","value":"ssh"},"availabilitySet":{"type":"String","value":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Compute/availabilitySets/vrfavailset"},"availabilitySetType":{"type":"String","value":"existingId"},"customOsDiskType":{"type":"String","value":"windows"},"customOsDiskUri":{"type":"String","value":""},"dnsNameForPublicIP":{"type":"String","value":""},"dnsNameType":{"type":"String","value":"none"},"location":{"type":"String","value":"West
+    body: {string: '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/azurecli1467920691.084143481014","name":"azurecli1467920691.084143481014","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30"},"adminPassword":{"type":"SecureString"},"adminUsername":{"type":"String","value":"burtbiel"},"authenticationType":{"type":"String","value":"ssh"},"availabilitySet":{"type":"String","value":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Compute/availabilitySets/vrfavailset"},"availabilitySetType":{"type":"String","value":"existingId"},"customOsDiskType":{"type":"String","value":"windows"},"customOsDiskUri":{"type":"String","value":""},"dnsNameForPublicIP":{"type":"String","value":""},"dnsNameType":{"type":"String","value":"none"},"location":{"type":"String","value":"West
         US"},"name":{"type":"String","value":"vrfvm"},"networkSecurityGroup":{"type":"String","value":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Network/networkSecurityGroups/vrfnsg"},"networkSecurityGroupRule":{"type":"String","value":"SSH"},"networkSecurityGroupType":{"type":"String","value":"existingId"},"networkInterfaceIds":{"type":"Array","value":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Network/networkInterfaces/vrfvmVMNic"}]},"networkInterfaceType":{"type":"String","value":"new"},"osDiskName":{"type":"String","value":"vrfosdisk"},"osDiskType":{"type":"String","value":"provided"},"osDiskUri":{"type":"String","value":"https://azureclivrfstorage0011.blob.core.windows.net/vrfcontainer/vrfosdisk.vhd"},"osOffer":{"type":"String","value":"UbuntuServer"},"osPublisher":{"type":"String","value":"Canonical"},"osSKU":{"type":"String","value":"14.04.4-LTS"},"osType":{"type":"String","value":"Custom"},"osVersion":{"type":"String","value":"latest"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddress":{"type":"String","value":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Network/publicIPAddresses/vrfpubip"},"publicIpAddressType":{"type":"String","value":"existingId"},"size":{"type":"String","value":"Standard_DS2"},"sshDestKeyPath":{"type":"String","value":"/home/burtbiel/.ssh/authorized_keys"},"sshKeyValue":{"type":"String","value":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
-        test@example.com\n"},"storageAccount":{"type":"String","value":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Storage/storageAccounts/azureclivrfstorage0011"},"storageAccountType":{"type":"String","value":"existingId"},"storageCaching":{"type":"String","value":"ReadWrite"},"storageContainerName":{"type":"String","value":"vrfcontainer"},"storageType":{"type":"String","value":"Premium_LRS"},"subnetIpAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetName":{"type":"String","value":"vrfsubnet"},"virtualNetworkIpAddressPrefix":{"type":"String","value":"10.0.0.0/16"},"virtualNetwork":{"type":"String","value":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Network/virtualNetworks/vrfvnet"},"virtualNetworkType":{"type":"String","value":"existingId"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-06T18:31:31.4299625Z","duration":"PT0.1214847S","correlationId":"e69edd8d-5790-4920-98a2-2e638b4cd2c8","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/vrfvmVNet","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmVNet"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/vrfvmNSG","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmNSG"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/vrfvmNicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmNicIp"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/vrfvmcx6amld72y7gg","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmcx6amld72y7gg"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/vrfvmNicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmNicIp"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/vrfvmVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmVM"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/vrfvmVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/vrfvmgbfon362o526eexistingId","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmgbfon362o526eexistingId"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/vrfvmVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/vrfvmgbfon362o526eexistingIdfqdn","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmgbfon362o526eexistingIdfqdn"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/vrfvmVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/vrfvmvrfvmVMNicmac","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmvrfvmVMNicmac"}]}}'}
+        test@example.com\n"},"storageAccount":{"type":"String","value":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Storage/storageAccounts/azureclivrfstorage0011"},"storageAccountType":{"type":"String","value":"existingId"},"storageCaching":{"type":"String","value":"ReadWrite"},"storageContainerName":{"type":"String","value":"vrfcontainer"},"storageType":{"type":"String","value":"Premium_LRS"},"subnetIpAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetName":{"type":"String","value":"vrfsubnet"},"virtualNetworkIpAddressPrefix":{"type":"String","value":"10.0.0.0/16"},"virtualNetwork":{"type":"String","value":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Network/virtualNetworks/vrfvnet"},"virtualNetworkType":{"type":"String","value":"existingId"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-07T19:44:53.3106967Z","duration":"PT0.1854464S","correlationId":"5b7adcdd-6ef5-468d-9649-ff425fb0d078","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/vrfvmVNet","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmVNet"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/vrfvmNSG","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmNSG"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/vrfvmNicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmNicIp"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/vrfvmcx6amld72y7gg","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmcx6amld72y7gg"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/vrfvmNicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmNicIp"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/vrfvmVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmVM"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/vrfvmVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/vrfvmgbfon362o526eexistingId","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmgbfon362o526eexistingId"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/vrfvmVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/vrfvmgbfon362o526eexistingIdfqdn","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmgbfon362o526eexistingIdfqdn"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/vrfvmVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/vrfvmvrfvmVMNicmac","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmvrfvmVMNicmac"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/azurecli1467829887.1535752/operationStatuses/08587337769941692369?api-version=2015-11-01']
-      cache-control: [no-cache]
-      content-length: ['7789']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:31:30 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1192']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/azurecli1467920691.084143481014/operationStatuses/08587336861923524674?api-version=2015-11-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['7799']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:44:52 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [db8d2a80-43a7-11e6-9dbd-001dd8b7c0ad]
+      x-ms-client-request-id: [45d47aee-447b-11e6-a757-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337769941692369?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336861923524674?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -884,30 +906,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:32:01 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:45:22 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [db8d2a80-43a7-11e6-9dbd-001dd8b7c0ad]
+      x-ms-client-request-id: [45d47aee-447b-11e6-a757-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337769941692369?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336861923524674?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -915,30 +937,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:32:31 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:45:53 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [db8d2a80-43a7-11e6-9dbd-001dd8b7c0ad]
+      x-ms-client-request-id: [45d47aee-447b-11e6-a757-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337769941692369?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336861923524674?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -946,30 +968,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:33:01 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:46:24 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [db8d2a80-43a7-11e6-9dbd-001dd8b7c0ad]
+      x-ms-client-request-id: [45d47aee-447b-11e6-a757-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337769941692369?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336861923524674?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -977,30 +999,92 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:33:32 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:46:53 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [db8d2a80-43a7-11e6-9dbd-001dd8b7c0ad]
+      x-ms-client-request-id: [45d47aee-447b-11e6-a757-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337769941692369?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336861923524674?api-version=2015-11-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
+        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:47:24 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [45d47aee-447b-11e6-a757-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336861923524674?api-version=2015-11-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
+        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:47:54 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [45d47aee-447b-11e6-a757-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336861923524674?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -1008,28 +1092,28 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['141']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:34:01 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['141']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:48:25 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [db8d2a80-43a7-11e6-9dbd-001dd8b7c0ad]
+      x-ms-client-request-id: [45d47aee-447b-11e6-a757-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/vm_create_existing_options_rg/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
@@ -1039,70 +1123,70 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
         o0cf3W3Wk2ZaF6u2qJbN3Xs7+/nBw4efbj94cD7Z3v80P9ieZLNs+/79B5/u7N5/uD/J9+/WeVOt
         62n+eV2tV83dy8XvP63zrM1///xd0bTF8uL3rwTc719f3F3V1WUxy+vm7hfFtK6a6rwdv1IAzd1Z
-        viqr60W+bJu72Q/WdT4ti939Tx8c7D08OHgw3r1/7/6D+3sfjT5aZouc0N3Yhrpa5XVb5M1Hj37x
-        R22+WJWE1fNi+RZ/r+uCAMzbdtU8uiudNbO302I8KavJeFrV+fiqWM6qq2a8zNu75vV51bR3T3h8
-        P7n4/fd2dj/d3vl0+96OQBD8xz/dVEtCYFotWxrKT9JoafjU2+54B/999EsIuaymIbT0FZD5/TPC
-        8zybts3zapqBWPi0vV5hkK/bmohI8C6zco0PvjGkgUg2WxTLl1nTXFU1cYDrNZ8SdO3btPuqyWsh
-        vWsnLRx2k3XdToq85JfW7ZwoUMiY3vAbw282zZxfusyKMpsUZdFev87bTW/c/blg15NqsVq3+d0O
-        ngSqPufPGkK6P46bRm+6P5vh5em6aavFl83Tonl705s65d3XvgKHD7+F5rNl8yJb5M+q+uV6UhbT
-        s5e3fOMmlJbVMkfz8hbs/N28adOvXqP5TbxFFL5ccMO8JX59y0xK5OW53PTi3Z8LRnkhSN6NIUvw
-        6vNlw6IV+/7VuiS8hwf0+vW3h169aW4M+sJoCuGMVBWx7zQ/m7FG0peP6zq7du9+7+fSTHTIaTEm
-        WGCLn/ziRTH96Jd8PzKmmyiyzK9AiorFBuy9qTF1VjUzauheuQm+jobpLW/cIJuBhif7Rn2SXNfZ
-        Rb6zs7s7oO2pESxOVizzGn8IluPLufb75fl5Xm/q9avJetmuX+f1JbXjV1grNHP6c8NrJxlJO6l4
-        1vhV8/r3+mpT69398c7+eH/7+RuW+Kq5iXgnrNKkrTWlw81h7xrWv6u6uKQ/zlbHsxkxn8/Wvbdi
-        7Y/L22iv2TUpLTAeAQC1pt/Y+5veuvtzKYCK50vFUwSQPixWkVHcNL2mc9FGTfED+nC49es2W86y
-        evb7P329x+2b+VOa7t8rv36ZtfNNb96dV4v8rnFO7o7pzbtwT6qaupz9/m/zazag9DEB+0l5aRga
-        Nduumyw9pufJvRc/yE52r6d7p/TX8dPjnzh+Qj9Pjn/iZHJ2sXuxfvXtydlO+ZO7u1fffdru1nvT
-        r2bTF7O9ByffaS4+eX1+cfJgUfxUvp60V1/NJ83L2fyLn2jOn17Pv/zut3/R7ic/9Xzni0+W3/mp
-        n/z03uzu7my+mLcX11/+ovynv7qqX5Y/+L3m17NmUjezr6r6k+8sXnzn6ey7O7uXD5783t++Xl8v
-        3hx8vt/sPPzpk6x58eVVsT6fvLz7i1YP9ur1emdydry7vH7dXJbnD1cnP3G8fvb2ePmTy/O79bP5
-        V+WXb+ftq9XV9BcdvP7qxe+z94NX33519/T3mtzdf/Hd32f3Oz94td9k937R3vl3z74zq+vfe+fp
-        5fMqu3/xcHJ2Ott/ev7g4SR7cPnJdfHVky9f7/zgzV5ZfvKD/YuHxQ++/XvdO/3y/uxg/nz/p3+f
-        d9Of/r2aT66mTfn693n13TprpufN9PnFF+UXn893Tma/V/7izdOf/vbq85fLaXZ+76c+eXZ1dfXT
-        383XxYsn7y4fTL5T7d67e/Dk7s7Dg9+r/Mmn5f7nP/WLmurJyelPv7z+zvlPfjr/cuf67vO3rz5/
-        +/ZB9e3v/l4X+XePz3+v9vz5GQ1tZyf/qf3z6Xde/F4P355kr79YnK4vqp/67vTswYvPJz/1e//g
-        Fz377i+arF7Rn9OnLx9+8t2zn/ikePjV/ctf9N3mF83u/mB5sf92sj7+zqdfrX+vX3T2gyc769Xv
-        Uz9/PT//idN7r4+nbw+q7Pn8O7/oF/2i+5/+5PnT9fHrF6vv/F7F7Cc/+cEv2nvw7fPXTxaT33v5
-        9tXd+8e/1717D2bTe1/83r/Xd65X1e919ydefvH89/rq+OX93/v5y0nzyYvZ7Ds/8ZMPTn/q957t
-        PXz6/GL1yfmrs4t7+Wz1e82+fPBTp/V355cPZp/c+72umk/y3d/nk+vV4tXed89+8vXVT14/Of3q
-        /OJy7+TgTfPwYvnm2f7qxfT097n7ei97Ukx/cP/0au+Tn55df/7iJ37is89SKM7fM3+XUdCQk3lZ
-        /L5LlggxPMfTaUXmYZNQ3P25UEqvBb27IZoufCTVpF/BdPYH9J76Sd49yaZz+mzTe6/ybPZd8snY
-        DTavGfN8Cx/DmnLv/ZtwfVnni2K9+P2fv2LbStNBfoHVxPTtefFu0/u7FJziv7t7++79W+AqDfHK
-        ZVG366x8IZbi63S9+2kfzqYX71LnP3SmU7zuhmgSJHJEo5S4aeZMx+AyenlRzfDp2ZLwQjaEfCsy
-        rEAE7g+1IztInEWA1tNpTmmHGX3fFgsSYJJe+lxi/AcU5r/ZPXh0796j+/fH9+893Nk52P8pajpb
-        1+qYfPTyzd4Xe/vjvXs79+/tfPqaviTHss7JjaLvCR3C7dOH+Wx2MNu+/+Dhzvb+w72d7YcH2d72
-        Xv7pvYPJ/nS2Nz2g1xg90InDBHJq8mZFvjcBcHSzmR5qbyYBpJF3/E/oNUmmYPhobnwpNF2uy/L7
-        5Ol/n0aSr/LlLF9OOc1DQOSD5ksaG/31cxet2KEGSS0wyOIniSloRKYLHe4Nr3oviERC8BTWLxn9
-        v3SkL15/7uH9QQMFKEz4/zvHCYfXQ/zDRsrAMKfU9v/tvDx992m2KGcP9q4fXEChmb4+iAIhUFDi
-        /5Vjl4lyQ/igMQuw/9dy+E9+4eH9QQMlSJhRavj/dt4mTN0QPnjM/2+d2YvJebW89+ledX/v09zA
-        I8PvRvJBQx8C/yMe+H/RKAcm6fwXzbCOZXr+oOFv6uJHvPD/olHyP5xMX2RTD/8PGjD/Y4Fi7NW6
-        pVU08tllsodDo7s/F/Qxa3waxX3B8T6NlMdB/NrNcm4awO698cEBrUvT/w7wKrP8hvZo081Fb2qv
-        oTOH7ETdW7yxs7O983T73vH2vf1t+v3+w49+Cb0rM2Jn1cnh7cnSe4GiE4S/N67Z/JL/B2mt6R6A
-        IAAA
+        viqr60W+bJu72Q/WdT4ti939Tx883Nv59OHueOdgf3f/3v7B7s7u/kejj5bZIiecb25Ina7yui3y
+        5qNHv/ijNl+sSsLvebF8i7/XdUFQ5m27ah7dlW6b2dtpMZ6U1WQ8rep8fFUsZ9VVM17m7V3z+rxq
+        2rsnPNKfXPz+ezu7n27vfLp9b0cgyEjGP91US0JgWi1bGtRP0riJENQboYj/PvolhFxW0zha+grI
+        /P4Z4XmeTdvmeTXNQDZ82l6vMNLXbU3kJHiXWbnGB98Y0kAkmy2K5cusaa6qmnjB9ZpPCbr2bdp9
+        1eS10N+1kxYOu8m6bidFXvJL63ZOFChkTG/4jeE3m2bOL11mRZlNirJor1/n7aY37v5cMO5JtVit
+        2/xuB08CVZ/zZw0h3R/HTaM33Z/N8PJ03bTV4svmadG8velNnfLua1+Bw4ffQvPZsnmRLfJnVf1y
+        PSmL6dnLW75xE0rLapmjeXkLdv5u3rTpV6/R/CbeIgpfLrhh3hK/vmUmJfLyXG568e7PBaO8ECTv
+        xpAlePX5smHRin3/al0S3sMDev3620Ov3jQ3Bn1hNIVwRqqK2Hean81YI+nLx3WdXbt3v/dzaTA6
+        5LQYEyywxU9+8aKYfvRLvh8Z000UWeZXIEXFYgP23tSYOquaGTV0r9wEX0fD9JY3bpDNQMOTkaM+
+        Sa7r7CLf2dndHdD21AgWJyuWeY0/BMvx5Vz7/fL8PK839frVZL1s16/z+pLa8SusFZo5/bnhtZOM
+        pJ1UPGv8qnn9e321qfXu/nhnf7y//fwNS3zV3ES8E1Zp0taa0uHmsHcN699VXVzSH2er49mMmM9n
+        695bsfbH5W201+yalBYYjwCAWtNv7P1Nb939uRRAxfOl4ikCSB8Wq8gobppe07loo6b4AX043Pp1
+        my1nWT37/Z++3uP2zfwpTffvlV+/zNr5pjfvzqtFftc4J3fH9OZduCdVTV3Ofv+3+TUbUPqYgP2k
+        vDQMjZpt102WHtPz5N6LH2Qnu9fTvVP66/jp8U8cP6GfJ8c/cTI5u9i9WL/69uRsp/zJ3d2r7z5t
+        d+u96Vez6YvZ3oOT7zQXn7w+vzh5sCh+Kl9P2quv5pPm5Wz+xU8050+v519+99u/aPeTn3q+88Un
+        y+/81E9+em92d3c2X8zbi+svf1H+019d1S/LH/xe8+tZM6mb2VdV/cl3Fi++83T23Z3dywdPfu9v
+        X6+vF28OPt9vdh7+9EnWvPjyqlifT17e/UWrB3v1er0zOTveXV6/bi7L84erk584Xj97e7z8yeX5
+        3frZ/Kvyy7fz9tXqavqLDl5/9eL32fvBq2+/unv6e03u7r/47u+z+50fvNpvsnu/aO/8u2ffmdX1
+        773z9PJ5ld2/eDg5O53tPz1/8HCSPbj85Lr46smXr3d+8GavLD/5wf7Fw+IH3/697p1+eX92MH++
+        /9O/z7vpT/9ezSdX06Z8/fu8+m6dNdPzZvr84ovyi8/nOyez3yt/8ebpT3979fnL5TQ7v/dTnzy7
+        urr66e/m6+LFk3eXDybfqXbv3T14cnfn4cHvVf7k03L/85/6RU315OT0p19ef+f8Jz+df7lzfff5
+        21efv337oPr2d3+vi/y7x+e/V3v+/IyGtrOT/9T++fQ7L36vh29PstdfLE7XF9VPfXd69uDF55Of
+        +r1/8IueffcXTVav6M/p05cPP/nu2U98Ujz86v7lL/pu84tmd3+wvNh/O1kff+fTr9a/1y86+8GT
+        nfXq96mfv56f/8TpvdfH07cHVfZ8/p1f9It+0f1Pf/L86fr49YvVd36vYvaTn/zgF+09+Pb56yeL
+        ye+9fPvq7v3j3+vevQez6b0vfu/f6zvXq+r3uvsTL794/nt9dfzy/u/9/OWk+eTFbPadn/jJB6c/
+        9XvP9h4+fX6x+uT81dnFvXy2+r1mXz74qdP6u/PLB7NP7v1eV80n+e7v88n1avFq77tnP/n66iev
+        n5x+dX5xuXdy8KZ5eLF882x/9WJ6+vvcfb2XPSmmP7h/erX3yU/Prj9/8RM/8dlnKRTn75m/yyho
+        yMm8LH7fJUuEGJ7j6bQi87BJKO7+XCil14Le3RBNF0iSatKvYDr7A3pP/STvnmTTOX226b1XeTb7
+        Lvlk7Aab14x5voWPYU259/5NuL6s80WxXvz+z1+xbaXpIL/AamL69rx4t+n9XQpO8d/dvX33/i1w
+        lYZ45bKo23VWvhBL8XW63v20D2fTi3ep8x860yled0M0CRI5olFK3DRzpmNwGb28qGb49GxJeCEv
+        Qr4VGVYgAveH2pEdJM4iQOvpNKe0w4y+b4sFCTBJL30uMf4D+t+b3YeP9g8e7eyN7yFLcu/gp6jp
+        bF2rY/LRyzf3vng43n14f3//3v3X9B35lXVOXhR9Tdg8+uj+5EE2m85m25/m5/eJogez7Yef7j/c
+        Pj/f37t/PtmZ7Tw4oNcYO5CJowTyafJmRa43AXBksykfam/mAJSRd/xP6DXJpWD0aG5cKTRdrsvy
+        ++Tof58Gkq/y5SxfTjnLQ0Dkg+ZLGhr99XMXrNihBtkt8MfiJ4knaESmCx3uDa96L4hAQu4U1i8Z
+        /b90pC9ef+7h/UEDBShM+P87xwl/10P8w0bKwDCn1Pb/7bw8ffdptihnD/auH1xAn5m+PogCIVBQ
+        4v+VY5eJckP4oDELsP/XcvhPfuHh/UEDJUiYUWr4/3beJkzdED54zP9vndmLyXm1vPfpXnV/79Pc
+        wCPD70byQUMfAv8jHvh/0SgHJun8F82wjGV6/qDhb+riR7zw/6JR8j+cS19kUw//Dxow/2OBYuzV
+        uqVFNPLZZbKHI6O7Pxf0MUt8GsR9weE+jZTHQfzaTXJuGsDuvfHBAQVYO+O9+5x/YJ7f8ALadHPR
+        m9pr6MwhO5H3Fm/s7GzvPN2+d7x9b3/75GAbITe9K1Nip9UJ4u3p0nuBwhOEvzeu2fyS/wclfmEX
+        iiAAAA==
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['2454']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:34:02 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['2455']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:48:25 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [36e2aa8f-43a8-11e6-9e3c-001dd8b7c0ad]
+      x-ms-client-request-id: [c4eec5b0-447b-11e6-8da3-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Compute/availabilitySets/vrfavailset?api-version=2016-03-30
   response:
@@ -1117,29 +1201,29 @@ interactions:
         Jzr//vm7ommL5cXvXwm437++2IhzdpkVZTYpyqK9fp23BKo+58+avP1IsFxmixx49r9pr1f8zc1g
         9YWymmZACy9d5U27Nl+02QVmVif0o1nREGtcv9Cej0NoTFIi5y/5fwCNn01SfwIAAA==
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:34:04 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:48:25 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [373c8a5e-43a8-11e6-8e15-001dd8b7c0ad]
+      x-ms-client-request-id: [c5280f6c-447b-11e6-9310-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Network/networkSecurityGroups/vrfnsg?api-version=2016-03-30
   response:
@@ -1149,44 +1233,44 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj96LI+XzYXH434w2KGj+4260kzrYtVW1TL5u69nf384OHDT7cfPDifbO9/mh9sT7JZ
         tn3//oNPd3bvP9yf5Pt367yp1vU0/7yu1qvm7uXi95/Wedbmv3/+rmjaYnnx+1cC7vevL+6u6uqy
-        mOV1c/eLYlpXTXXejl/k7VVVv727lJ+v8+m6LtprA8/HMm+zC+D53bu/70efTs93zh/s3Nu+9+n5
-        +fb+JNvZzvKd+9sHu5/uPdyZ7Gefnu//vh/pi+31isd8y171rbKaZkAdb17lTbs2X9AwVnndFnlD
-        XzFV5cPLoqHmNObXLVGAvvvo9Xo6zfNZPpM3qZml11ponucP7u1M7+1u70/P6Z/Zp9Ptg4cHs+3z
-        88nDBzv5eZY/vGdfbhTNV+uS+/7e9803M2q5LlszDttAvk4NlngsBxyXZXX1k0SBs+WTar20OOL5
-        fztH3I0N+O7GEX1d7pEH89ubdHnw1S2mXh6aKUtQNGOU02I5Ab5pW2fn58U0Pa+rRZqVZfqTXzT0
-        ZfqTL07fdOBQp201rUoA+VbnO5mAl1XdvsqWF4xOtwmhQXPB/L2xnYA6ns1oWpuXdX5evEOznyzq
-        dp2VOlWddzzY7/diRiRrQF8hS+fbVV1UmGv6/tP7Ozs74bezos6n6JK+/uhM6PmRa/FLzK+/xL7m
-        TWIoE8c/WNf58yqbPcnKbDnN6xg7/X9XQG41vP/vSQtGlZY0rHSi4+rAoo5/DiWmR/XOax743rvd
-        Lt5LTnbDb78ZOXmaL6+p7xjn/H9SMDaM5/+dkgCE2UIUMoVGGDpvURc/hzzfbeaBu7Gt43EMtfNl
-        wOLE4+G33wyLEzuIM/Hluu1zxf8nuXzzkP7fyeiMc1qtW55Gw+aq84n/4SG1lf31R84SPzRiT0I2
-        O0vEDEzbrykiZ8s2r4d46v+7YrJxWP+fFhUzsg4w6vnnUEa6zTxwvbYDA3gvgdjkFdGUMwXfXyBg
-        qqhzAtDnmf9PisKmAf2/UwiAMXN7Vw46r1Ef/x9h925bx+cYa+fLgM2Jz8Nvb8/m8ovNLynnsOSd
-        Z9Q/AYgml/7fw+UOV3D45eInv3hBTGBQNQPED/r9l/w/zxZ2Mx0VAAA=
+        mOV1c/eLYlpXTXXejl/k7VVVv727lJ+v8+m6LtprA8/HMm+zC+D53bu/70f5g4f7Dx/cn26fT7OH
+        2/u7B9Ptg3sP723vn2cPdu5lD2fT3b3f9yN9sb1e8Zhv2au+VVbTDKjjzau8adfmCxrGKq/bIm/o
+        K6aqfHhZNNScxvy6JQrQdx+9Xk+neT7LZ/ImNbP0WgvNH+6dP8zv5bvbkymw39/7dHuyN/l0e3p/
+        dm9nOrt/b5Lt2JcbRfPVuuS+v/d9880sP8/WZWvGYRvI16nBEo/lgOOyrK5+kihwtnxSrZcWRzz/
+        b+eIu7EB3904oq/LPfJgfnuTLg++usXUy0MzZQmKZoxyWiwnwDdt6+z8vJim53W1SLOyTH/yi4a+
+        TH/yxembDhzqtK2mVQkg3+p8JxPwsqrbV9nygtHpNiE0aC6Yvze2E1DHsxlNa/Oyzs+Ld2j2k0Xd
+        rrNSp6rzjgf7/V7MiGQN6Ctk6Xy7qosKc03ff3p/Z2cn/HZW1PkUXdLXH50JPT9yLX6J+fWX2Ne8
+        SQxl4vgH6zp/XmWzJ1mZLad5HWOn/+8KyK2G9/89acGo0pKGlU50XB1Y1PHPocT0qN55zQPfe7fb
+        xXvJyW747TcjJ0/z5TX1HeOc/08Kxobx/L9TEoAwW4hCptAIQ+ct6uLnkOe7zTxwN7Z1PI6hdr4M
+        WJx4PPz2m2FxYgdxJr5ct32u+P8kl28e0v87GZ1xTqt1y9No2Fx1PvE/PKS2sr/+yFnih0bsSchm
+        Z4mYgWn7NUXkbNnm9RBP/X9XTDYO6//TomJG1gFGPf8cyki3mQeu13ZgAO8lEJu8IppypuD7CwRM
+        FXVOAPo88/9JUdg0oP93CgEwZm7vykHnNerj/yPs3m3r+Bxj7XwZsDnxefjt7dlcfrH5JeUclrzz
+        jPonANHk0v97uNzhCg6/XPzkFy+ICQyqZoD4Qb//kv8H7DCznB0VAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:34:05 GMT']
-      etag: [W/"6cf0f703-36ff-4ba0-ae05-816290b4a6f4"]
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:48:25 GMT']
+      ETag: [W/"e794975c-fca9-418c-8393-4fa703a9dc12"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [37d7b8f0-43a8-11e6-8610-001dd8b7c0ad]
+      x-ms-client-request-id: [c563bd62-447b-11e6-8308-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Network/networkInterfaces/vrfvmVMNic?api-version=2016-03-30
   response:
@@ -1196,43 +1280,43 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj96LI+v1z85BcviulHI/6imOHju8160kzrYtUW1bK5e29nPz94+PDT7QcPzifb+5/m
         B9uTbJZt37//4NOd3fsP9yf5/t06b6p1Pc0/r6v1qrl7ufj9p3Wetfnvn78rmrZYXvz+lYD7/euL
-        u6u6uixmed3c/aKY1lVTnbfjF3l7VdVv7y7l59myzevzbJoTrC6WeZtdAM/v3v19P9q/9yDby6c5
-        IZdNt/d3Hky2Jzvn97cfTqcP9/bOd3byfPf3/UhfLKtpBiTw8lXetOtGvyCADX3I1KE/Z0WzKrPr
-        F0omRc2i9BGa/RJ5k4ayyuu2yP336cPLoqGOaNyvW6ICfffR6/V0muezfCZ9UjNLs7XQ/eGD/P79
-        vdmD7d3dKY3l4c7O9sFOPt1+ML2/f3B/d+/Bvb3cvlysTqrleXGxrnlI6P578lVq8MBj57pYTbk9
-        U9NAwfP/9km/2x0pfTA0lK/LGfJg3nqTKQ++usWUykONi0tqcvbyeDYjGgHaR7s7Y/y3P9i0NNz5
-        Rd7OK56Tp9c0e4btzfPRaj0piym9YYEHqFKL/xfMaAdJmVH6sFix9JhHpMg8HxHGxAqE/P8LR3RZ
-        1O06K/VPgkTcR8jeJZzoB/8tv24aIE33IquvaTBtvc573ykrCM1+kvAgxKjtR2cvL/c9sL/E/Kq/
-        fF8BfTRbNq/zFqMK2EI+ry8JIH38PdOcvshWq7LIZ0+Hvi8gkcusfFotsmIJhfh6fX5evKNmH52/
-        K3bae9Ory7f38nm+unfR3Cvevm2Xl+fj2buxeXM8Lav1jPoZO9IYony0yKY6WAAkfbfzdPve8fa9
-        /W36/f5Dw/gf5ctsUhJlnlX1VVbPaHzU/jwrG0PCjwg4puV1Pl3XRXvNs01tHAn+X8BBMRwJXn2+
-        bC66lCFm6DPKR8qDX2TTebGECvp/xfhOqsVq3eZGQhQ7gkQSsjADww8Z3Uft9Qq4f+QgdCjk7AC9
-        /Uv+H9XsLbG0CAAA
+        u6u6uixmed3c/aKY1lVTnbfjF3l7VdVv7y7l59myzevzbJoTrC6WeZtdAM/v3v19P5rs7tzbnx3s
+        bO/eP79HyN17sH1wf+/e9mxy/+Hu+UF2fn7/09/3I32xrKYZkMDLV3nTrhv9ggA29CFTh/6cFc2q
+        zK5fKJkUNYvSR2j2S+RNGsoqr9si99+nDy+Lhjqicb9uiQr03Uev19Npns/ymfRJzSzN1kL33d3s
+        wYO9+w+3893d8+39/Qfn21n+MN/OD3bu7e2ff7r76Sy3Lxerk2p5Xlysax4Suv+efJUaPPDYuS5W
+        U27P1DRQ8Py/fdLvdkdKHwwN5etyhjyYt95kyoOvbjGl8lDj4pKanL08ns2IRoD20e7OGP/tDzYt
+        DXd+kbfziufk6TXNnmF783y0Wk/KYkpvWOABqtTi/wUz2kFSZpQ+LFYsPeYRKTLPR4QxsQIh///C
+        EV0WdbvOSv2TIBH3EbJ3CSf6wX/Lr5sGSNO9yOprGkxbr/Ped8oKQrOfJDwIMWr70dnLy30P7C8x
+        v+ov31dAH82Wzeu8xagCtpDP60sCSB9/zzSnL7LVqizy2dOh7wtI5DIrn1aLrFhCIb5en58X76jZ
+        R7uX11fn73b3F835ejW7qK/eXRfXb5dvf3o+nr0bmzfH07Jaz6ifsSONIcpHi2yqgwXAnZ3tnafb
+        94637+1vnxxs735qGP+jfJlNSqLMs6q+yuoZjY/an2dlY0j4EQHHtLzOp+u6aK95tqmNI8H/Czgo
+        hiPBq8+XzUWXMsQMfUb5SHnwi2w6L5ZQQf+vGN9JtVit29xIiGJHkEhCFmZg+CGj+6i9XgH3jxyE
+        DoWcHaC3f8n/A1JQ5g+0CAAA
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:34:05 GMT']
-      etag: [W/"437a2ece-77ac-407b-b0f5-9cc922f00ee1"]
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:48:26 GMT']
+      ETag: [W/"b1034d80-15f3-4637-8523-db591f8aff56"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [386b9480-43a8-11e6-b9d4-001dd8b7c0ad]
+      x-ms-client-request-id: [c59e8170-447b-11e6-8d25-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Compute/virtualMachines/vrfvm?api-version=2016-03-30
   response:
@@ -1240,44 +1324,44 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UerulrldVvkzUePUv6IPrxcnM3oz4/Op5Pd83vTB9vTT+/d296f7Ey2s0mebT/4dHfyYPbgYHr+
-        YO+jkb6UXWZFmU2KsmivX+ctva/g6LuCwd1t1pNmWhertqiWzd17O/v5wcOHn24/eHA+2d7/ND/Y
-        nmSzbPv+/Qef7uzef7g/yffv1nlTretp/nldrVfN3cvF7z+t86zNf//8XdG0xfLi968E3O9fX9yl
-        wVwWs7xu7n5RTOuqqc7b8Um1WK3b/G4HvebuT756dvyTx2fPX5+++UgQ/SVmKPOsnl1ldf6yrs6L
-        Mifc3VAuF6+LH+Cjj1632XJGLX//p6/3uhCatqqziyiAYkFfvMrP8zpfToOv6MvVelIWzTyv6fOP
-        TrJltSymWWlojOej6pxexddfTdbLdv06ry/pb79F83aN73f3xzv74/3t529eB19T84YohiYlUbJp
-        FXmHPjWqmqdF85ba+NhVzZvrFVD+6HmxXL8LoC6zBX9zWZ9XzQzv+t/KpH3JU4VWz+pqcQZCBK0u
-        5+ATr0f6bF0X9NlH87ZdNY/u3s1+sK7zaVlQN0rjnZ3d3fGkrCbjaVXn46tiOauumvEyb+9So2m1
-        bLNimdf4QxAboxvXhxs09TbNpnNiKvT4Ks9m362LNrdtXcuPZlmbgUCQmu99Xz42XxOZYvM+FUas
-        XzhCXS7c8D/KZoti+VWT14aSk3XdTorcm/2PSpD9pFqeFxfrOlNi2i6oAY0vm5T5y6xprqp6drxu
-        5/myJR7Stm29zi04at80c/rUg0CfMQ9Of6/8mgfnf5WGLfF8tMpagPjo7rxa5HcNznfHBPluRt1X
-        NYnL7Pd/C3Bez/J8RB8/JVICAL2wXTdZekzPk3svfpCd7F5P907pr+Onxz9x/IR+nhz/xMnk7GL3
-        Yv3q25OznfInd3evvvu03a33pl/Npi9mew9OvtNcfPL6/OLkwaL4qXw9aa++mk+al7P5Fz/RnD+9
-        nn/53W//ot1Pfur5zhefLL/zUz/56b3Z3d3ZfDFvL66//EX5T391Vb8sf/B7za9nzaRuZl9V9Sff
-        Wbz4ztPZd3d2Lx88+b2/fb2+Xrw5+Hy/2Xn40ydZ8+LLq2J9Pnl59xetHuzV6/XO5Ox4d3n9urks
-        zx+uTn7ieP3s7fHyJ5fnd+tn86/KL9/O21erq+kvOnj91YvfZ+8Hr7796u7p7zW5u//iu7/P7nd+
-        8Gq/ye79or3z7559Z1bXv/fO08vnVXb/4uHk7HS2//T8wcNJ9uDyk+viqydfvt75wZu9svzkB/sX
-        D4sffPv3unf65f3Zwfz5/k//Pu+mP/17NZ9cTZvy9e/z6rt11kzPm+nziy/KLz6f75zMfq/8xZun
-        P/3t1ecvl9Ps/N5PffLs6urqp7+br4sXT95dPph8p9q9d/fgyd2dhwe/V/mTT8v9z3/qFzXVk5PT
-        n355/Z3zn/x0/uXO9d3nb199/vbtg+rb3/29LvLvHp//Xu358zMa2s5O/lP759PvvPi9Hr49yV5/
-        sThdX1Q/9d3p2YMXn09+6vf+wS969t1fNFm9oj+nT18+/OS7Zz/xSfHwq/uXv+i7zS+a3f3B8mL/
-        7WR9/J1Pv1r/Xr/o7AdPdtar36d+/np+/hOn914fT98eVNnz+Xd+0S/6Rfc//cnzp+vj1y9W3/m9
-        itlPfvKDX7T34Nvnr58sJr/38u2ru/ePf6979x7Mpve++L1/r+9cr6rf6+5PvPzi+e/11fHL+7/3
-        85eT5pMXs9l3fuInH5z+1O8923v49PnF6pPzV2cX9/LZ6veaffngp07r784vH8w+ufd7XTWf5Lu/
-        zyfXq8Wrve+e/eTrq5+8fnL61fnF5d7JwZvm4cXyzbP91Yvp6e9z9/Ve9qSY/uD+6dXeJz89u/78
-        xU/8xGefpVCvv2f+Llusypz00+L3XVptIs8v8f9URYLHfm60CglLk5MabVkqtaX58iPSdiTvbz29
-        Yz46W5LOOc+mMPDf+8UfwRL/3BjiF4LP3R5e0MyXi5/84kUx/eiXfN8OiWHAUBFsMrWkh0lJvF5P
-        p3k+y0WBS1seEymgn4tBGe/isqjbdVZ+webDDEn0nW8Z7Wet2tEbIWn7srIq/KMr4qm1+aLNLmhi
-        jV6G/l+V2bWxMT8ZABOa/cbJL/l/ABGg6BP7CQAA
+        6UerulrldVvkzUePUv6IPrxcnM3oz4+y8/uTe7s7+9ufZtPd7f38Yb6dPTzY336Q7eafPsz370/y
+        3Y9G+lJ2mRVlNinKor1+nbf0voKj7woGd7dZT5ppXazaolo2d+/t7OcHDx9+uv3gwflke//T/GB7
+        ks2y7fv3H3y6s3v/4f4k379b5021rqf553W1XjV3Lxe//7TOszb//fN3RdMWy4vfvxJwv399cZcG
+        c1nM8rq5+0UxraumOm/HJ9VitW7zux30mrs/+erZ8U8enz1/ffrmI0H0l5ihzLN6dpXV+cu6Oi/K
+        nHB3Q7lcvC5+gI8+et1myxm1/P2fvt7rQmjaqs4uogCKBX3xKj/P63w5Db6iL1frSVk087ymzz86
+        yZbVsphmpaExno+qc3oVX381WS/b9eu8vqS//RbN2zW+390f7+yP97efv3kdfE3NG6IYmpREyaZV
+        5B361KhqnhbNW2rjY1c1b65XQPmj58Vy/S6AuswW/M1lfV41M7zrfyuT9iVPFVo9q6vFGQgRtLqc
+        g0+8HumzdV3QZx/N23bVPLp7N/vBus6nZUHdKI13dnZ3x5OymoynVZ2Pr4rlrLpqxsu8vUuNptWy
+        zYplXuMPQWyMblwfbtDU2zSbzomp0OOrPJt9ty7a3LZ1LT+aZW0GAkFqvvd9+dh8TWSKzftUGLF+
+        4Qh1uXDD/yibLYrlV01eG0pO1nU7KXJv9j8qQfaTanleXKzrTIlpu6AGNL5sUuYvs6a5qurZ8bqd
+        58uWeEjbtvU6t+CofdPM6VMPAn3GPDj9vfJrHpz/VRq2xPPRKmsB4qO782qR3zU43x0T5LsZdV/V
+        JC6z3/8twHk9y/MRffyUSAkA9MJ23WTpMT1P7r34QXayez3dO6W/jp8e/8TxE/p5cvwTJ5Ozi92L
+        9atvT852yp/c3b367tN2t96bfjWbvpjtPTj5TnPxyevzi5MHi+Kn8vWkvfpqPmlezuZf/ERz/vR6
+        /uV3v/2Ldj/5qec7X3yy/M5P/eSn92Z3d2fzxby9uP7yF+U//dVV/bL8we81v541k7qZfVXVn3xn
+        8eI7T2ff3dm9fPDk9/729fp68ebg8/1m5+FPn2TNiy+vivX55OXdX7R6sFev1zuTs+Pd5fXr5rI8
+        f7g6+Ynj9bO3x8ufXJ7frZ/Nvyq/fDtvX62upr/o4PVXL36fvR+8+varu6e/1+Tu/ovv/j673/nB
+        q/0mu/eL9s6/e/adWV3/3jtPL59X2f2Lh5Oz09n+0/MHDyfZg8tProuvnnz5eucHb/bK8pMf7F88
+        LH7w7d/r3umX92cH8+f7P/37vJv+9O/VfHI1bcrXv8+r79ZZMz1vps8vvii/+Hy+czL7vfIXb57+
+        9LdXn79cTrPzez/1ybOrq6uf/m6+Ll48eXf5YPKdavfe3YMnd3ceHvxe5U8+Lfc//6lf1FRPTk5/
+        +uX1d85/8tP5lzvXd5+/ffX527cPqm9/9/e6yL97fP57tefPz2hoOzv5T+2fT7/z4vd6+PYke/3F
+        4nR9Uf3Ud6dnD158Pvmp3/sHv+jZd3/RZPWK/pw+ffnwk++e/cQnxcOv7l/+ou82v2h29wfLi/23
+        k/Xxdz79av17/aKzHzzZWa9+n/r56/n5T5zee308fXtQZc/n3/lFv+gX3f/0J8+fro9fv1h95/cq
+        Zj/5yQ9+0d6Db5+/frKY/N7Lt6/u3j/+ve7dezCb3vvi9/69vnO9qn6vuz/x8ovnv9dXxy/v/97P
+        X06aT17MZt/5iZ98cPpTv/ds7+HT5xerT85fnV3cy2er32v25YOfOq2/O798MPvk3u911XyS7/4+
+        n1yvFq/2vnv2k6+vfvL6yelX5xeXeycHb5qHF8s3z/ZXL6anv8/d13vZk2L6g/unV3uf/PTs+vMX
+        P/ETn32WQr3+nvm7bLEqc9JPi993abWJPL/E/1MVCR77udEqJCxNTmq0ZanUlubLj0jbkby/9fSO
+        +ehsSTrnPJvCwH/vF38ES/xzY4hfCD53e3hBM18ufvKLF8X0o1/yfTskhgFDRbDJ1JIeJiXxej2d
+        5vksFwUubXlMpIB+LgZlvIvLom7XWfkFmw8zJNF3vmW0n7VqR2+EpO3Lyqrwj66Ip9bmiza7oIk1
+        ehn6f1Vm18bG/GQATGj2Gye/5P8BiIOalvsJAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:34:06 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:48:27 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_create_state_modifications.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_create_state_modifications.yaml
@@ -4,14 +4,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [1825a8de-43bd-11e6-b197-001dd8b7c0ad]
+      x-ms-client-request-id: [e5d3c4c0-447a-11e6-bf4a-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Compute/virtualMachines?api-version=2016-03-30
   response:
@@ -21,29 +21,29 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
         uc4/evS97/+S/wdC6kBEDAAAAA==
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['133']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:03:31 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['133']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:42:12 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 resourcemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [18a7f840-43bd-11e6-885d-001dd8b7c0ad]
+      x-ms-client-request-id: [e708b528-447a-11e6-bd2e-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27cliTestRg_VmStateMod%27%20and%20name%20eq%20%27vm-state-mod%27%20and%20resourceType%20eq%20%27Microsoft.Compute%2FvirtualMachines%27
   response:
@@ -53,72 +53,145 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
         uc4/evS97/+S/wdC6kBEDAAAAA==
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['133']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:03:33 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['133']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:42:15 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30/azuredeploy.json"},
-      "mode": "Incremental", "parameters": {"osSKU": {"value": "14.04.4-LTS"}, "publicIpAddressAllocation":
-      {"value": "dynamic"}, "authenticationType": {"value": "password"}, "osDiskType":
-      {"value": "provided"}, "storageType": {"value": "Premium_LRS"}, "dnsNameType":
-      {"value": "none"}, "subnetIpAddressPrefix": {"value": "10.0.0.0/24"}, "adminUsername":
-      {"value": "ubuntu"}, "networkInterfaceType": {"value": "new"}, "_artifactsLocation":
-      {"value": "https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30"},
-      "osType": {"value": "Custom"}, "osVersion": {"value": "latest"}, "customOsDiskType":
-      {"value": "windows"}, "virtualNetworkIpAddressPrefix": {"value": "10.0.0.0/16"},
-      "name": {"value": "vm-state-mod"}, "storageCaching": {"value": "ReadWrite"},
-      "adminPassword": {"value": "testPassword0"}, "networkSecurityGroupRule": {"value":
-      "SSH"}, "storageContainerName": {"value": "vhds"}, "osOffer": {"value": "UbuntuServer"},
-      "osPublisher": {"value": "Canonical"}, "privateIpAddressAllocation": {"value":
-      "dynamic"}, "size": {"value": "Standard_DS1"}, "osDiskName": {"value": "osdisk1467839013"},
-      "location": {"value": "westus"}}}}'
+    body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 storagemanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e860d142-447a-11e6-9ada-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Storage/storageAccounts?api-version=2016-01-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS97/+S5P8BxWZBqg0AAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Thu, 07 Jul 2016 19:42:17 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e99eaeca-447a-11e6-8d8a-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Network/virtualnetworks?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS97/+S/wdC6kBEDAAAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['133']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:42:17 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJwcm9wZXJ0aWVzIjogeyJ0ZW1wbGF0ZUxpbmsiOiB7InVyaSI6ICJodHRwczovL2F6dXJlc2Rr
+      Y2kuYmxvYi5jb3JlLndpbmRvd3MubmV0L3RlbXBsYXRlaG9zdC9DcmVhdGVWbV8yMDE2LTA2LTMw
+      L2F6dXJlZGVwbG95Lmpzb24ifSwgIm1vZGUiOiAiSW5jcmVtZW50YWwiLCAicGFyYW1ldGVycyI6
+      IHsiYWRtaW5Vc2VybmFtZSI6IHsidmFsdWUiOiAidWJ1bnR1In0sICJwcml2YXRlSXBBZGRyZXNz
+      QWxsb2NhdGlvbiI6IHsidmFsdWUiOiAiZHluYW1pYyJ9LCAiYWRtaW5QYXNzd29yZCI6IHsidmFs
+      dWUiOiAidGVzdFBhc3N3b3JkMCJ9LCAic3RvcmFnZVR5cGUiOiB7InZhbHVlIjogIlByZW1pdW1f
+      TFJTIn0sICJfYXJ0aWZhY3RzTG9jYXRpb24iOiB7InZhbHVlIjogImh0dHBzOi8vYXp1cmVzZGtj
+      aS5ibG9iLmNvcmUud2luZG93cy5uZXQvdGVtcGxhdGVob3N0L0NyZWF0ZVZtXzIwMTYtMDYtMzAi
+      fSwgIm9zVHlwZSI6IHsidmFsdWUiOiAiQ3VzdG9tIn0sICJuZXR3b3JrU2VjdXJpdHlHcm91cFJ1
+      bGUiOiB7InZhbHVlIjogIlNTSCJ9LCAidmlydHVhbE5ldHdvcmtJcEFkZHJlc3NQcmVmaXgiOiB7
+      InZhbHVlIjogIjEwLjAuMC4wLzE2In0sICJhdXRoZW50aWNhdGlvblR5cGUiOiB7InZhbHVlIjog
+      InBhc3N3b3JkIn0sICJuZXR3b3JrSW50ZXJmYWNlVHlwZSI6IHsidmFsdWUiOiAibmV3In0sICJz
+      dG9yYWdlQ2FjaGluZyI6IHsidmFsdWUiOiAiUmVhZFdyaXRlIn0sICJvc1ZlcnNpb24iOiB7InZh
+      bHVlIjogImxhdGVzdCJ9LCAic3RvcmFnZUNvbnRhaW5lck5hbWUiOiB7InZhbHVlIjogInZoZHMi
+      fSwgImN1c3RvbU9zRGlza1R5cGUiOiB7InZhbHVlIjogIndpbmRvd3MifSwgInB1YmxpY0lwQWRk
+      cmVzc0FsbG9jYXRpb24iOiB7InZhbHVlIjogImR5bmFtaWMifSwgImxvY2F0aW9uIjogeyJ2YWx1
+      ZSI6ICJ3ZXN0dXMifSwgIm9zU0tVIjogeyJ2YWx1ZSI6ICIxNC4wNC40LUxUUyJ9LCAibmFtZSI6
+      IHsidmFsdWUiOiAidm0tc3RhdGUtbW9kIn0sICJzaXplIjogeyJ2YWx1ZSI6ICJTdGFuZGFyZF9E
+      UzEifSwgIm9zUHVibGlzaGVyIjogeyJ2YWx1ZSI6ICJDYW5vbmljYWwifSwgImRuc05hbWVUeXBl
+      IjogeyJ2YWx1ZSI6ICJub25lIn0sICJvc0Rpc2tOYW1lIjogeyJ2YWx1ZSI6ICJvc2Rpc2sxNDY3
+      OTIwNTM2In0sICJzdWJuZXRJcEFkZHJlc3NQcmVmaXgiOiB7InZhbHVlIjogIjEwLjAuMC4wLzI0
+      In0sICJvc09mZmVyIjogeyJ2YWx1ZSI6ICJVYnVudHVTZXJ2ZXIifSwgIm9zRGlza1R5cGUiOiB7
+      InZhbHVlIjogInByb3ZpZGVkIn19fX0=
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Length: ['1277']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [1944ad70-43bd-11e6-aa3f-001dd8b7c0ad]
+      x-ms-client-request-id: [e9c6f840-447a-11e6-bd22-001dd8b7c0ad]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/azurecli-test-deployment-vm-state-mod","name":"azurecli-test-deployment-vm-state-mod","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30"},"adminPassword":{"type":"SecureString"},"adminUsername":{"type":"String","value":"ubuntu"},"authenticationType":{"type":"String","value":"password"},"availabilitySet":{"type":"String","value":""},"availabilitySetType":{"type":"String","value":"none"},"customOsDiskType":{"type":"String","value":"windows"},"customOsDiskUri":{"type":"String","value":""},"dnsNameForPublicIP":{"type":"String","value":""},"dnsNameType":{"type":"String","value":"none"},"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"vm-state-mod"},"networkSecurityGroup":{"type":"String","value":"vm-state-modNSG"},"networkSecurityGroupRule":{"type":"String","value":"SSH"},"networkSecurityGroupType":{"type":"String","value":"new"},"networkInterfaceIds":{"type":"Array","value":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Network/networkInterfaces/vm-state-modVMNic"}]},"networkInterfaceType":{"type":"String","value":"new"},"osDiskName":{"type":"String","value":"osdisk1467839013"},"osDiskType":{"type":"String","value":"provided"},"osDiskUri":{"type":"String","value":"https://vhdstoragekb5sp45f3g2h4.blob.core.windows.net/vhds/osdisk1467839013.vhd"},"osOffer":{"type":"String","value":"UbuntuServer"},"osPublisher":{"type":"String","value":"Canonical"},"osSKU":{"type":"String","value":"14.04.4-LTS"},"osType":{"type":"String","value":"Custom"},"osVersion":{"type":"String","value":"latest"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddress":{"type":"String","value":"vm-state-modPublicIP"},"publicIpAddressType":{"type":"String","value":"new"},"size":{"type":"String","value":"Standard_DS1"},"sshDestKeyPath":{"type":"String","value":"/home/ubuntu/.ssh/authorized_keys"},"sshKeyValue":{"type":"String","value":""},"storageAccount":{"type":"String","value":"vhdstoragekb5sp45f3g2h4"},"storageAccountType":{"type":"String","value":"new"},"storageCaching":{"type":"String","value":"ReadWrite"},"storageContainerName":{"type":"String","value":"vhds"},"storageType":{"type":"String","value":"Premium_LRS"},"subnetIpAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetName":{"type":"String","value":"vm-state-modSubnet"},"virtualNetworkIpAddressPrefix":{"type":"String","value":"10.0.0.0/16"},"virtualNetwork":{"type":"String","value":"vm-state-modVNET"},"virtualNetworkType":{"type":"String","value":"new"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-06T21:03:34.7009117Z","duration":"PT0.1462144S","correlationId":"31899e8b-4592-4211-b00f-1c748a48e41c","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/vm-state-modVNet","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-state-modVNet"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/vm-state-modNSG","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-state-modNSG"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/vm-state-modNicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-state-modNicIp"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/vm-state-modshrkeio6cqly2","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-state-modshrkeio6cqly2"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/vm-state-modNicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-state-modNicIp"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/vm-state-modVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-state-modVM"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/vm-state-modVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-state-modVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/vm-state-mod2i4qm5e5wnw4mnew","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-state-mod2i4qm5e5wnw4mnew"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/vm-state-modVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-state-modVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/vm-state-mod2i4qm5e5wnw4mnewfqdn","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-state-mod2i4qm5e5wnw4mnewfqdn"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/vm-state-modVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-state-modVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/vm-state-modvm-state-modVMNicmac","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-state-modvm-state-modVMNicmac"}]}}'}
+    body: {string: '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/azurecli-test-deployment-vm-state-mod","name":"azurecli-test-deployment-vm-state-mod","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30"},"adminPassword":{"type":"SecureString"},"adminUsername":{"type":"String","value":"ubuntu"},"authenticationType":{"type":"String","value":"password"},"availabilitySet":{"type":"String","value":""},"availabilitySetType":{"type":"String","value":"none"},"customOsDiskType":{"type":"String","value":"windows"},"customOsDiskUri":{"type":"String","value":""},"dnsNameForPublicIP":{"type":"String","value":""},"dnsNameType":{"type":"String","value":"none"},"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"vm-state-mod"},"networkSecurityGroup":{"type":"String","value":"vm-state-modNSG"},"networkSecurityGroupRule":{"type":"String","value":"SSH"},"networkSecurityGroupType":{"type":"String","value":"new"},"networkInterfaceIds":{"type":"Array","value":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Network/networkInterfaces/vm-state-modVMNic"}]},"networkInterfaceType":{"type":"String","value":"new"},"osDiskName":{"type":"String","value":"osdisk1467920536"},"osDiskType":{"type":"String","value":"provided"},"osDiskUri":{"type":"String","value":"https://vhdstoragekb5sp45f3g2h4.blob.core.windows.net/vhds/osdisk1467920536.vhd"},"osOffer":{"type":"String","value":"UbuntuServer"},"osPublisher":{"type":"String","value":"Canonical"},"osSKU":{"type":"String","value":"14.04.4-LTS"},"osType":{"type":"String","value":"Custom"},"osVersion":{"type":"String","value":"latest"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddress":{"type":"String","value":"vm-state-modPublicIP"},"publicIpAddressType":{"type":"String","value":"new"},"size":{"type":"String","value":"Standard_DS1"},"sshDestKeyPath":{"type":"String","value":"/home/ubuntu/.ssh/authorized_keys"},"sshKeyValue":{"type":"String","value":""},"storageAccount":{"type":"String","value":"vhdstoragekb5sp45f3g2h4"},"storageAccountType":{"type":"String","value":"new"},"storageCaching":{"type":"String","value":"ReadWrite"},"storageContainerName":{"type":"String","value":"vhds"},"storageType":{"type":"String","value":"Premium_LRS"},"subnetIpAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetName":{"type":"String","value":"vm-state-modSubnet"},"virtualNetworkIpAddressPrefix":{"type":"String","value":"10.0.0.0/16"},"virtualNetwork":{"type":"String","value":"vm-state-modVNET"},"virtualNetworkType":{"type":"String","value":"new"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-07T19:42:18.8972628Z","duration":"PT0.1014926S","correlationId":"e2dddd1a-962a-4943-a5ec-d32cf607e955","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/vm-state-modVNet","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-state-modVNet"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/vm-state-modNSG","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-state-modNSG"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/vm-state-modNicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-state-modNicIp"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/vm-state-modshrkeio6cqly2","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-state-modshrkeio6cqly2"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/vm-state-modNicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-state-modNicIp"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/vm-state-modVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-state-modVM"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/vm-state-modVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-state-modVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/vm-state-mod2i4qm5e5wnw4mnew","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-state-mod2i4qm5e5wnw4mnew"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/vm-state-modVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-state-modVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/vm-state-mod2i4qm5e5wnw4mnewfqdn","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-state-mod2i4qm5e5wnw4mnewfqdn"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/vm-state-modVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-state-modVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/vm-state-modvm-state-modVMNicmac","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-state-modvm-state-modVMNicmac"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/azurecli-test-deployment-vm-state-mod/operationStatuses/08587337678709230162?api-version=2015-11-01']
-      cache-control: [no-cache]
-      content-length: ['6390']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:03:34 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/azurecli-test-deployment-vm-state-mod/operationStatuses/08587336863466819387?api-version=2015-11-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['6390']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:42:18 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [1944ad70-43bd-11e6-aa3f-001dd8b7c0ad]
+      x-ms-client-request-id: [e9c6f840-447a-11e6-bd22-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337678709230162?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863466819387?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -126,30 +199,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:04:04 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:42:48 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [1944ad70-43bd-11e6-aa3f-001dd8b7c0ad]
+      x-ms-client-request-id: [e9c6f840-447a-11e6-bd22-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337678709230162?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863466819387?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -157,30 +230,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:04:35 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:43:19 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [1944ad70-43bd-11e6-aa3f-001dd8b7c0ad]
+      x-ms-client-request-id: [e9c6f840-447a-11e6-bd22-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337678709230162?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863466819387?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -188,30 +261,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:05:05 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:43:49 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [1944ad70-43bd-11e6-aa3f-001dd8b7c0ad]
+      x-ms-client-request-id: [e9c6f840-447a-11e6-bd22-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337678709230162?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863466819387?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -219,30 +292,92 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:05:35 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:44:19 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [1944ad70-43bd-11e6-aa3f-001dd8b7c0ad]
+      x-ms-client-request-id: [e9c6f840-447a-11e6-bd22-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337678709230162?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863466819387?api-version=2015-11-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
+        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:44:49 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e9c6f840-447a-11e6-bd22-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863466819387?api-version=2015-11-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
+        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:45:19 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e9c6f840-447a-11e6-bd22-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863466819387?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -250,28 +385,28 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['141']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:06:05 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['141']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:45:49 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [1944ad70-43bd-11e6-aa3f-001dd8b7c0ad]
+      x-ms-client-request-id: [e9c6f840-447a-11e6-bd22-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmStateMod/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
@@ -288,48 +423,48 @@ interactions:
         J+tlu+ZX1u2cxl/IiN5w++H3VgYHvHmZFWU2KcqivX6dt5teizS/qadltczx2nTdtNXiy+Zp0by9
         6R0la/e1r8BFw2+h+WzZvMgW+bOqfrmelMX07OUt37gJJTOM8hYsc0Wismbsb5q+QIjQPm9pVt4y
         OxB5WeJv+/6L158PgXi1Lqn1MJjXr7899OqNdMmvvFfPSAZrEq38bMaipm8d13V27V763s+BMnwh
-        CN7tItrc9Wn4k1+8KKYf/ZLvR0Z0S0JUzKngqE2Nq2ZGrXb3P31wcO/hzu499+ZN3ejYmFvkjRuk
-        wuivy/mMJKnOLvK3k/vNav/++b2Lvfn+gDJD67tdLMf0qfT75fl5Xm/q9SvWS6/z+pLa8Sssj82c
-        /tzw2klGckYqrJR3Xv9eX21qvbs/3tkf728/f/Na2t9EvBNWJtLWGorh5tDmTYvmq7q4pD/OVsez
-        GXGgz9u9t2Ltj8vb6I3ZNekL8B8BALWm39j7m97y+Z8nCUqzD+Im2ir/N8UP6K/hZiSky1lWz37/
-        p693uX0zf0pE/r3y65dZO9/05t15tcjvisG7O6b37sLkVTV1OPv93+bXrHDpYwL1k/LKMCxuKtJw
-        PJ1WBHJTa2J7bRyITh/IbWkkL51k0zm+3/DCqzybfZd0MZse8xo5OlmxzOublAzQ9t67CbmXdb4o
-        1ovf//krlibSzaQI7PTTt+fFu03v75Kzhf/u7gll+P0bcfSY7zW/gXcvi7pdZ6Xq7K+Dw+6nfTib
-        XvTx+MkXp2/6b99EPp5beosA4M+z5ZToSQ4Z6TKSJWhtqBt6hySA5pMgrKfTnJxYeM9tsSAhyBZk
-        7D8Sj/EBOY1v9nYf7dx/dH9/fPDp/fu7+3s/RU1n61oVwUcv3+x9sbczvre7c7D76cPX9CXp8Ton
-        tUXfn8HC3tslg5ofkDW9/3Bve39vd3d7srNzvr07fbB/kO0f5Pu7U3qN0YPBZNtMSiRvVmTyCIAz
-        oDaaoPY0Gfw7aCLv+J/Qa+KaY/hobnQXmi7XZfl9MrDfp5Hkq3w5y5dTDhoIiHzQfEljo79+6C6C
-        HWEQL4WcQfwZDp9wvAGC94JIQ4fZCOQvGf2/crjwKB3y38RoARFT///GwcLWedh/I8NlmJhdeuX/
-        3azdzOu3eVF9Ov1F5fWeN6pvggwhbJDj/4UEkLly4/gmBi4w/1/K8D/5hYf8NzFaAoi5pfb/72Z1
-        wtON45sa+P8753iv2P9Fi/v5/avl1f4CHoobxzcx8B74H83/3f9XDbU7Qee/aIZcqenwmxh8tIsf
-        8cHd/1cN1f+dc1yLDH6/6fCbGLz/u+0C5KjW7WpNb1PsBMoMR1B3f4gkO6kWhFR+V2O8LzgUp+H6
-        oyAu7iZBNqG/vzPe3d0b7957ML4HL+cjloQNL6BNN1G0qb0GtxxdE3Fv8cbOzvbO0+17x9v3drfv
-        HWwjz0jvyoTYKXbi+d7k6b1HwQxi5dtlWW98PUhEhyA4kBgGoNP2UmnU6d/Lcg1C0JHrn+H7miDo
-        vftaEi13NeGiSSF6lxIx8lEnf/T9X/JL/h9tx/vXGBwAAA==
+        CN7tItrc9Wn4k1+8KKYf/ZLvR0Z0S0JUzKngqE2Nq2ZGrXb3P33wcG/n/r1P3Zs3daNjY26RN26Q
+        CqO/LuczkqQ6u8jfTu43q/375/cu9ub7A8oMre92sRzTp9Lvl+fneb2p169YL73O60tqx6+wPDZz
+        +nPDaycZyRmpsFLeef17fbWp9e7+eGd/vL/9/M1raX8T8U5YmUhbayiGm0ObNy2ar+rikv44Wx3P
+        ZsSBPm/33oq1Py5vozdm16QvwH8EANSafmPvb3rL53+eJCjNPoibaKv83xQ/oL+Gm5GQLmdZPfv9
+        n77e5fbN/CkR+ffKr19m7XzTm3fn1SK/Kwbv7pjeuwuTV9XU4ez3f5tfs8KljwnUT8orw7C4qUjD
+        8XRaEchNrYnttXEgOn0gt6WRvHSSTef4fsMLr/Js9l3SxWx6zGvk6GTFMq9vUjJA23vvJuRe1vmi
+        WC9+/+evWJpIN5MisNNP354X7za9v0vOFv67uyeU4fdvxNFjvtf8Bt69LOp2nZWqs78ODrusUkM4
+        m1708fjJF6dv+m/fRD6eW3qLAODPs+WU6EkOGekykiVobagbeockgOaTIKyn05ycWHjPbbEgIcgW
+        ZOw/Eo/xAf3vze7DR/v3H927P9598OmD/fv3foqazta1KoKPXr6598Xup+N7BzsPH9zffU1fkh6v
+        c1Jb9P0ZLGy+N6NnN9t++Oletr3/cP/ednY/n27P7u1Nzz/deZA/vH+fXmP0YDDZNpMSyZsVmTwC
+        4AyojSaoPU0G/w6ayDv+J/SauOYYPpob3YWmy3VZfp8M7PdpJPkqX87y5ZSDBgIiHzRf0tjorx+6
+        i2BHGMRLIWcQf4bDJxxvgOC9INLQYTYC+UtG/68cLjxKh/w3MVpAxNT/v3GwsHUe9t/IcBkmZpde
+        +X83azfz+m1eVJ9Of1F5veeN6psgQwgb5Ph/IQFkrtw4vomBC8z/lzL8T37hIf9NjJYAYm6p/f+7
+        WZ3wdOP4pgb+/8453iv2f9Hifn7/anm1v4CH4sbxTQy8B/5H83/3/1VD7U7Q+S+aIVdqOvwmBh/t
+        4kd8cPf/VUP1f+cc1yKbemP5Jgbv/267ADmqdbta09sUO4EywxHU3R8iyU6qBSGV39UY7wsOxWm4
+        /iiIi7tJkE3o794bHxyMdx/ujvf2OLXBkrDhBbTpJoo2tdfglqNrIu4t3tjZ2d55un3vePve/vbJ
+        0+2H9zhClQmxU+zE873J03uPghnEyrfLst74epCIDkFwIDEMQKftpdKo07+X5RqEoCPXP8P3NUHQ
+        e/e1JFruasJFk0L0LiVi5KNO/uj7v+SX/D97/kaeGBwAAA==
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['1630']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:06:06 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['1630']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:45:50 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [751fff4f-43bd-11e6-a890-001dd8b7c0ad]
+      x-ms-client-request-id: [68d1935c-447b-11e6-b4d1-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Compute/virtualMachines?api-version=2016-03-30
   response:
@@ -337,43 +472,43 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UeXWbnOP3qUfg9/pSl/iOejVV2t8rot8oa+tR/TF5eLsxl99NFu9iB/sL+3t737cLq3vZ89nG0f
-        7O3vbOfnkwfZ3nRy78Fs76OR9+I8q2dXWZ2/rKvzokSnHlj6/nLxuvgBPv7odZstZ9T693/6evcj
-        1+aX+NCatqqzi0FgxYK+fJWf53W+nPa+pgar9aQsmnle03cfnWTLallMs9JHGM9H1TmBQJOvJutl
-        u36d15f0d7dV83aNNrv745398f728zeve03otaaolmhWZm3etN7AwqFR46p5WjRvqW0X66p5c73C
-        cD56XizX73q9LLMFf1s1MwKwu//pg4N7D3d27/UaTuucsPhy1SpOz+pqcQaa9VpezjHdHUTo83Vd
-        0Ocfzdt21Ty6e5ea6ZS8ndxvVvv3z+9d7M33x5OymoynVZ2Pr4rlrLpqxsu85dZ3u0iO6dOAKl26
-        UK/TbDovlhfo+VWezb5bF20evBO+8dEsazPQElz8ve+7r/xmRK0hNppWi9W6zesXStfLxXbTEuG2
-        F9UspNRH2WxRLL9q8trMwZo5ptOqxLSdVMvz4mJdZ0r9oE9qRGTJJmX+Mmuaq6qeHa/beb5siT+1
-        /XlWNrn/jj8aer/JaXrbjUOmSSDQb71xm4/OljTe82wKwf/eL/6ooNn/6G6znjTTumB2ae7e29nP
-        Dx4+/HT7wYPzyfb+p/nB9iSbZdv37z/4dGf3/sP9Sb5/t86bal1P88/rar1q7k7L4g1x/auL3/8n
-        FyTfbf5FNbtLSuaymJFk3P2imNZVU5234xeCxt0eOnd94v/kFy+K6Ue/5PvBoBgcpIw4hPugcX30
-        ej2d5vksd6zl3uHRpT/U4Z0IR929LOp2nZVfMD93Bud4xgr0wNetaoMb4XvvlJVlpI+uCOe1/2Wb
-        XdC8+xwJblyV2bURgZ8MADuiyi/8g5jul/w/mhBkLV8GAAA=
+        6UeXWbnOP3qUfg9/pSl/iOejVV2t8rot8oa+tR/TF5eLsxl99NHDyez8050HD7bPd2f72/v72afb
+        k4Ps3vbO/uzT+3l+bzp5cO+jkffiPKtnV1mdv6yr86JEpx5Y+v5y8br4AT7+6HWbLWfU+vd/+nr3
+        I9fml/jQmraqs4tBYMWCvnyVn+d1vpz2vqYGq/WkLJp5XtN3H51ky2pZTLPSRxjPR9U5gUCTrybr
+        Zbt+ndeX9He3VfN2jTa7++Od/fH+9vM3r3tN6LWmqJZoVmZt3rTewMKhUeOqeVo0b6ltF+uqeXO9
+        wnA+el4s1+96vSyzBX9bNTMCsLv/6YOHezv3733aazitc8Liy1WrOD2rq8UZaNZreTnHdHcQoc/X
+        dUGffzRv21Xz6O5daqZT8nZyv1nt3z+/d7E33x9PymoynlZ1Pr4qlrPqqhkv85Zb3+0iOaZPA6p0
+        6UK9TrPpvFheoOdXeTb7bl20efBO+MZHs6zNQEtw8fe+777ymxG1hthoWi1W6zavXyhdLxfbTUuE
+        215Us5BSH2WzRbH8qslrMwdr5phOqxLTdlItz4uLdZ0p9YM+qRGRJZuU+cusaa6qena8buf5siX+
+        1PbnWdnk/jv+aOj9JqfpbTcOmSaBQL/1xm0+OlvSeM+zKQT/e7/4o4Jm/6O7zXrSTOuC2aW5e29n
+        Pz94+PDT7QcPzifb+5/mB9uTbJZt37//4NOd3fsP9yf5/t06b6p1Pc0/r6v1qrk7LYs3xPWvLn7/
+        n1yQfLf5F9XsLimZy2JGknH3i2JaV0113o5fCBp3e+jc9Yn/k1+8KKYf/ZLvB4NicJAy4hDug8b1
+        0ev1dJrns9yxlnuHR5f+UId3Ihx197Ko23VWfsH83Bmc4xkr0ANft6oNboTvvVNWlpE+uiKc1/6X
+        bXZB8+5zJLhxVWbXRgR+MgDsiCq/8A9iul/y/wCh8grsXwYAAA==
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:06:07 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:45:50 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [75880ff0-43bd-11e6-b9db-001dd8b7c0ad]
+      x-ms-client-request-id: [68fb8b0c-447b-11e6-aacc-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Compute/virtualMachines/vm-state-mod?api-version=2016-03-30&$expand=instanceView
   response:
@@ -381,112 +516,112 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UerulrldVvkzUePUv6IPrxcnM3oz492swf5g/29ve3dh9O97f3s4Wz7YG9/Zzs/nzzI9qaTew9m
-        ex+N9KV5Vs+usjp/WVfnRZnT+wqOvrtcvC5+gI8+et1myxm1/P2fvt79SL7/JQZC01Z1dhEFUCzo
-        i1f5eV7ny2nwFX25Wk/KopnnNX3+0Um2rJbFNCsNYng+qs7pVXz91WS9bNev8/qS/vZbNG/X+H53
-        f7yzP97ffv7mdfA1NW+KaokmZdbmTavIO/SpUdU8LZq31MbHrmreXK+A8kfPi+X6XQB1mS34m6qZ
-        0Yu7+58+OLj3cGf3XtBoWufU45erVvt/VleLM9AjaHU5x5R5HdNn67qgzz6at+2qeXT3LjVREr+d
-        3G9W+/fP713szffHk7KajKdVnY+viuWsumrGy7zl1ne7iI3pUztyf+zU2zSbzovlBXp8lWez79ZF
-        m9u2ruVHs6zNQCdw3Pe+Lx+br4kSsemfVovVus3rF0qvy8V20xJRthfVzFHho2y2KJZfNXlt6Lrm
-        2fZalJiCk2p5Xlys60wpavuhBjTcbFLmL7Omuarq2fG6nefLlvhJ255nZZOb9gZreq/JaZra6JCI
-        mATqrTcu89HZksZ0nk0hfN/7xR8VNIMf3W3Wk2ZaFzzdzd17O/v5wcOHn24/eHA+2d7/ND/YnmSz
-        bPv+/Qef7uzef7g/yffv1nlTretp/nldrVfN3WlZvCEOfXXx+//kguStzb+oZndJ0C+LGXHx3S+K
-        aV011Xk7fiFo3O2hc9cn8E9+8aKYfvRLvm8HxKAgDTTbDJ/G9NHr9XSa57PczsdHxZJAkLT+ZJFf
-        UQtLZZq94wsiqv+Z+/QnCUUCTV9+9N1jlhj+eHtvvDPe/dQAx0P6ImvXDYiXfs99nPpQ8RD3zBhF
-        moEQ77tNF2nzfFTml3mJl86W51XvW+KSVZldA8ga3X8Ehr/uNVvkTUPShgafr2lGeCRp0aT1egkk
-        UtKFaUYo0GTTX8v8Kp36vNmMeyDbQjh7b2f30+2dB9s7n77Z23208+mjnQef7Ow82tmxEofnl7g/
-        vu9B+ih/1+ZLUOLbhEFJFCeQhm/pLdsUAxU5NZ90qHsrDUbNhqaqAw7P15kuemvjhNH3hF44ZT74
-        dBPkAZLvP9rbH+/t79/fe/gwQnoio/+nJa73uZuSAfoEtHl/umyiydejxxAt7j/a3xs/vLd3/97O
-        QY8Wjp0GR1Rd5TUwye+qZHS6fa+B/OQXRr58JMyvOhH8t2DGejf9oSreE7Fndy+Lul1n5RdsOTtq
-        V4ZpBSzyVat+xY1wtX1ZWTP20RXhSeSSL9rsApTTyTEUNcb2JwNgTFOi3i/5fwDkfnwhQAoAAA==
+        6UerulrldVvkzUePUv6IPrxcnM3oz48eTmbnn+48eLB9vjvb397fzz7dnhxk97Z39mef3s/ze9PJ
+        g3sfjfSleVbPrrI6f1lX50WZ0/sKjr67XLwufoCPPnrdZssZtfz9n77e/Ui+/yUGQtNWdXYRBVAs
+        6ItX+Xle58tp8BV9uVpPyqKZ5zV9/tFJtqyWxTQrDWJ4PqrO6VV8/dVkvWzXr/P6kv72WzRv1/h+
+        d3+8sz/e337+5nXwNTVvimqJJmXW5k2ryDv0qVHVPC2at9TGx65q3lyvgPJHz4vl+l0AdZkt+Juq
+        mdGLu/ufPni4t3P/3qdBo2mdU49frlrt/1ldLc5Aj6DV5RxT5nVMn63rgj77aN62q+bR3bvUREn8
+        dnK/We3fP793sTffH0/KajKeVnU+viqWs+qqGS/zllvf7SI2pk/tyP2xU2/TbDovlhfo8VWezb5b
+        F21u27qWH82yNgOdwHHf+758bL4mSsSmf1otVus2r18ovS4X201LRNleVDNHhY+y2aJYftXktaHr
+        mmfba1FiCk6q5Xlxsa4zpajthxrQcLNJmb/MmuaqqmfH63aeL1viJ217npVNbtobrOm9JqdpaqND
+        ImISqLfeuMxHZ0sa03k2hfB97xd/VNAMfnS3WU+aaV3wdDd37+3s5wcPH366/eDB+WR7/9P8YHuS
+        zbLt+/cffLqze//h/iTfv1vnTbWup/nndbVeNXenZfGGOPTVxe//kwuStzb/oprdJUG/LGbExXe/
+        KKZ11VTn7fiFoHG3h85dn8A/+cWLYvrRL/m+HRCDgjTQbDN8GtNHr9fTaZ7PcjsfHxVLAkHS+pNF
+        fkUtLJVp9o4viKj+Z+7TnyQUCTR9+dF3j1li+OPtvfHOeDcUDALfrhsQL/2e+zj1oeIh7pkxijQD
+        Id53my7S5vmozC/zEi+dLc+r3rfEJasyuwaQNbr/CAx/3Wu2yJuGpA0NPl/TjPBI0qJJ6/USSKSk
+        C9OMUKDJpr+W+VU69XmzGfdAtoVw9t7O7qfbOw/of292Hz7av//o/s4nOzuPdnasxOH5Je6P73uQ
+        PsrftfkSlPg2YVASxQmk4Vt6yzbFQEVOzScd6t5Kg1GzoanqgMPzdaaL3to4YfQ9oRdOmQ8+3QR5
+        gOT3Hu3dGz/cO9g5uPcgQnoio/+nJa73uZuSAfoEtHl/umyiydejxxAt7j/a+XS8+3D/3sG9hz1a
+        OHYaHFF1ldfAJL+rktHp9r0G8pNfGPnykTC/6kTw34IZ6930h6p4T8Se3b0s6nadlV+w5eyoXRmm
+        FbDIV636FTfC1fZlZc3YR1eEJ5FLvmizC1BOJ8dQ1BjbnwyAMU2Jer/k/wHqn7ZLQAoAAA==
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:06:08 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:45:51 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [75bb2de1-43bd-11e6-974c-001dd8b7c0ad]
+      x-ms-client-request-id: [692d8f50-447b-11e6-bf80-001dd8b7c0ad]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Compute/virtualMachines/vm-state-mod/powerOff?api-version=2016-03-30
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/6fedbed9-7c14-4588-a4d1-a005dc0ebcf1?api-version=2016-03-30']
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Wed, 06 Jul 2016 21:06:07 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/6fedbed9-7c14-4588-a4d1-a005dc0ebcf1?monitor=true&api-version=2016-03-30']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/b53fbf8a-d966-4431-87cf-8a845398e563?api-version=2016-03-30']
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Thu, 07 Jul 2016 19:45:51 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/b53fbf8a-d966-4431-87cf-8a845398e563?monitor=true&api-version=2016-03-30']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
     status: {code: 202, message: Accepted}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [75bb2de1-43bd-11e6-974c-001dd8b7c0ad]
+      x-ms-client-request-id: [692d8f50-447b-11e6-bf80-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/6fedbed9-7c14-4588-a4d1-a005dc0ebcf1?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/b53fbf8a-d966-4431-87cf-8a845398e563?api-version=2016-03-30
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H2zufvtnbfbTz6aOdh+ODvXv39h7sfrKz82hn56MRv5QvZ4Ov
-        3Nsd7+3u7zzcvRe8Qv206wZvvF5Pp3k+y2f6zTITSJ+e57NJPnu4/WC6u7+9f//gYDvbn+1uZzs7
-        92fTnXwyPd/96DdOfsn/A2aHpQC4AAAA
+        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H9L83uw8f7d9/dH93vLfz4N69B5/s7Dza2floxO/ky9nwGwfj
+        +wc7n366sx+8Qt206wZvvF5Pp3k+y2f6zTITSJP7984n5wfZ9uzhp59u7+/f290+eDA93z7IDvbv
+        33t4kN//9N5Hv3HyS/4fQq0YwLcAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:06:38 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:46:21 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [8840b200-43bd-11e6-9a7c-001dd8b7c0ad]
+      x-ms-client-request-id: [7bb2d34a-447b-11e6-a278-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Compute/virtualMachines/vm-state-mod?api-version=2016-03-30&$expand=instanceView
   response:
@@ -494,112 +629,112 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UerulrldVvkzUePUv6IPrxcnM3oz492swf5g/29ve3dh9O97f3s4Wz7YG9/Zzs/nzzI9qaTew9m
-        ex+N9KV5Vs+usjp/WVfnRZnT+wqOvrtcvC5+gI8+et1myxm1/P2fvt79SL7/JQZC01Z1dhEFUCzo
-        i1f5eV7ny2nwFX25Wk/KopnnNX3+0Um2rJbFNCsNYng+qs7pVXz91WS9bNev8/qS/vZbNG/X+H53
-        f7yzP97ffv7mdfA1NW+KaokmZdbmTavIO/SpUdU8LZq31MbHrmreXK+A8kfPi+X6XQB1mS34m6qZ
-        0Yu7+58+OLj3cGf3XtBoWufU45erVvt/VleLM9AjaHU5x5R5HdNn67qgzz6at+2qeXT3LjVREr+d
-        3G9W+/fP713szffHk7KajKdVnY+viuWsumrGy7zl1ne7iI3pUztyf+zU2zSbzovlBXp8lWez79ZF
-        m9u2ruVHs6zNQCdw3Pe+Lx+br4kSsemfVovVus3rF0qvy8V20xJRthfVzFHho2y2KJZfNXlt6Lrm
-        2fZalJiCk2p5Xlys60wpavuhBjTcbFLmL7Omuarq2fG6nefLlvhJ255nZZOb9gZreq/JaZra6JCI
-        mATqrTcu89HZksZ0nk0hfN/7xR8VNIMf3W3Wk2ZaFzzdzd17O/v5wcOHn24/eHA+2d7/ND/YnmSz
-        bPv+/Qef7uzef7g/yffv1nlTretp/nldrVfN3WlZvCEOfXXx+//kguStzb+oZndJ0C+LGXHx3S+K
-        aV011Xk7fiFo3O2hc9cn8E9+8aKYfvRLvm8HxKAgDTTbDJ/G9NHr9XSa57PczsdHxZJAkLT+ZJFf
-        UQtLZZq94wsiqv+Z+/QnCUUCTV9+9N1jlhj+eHtvvDPe/dQAx0P6ImvXDYiXfs99nPpQ8RD3zBhF
-        moEQ77tNF2nzfFTml3mJl86W51XvW+KSVZldA8ga3X8Ehr/uNVvkTUPShgafr2lGeCRp0aT1egkk
-        UtKFaUYo0GTTX8v8Kp36vNmMeyDbQjh7b2f30+2dB9s7n77Z23208+mjnQef7Ow82tmxEofnl7g/
-        vu9B+ih/1+ZLUOLbhEFJFCeQhm/pLdsUAxU5NZ90qHsrDUbNhqaqAw7P15kuemvjhNH3hF44ZT74
-        dBPkAZLvP9rbH+/t79/fe/gwQnoio/+nJa73uZuSAfoEtHl/umyiydejxxAtPn10b3e8e3/3/qf7
-        n/Zo4dhpcETVVV4DExpKW61WvW7fayA/+UVqoLiGjujyC/8tmLHeTX+oivdE7Nndy6Ju11n5BVvO
-        jtqVYVoBi3zVql9xI1xtX1bWjH10RXgSueSLNrsA5XRyDEWNsf3JABjTlKj3S/4fjmGGN0AKAAA=
+        6UerulrldVvkzUePUv6IPrxcnM3oz48eTmbnn+48eLB9vjvb397fzz7dnhxk97Z39mef3s/ze9PJ
+        g3sfjfSleVbPrrI6f1lX50WZ0/sKjr67XLwufoCPPnrdZssZtfz9n77e/Ui+/yUGQtNWdXYRBVAs
+        6ItX+Xle58tp8BV9uVpPyqKZ5zV9/tFJtqyWxTQrDWJ4PqrO6VV8/dVkvWzXr/P6kv72WzRv1/h+
+        d3+8sz/e337+5nXwNTVvimqJJmXW5k2ryDv0qVHVPC2at9TGx65q3lyvgPJHz4vl+l0AdZkt+Juq
+        mdGLu/ufPni4t3P/3qdBo2mdU49frlrt/1ldLc5Aj6DV5RxT5nVMn63rgj77aN62q+bR3bvUREn8
+        dnK/We3fP793sTffH0/KajKeVnU+viqWs+qqGS/zllvf7SI2pk/tyP2xU2/TbDovlhfo8VWezb5b
+        F21u27qWH82yNgOdwHHf+758bL4mSsSmf1otVus2r18ovS4X201LRNleVDNHhY+y2aJYftXktaHr
+        mmfba1FiCk6q5Xlxsa4zpajthxrQcLNJmb/MmuaqqmfH63aeL1viJ217npVNbtobrOm9JqdpaqND
+        ImISqLfeuMxHZ0sa03k2hfB97xd/VNAMfnS3WU+aaV3wdDd37+3s5wcPH366/eDB+WR7/9P8YHuS
+        zbLt+/cffLqze//h/iTfv1vnTbWup/nndbVeNXenZfGGOPTVxe//kwuStzb/oprdJUG/LGbExXe/
+        KKZ11VTn7fiFoHG3h85dn8A/+cWLYvrRL/m+HRCDgjTQbDN8GtNHr9fTaZ7PcjsfHxVLAkHS+pNF
+        fkUtLJVp9o4viKj+Z+7TnyQUCTR9+dF3j1li+OPtvfHOeDcUDALfrhsQL/2e+zj1oeIh7pkxijQD
+        Id53my7S5vmozC/zEi+dLc+r3rfEJasyuwaQNbr/CAx/3Wu2yJuGpA0NPl/TjPBI0qJJ6/USSKSk
+        C9OMUKDJpr+W+VU69XmzGfdAtoVw9t7O7qfbOw/of292Hz7av//o/s4nOzuPdnasxOH5Je6P73uQ
+        PsrftfkSlPg2YVASxQmk4Vt6yzbFQEVOzScd6t5Kg1GzoanqgMPzdaaL3to4YfQ9oRdOmQ8+3QR5
+        gOT3Hu3dGz/cO9g5uPcgQnoio/+nJa73uZuSAfoEtHl/umyiydejxxAtiP0Oxvd3D/Z2H+72aOHY
+        aXBE1VVeAxMaSlutVr1u32sgP/lFaqC4ho7o8gv/LZix3k1/qIr3ROzZ3cuibtdZ+QVbzo7alWFa
+        AYt81apfcSNcbV9W1ox9dEV4Ernkiza7AOV0cgxFjbH9yQAY05So90v+H0FKs9lACgAA
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:06:39 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:46:23 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [886b1d61-43bd-11e6-bdfd-001dd8b7c0ad]
+      x-ms-client-request-id: [7be25446-447b-11e6-89aa-001dd8b7c0ad]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Compute/virtualMachines/vm-state-mod/start?api-version=2016-03-30
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/1decf421-7f44-4abd-9494-03cfac8b6004?api-version=2016-03-30']
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Wed, 06 Jul 2016 21:06:39 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/1decf421-7f44-4abd-9494-03cfac8b6004?monitor=true&api-version=2016-03-30']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/2d243c7a-12ff-4b5b-acd5-8978b2f13971?api-version=2016-03-30']
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Thu, 07 Jul 2016 19:46:22 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/2d243c7a-12ff-4b5b-acd5-8978b2f13971?monitor=true&api-version=2016-03-30']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1190']
     status: {code: 202, message: Accepted}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [886b1d61-43bd-11e6-bdfd-001dd8b7c0ad]
+      x-ms-client-request-id: [7be25446-447b-11e6-89aa-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/1decf421-7f44-4abd-9494-03cfac8b6004?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/2d243c7a-12ff-4b5b-acd5-8978b2f13971?api-version=2016-03-30
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H2zufvtnbfbTz6aP93fHu3s7+p7v3PtnZebSz89GIX8qXs8FX
-        7t8f39/fu/fpzv3gFeqnXTd44/V6Os3zWT7Tb5aZQNqd5dPz/b3d7Qfn+/vb+9lktv1w/+H+9s69
-        6Xk2PZh8urOz/9FvnPyS/wewttXPuAAAAA==
+        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H9L83uw8f7X/6aG9vfP/B/Xt7n+5/srPzaGfnoxG/lC9ng6/c
+        3x3v3L93b+f+g+AV6qddN3jj9Xo6zfNZPtNvlplCmu3t35s+yLZ3987Pt/cn9yfb2XR2f/vg4YOD
+        yd757r2HD3Y/+o2TX/L/ABbobTq4AAAA
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:07:10 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:46:53 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [9aef6900-43bd-11e6-92ef-001dd8b7c0ad]
+      x-ms-client-request-id: [8e67285c-447b-11e6-a2c1-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Compute/virtualMachines/vm-state-mod?api-version=2016-03-30&$expand=instanceView
   response:
@@ -607,112 +742,112 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UerulrldVvkzUePUv6IPrxcnM3oz492swf5g/29ve3dh9O97f3s4Wz7YG9/Zzs/nzzI9qaTew9m
-        ex+N9KV5Vs+usjp/WVfnRZnT+wqOvrtcvC5+gI8+et1myxm1/P2fvt79SL7/JQZC01Z1dhEFUCzo
-        i1f5eV7ny2nwFX25Wk/KopnnNX3+0Um2rJbFNCsNYng+qs7pVXz91WS9bNev8/qS/vZbNG/X+H53
-        f7yzP97ffv7mdfA1NW+KaokmZdbmTavIO/SpUdU8LZq31MbHrmreXK+A8kfPi+X6XQB1mS34m6qZ
-        0Yu7+58+OLj3cGf3XtBoWufU45erVvt/VleLM9AjaHU5x5R5HdNn67qgzz6at+2qeXT3LjVREr+d
-        3G9W+/fP713szffHk7KajKdVnY+viuWsumrGy7zl1ne7iI3pUztyf+zU2zSbzovlBXp8lWez79ZF
-        m9u2ruVHs6zNQCdw3Pe+Lx+br4kSsemfVovVus3rF0qvy8V20xJRthfVzFHho2y2KJZfNXlt6Lrm
-        2fZalJiCk2p5Xlys60wpavuhBjTcbFLmL7Omuarq2fG6nefLlvhJ255nZZOb9gZreq/JaZra6JCI
-        mATqrTcu89HZksZ0nk0hfN/7xR8VNIMf3W3Wk2ZaFzzdzd17O/v5wcOHn24/eHA+2d7/ND/YnmSz
-        bPv+/Qef7uzef7g/yffv1nlTretp/nldrVfN3WlZvCEOfXXx+//kguStzb+oZndJ0C+LGXHx3S+K
-        aV011Xk7fiFo3O2hc9cn8E9+8aKYfvRLvm8HxKAgDTTbDJ/G9NHr9XSa57PczsdHxZJAkLT+ZJFf
-        UQtLZZq94wsiqv+Z+/QnCUUCTV9+9N1jlhj+eHtvvDPe/dQAx0P6ImvXDYiXfs99nPpQ8RD3zBhF
-        moEQ77tNF2nzfFTml3mJl86W51XvW+KSVZldA8ga3X8Ehr/uNVvkTUPShgafr2lGeCRp0aT1egkk
-        UtKFaUYo0GTTX8v8Kp36vNmMeyDbQjh7b2f30+2dB9s7n77Z23208+DRzv1PdnYe7exYicPzS9wf
-        3/cgfZS/a/MlKPFtwqAkihNIw7f0lm2KgYqcmk861L2VBqNmQ1PVAYfn60wXvbVxwuh7Qi+cMh98
-        ugnyAMn3H+3tj/f29+/vPXwYIT2R0f/TEtf73E3JAH0C2rw/XTbR5OvRY4gWnz66f3+8/+Dhw92H
-        +z1aOHYaHFF1ldfAJL+rktHp9r0G8pNfGPnykTC/6kTw34IZ6930h6p4T8Se3b0s6nadlV+w5eyo
-        XRmmFbDIV636FTfC1fZlZc3YR1eEJ5FLvmizC1BOJ8dQ1BjbnwyAMU2Jer/k/wH+AAMuQAoAAA==
+        6UerulrldVvkzUePUv6IPrxcnM3oz48eTmbnn+48eLB9vjvb397fzz7dnhxk97Z39mef3s/ze9PJ
+        g3sfjfSleVbPrrI6f1lX50WZ0/sKjr67XLwufoCPPnrdZssZtfz9n77e/Ui+/yUGQtNWdXYRBVAs
+        6ItX+Xle58tp8BV9uVpPyqKZ5zV9/tFJtqyWxTQrDWJ4PqrO6VV8/dVkvWzXr/P6kv72WzRv1/h+
+        d3+8sz/e337+5nXwNTVvimqJJmXW5k2ryDv0qVHVPC2at9TGx65q3lyvgPJHz4vl+l0AdZkt+Juq
+        mdGLu/ufPni4t3P/3qdBo2mdU49frlrt/1ldLc5Aj6DV5RxT5nVMn63rgj77aN62q+bR3bvUREn8
+        dnK/We3fP793sTffH0/KajKeVnU+viqWs+qqGS/zllvf7SI2pk/tyP2xU2/TbDovlhfo8VWezb5b
+        F21u27qWH82yNgOdwHHf+758bL4mSsSmf1otVus2r18ovS4X201LRNleVDNHhY+y2aJYftXktaHr
+        mmfba1FiCk6q5Xlxsa4zpajthxrQcLNJmb/MmuaqqmfH63aeL1viJ217npVNbtobrOm9JqdpaqND
+        ImISqLfeuMxHZ0sa03k2hfB97xd/VNAMfnS3WU+aaV3wdDd37+3s5wcPH366/eDB+WR7/9P8YHuS
+        zbLt+/cffLqze//h/iTfv1vnTbWup/nndbVeNXenZfGGOPTVxe//kwuStzb/oprdJUG/LGbExXe/
+        KKZ11VTn7fiFoHG3h85dn8A/+cWLYvrRL/m+HRCDgjTQbDN8GtNHr9fTaZ7PcjsfHxVLAkHS+pNF
+        fkUtLJVp9o4viKj+Z+7TnyQUCTR9+dF3j1li+OPtvfHOeDcUDALfrhsQL/2e+zj1oeIh7pkxijQD
+        Id53my7S5vmozC/zEi+dLc+r3rfEJasyuwaQNbr/CAx/3Wu2yJuGpA0NPl/TjPBI0qJJ6/USSKSk
+        C9OMUKDJpr+W+VU69XmzGfdAtoVw9t7O7qfbOw/of292Hz7av//o/s4nOzuPdnasxOH5Je6P73uQ
+        PsrftfkSlPg2YVASxQmk4Vt6yzbFQEVOzScd6t5Kg1GzoanqgMPzdaaL3to4YfQ9oRdOmQ8+3QR5
+        gOT3Hu3dGz/cO9g5uPcgQnoio/+nJa73uZuSAfoEtHl/umyiydejxxAtPn10f3e8s/Pp/r293R4t
+        HDsNjqi6ymtgkt9Vyeh0+14D+ckvjHz5SJhfdSL4b8GM9W76Q1W8J2LP7l4WdbvOyi/YcnbUrgzT
+        Cljkq1b9ihvhavuysmbsoyvCk8glX7TZBSink2MoaoztTwbAmKZEvV/y/wDju4SKQAoAAA==
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:07:11 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:46:54 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [9b36d240-43bd-11e6-8945-001dd8b7c0ad]
+      x-ms-client-request-id: [8e8a5cee-447b-11e6-8f6a-001dd8b7c0ad]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Compute/virtualMachines/vm-state-mod/restart?api-version=2016-03-30
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/5fc56b56-ecd0-4f29-a4f4-ff5d3af0aa57?api-version=2016-03-30']
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Wed, 06 Jul 2016 21:07:11 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/5fc56b56-ecd0-4f29-a4f4-ff5d3af0aa57?monitor=true&api-version=2016-03-30']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/efd3ae3e-0106-45cd-9e4d-e5148ecee0ec?api-version=2016-03-30']
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Thu, 07 Jul 2016 19:46:54 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/efd3ae3e-0106-45cd-9e4d-e5148ecee0ec?monitor=true&api-version=2016-03-30']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
     status: {code: 202, message: Accepted}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [9b36d240-43bd-11e6-8945-001dd8b7c0ad]
+      x-ms-client-request-id: [8e8a5cee-447b-11e6-8f6a-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/5fc56b56-ecd0-4f29-a4f4-ff5d3af0aa57?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/efd3ae3e-0106-45cd-9e4d-e5148ecee0ec?api-version=2016-03-30
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H2zufvtnbfbTz4NHuvfHupw/2D/Y/2dl5tLPz0YjfyZezTW/c
-        v3+wu/PwYfAKddOuG7zxej2d5vksn+k3y0wg3T+f3v90cv/T7Xw629neP997uJ3tn+9vn5/fn93L
-        zney7P6Dj37j5Jf8P03Gv663AAAA
+        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H9L83uw8f7X/66P698cPdvZ2d3f1PdnYe7ex8NOKX8uVs+JX9
+        8b2dvfsH9x8Gr1A/7brBG6/X02mez/KZfrPMBFJ+PruX5ffy7Z3dnU+39+9PZ9sP8/3Zdn5/d/8g
+        p1d28ulHv3HyS/4fG2fiargAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:07:42 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:47:24 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [adbc2f4f-43bd-11e6-9b7d-001dd8b7c0ad]
+      x-ms-client-request-id: [a11010cc-447b-11e6-9b67-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Compute/virtualMachines/vm-state-mod?api-version=2016-03-30&$expand=instanceView
   response:
@@ -720,588 +855,248 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UerulrldVvkzUePUv6IPrxcnM3oz492swf5g/29ve3dh9O97f3s4Wz7YG9/Zzs/nzzI9qaTew9m
-        ex+N9KV5Vs+usjp/WVfnRZnT+wqOvrtcvC5+gI8+et1myxm1/P2fvt79SL7/JQZC01Z1dhEFUCzo
-        i1f5eV7ny2nwFX25Wk/KopnnNX3+0Um2rJbFNCsNYng+qs7pVXz91WS9bNev8/qS/vZbNG/X+H53
-        f7yzP97ffv7mdfA1NW+KaokmZdbmTavIO/SpUdU8LZq31MbHrmreXK+A8kfPi+X6XQB1mS34m6qZ
-        0Yu7+58+OLj3cGf3XtBoWufU45erVvt/VleLM9AjaHU5x5R5HdNn67qgzz6at+2qeXT3LjVREr+d
-        3G9W+/fP713szffHk7KajKdVnY+viuWsumrGy7zl1ne7iI3pUztyf+zU2zSbzovlBXp8lWez79ZF
-        m9u2ruVHs6zNQCdw3Pe+Lx+br4kSsemfVovVus3rF0qvy8V20xJRthfVzFHho2y2KJZfNXlt6Lrm
-        2fZalJiCk2p5Xlys60wpavuhBjTcbFLmL7Omuarq2fG6nefLlvhJ255nZZOb9gZreq/JaZra6JCI
-        mATqrTcu89HZksZ0nk0hfN/7xR8VNIMf3W3Wk2ZaFzzdzd17O/v5wcOHn24/eHA+2d7/ND/YnmSz
-        bPv+/Qef7uzef7g/yffv1nlTretp/nldrVfN3WlZvCEOfXXx+//kguStzb+oZndJ0C+LGXHx3S+K
-        aV011Xk7fiFo3O2hc9cn8E9+8aKYfvRLvm8HxKAgDTTbDJ/G9NHr9XSa57PczsdHxZJAkLT+ZJFf
-        UQtLZZq94wsiqv+Z+/QnCUUCTV9+9N1jlhj+eHtvvDPe/dQAx0P6ImvXDYiXfs99nPpQ8RD3zBhF
-        moEQ77tNF2nzfFTml3mJl86W51XvW+KSVZldA8ga3X8Ehr/uNVvkTUPShgafr2lGeCRp0aT1egkk
-        UtKFaUYo0GTTX8v8Kp36vNmMeyDbQjh7b2f30+2dB9s7n77Z23208+DRzv1PdnYe7exYicPzS9wf
-        3/cgfZS/a/MlKPFtwqAkihNIw7f0lm2KgYqcmk861L2VBqNmQ1PVAYfn60wXvbVxwuh7Qi+cMh98
-        ugnyAMn3H+3tj/f29+/vPXwYIT2R0f/TEtf73E3JAH0C2rw/XTbR5OvRY4gWDx6Radh/eP/T3Xt9
-        Wjh2GhxRdZXXwCS/q5LR6fa9BvKTXxj58pEwv+pE8N+CGevd9IeqeE/Ent29LOp2nZVfsOXsqF0Z
-        phWwyFet+hU3wtX2ZWXN2EdXhCeRS75oswtQTifHUNQY258MgDFNiXq/5P8BnoMGOUAKAAA=
+        6UerulrldVvkzUePUv6IPrxcnM3oz48eTmbnn+48eLB9vjvb397fzz7dnhxk97Z39mef3s/ze9PJ
+        g3sfjfSleVbPrrI6f1lX50WZ0/sKjr67XLwufoCPPnrdZssZtfz9n77e/Ui+/yUGQtNWdXYRBVAs
+        6ItX+Xle58tp8BV9uVpPyqKZ5zV9/tFJtqyWxTQrDWJ4PqrO6VV8/dVkvWzXr/P6kv72WzRv1/h+
+        d3+8sz/e337+5nXwNTVvimqJJmXW5k2ryDv0qVHVPC2at9TGx65q3lyvgPJHz4vl+l0AdZkt+Juq
+        mdGLu/ufPni4t3P/3qdBo2mdU49frlrt/1ldLc5Aj6DV5RxT5nVMn63rgj77aN62q+bR3bvUREn8
+        dnK/We3fP793sTffH0/KajKeVnU+viqWs+qqGS/zllvf7SI2pk/tyP2xU2/TbDovlhfo8VWezb5b
+        F21u27qWH82yNgOdwHHf+758bL4mSsSmf1otVus2r18ovS4X201LRNleVDNHhY+y2aJYftXktaHr
+        mmfba1FiCk6q5Xlxsa4zpajthxrQcLNJmb/MmuaqqmfH63aeL1viJ217npVNbtobrOm9JqdpaqND
+        ImISqLfeuMxHZ0sa03k2hfB97xd/VNAMfnS3WU+aaV3wdDd37+3s5wcPH366/eDB+WR7/9P8YHuS
+        zbLt+/cffLqze//h/iTfv1vnTbWup/nndbVeNXenZfGGOPTVxe//kwuStzb/oprdJUG/LGbExXe/
+        KKZ11VTn7fiFoHG3h85dn8A/+cWLYvrRL/m+HRCDgjTQbDN8GtNHr9fTaZ7PcjsfHxVLAkHS+pNF
+        fkUtLJVp9o4viKj+Z+7TnyQUCTR9+dF3j1li+OPtvfHOeDcUDALfrhsQL/2e+zj1oeIh7pkxijQD
+        Id53my7S5vmozC/zEi+dLc+r3rfEJasyuwaQNbr/CAx/3Wu2yJuGpA0NPl/TjPBI0qJJ6/USSKSk
+        C9OMUKDJpr+W+VU69XmzGfdAtoVw9t7O7qfbOw/of292Hz7a//TR/YNPdnYe7exYicPzS9wf3/cg
+        fZS/a/MlKPFtwqAkihNIw7f0lm2KgYqcmk861L2VBqNmQ1PVAYfn60wXvbVxwuh7Qi+cMh98ugny
+        AMnvPdq7N364d7BzcO9BhPRERv9PS1zvczclA/QJaPP+dNlEk69HjyFaEPvtj/dIJ+3v3O/RwrHT
+        4Iiqq7wGJvldlYxOt+81kJ/8wsiXj4T5VSeC/xbMWO+mP1TFeyL27O5lUbfrrPyCLWdH7cowrYBF
+        vmrVr7gRrrYvK2vGProiPIlc8kWbXYByOjmGosbY/mQAjGlK1Psl/w/J023oQAoAAA==
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:07:42 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:47:25 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [ade477cf-43bd-11e6-9665-001dd8b7c0ad]
+      x-ms-client-request-id: [a135156c-447b-11e6-84b8-001dd8b7c0ad]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Compute/virtualMachines/vm-state-mod/deallocate?api-version=2016-03-30
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/38125c1c-d501-4867-bcba-d15d2a439d40?api-version=2016-03-30']
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Wed, 06 Jul 2016 21:07:42 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/38125c1c-d501-4867-bcba-d15d2a439d40?monitor=true&api-version=2016-03-30']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/46c31e39-a10a-4cdc-9b0a-af8388358683?api-version=2016-03-30']
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Thu, 07 Jul 2016 19:47:25 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/46c31e39-a10a-4cdc-9b0a-af8388358683?monitor=true&api-version=2016-03-30']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1189']
     status: {code: 202, message: Accepted}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [ade477cf-43bd-11e6-9665-001dd8b7c0ad]
+      x-ms-client-request-id: [a135156c-447b-11e6-84b8-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/38125c1c-d501-4867-bcba-d15d2a439d40?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/46c31e39-a10a-4cdc-9b0a-af8388358683?api-version=2016-03-30
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H2zufvtnbfbTz4NH+vfHDh/cPdj7d/2Rn59HOzkcj81K7bvDG
-        2fJlXV3UedPoV8tMQN072N27P92dbs/u7+xu7x98+mB7Mp1k27Pd+7O9bP/ew9n+zke/cfJL/h8J
-        UXgchgAAAA==
+        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H9L83uw8f7T94tHd/vLf74MH9/Yef7Ow82tn5aGReatcN3jhb
+        vqyrizpvGv1qmQmo/U+n93bzew+3s92dbHt/OptuP5zQb9n5wb2Dg3v3Dz49uPfRb5z8kv8HvM49
+        iIYAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:08:12 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:47:55 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [ade477cf-43bd-11e6-9665-001dd8b7c0ad]
+      x-ms-client-request-id: [a135156c-447b-11e6-84b8-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/38125c1c-d501-4867-bcba-d15d2a439d40?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/46c31e39-a10a-4cdc-9b0a-af8388358683?api-version=2016-03-30
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H2zufvtnbfbTz4NH+vfHDh/cPdj7d/2Rn59HOzkcj81K7bvDG
-        2fJlXV3UedPoV8tMQN072N27P92dbs/u7+xu7x98+mB7Mp1k27Pd+7O9bP/ew9n+zke/cfJL/h8J
-        UXgchgAAAA==
+        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H9L83uw8f7T94tHd/vLf74MH9/Yef7Ow82tn5aGReatcN3jhb
+        vqyrizpvGv1qmQmo/U+n93bzew+3s92dbHt/OptuP5zQb9n5wb2Dg3v3Dz49uPfRb5z8kv8HvM49
+        iIYAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:08:42 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:48:26 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [ade477cf-43bd-11e6-9665-001dd8b7c0ad]
+      x-ms-client-request-id: [a135156c-447b-11e6-84b8-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/38125c1c-d501-4867-bcba-d15d2a439d40?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/46c31e39-a10a-4cdc-9b0a-af8388358683?api-version=2016-03-30
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H2zufvtnbfbTz4NH+vfHDh/cPdj7d/2Rn59HOzkcj81K7bvDG
-        2fJlXV3UedPoV8tMQN072N27P92dbs/u7+xu7x98+mB7Mp1k27Pd+7O9bP/ew9n+zke/cfJL/h8J
-        UXgchgAAAA==
+        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H9L83uw8f7T94tHd/vLf74MH9/Yef7Ow82tn5aGReatcN3jhb
+        vqyrizpvGv1qmQmo/U+n93bzew+3s92dbHt/OptuP5zQb9n5wb2Dg3v3Dz49uPfRb5z8kv8HvM49
+        iIYAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:09:13 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:48:56 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [ade477cf-43bd-11e6-9665-001dd8b7c0ad]
+      x-ms-client-request-id: [a135156c-447b-11e6-84b8-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/38125c1c-d501-4867-bcba-d15d2a439d40?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/46c31e39-a10a-4cdc-9b0a-af8388358683?api-version=2016-03-30
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H2zufvtnbfbTz4NH+vfHDh/cPdj7d/2Rn59HOzkcj81K7bvDG
-        2fJlXV3UedPoV8tMQN072N27P92dbs/u7+xu7x98+mB7Mp1k27Pd+7O9bP/ew9n+zke/cfJL/h8J
-        UXgchgAAAA==
+        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H9L83uw8f7T94tHd/vLf74MH9/Yef7Ow82tn5aGReatcN3jhb
+        vqyrizpvGv1qmQmo/U+n93bzew+3s92dbHt/OptuP5zQb9n5wb2Dg3v3Dz49uPfRb5z8kv8HvM49
+        iIYAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:09:43 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:49:26 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [ade477cf-43bd-11e6-9665-001dd8b7c0ad]
+      x-ms-client-request-id: [a135156c-447b-11e6-84b8-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/38125c1c-d501-4867-bcba-d15d2a439d40?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/46c31e39-a10a-4cdc-9b0a-af8388358683?api-version=2016-03-30
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H2zufvtnbfbTz4NH+vfHDh/cPdj7d/2Rn59HOzkcj81K7bvDG
-        2fJlXV3UedPoV8tMQN072N27P92dbs/u7+xu7x98+mB7Mp1k27Pd+7O9bP/ew9n+zke/cfJL/h8J
-        UXgchgAAAA==
+        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H9L83uw8f7T94tHd/vLf74MH9/Yef7Ow82tn5aMQv5cvZwCv0
+        vwfjB/fuPbj38CB4hfpp1w3eeL2eTvN8ls/0m2UmkPY/nd7bze893M52d7Lt/elsuv1wQr9l5wf3
+        Dg7u3T/49ODeR79x8kv+H/c2lp+4AAAA
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:10:13 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:49:56 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [ade477cf-43bd-11e6-9665-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/38125c1c-d501-4867-bcba-d15d2a439d40?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H2zufvtnbfbTz4NH+vfHDh/cPdj7d/2Rn59HOzkcj81K7bvDG
-        2fJlXV3UedPoV8tMQN072N27P92dbs/u7+xu7x98+mB7Mp1k27Pd+7O9bP/ew9n+zke/cfJL/h8J
-        UXgchgAAAA==
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:10:44 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [ade477cf-43bd-11e6-9665-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/38125c1c-d501-4867-bcba-d15d2a439d40?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H2zufvtnbfbTz4NH+vfHDh/cPdj7d/2Rn59HOzkcj81K7bvDG
-        2fJlXV3UedPoV8tMQN072N27P92dbs/u7+xu7x98+mB7Mp1k27Pd+7O9bP/ew9n+zke/cfJL/h8J
-        UXgchgAAAA==
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:11:15 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [ade477cf-43bd-11e6-9665-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/38125c1c-d501-4867-bcba-d15d2a439d40?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H2zufvtnbfbTz4NH+vfHDh/cPdj7d/2Rn59HOzkcj81K7bvDG
-        2fJlXV3UedPoV8tMQN072N27P92dbs/u7+xu7x98+mB7Mp1k27Pd+7O9bP/ew9n+zke/cfJL/h8J
-        UXgchgAAAA==
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:11:46 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [ade477cf-43bd-11e6-9665-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/38125c1c-d501-4867-bcba-d15d2a439d40?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H2zufvtnbfbTz4NH+vfHDh/cPdj7d/2Rn59HOzkcj81K7bvDG
-        2fJlXV3UedPoV8tMQN072N27P92dbs/u7+xu7x98+mB7Mp1k27Pd+7O9bP/ew9n+zke/cfJL/h8J
-        UXgchgAAAA==
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:12:16 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [ade477cf-43bd-11e6-9665-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/38125c1c-d501-4867-bcba-d15d2a439d40?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H2zufvtnbfbTz4NH+vfHDh/cPdj7d/2Rn59HOzkcj81K7bvDG
-        2fJlXV3UedPoV8tMQN072N27P92dbs/u7+xu7x98+mB7Mp1k27Pd+7O9bP/ew9n+zke/cfJL/h8J
-        UXgchgAAAA==
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:12:46 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [ade477cf-43bd-11e6-9665-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/38125c1c-d501-4867-bcba-d15d2a439d40?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H2zufvtnbfbTz4NH+vfHDh/cPdj7d/2Rn59HOzkcj81K7bvDG
-        2fJlXV3UedPoV8tMQN072N27P92dbs/u7+xu7x98+mB7Mp1k27Pd+7O9bP/ew9n+zke/cfJL/h8J
-        UXgchgAAAA==
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:13:16 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [ade477cf-43bd-11e6-9665-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/38125c1c-d501-4867-bcba-d15d2a439d40?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H2zufvtnbfbTz4NH+vfHDh/cPdj7d/2Rn59HOzkcj81K7bvDG
-        2fJlXV3UedPoV8tMQN072N27P92dbs/u7+xu7x98+mB7Mp1k27Pd+7O9bP/ew9n+zke/cfJL/h8J
-        UXgchgAAAA==
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:13:48 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [ade477cf-43bd-11e6-9665-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/38125c1c-d501-4867-bcba-d15d2a439d40?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H2zufvtnbfbTz4NH+vfHDh/cPdj7d/2Rn59HOzkcj81K7bvDG
-        2fJlXV3UedPoV8tMQN072N27P92dbs/u7+xu7x98+mB7Mp1k27Pd+7O9bP/ew9n+zke/cfJL/h8J
-        UXgchgAAAA==
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:14:18 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [ade477cf-43bd-11e6-9665-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/38125c1c-d501-4867-bcba-d15d2a439d40?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H2zufvtnbfbTz4NH+vfHDh/cPdj7d/2Rn59HOzkcj81K7bvDG
-        2fJlXV3UedPoV8tMQN072N27P92dbs/u7+xu7x98+mB7Mp1k27Pd+7O9bP/ew9n+zke/cfJL/h8J
-        UXgchgAAAA==
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:14:49 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [ade477cf-43bd-11e6-9665-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/38125c1c-d501-4867-bcba-d15d2a439d40?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H2zufvtnbfbTz4NH+vfHDh/cPdj7d/2Rn59HOzkcjfilfzuKv
-        7N6nRuPdvXuffhq8QL206wbtX6+n0zyf5TP9ZpkJnHsHu3v3p7vT7dn9nd3t/YNPH2xPppNse7Z7
-        f7aX7d97ONvf+eg3Tn7J/wOE+QautgAAAA==
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:15:18 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [be66955e-43be-11e6-b36e-001dd8b7c0ad]
+      x-ms-client-request-id: [fbdff5ec-447b-11e6-b56c-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Compute/virtualMachines/vm-state-mod?api-version=2016-03-30&$expand=instanceView
   response:
@@ -1309,113 +1104,112 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UerulrldVvkzUePUv6IPrxcnM3oz492swf5g/29ve3dh9O97f3s4Wz7YG9/Zzs/nzzI9qaTew9m
-        ex+N9KV5Vs+usjp/WVfnRZnT+wqOvrtcvC5+gI8+et1myxm1/P2fvt79SL7/JQZC01Z1dhEFUCzo
-        i1f5eV7ny2nwFX25Wk/KopnnNX3+0Um2rJbFNCsNYng+qs7pVXz91WS9bNev8/qS/vZbNG/X+H53
-        f7yzP97ffv7mdfA1NW+KaokmZdbmTavIO/SpUdU8LZq31MbHrmreXK+A8kfPi+X6XQB1mS34m6qZ
-        0Yu7+58+OLj3cGf3XtBoWufU45erVvt/VleLM9AjaHU5x5R5HdNn67qgzz6at+2qeXT3LjVREr+d
-        3G9W+/fP713szffHk7KajKdVnY+viuWsumrGy7zl1ne7iI3pUztyf+zU2zSbzovlBXp8lWez79ZF
-        m9u2ruVHs6zNQCdw3Pe+Lx+br4kSsemfVovVus3rF0qvy8V20xJRthfVzFHho2y2KJZfNXlt6Lrm
-        2fZalJiCk2p5Xlys60wpavuhBjTcbFLmL7Omuarq2fG6nefLlvhJ255nZZOb9gZreq/JaZra6JCI
-        mATqrTcu89HZksZ0nk0hfN/7xR8VNIMf3W3Wk2ZaFzzdzd17O/v5wcOHn24/eHA+2d7/ND/YnmSz
-        bPv+/Qef7uzef7g/yffv1nlTretp/nldrVfN3WlZvCEOfXXx+//kguStzb+oZndJ0C+LGXHx3S+K
-        aV011Xk7fiFo3O2hc9cn8E9+8aKYfvRLvm8HxKAgDTTbDJ/G9NHr9XSa57PczsdHxZJAkLT+ZJFf
-        UQtLZZq94wsiqv+Z+/QnCUUCTV9+9N1jlhj+eHtvvDPe/dQAx0P6ImvXDYiXfs99nPpQ8RD3zBhF
-        moEQ77tNF2nzfFTml3mJl86W51XvW+KSVZldA8ga3X8Ehr/uNVvkTUPShgafr2lGeCRp0aT1egkk
-        UtKFaUYo0GTTX8v8Kp36vNmMeyDbQjh7b2f30+2dB9s7n77Z23208+DRzv1PdnYe7exYicPzS9wf
-        3/cgfZS/a/MlKPFtwqAkihNIw7f0lm2KgYqcmk861L2VBqNmQ1PVAYfn60wXvbVxwuh7Qi+cMh98
-        uglynOS7+4/uPxw/fHhw/+HBvQjpiYz+n5a43uduSgboE9Dm/emyiSZfjx5DtLhPox/vfLq7u7N7
-        0KOFY6fBEVVXeQ1M8ruzPCvLitRtr+v3GsxPfpH6kFxjR3z5hf8WDFn/pj9UBXwidu3uZVG366z8
-        gi1oR/3KUK2gRb5q1b+4Ea62Z6rQ4PDOFeFJJJMv2uwC1NNJMlQ1RvcnA2BMU6LeL/l/AATsiARI
-        CgAA
+        6UerulrldVvkzUePUv6IPrxcnM3oz48eTmbnn+48eLB9vjvb397fzz7dnhxk97Z39mef3s/ze9PJ
+        g3sfjfSleVbPrrI6f1lX50WZ0/sKjr67XLwufoCPPnrdZssZtfz9n77e/Ui+/yUGQtNWdXYRBVAs
+        6ItX+Xle58tp8BV9uVpPyqKZ5zV9/tFJtqyWxTQrDWJ4PqrO6VV8/dVkvWzXr/P6kv72WzRv1/h+
+        d3+8sz/e337+5nXwNTVvimqJJmXW5k2ryDv0qVHVPC2at9TGx65q3lyvgPJHz4vl+l0AdZkt+Juq
+        mdGLu/ufPni4t3P/3qdBo2mdU49frlrt/1ldLc5Aj6DV5RxT5nVMn63rgj77aN62q+bR3bvUREn8
+        dnK/We3fP793sTffH0/KajKeVnU+viqWs+qqGS/zllvf7SI2pk/tyP2xU2/TbDovlhfo8VWezb5b
+        F21u27qWH82yNgOdwHHf+758bL4mSsSmf1otVus2r18ovS4X201LRNleVDNHhY+y2aJYftXktaHr
+        mmfba1FiCk6q5Xlxsa4zpajthxrQcLNJmb/MmuaqqmfH63aeL1viJ217npVNbtobrOm9JqdpaqND
+        ImISqLfeuMxHZ0sa03k2hfB97xd/VNAMfnS3WU+aaV3wdDd37+3s5wcPH366/eDB+WR7/9P8YHuS
+        zbLt+/cffLqze//h/iTfv1vnTbWup/nndbVeNXenZfGGOPTVxe//kwuStzb/oprdJUG/LGbExXe/
+        KKZ11VTn7fiFoHG3h85dn8A/+cWLYvrRL/m+HRCDgjTQbDN8GtNHr9fTaZ7PcjsfHxVLAkHS+pNF
+        fkUtLJVp9o4viKj+Z+7TnyQUCTR9+dF3j1li+OPtvfHOeDcUDALfrhsQL/2e+zj1oeIh7pkxijQD
+        Id53my7S5vmozC/zEi+dLc+r3rfEJasyuwaQNbr/CAx/3Wu2yJuGpA0NPl/TjPBI0qJJ6/USSKSk
+        C9OMUKDJpr+W+VU69XmzGfdAtoVw9t7O7qfbOw/of292Hz7a//TR/YNPdnYe7exYicPzS9wf3/cg
+        fZS/a/MlKPFtwqAkihNIw7f0lm2KgYqcmk861L2VBqNmQ1PVAYfn60wXvbVxwuh7Qi+cMh98ugny
+        AMnpfw/Gn+7t33tw716E9ERG/09LXO9zNyUD9Alo8/502USTr0ePzbQ4+PRg/+DTHi0cOw2OqLrK
+        a2CS353lWVlWpG57Xb/XYH7yi9SH5Bo74ssv/LdgyPo3/aEq4BOxa3cvi7pdZ+UXbEE76leGagUt
+        8lWr/sWNcLU9U4UGh3euCE8imXzRZhegnk6Soaoxuj8ZAGOaEvV+yf8Du4e5VkgKAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:15:19 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:49:57 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [be948330-43be-11e6-b605-001dd8b7c0ad]
+      x-ms-client-request-id: [fc01934c-447b-11e6-acbd-001dd8b7c0ad]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Compute/virtualMachines/vm-state-mod?api-version=2016-03-30
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/1e866419-646f-4f7a-b802-ab85d4bce1cf?api-version=2016-03-30']
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Wed, 06 Jul 2016 21:15:19 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/1e866419-646f-4f7a-b802-ab85d4bce1cf?monitor=true&api-version=2016-03-30']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/c7e8ab07-0f7b-4571-9362-c10aaa85399b?api-version=2016-03-30']
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Thu, 07 Jul 2016 19:49:58 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/c7e8ab07-0f7b-4571-9362-c10aaa85399b?monitor=true&api-version=2016-03-30']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1191']
     status: {code: 202, message: Accepted}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [be948330-43be-11e6-b605-001dd8b7c0ad]
+      x-ms-client-request-id: [fc01934c-447b-11e6-acbd-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/1e866419-646f-4f7a-b802-ab85d4bce1cf?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/c7e8ab07-0f7b-4571-9362-c10aaa85399b?api-version=2016-03-30
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H2zufvtnbfbR7/9He7vj+w7379w72P9nZebSz89GIX8qXs8FX
-        7u2NH+wfPNh/8CB4hfpp1w3eeL2eTvN8ls/0m2UmkHbzg08/3d99uP3p/qfn2/vnD7LtycHO3nY2
-        Obg/259M893p+Ue/cfJL/h9XrVb0uAAAAA==
+        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H9L83uw8f7T98dP/B+NO9vb37D+5/srPzaGfnoxG/lC9n8Vfu
+        U6OD8f7D/Yef7j4IXqF+2nWDN16vp9M8n+Uz/WaZCaTpg/wgmwDU+YPJ9v79B7vbD+99urc93d3J
+        suzg/r2HDycf/cbJL/l/AAQ9V7a4AAAA
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:15:50 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:50:29 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODM4NzA5LCJuYmYiOjE0Njc4Mzg3MDksImV4cCI6MTQ2Nzg0MjYwOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.q6j_IRaIDshMX950ij2Nv6zwYZMJlgFPaEe2dTcwRj9xpFTxTpeLI_rhc5J5pI77B9JrdKbtYms8_tN71U2Di3FDekbkNDSejHXZiCVMwp_f5_nycOUZF7pzc-Zcpkv_tKvrCFb9VWHqUuhiuxxnvvQpjqfW4HZYIZeVvsgRRCI9WZPfx3ucx85DgaYcWbXB-suI-kMLAwAGDczvOdcfnHTCNi2gZk0dUz0Jvml0-NJO9AEwjHHCh51ACWMEt_ZLJ5cn9C5Fkfhn8n-oMGd_6AELk3jofGWEt_cpk8MvfLG9YlRgf4kceJP06RO-nBjGRbRSh1vh5fBpmoMayo3iTg]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [d119b92e-43be-11e6-aadf-001dd8b7c0ad]
+      x-ms-client-request-id: [0e8bf6c8-447c-11e6-ab4c-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmStateMod/providers/Microsoft.Compute/virtualMachines?api-version=2016-03-30
   response:
@@ -1425,14 +1219,14 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
         uc4/evS97/+S/wdC6kBEDAAAAA==
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['133']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 21:15:51 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['133']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:50:28 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_create_ubuntu.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_create_ubuntu.yaml
@@ -4,11 +4,11 @@ interactions:
     headers:
       Connection: [close]
       Host: [raw.githubusercontent.com]
-      User-Agent: [Python-urllib/2.7]
+      User-Agent: [Python-urllib/3.5]
     method: GET
     uri: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json
   response:
-    body: {string: !!python/unicode "{\n  \"$schema\":\"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json\"\
+    body: {string: "{\n  \"$schema\":\"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json\"\
         ,\n  \"contentVersion\":\"1.0.0.0\",\n  \"parameters\":{},\n  \"variables\"\
         :{},\n  \"resources\":[],\n\n  \"outputs\":{\n    \"aliases\":{\n      \"\
         metadata\":{\n        \"description\":\"This list of aliases is used by Azure\
@@ -45,45 +45,45 @@ interactions:
         \     \"version\":\"latest\"\n          }\n        }\n      }\n    }\n  }\n\
         }\n"}
     headers:
-      accept-ranges: [bytes]
-      access-control-allow-origin: ['*']
-      cache-control: [max-age=300]
-      connection: [close]
-      content-length: ['2297']
-      content-security-policy: [default-src 'none'; style-src 'unsafe-inline']
-      content-type: [text/plain; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:28:17 GMT']
-      etag: ['"db78eb36618a060181b32ac2de91b1733f382e01"']
-      expires: ['Wed, 06 Jul 2016 18:33:17 GMT']
-      source-age: ['0']
-      strict-transport-security: [max-age=31536000]
-      vary: ['Authorization,Accept-Encoding']
-      via: [1.1 varnish]
-      x-cache: [MISS]
-      x-cache-hits: ['0']
-      x-content-type-options: [nosniff]
-      x-fastly-request-id: [46119c4d9a0443a7927fac7d74f50b3dce5d160c]
-      x-frame-options: [deny]
-      x-geo-block-list: ['']
-      x-github-request-id: ['C71B4F14:5AD4:50AE121:577D4DC1']
-      x-served-by: [cache-lax1425-LAX]
-      x-xss-protection: [1; mode=block]
+      Accept-Ranges: [bytes]
+      Access-Control-Allow-Origin: ['*']
+      Cache-Control: [max-age=300]
+      Connection: [close]
+      Content-Length: ['2297']
+      Content-Security-Policy: [default-src 'none'; style-src 'unsafe-inline']
+      Content-Type: [text/plain; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:42:11 GMT']
+      ETag: ['"db78eb36618a060181b32ac2de91b1733f382e01"']
+      Expires: ['Thu, 07 Jul 2016 19:47:11 GMT']
+      Source-Age: ['102']
+      Strict-Transport-Security: [max-age=31536000]
+      Vary: ['Authorization,Accept-Encoding']
+      Via: [1.1 varnish]
+      X-Cache: [HIT]
+      X-Cache-Hits: ['1']
+      X-Content-Type-Options: [nosniff]
+      X-Fastly-Request-ID: [826d999b8e3f58f8c041030aa11765581c939d25]
+      X-Frame-Options: [deny]
+      X-Geo-Block-List: ['']
+      X-GitHub-Request-Id: ['17EB2F14:5AD4:5836B6B:577EB02D']
+      X-Served-By: [cache-sjc3132-SJC]
+      X-XSS-Protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI2MTE1LCJuYmYiOjE0Njc4MjYxMTUsImV4cCI6MTQ2NzgzMDAxNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.BsXPjbpDDitiOiqCh89LqEkRNwGth9IsXslnNhFEHJBysUJjzEBeOZaEwQCAZtLOO2DLZkoTvDZ2ddXEfZ3XNXS4wSAj2Hf0L0-d3gbP7mvzGpcZIsAH4eUlfX8LoGuQt4MyBNPH1pfTfNJYTMOFAsnsy3vPjr6qVj8butsv2XpDhPrDGRTE7WrgCBF-I7OfWqeiej_zc3ZKEXneOgxc6IbWGBqmUfM8SyLh48O2a_hoEs1KciA4AKt77zbsCbqrnbHdNadvVTDvkM-ToYNzgjWXp6kcW13cwS_roFV3Afz3YNB61ICCYog45D3uATmoKVE9BCZkrwCGrljteh9djw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 resourcemanagementclient/0.30.0rc5 Azure-SDK-For-Python
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [68a10000-43a7-11e6-bd11-001dd8b7c0ad]
+      x-ms-client-request-id: [e5aa1230-447a-11e6-a137-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27cliTestRg_VMCreate_Ubuntu2%27%20and%20name%20eq%20%27cli-test-vm2%27%20and%20resourceType%20eq%20%27Microsoft.Compute%2FvirtualMachines%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Network/virtualnetworks?api-version=2016-03-30
   response:
     body:
       string: !!binary |
@@ -91,74 +91,160 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
         uc4/evS97/+S/wdC6kBEDAAAAA==
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['133']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:28:17 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['133']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:42:13 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30/azuredeploy.json"},
-      "mode": "Incremental", "parameters": {"osSKU": {"value": "14.04.4-LTS"}, "publicIpAddressAllocation":
-      {"value": "dynamic"}, "authenticationType": {"value": "ssh"}, "osDiskType":
-      {"value": "provided"}, "storageType": {"value": "Premium_LRS"}, "dnsNameType":
-      {"value": "none"}, "subnetIpAddressPrefix": {"value": "10.0.0.0/24"}, "adminUsername":
-      {"value": "ubuntu"}, "networkInterfaceType": {"value": "new"}, "_artifactsLocation":
-      {"value": "https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30"},
-      "osType": {"value": "Custom"}, "sshKeyValue": {"value": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
-      test@example.com\n"}, "osVersion": {"value": "latest"}, "customOsDiskType":
-      {"value": "windows"}, "virtualNetworkIpAddressPrefix": {"value": "10.0.0.0/16"},
-      "name": {"value": "cli-test-vm2"}, "storageCaching": {"value": "ReadWrite"},
-      "networkSecurityGroupRule": {"value": "SSH"}, "storageContainerName": {"value":
-      "vhds"}, "osOffer": {"value": "UbuntuServer"}, "osPublisher": {"value": "Canonical"},
-      "privateIpAddressAllocation": {"value": "dynamic"}, "size": {"value": "Standard_DS1"},
-      "osDiskName": {"value": "osdisk1467829698"}, "location": {"value": "westus"}}}}'
+    body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI2MTE1LCJuYmYiOjE0Njc4MjYxMTUsImV4cCI6MTQ2NzgzMDAxNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.BsXPjbpDDitiOiqCh89LqEkRNwGth9IsXslnNhFEHJBysUJjzEBeOZaEwQCAZtLOO2DLZkoTvDZ2ddXEfZ3XNXS4wSAj2Hf0L0-d3gbP7mvzGpcZIsAH4eUlfX8LoGuQt4MyBNPH1pfTfNJYTMOFAsnsy3vPjr6qVj8butsv2XpDhPrDGRTE7WrgCBF-I7OfWqeiej_zc3ZKEXneOgxc6IbWGBqmUfM8SyLh48O2a_hoEs1KciA4AKt77zbsCbqrnbHdNadvVTDvkM-ToYNzgjWXp6kcW13cwS_roFV3Afz3YNB61ICCYog45D3uATmoKVE9BCZkrwCGrljteh9djw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 storagemanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e70ad808-447a-11e6-b06a-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Storage/storageAccounts?api-version=2016-01-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS97/+S5P8BxWZBqg0AAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Thu, 07 Jul 2016 19:42:14 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 resourcemanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e829c61c-447a-11e6-a40b-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?$filter=resourceGroup%20eq%20%27cliTestRg_VMCreate_Ubuntu2%27%20and%20name%20eq%20%27cli-test-vm2%27%20and%20resourceType%20eq%20%27Microsoft.Compute%2FvirtualMachines%27&api-version=2016-02-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS97/+S/wdC6kBEDAAAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['133']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:42:15 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJwcm9wZXJ0aWVzIjogeyJwYXJhbWV0ZXJzIjogeyJzc2hLZXlWYWx1ZSI6IHsidmFsdWUiOiAi
+      c3NoLXJzYSBBQUFBQjNOemFDMXljMkVBQUFBREFRQUJBQUFDQVFDYklnMWd1UkhiSTBsVjExd1dE
+      dDFyMmNVZGNOZDI3Q0pzZytTZmdDN21pWmV1YnR3VWhic1BkaE1Rc2ZEeWhPV0hxMStaTDBNK25K
+      WlY2M2QvMWRobWh0Z3lPcWVqVXdyUGx6S2h5ZHNicnNkVW9yK0ptTkpEZFcwMXY3QlhIeXV5bVQ4
+      RzRzMDlqQ2FzTk93aXVmYlAvcXA3MnJ1dTBiSUExbnlTc3ZsZjlwQ1FBdUZrQW5WbmYvckZoVWxP
+      a2h0UnB3Y3E4U1VOWTJ6UkhSL0VLYi80TldZMUp6UjRzYTNxMmZXSUpkcnJYMER2TG9hNWc5YklF
+      ZDREZjc5YmE3dit5aVVCT1MwelQybGwrejRnOWl6SEszRU81ZDhoTDRqWXhjaktzK3djc2xTWVJX
+      cmFzY2ZzY0xnTWxNR2gwQ2RLZU5URGpIcEdQbmNhZjNaK0Z3d3dqV2V1aU5CeHY3YkpvMTMvOEIv
+      MDk4S2xWRGw0R1pxc29CQ0VqUHlKZlY2aE8weS9Ma1JHa2s3b0hXS2dlV0FmS3RmTEl0UnAwMGVa
+      NGZjSk5LOWtDYVNNbUV1Z29aV2NJN05HYlpYenFGV3FicFJJN05jRFA5K1dJUStpOVU1dnFXc3Fk
+      L3puZzRrYnVBSjZVdUtxSXpCMHVwWXJMU2hmUUUzU0FjazhvYUxoSnFxcTU2VmZEdUFTTnBKS2lk
+      Vit6cTI3SGZTQm1iWG5rUi81QUszMzdkYzNNWEtKeXBvSy9RUE1MS1VBUDVYTFBicytOZGRKUVY3
+      RVpYZDI5RExncCtmUklnM2VkcEtkTzdaRXJXaHY3ZCszS3dzK2UxWSt5cG1SMldJVlN3VnlCRVVm
+      Z3YyQzhUczlnblRGNHBOY0VZL1MyYUJpY3o1RXcyK2pkeUdOUVE9PSB0ZXN0QGV4YW1wbGUuY29t
+      XG4ifSwgIm9zU0tVIjogeyJ2YWx1ZSI6ICIxNC4wNC40LUxUUyJ9LCAiY3VzdG9tT3NEaXNrVHlw
+      ZSI6IHsidmFsdWUiOiAid2luZG93cyJ9LCAib3NUeXBlIjogeyJ2YWx1ZSI6ICJDdXN0b20ifSwg
+      InByaXZhdGVJcEFkZHJlc3NBbGxvY2F0aW9uIjogeyJ2YWx1ZSI6ICJkeW5hbWljIn0sICJzdG9y
+      YWdlVHlwZSI6IHsidmFsdWUiOiAiUHJlbWl1bV9MUlMifSwgImF1dGhlbnRpY2F0aW9uVHlwZSI6
+      IHsidmFsdWUiOiAic3NoIn0sICJzdWJuZXRJcEFkZHJlc3NQcmVmaXgiOiB7InZhbHVlIjogIjEw
+      LjAuMC4wLzI0In0sICJuZXR3b3JrSW50ZXJmYWNlVHlwZSI6IHsidmFsdWUiOiAibmV3In0sICJz
+      dG9yYWdlQ2FjaGluZyI6IHsidmFsdWUiOiAiUmVhZFdyaXRlIn0sICJwdWJsaWNJcEFkZHJlc3NB
+      bGxvY2F0aW9uIjogeyJ2YWx1ZSI6ICJkeW5hbWljIn0sICJzaXplIjogeyJ2YWx1ZSI6ICJTdGFu
+      ZGFyZF9EUzEifSwgIm9zT2ZmZXIiOiB7InZhbHVlIjogIlVidW50dVNlcnZlciJ9LCAib3NEaXNr
+      VHlwZSI6IHsidmFsdWUiOiAicHJvdmlkZWQifSwgInZpcnR1YWxOZXR3b3JrSXBBZGRyZXNzUHJl
+      Zml4IjogeyJ2YWx1ZSI6ICIxMC4wLjAuMC8xNiJ9LCAibmFtZSI6IHsidmFsdWUiOiAiY2xpLXRl
+      c3Qtdm0yIn0sICJvc0Rpc2tOYW1lIjogeyJ2YWx1ZSI6ICJvc2Rpc2sxNDY3OTIwNTM2In0sICJv
+      c1B1Ymxpc2hlciI6IHsidmFsdWUiOiAiQ2Fub25pY2FsIn0sICJzdG9yYWdlQ29udGFpbmVyTmFt
+      ZSI6IHsidmFsdWUiOiAidmhkcyJ9LCAibG9jYXRpb24iOiB7InZhbHVlIjogIndlc3R1cyJ9LCAi
+      bmV0d29ya1NlY3VyaXR5R3JvdXBSdWxlIjogeyJ2YWx1ZSI6ICJTU0gifSwgImRuc05hbWVUeXBl
+      IjogeyJ2YWx1ZSI6ICJub25lIn0sICJfYXJ0aWZhY3RzTG9jYXRpb24iOiB7InZhbHVlIjogImh0
+      dHBzOi8vYXp1cmVzZGtjaS5ibG9iLmNvcmUud2luZG93cy5uZXQvdGVtcGxhdGVob3N0L0NyZWF0
+      ZVZtXzIwMTYtMDYtMzAifSwgIm9zVmVyc2lvbiI6IHsidmFsdWUiOiAibGF0ZXN0In0sICJhZG1p
+      blVzZXJuYW1lIjogeyJ2YWx1ZSI6ICJ1YnVudHUifX0sICJtb2RlIjogIkluY3JlbWVudGFsIiwg
+      InRlbXBsYXRlTGluayI6IHsidXJpIjogImh0dHBzOi8vYXp1cmVzZGtjaS5ibG9iLmNvcmUud2lu
+      ZG93cy5uZXQvdGVtcGxhdGVob3N0L0NyZWF0ZVZtXzIwMTYtMDYtMzAvYXp1cmVkZXBsb3kuanNv
+      biJ9fX0=
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Length: ['2000']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [68f7f99e-43a7-11e6-a2b9-001dd8b7c0ad]
+      x-ms-client-request-id: [e8704886-447a-11e6-bbbc-001dd8b7c0ad]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/azurecli1467829697.5246409","name":"azurecli1467829697.5246409","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30"},"adminPassword":{"type":"SecureString"},"adminUsername":{"type":"String","value":"ubuntu"},"authenticationType":{"type":"String","value":"ssh"},"availabilitySet":{"type":"String","value":""},"availabilitySetType":{"type":"String","value":"none"},"customOsDiskType":{"type":"String","value":"windows"},"customOsDiskUri":{"type":"String","value":""},"dnsNameForPublicIP":{"type":"String","value":""},"dnsNameType":{"type":"String","value":"none"},"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"cli-test-vm2"},"networkSecurityGroup":{"type":"String","value":"cli-test-vm2NSG"},"networkSecurityGroupRule":{"type":"String","value":"SSH"},"networkSecurityGroupType":{"type":"String","value":"new"},"networkInterfaceIds":{"type":"Array","value":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Network/networkInterfaces/cli-test-vm2VMNic"}]},"networkInterfaceType":{"type":"String","value":"new"},"osDiskName":{"type":"String","value":"osdisk1467829698"},"osDiskType":{"type":"String","value":"provided"},"osDiskUri":{"type":"String","value":"https://vhdstorageqove4nrsszaz6.blob.core.windows.net/vhds/osdisk1467829698.vhd"},"osOffer":{"type":"String","value":"UbuntuServer"},"osPublisher":{"type":"String","value":"Canonical"},"osSKU":{"type":"String","value":"14.04.4-LTS"},"osType":{"type":"String","value":"Custom"},"osVersion":{"type":"String","value":"latest"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddress":{"type":"String","value":"cli-test-vm2PublicIP"},"publicIpAddressType":{"type":"String","value":"new"},"size":{"type":"String","value":"Standard_DS1"},"sshDestKeyPath":{"type":"String","value":"/home/ubuntu/.ssh/authorized_keys"},"sshKeyValue":{"type":"String","value":"ssh-rsa
+    body: {string: '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/azurecli1467920535.76603774011","name":"azurecli1467920535.76603774011","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30"},"adminPassword":{"type":"SecureString"},"adminUsername":{"type":"String","value":"ubuntu"},"authenticationType":{"type":"String","value":"ssh"},"availabilitySet":{"type":"String","value":""},"availabilitySetType":{"type":"String","value":"none"},"customOsDiskType":{"type":"String","value":"windows"},"customOsDiskUri":{"type":"String","value":""},"dnsNameForPublicIP":{"type":"String","value":""},"dnsNameType":{"type":"String","value":"none"},"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"cli-test-vm2"},"networkSecurityGroup":{"type":"String","value":"cli-test-vm2NSG"},"networkSecurityGroupRule":{"type":"String","value":"SSH"},"networkSecurityGroupType":{"type":"String","value":"new"},"networkInterfaceIds":{"type":"Array","value":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Network/networkInterfaces/cli-test-vm2VMNic"}]},"networkInterfaceType":{"type":"String","value":"new"},"osDiskName":{"type":"String","value":"osdisk1467920536"},"osDiskType":{"type":"String","value":"provided"},"osDiskUri":{"type":"String","value":"https://vhdstorageqove4nrsszaz6.blob.core.windows.net/vhds/osdisk1467920536.vhd"},"osOffer":{"type":"String","value":"UbuntuServer"},"osPublisher":{"type":"String","value":"Canonical"},"osSKU":{"type":"String","value":"14.04.4-LTS"},"osType":{"type":"String","value":"Custom"},"osVersion":{"type":"String","value":"latest"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddress":{"type":"String","value":"cli-test-vm2PublicIP"},"publicIpAddressType":{"type":"String","value":"new"},"size":{"type":"String","value":"Standard_DS1"},"sshDestKeyPath":{"type":"String","value":"/home/ubuntu/.ssh/authorized_keys"},"sshKeyValue":{"type":"String","value":"ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAACAQCbIg1guRHbI0lV11wWDt1r2cUdcNd27CJsg+SfgC7miZeubtwUhbsPdhMQsfDyhOWHq1+ZL0M+nJZV63d/1dhmhtgyOqejUwrPlzKhydsbrsdUor+JmNJDdW01v7BXHyuymT8G4s09jCasNOwiufbP/qp72ruu0bIA1nySsvlf9pCQAuFkAnVnf/rFhUlOkhtRpwcq8SUNY2zRHR/EKb/4NWY1JzR4sa3q2fWIJdrrX0DvLoa5g9bIEd4Df79ba7v+yiUBOS0zT2ll+z4g9izHK3EO5d8hL4jYxcjKs+wcslSYRWrascfscLgMlMGh0CdKeNTDjHpGPncaf3Z+FwwwjWeuiNBxv7bJo13/8B/098KlVDl4GZqsoBCEjPyJfV6hO0y/LkRGkk7oHWKgeWAfKtfLItRp00eZ4fcJNK9kCaSMmEugoZWcI7NGbZXzqFWqbpRI7NcDP9+WIQ+i9U5vqWsqd/zng4kbuAJ6UuKqIzB0upYrLShfQE3SAck8oaLhJqqq56VfDuASNpJKidV+zq27HfSBmbXnkR/5AK337dc3MXKJypoK/QPMLKUAP5XLPbs+NddJQV7EZXd29DLgp+fRIg3edpKdO7ZErWhv7d+3Kws+e1Y+ypmR2WIVSwVyBEUfgv2C8Ts9gnTF4pNcEY/S2aBicz5Ew2+jdyGNQQ==
-        test@example.com\n"},"storageAccount":{"type":"String","value":"vhdstorageqove4nrsszaz6"},"storageAccountType":{"type":"String","value":"new"},"storageCaching":{"type":"String","value":"ReadWrite"},"storageContainerName":{"type":"String","value":"vhds"},"storageType":{"type":"String","value":"Premium_LRS"},"subnetIpAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetName":{"type":"String","value":"cli-test-vm2Subnet"},"virtualNetworkIpAddressPrefix":{"type":"String","value":"10.0.0.0/16"},"virtualNetwork":{"type":"String","value":"cli-test-vm2VNET"},"virtualNetworkType":{"type":"String","value":"new"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-06T18:28:19.2425419Z","duration":"PT0.1071532S","correlationId":"1d2007d6-b4d0-4cb4-8f3f-a97cd1a66c9e","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/cli-test-vm2VNet","resourceType":"Microsoft.Resources/deployments","resourceName":"cli-test-vm2VNet"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/cli-test-vm2NSG","resourceType":"Microsoft.Resources/deployments","resourceName":"cli-test-vm2NSG"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/cli-test-vm2NicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"cli-test-vm2NicIp"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/cli-test-vm2b45twdxwd52fw","resourceType":"Microsoft.Resources/deployments","resourceName":"cli-test-vm2b45twdxwd52fw"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/cli-test-vm2NicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"cli-test-vm2NicIp"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/cli-test-vm2VM","resourceType":"Microsoft.Resources/deployments","resourceName":"cli-test-vm2VM"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/cli-test-vm2VM","resourceType":"Microsoft.Resources/deployments","resourceName":"cli-test-vm2VM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/cli-test-vm2lubf3fjauaswsnew","resourceType":"Microsoft.Resources/deployments","resourceName":"cli-test-vm2lubf3fjauaswsnew"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/cli-test-vm2VM","resourceType":"Microsoft.Resources/deployments","resourceName":"cli-test-vm2VM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/cli-test-vm2lubf3fjauaswsnewfqdn","resourceType":"Microsoft.Resources/deployments","resourceName":"cli-test-vm2lubf3fjauaswsnewfqdn"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/cli-test-vm2VM","resourceType":"Microsoft.Resources/deployments","resourceName":"cli-test-vm2VM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/cli-test-vm2cli-test-vm2VMNicmac","resourceType":"Microsoft.Resources/deployments","resourceName":"cli-test-vm2cli-test-vm2VMNicmac"}]}}'}
+        test@example.com\n"},"storageAccount":{"type":"String","value":"vhdstorageqove4nrsszaz6"},"storageAccountType":{"type":"String","value":"new"},"storageCaching":{"type":"String","value":"ReadWrite"},"storageContainerName":{"type":"String","value":"vhds"},"storageType":{"type":"String","value":"Premium_LRS"},"subnetIpAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetName":{"type":"String","value":"cli-test-vm2Subnet"},"virtualNetworkIpAddressPrefix":{"type":"String","value":"10.0.0.0/16"},"virtualNetwork":{"type":"String","value":"cli-test-vm2VNET"},"virtualNetworkType":{"type":"String","value":"new"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-07T19:42:18.4739505Z","duration":"PT0.1486433S","correlationId":"95748164-3b75-4f12-ac87-ec91e999d6d2","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/cli-test-vm2VNet","resourceType":"Microsoft.Resources/deployments","resourceName":"cli-test-vm2VNet"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/cli-test-vm2NSG","resourceType":"Microsoft.Resources/deployments","resourceName":"cli-test-vm2NSG"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/cli-test-vm2NicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"cli-test-vm2NicIp"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/cli-test-vm2b45twdxwd52fw","resourceType":"Microsoft.Resources/deployments","resourceName":"cli-test-vm2b45twdxwd52fw"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/cli-test-vm2NicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"cli-test-vm2NicIp"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/cli-test-vm2VM","resourceType":"Microsoft.Resources/deployments","resourceName":"cli-test-vm2VM"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/cli-test-vm2VM","resourceType":"Microsoft.Resources/deployments","resourceName":"cli-test-vm2VM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/cli-test-vm2lubf3fjauaswsnew","resourceType":"Microsoft.Resources/deployments","resourceName":"cli-test-vm2lubf3fjauaswsnew"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/cli-test-vm2VM","resourceType":"Microsoft.Resources/deployments","resourceName":"cli-test-vm2VM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/cli-test-vm2lubf3fjauaswsnewfqdn","resourceType":"Microsoft.Resources/deployments","resourceName":"cli-test-vm2lubf3fjauaswsnewfqdn"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/cli-test-vm2VM","resourceType":"Microsoft.Resources/deployments","resourceName":"cli-test-vm2VM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/cli-test-vm2cli-test-vm2VMNicmac","resourceType":"Microsoft.Resources/deployments","resourceName":"cli-test-vm2cli-test-vm2VMNicmac"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/azurecli1467829697.5246409/operationStatuses/08587337771863423212?api-version=2015-11-01']
-      cache-control: [no-cache]
-      content-length: ['7190']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:28:18 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1193']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/azurecli1467920535.76603774011/operationStatuses/08587336863471523925?api-version=2015-11-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['7198']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:42:18 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [68f7f99e-43a7-11e6-a2b9-001dd8b7c0ad]
+      x-ms-client-request-id: [e8704886-447a-11e6-bbbc-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771863423212?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863471523925?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -166,30 +252,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:28:50 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:42:47 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [68f7f99e-43a7-11e6-a2b9-001dd8b7c0ad]
+      x-ms-client-request-id: [e8704886-447a-11e6-bbbc-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771863423212?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863471523925?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -197,30 +283,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:29:20 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:43:18 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [68f7f99e-43a7-11e6-a2b9-001dd8b7c0ad]
+      x-ms-client-request-id: [e8704886-447a-11e6-bbbc-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771863423212?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863471523925?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -228,30 +314,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:29:51 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:43:48 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [68f7f99e-43a7-11e6-a2b9-001dd8b7c0ad]
+      x-ms-client-request-id: [e8704886-447a-11e6-bbbc-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771863423212?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863471523925?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -259,30 +345,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:30:20 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:44:19 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [68f7f99e-43a7-11e6-a2b9-001dd8b7c0ad]
+      x-ms-client-request-id: [e8704886-447a-11e6-bbbc-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771863423212?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863471523925?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -290,30 +376,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:30:53 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:44:49 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [68f7f99e-43a7-11e6-a2b9-001dd8b7c0ad]
+      x-ms-client-request-id: [e8704886-447a-11e6-bbbc-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771863423212?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863471523925?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -321,92 +407,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:31:22 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:45:18 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [68f7f99e-43a7-11e6-a2b9-001dd8b7c0ad]
+      x-ms-client-request-id: [e8704886-447a-11e6-bbbc-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771863423212?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:31:53 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [68f7f99e-43a7-11e6-a2b9-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771863423212?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:32:23 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [68f7f99e-43a7-11e6-a2b9-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771863423212?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863471523925?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -414,28 +438,28 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['141']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:32:54 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['141']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:45:48 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [68f7f99e-43a7-11e6-a2b9-001dd8b7c0ad]
+      x-ms-client-request-id: [e8704886-447a-11e6-bbbc-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
@@ -445,69 +469,69 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
         o0cf3W3Wk2ZaF6u2qJbN3Xs7+/nBw4efbj94cD7Z3v80P9ieZLNs+/79B5/u7N5/uD/J9+/WeVOt
         62n+eV2tV83daVm8yZv21cXv/5NfnNR51ua//1eT9bJd791d1dVlMcvr5u4XxbSumuq8Hb/St5u7
-        s3xVVteLfNk2d7MfrOucIO3uf/rgYO/hpw8fjO/v7X+6v/Pwo9FHy2yRE64b21BXq7xui7z56NEv
-        /qjNF6uSMHleLN/i73VdEIB5266aR3els2b2dlqMJ2U1GU+rOh9fFctZddWMl3l717w+r5r2rozp
-        Jxe//97O7qfbO59u39sRCIL/+KebakkITKtlS0P5SRotkZJ62x3v4L+Pfgkhl9U0hJa+AjK/f0Z4
-        nmfTtnleTTMQHp+21ysM8nVbF8sLgneZlWt88I0hDUSy2aJYvsya5qqqafpdr/mUoGvfpt1XTV4L
-        6V07aeGwW/NM8yvrdk7jL2REb7j98HtNM+eXLrOizCZFWbTXr/N20xuR5jd1sqyWOV6brpu2WnzZ
-        PC2atze9oxTtvvYVGGj4LTSfLZsX2SJ/VtUv15OymJ69vOUbN6FkhlHegluuSBLXjP1NM0eCtN1S
-        6+3LxR63z1tiirfMCUReFu7bvv/i9edDIF6tS2o9DOb1628PvXojXfIr79UzEr+apCo/m7GU6VvH
-        dZ1du5e+93Om914Imne76DIgS8mf/OJFMf3ol3w/Mq5bkqNifgVfbWpcNTNqZTXpgXvzpm50bDP3
-        xg2yYRTY5XxG8lRnF/kvqi7z/WXdND/IfvDpgDZD67tdLMf0qfT75fl5Xm/qVabidV5fUjt+haWy
-        mdOfG147yUjaSIeV8s7r3+urTa1398c7++P97edvXkv7m4h3wipF2lpLMdwc6rxp0XxVF5f0x9nq
-        eDYjPvQ5vPdWrP1xeRvtMbsmrQH+IwCg1vQbe3/TWz7/8yRBdfZB3ERb5f+m+AH9NdzsdZstZ1k9
-        +/2fvt7l9s38KXX+e+XXL7N2vunNu/Nqkd8Vi3d3TO/dhc2raupw9vu/za9Z7dLHBOon5ZVhWNRs
-        u26y9JieJ/de/CA72b2e7p3SX8dPj3/i+An9PDn+iZPJ2cXuxfrVtydnO+VP7u5effdpu1vvTb+a
-        TV/M9h6cfKe5+OT1+cXJg0XxU/l60l59NZ80L2fzL36iOX96Pf/yu9/+Rbuf/NTznS8+WX7np37y
-        03uzu7uz+WLeXlx/+Yvyn/7qqn5Z/uD3ml/PmkndzL6q6k++s3jxnaez7+7sXj548nt/+3p9vXhz
-        8Pl+s/Pwp0+y5sWXV8X6fPLy7i9aPdir1+udydnx7vL6dXNZnj9cnfzE8frZ2+PlTy7P79bP5l+V
-        X76dt69WV9NfdPD6qxe/z94PXn371d3T32tyd//Fd3+f3e/84NV+k937RXvn3z37zqyuf++dp5fP
-        q+z+xcPJ2els/+n5g4eT7MHlJ9fFV0++fL3zgzd7ZfnJD/YvHhY/+Pbvde/0y/uzg/nz/Z/+fd5N
-        f/r3aj65mjbl69/n1XfrrJmeN9PnF1+UX3w+3zmZ/V75izdPf/rbq89fLqfZ+b2f+uTZ1dXVT383
-        Xxcvnry7fDD5TrV77+7Bk7s7Dw9+r/Inn5b7n//UL2qqJyenP/3y+jvnP/np/Mud67vP3776/O3b
-        B9W3v/t7XeTfPT7/vdrz52c0tJ2d/Kf2z6ffefF7PXx7kr3+YnG6vqh+6rvTswcvPp/81O/9g1/0
-        7Lu/aLJ6RX9On758+Ml3z37ik+LhV/cvf9F3m180u/uD5cX+28n6+DuffrX+vX7R2Q+e7KxXv0/9
-        /PX8/CdO770+nr49qLLn8+/8ol/0i+5/+pPnT9fHr1+svvN7FbOf/OQHv2jvwbfPXz9ZTH7v5dtX
-        d+8f/1737j2YTe998Xv/Xt+5XlW/192fePnF89/rq+OX93/v5y8nzScvZrPv/MRPPjj9qd97tvfw
-        6fOL1Sfnr84u7uWz1e81+/LBT53W351fPph9cu/3umo+yXd/n0+uV4tXe989+8nXVz95/eT0q/OL
-        y72TgzfNw4vlm2f7qxfT09/n7uu97Ekx/cH906u9T356dv35i5/4ic8+SyHEv2f+LiM/NCeNvvh9
-        lywRovSPp9OKJGeTUJB218aBhegDua0qkJdOsukc32944VWezb5Ljgf7WeY1cuizYpnXN9lSoO29
-        dxNyL+t8UawXv//zV2w0yBEhe2e1HH17Xrzb9P4uBRX47+7evnv/Jhx9Hfua38C7l0XdrrPyhXoa
-        XwOHXZ6dEM6mF308fvLF6Zv+2zeRj+eW3lpUM/x5tpwSPSnwIJNNJgPOCawqvUOKnuaTIKyn05yC
-        tRl93xYL6pwYlD6XyOgBBUdvdg8e3dt7tL83fnjv4OHOwf5PUdPZulZ799HLN/tf7N0bH+zcu7/7
-        8MFr+pLclTon60zfn8Gd3J3t7ew8mH26Pdmf7WzvTyf72wfn9863s4cPprPd7NNPpw9zeo3Rg1/I
-        jijZyrxZkWdHAJyfaONjak+Twb+DJvKO/wm9JiEoho/mxkSj6XJdlt8nP/L7NJJ8lS9n+XLKwTEB
-        kQ+aL2ls9NfPkT9sxxnkAQiIxx/EpSERCNMbIHgviEx0WI5A/pLR/4sHjVDKDeGbGDMggg3+3ztk
-        OHneGL6RQTNMzDS98v8FZp/s32+vZu+uZvf3zq+8sX0TxAhhgyj/ryWDzJsbzTcxfIH5/2oR+Mkv
-        vCF8E2MmgJhnav//BeYnbN1ovqnh/795vsv1hNyDn87WWXPVwKNxo/kmht8D/yNe+H/vgLuTdf6L
-        ZlhPMN1+EySIdvEjnvh/74D93zklvMim3oi+CRL4v9suQJRq3a7W9DbFYKDPcCR294dOuJNqQajl
-        dy8lYvyCA3saNIGxYyG+7mYONw1il+K6g/Hu/fE+v8mSsaE52nRzq5vaa6DMkToR+BZv7Oxs7zzd
-        vne8fW9/e2d3e/8BR7syKXaanbi+N3F671FIhLj7dgsTN74erOCEIDgQGQagk/ZSadTp30sMD0K4
-        lJHrn+H7mmzovftakjZ3NXmjCaaG1x/ko04u6vu/5Jf8P+mZcqY8HwAA
+        s3xVVteLfNk2d7MfrOucIO3uf/rg4d7O/Xv3xw8+/XTn3oMH+zu7ux+NPlpmi5zwvbEddbnK67bI
+        m48e/eKP2nyxKgmj58XyLf5e1wUBmbftqnl0VzptZm+nxXhSVpPxtKrz8VWxnFVXzXiZt3fN6/Oq
+        ae/K2H5y8fvv7ex+ur3z6fa9HYEg4xj/dFMtCYFptWxpSD9JoyaSUm+74x3899EvIeSymobR0ldA
+        5vfPCM/zbNo2z6tphgnAp+31CgN93dbF8oLgXWblGh98Y0gDkWy2KJYvs6a5qmpiA9drPiXo2rdp
+        91WT10J+105aOOzWPOP8yrqd0/gLGdEbbj/8XtPM+aXLrCizSVEW7fXrvN30RqT5TZ0sq2WO16br
+        pq0WXzZPi+btTe8oRbuvfQUGGn4LzWfL5kW2yJ9V9cv1pCymZy9v+cZNKJlhlLfgliuSyDVjf9PM
+        kTBtt9R6+3Kxx+3zlpjiLXMCkZeF/Lbvv3j9+RCIV+uSWg+Def3620Ov3kiX/Mp79YzEryapys9m
+        LGX61nFdZ9fupe/9nOm/F4Lm3S66DMhS8ie/eFFMP/ol34+M65bkqJhfwVebGlfNjFpZbfqpe/Om
+        bnRsM/fGDbJhFNjlfEbyVGcX+S+qLvP9Zd00P8h+8OmANkPru10sx/Sp9Pvl+Xleb+pVpuJ1Xl9S
+        O36FpbKZ058bXjvJSNpIh5Xyzuvf66tNrXf3xzv74/3t529eS/ubiHfCKkXaWksx3BzqvGnRfFUX
+        l/TH2ep4NiM+9Dm891as/XF5G+0xuyatAf4jAKDW9Bt7f9NbPv/zJEF19kHcRFvl/6b4Af013Ox1
+        my1nWT37/Z++3uX2zfwpdf575dcvs3a+6c2782qR3xWLd3dM792Fzatq6nD2+7/Nr1nt0scE6ifl
+        lWFY1Gy7brL0mJ4n9178IDvZvZ7undJfx0+Pf+L4Cf08Of6Jk8nZxe7F+tW3J2c75U/u7l5992m7
+        W+9Nv5pNX8z2Hpx8p7n45PX5xcmDRfFT+XrSXn01nzQvZ/MvfqI5f3o9//K73/5Fu5/81POdLz5Z
+        fuenfvLTe7O7u7P5Yt5eXH/5i/Kf/uqqfln+4PeaX8+aSd3MvqrqT76zePGdp7Pv7uxePnjye3/7
+        en29eHPw+X6z8/CnT7LmxZdXxfp88vLuL1o92KvX653J2fHu8vp1c1meP1yd/MTx+tnb4+VPLs/v
+        1s/mX5Vfvp23r1ZX01908PqrF7/P3g9effvV3dPfa3J3/8V3f5/d7/zg1X6T3ftFe+ffPfvOrK5/
+        752nl8+r7P7Fw8nZ6Wz/6fmDh5PsweUn18VXT758vfODN3tl+ckP9i8eFj/49u917/TL+7OD+fP9
+        n/593k1/+vdqPrmaNuXr3+fVd+usmZ430+cXX5RffD7fOZn9XvmLN09/+turz18up9n5vZ/65NnV
+        1dVPfzdfFy+evLt8MPlOtXvv7sGTuzsPD36v8ieflvuf/9QvaqonJ6c//fL6O+c/+en8y53ru8/f
+        vvr87dsH1be/+3td5N89Pv+92vPnZzS0nZ38p/bPp9958Xs9fHuSvf5icbq+qH7qu9OzBy8+n/zU
+        7/2DX/Tsu79osnpFf06fvnz4yXfPfuKT4uFX9y9/0XebXzS7+4Plxf7byfr4O59+tf69ftHZD57s
+        rFe/T/389fz8J07vvT6evj2osufz7/yiX/SL7n/6k+dP18evX6y+83sVs5/85Ae/aO/Bt89fP1lM
+        fu/l21d37x//XvfuPZhN733xe/9e37leVb/X3Z94+cXz3+ur45f3f+/nLyfNJy9ms+/8xE8+OP2p
+        33u29/Dp84vVJ+evzi7u5bPV7zX78sFPndbfnV8+mH1y7/e6aj7Jd3+fT65Xi1d73z37yddXP3n9
+        5PSr84vLvZODN83Di+WbZ/urF9PT3+fu673sSTH9wf3Tq71Pfnp2/fmLn/iJzz5LIcS/Z/4uIz80
+        J42++H2XLBGi9I+n04okZ5NQkHbXxoGF6AO5rSqQl06y6Rzfb3jhVZ7NvkuOB/tZ5jVy6LNimdc3
+        2VKg7b13E3Iv63xRrBe///NXbDTIESF7Z7UcfXtevNv0/i4FFfjv7t6+e/8mHH0d+5rfwLuXRd2u
+        s/KFehpfA4ddnp0QzqYXfTx+8sXpm/7bN5GP55beWlQz/Hm2nBI9KfAgk00mA84JrCq9Q4qe5pMg
+        rKfTnIK1GX3fFgvqnBiUPpfI6AH9783uw0f79x9RTHnv3t7Dg/2fopazda3m7qOXb+59sftgvLPz
+        4NMHnx68pi/JW6lzMs70/Rm8yYf3H+wf7H66v31v8uD+9v757t52Nj14sJ1PH+7mDx8+nH0626PX
+        GDu4heyHkqnMmxU5dgTAuYk2TKb2NBf8O0gi7/if0GsSgWL0aG4sNJou12X5fXIjv08jyVf5cpYv
+        pxwbExD5oPmSxkZ//Ry5w3acQTqAgHjsQUwaEoEwvQGC94KIRIfjCOQvGf2/eNCIpNwQvokxAyLY
+        4P+9Q4aP543hGxk0w8RM0yv/X2D2yf799mr27mp2f+/8yhvbN0GMEDaI8v9aMsi8udF8E8MXmP+v
+        FoGf/MIbwjcxZgKIeab2/19gfsLWjeabGv7/m+e7XE/O753/dLbOmqsGDo0bzTcx/B74H/HC/3sH
+        3J2s8180w3KC6fabIEG0ix/xxP97B+z/zhnhRTb1RvRNkMD/3XYBolTrdrWmtykEA32GA7G7P3TC
+        nVQLQi2/eykB4xcc19OgCYwdC/F1N3G4aRC798YHB+Pdg0/He/v8LsvGhhfQpptc3dReI2UO1YnE
+        t3hjZ2d75+n2vePte7vbpw+3n9Gr9K5Mi51oJ7DvTZ7eexQUIfC+3crEja8HSzghCA5FhgHotL1U
+        GnX69zLDgxAuZeT6Z/i+Zht6776WrM1dzd5ohqnhBQj5qJOM+v4v+SX/D5XArfVFHwAA
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['2436']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:32:55 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['2445']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:45:49 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [0ec2e840-43a8-11e6-9a05-001dd8b7c0ad]
+      x-ms-client-request-id: [68170d2e-447b-11e6-b323-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Compute/virtualMachines/cli-test-vm2?api-version=2016-03-30
   response:
@@ -515,43 +539,43 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UerulrldVvkzUePUv6IPrxcnM3oz48eTHYPZruzne383nS2vb+zd2/74cPd/e0H05296cPs3r29
-        yf5HI31pntWzq6zOX9bVeVHm9L6Co+8uF6+LH+Cjj1632XJGLX//p693P5Lvf4mB0LRVnV1EARQL
-        +uJVfp7X+XIafEVfrtaTsmjmeU2ff3SSLatlMc1Kgxiej6pzehVffzVZL9v167y+pL/9Fs3bNb7f
-        3R/v7I/3t5+/eR18Tc2bolqiSZm1edMq8g59alQ1T4vmLbXxsauaN9croPzR82K5fhdAXWYL/qZq
-        ZvTi7v6nDw72Hn768CBoNK1z6vHLVav9P6urxRnoEbS6nGPKvI7ps3Vd0Gcfzdt21Ty6e5eaKIl/
-        UXWZ7y/rpvlB9oNPx5OymoynVZ2Pr4rlrLpqxsu85dZ3u4iN6VM7cn/s1Ns0m86L5QV6fJVns+/W
-        RZvbtq7lR7OszUAncNz3vi8fm6+JErHpn1aL1brN6xdKr2lZbGMSti8Xe44KH2WzRbH8qslrQ9c1
-        z7bXosQUnFTL8+JiXWdKUdsPNaDhZpMyf5k1zVVVz47X7TxftsRP2rat17kFR+2bZk6fehDoM+bH
-        6e+VX/MI/a/SsCWej1ZZCxAf3Z1Xi/yuYHx3THDvZtR5VZPgzH7/twDm9SvPR/TxU6ImXqcXtusm
-        S4/peXLvxQ+yk93r6d4p/XX89Pgnjp/Qz5PjnziZnF3sXqxffXtytlP+5O7u1Xeftrv13vSr2fTF
-        bO/ByXeai09en1+cPFgUP5WvJ+3VV/NJ83I2/+InmvOn1/Mvv/vtX7T7yU893/nik+V3fuonP703
-        u7s7my/m7cX1l78o/+mvruqX5Q9+r/n1rJnUzeyrqv7kO4sX33k6++7O7uWDJ7/3t6/X14s3B5/v
-        NzsPf/oka158eVWszycv7/6i1YO9er3emZwd7y6vXzeX5fnD1clPHK+fvT1e/uTy/G79bP5V+eXb
-        eftqdTX9RQevv3rx++z94NW3X909/b0md/dffPf32f3OD17tN9m9X7R3/t2z78zq+vfeeXr5vMru
-        XzycnJ3O9p+eP3g4yR5cfnJdfPXky9c7P3izV5af/GD/4mHxg2//XvdOv7w/O5g/3//p3+fd9Kd/
-        r+aTq2lTvv59Xn23zprpeTN9fvFF+cXn852T2e+Vv3jz9Ke/vfr85XKand/7qU+eXV1d/fR383Xx
-        4sm7yweT71S79+4ePLm78/Dg9yp/8mm5//lP/aKmenJy+tMvr79z/pOfzr/cub77/O2rz9++fVB9
-        +7u/10X+3ePz36s9f35GQ9vZyX9q/3z6nRe/18O3J9nrLxan64vqp747PXvw4vPJT/3eP/hFz777
-        iyarV/Tn9OnLh5989+wnPikefnX/8hd9t/lFs7s/WF7sv52sj7/z6Vfr3+sXnf3gyc569fvUz1/P
-        z3/i9N7r4+nbgyp7Pv/OL/pFv+j+pz95/nR9/PrF6ju/VzH7yU9+8Iv2Hnz7/PWTxeT3Xr59dff+
-        8e91796D2fTeF7/37/Wd61X1e939iZdfPP+9vjp+ef/3fv5y0nzyYjb7zk/85IPTn/q9Z3sPnz6/
-        WH1y/urs4l4+W/1esy8f/NRp/d355YPZJ/d+r6vmk3z39/nkerV4tffds598ffWT109Ovzq/uNw7
-        OXjTPLxYvnm2v3oxPf197r7ey54U0x/cP73a++SnZ9efv/iJn/jssxQy/nvm77LFqsxJQy1+36VV
-        KPL8Ev9P1SV47OdGsZCwNDlp0pZlUluaLz8ifUfS/tZTPeajsyWpnfNsCvv4vV/8UUFK9qO7zXrS
-        TOuCNXJz997Ofn7w8OGn2w8enE+29z/ND7Yn2Szbvn//wac7u/cf7k/y/bt13lTrepp/XlfrVXOX
-        FNgbGturi9//J784Yf3++4tl2rtLFvmymJG5uftFMa2rpjpvxy8Embs9pADIasKf/OJFMf3ol3zf
-        DotBwWyRWibDS+qYFMXr9XSa57Nc9Li05XGRCvqhD+xEFPvdy6Ju11n5BZuQzrBE71lbGfmqVQN7
-        I1xtX1ZWn390RaDW5os2u6B5NkoaxmBVZtfG6vxkAEzI9xsnv+T/ARiquWJJCQAA
+        6UerulrldVvkzUePUv6IPrxcnM3oz48eTqaTvdluvv3w/N7e9v7e5OH2wfRhvj0539v5NMvyye7+
+        /kcjfWme1bOrrM5f1tV5Ueb0voKj7y4Xr4sf4KOPXrfZckYtf/+nr3c/ku9/iYHQtFWdXUQBFAv6
+        4lV+ntf5chp8RV+u1pOyaOZ5TZ9/dJItq2UxzUqDGJ6PqnN6FV9/NVkv2/XrvL6kv/0Wzds1vt/d
+        H+/sj/e3n795HXxNzZuiWqJJmbV50yryDn1qVDVPi+YttfGxq5o31yug/NHzYrl+F0BdZgv+pmpm
+        9OLu/qcPHu7t3L/3adBoWufU45erVvt/VleLM9AjaHU5x5R5HdNn67qgzz6at+2qeXT3LjVREv+i
+        6jLfX9ZN84PsB5+OJ2U1GU+rOh9fFctZddWMl3nLre92ERvTp3bk/tipt2k2nRfLC/T4Ks9m362L
+        NrdtXcuPZlmbgU7guO99Xz42XxMlYtM/rRardZvXL5Re07LYxiRsXy72HBU+ymaLYvlVk9eGrmue
+        ba9FiSk4qZbnxcW6zpSith9qQMPNJmX+Mmuaq6qeHa/beb5siZ+0bVuvcwuO2jfNnD71INBnzI/T
+        3yu/5hH6X6VhSzwfrbIWID66O68W+V3B+O6Y4N7NqPOqJsGZ/f5vAczrV56P6OOnRE28Ti9s102W
+        HtPz5N6LH2Qnu9fTvVP66/jp8U8cP6GfJ8c/cTI5u9i9WL/69uRsp/zJ3d2r7z5td+u96Vez6YvZ
+        3oOT7zQXn7w+vzh5sCh+Kl9P2quv5pPm5Wz+xU8050+v519+99u/aPeTn3q+88Uny+/81E9+em92
+        d3c2X8zbi+svf1H+019d1S/LH/xe8+tZM6mb2VdV/cl3Fi++83T23Z3dywdPfu9vX6+vF28OPt9v
+        dh7+9EnWvPjyqlifT17e/UWrB3v1er0zOTveXV6/bi7L84erk584Xj97e7z8yeX53frZ/Kvyy7fz
+        9tXqavqLDl5/9eL32fvBq2+/unv6e03u7r/47u+z+50fvNpvsnu/aO/8u2ffmdX1773z9PJ5ld2/
+        eDg5O53tPz1/8HCSPbj85Lr46smXr3d+8GavLD/5wf7Fw+IH3/697p1+eX92MH++/9O/z7vpT/9e
+        zSdX06Z8/fu8+m6dNdPzZvr84ovyi8/nOyez3yt/8ebpT3979fnL5TQ7v/dTnzy7urr66e/m6+LF
+        k3eXDybfqXbv3T14cnfn4cHvVf7k03L/85/6RU315OT0p19ef+f8Jz+df7lzfff521efv337oPr2
+        d3+vi/y7x+e/V3v+/IyGtrOT/9T++fQ7L36vh29PstdfLE7XF9VPfXd69uDF55Of+r1/8IueffcX
+        TVav6M/p05cPP/nu2U98Ujz86v7lL/pu84tmd3+wvNh/O1kff+fTr9a/1y86+8GTnfXq96mfv56f
+        /8TpvdfH07cHVfZ8/p1f9It+0f1Pf/L86fr49YvVd36vYvaTn/zgF+09+Pb56yeLye+9fPvq7v3j
+        3+vevQez6b0vfu/f6zvXq+r3uvsTL794/nt9dfzy/u/9/OWk+eTFbPadn/jJB6c/9XvP9h4+fX6x
+        +uT81dnFvXy2+r1mXz74qdP6u/PLB7NP7v1eV80n+e7v88n1avFq77tnP/n66ievn5x+dX5xuXdy
+        8KZ5eLF882x/9WJ6+vvcfb2XPSmmP7h/erX3yU/Prj9/8RM/8dlnKWT898zfZYtVmZOGWvy+S6tQ
+        5Pkl/p+qS/DYz41iIWFpctKkLcuktjRffkT6jqT9rad6zEdnS1I759kU9vF7v/ijgpTsR3eb9aSZ
+        1gVr5ObuvZ39/ODhw0+3Hzw4n2zvf5ofbE+yWbZ9//6DT3d27z/cn+T7d+u8qdb1NP+8rtar5i4p
+        sDc0tlcXv/9PfnHC+v33F8u0d5cs8mUxI3Nz94tiWldNdd6OXwgyd3tIAZDVhD/5xYti+tEv+b4d
+        FoOC2SK1TIaX1DEpitfr6TTPZ7nocWnL4yIV9EMf2Iko9ruXRd2us/ILNiGdYYnes7Yy8lWrBvZG
+        uNq+rKw+/+iKQK3NF212QfNslDSMwarMro3V+ckAmJDvN05+yf8DPC6cvEkJAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:32:56 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:45:49 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_data_disk.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_data_disk.yaml
@@ -52,21 +52,21 @@ interactions:
       content-length: ['2297']
       content-security-policy: [default-src 'none'; style-src 'unsafe-inline']
       content-type: [text/plain; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:43:16 GMT']
+      date: ['Thu, 07 Jul 2016 20:02:31 GMT']
       etag: ['"db78eb36618a060181b32ac2de91b1733f382e01"']
-      expires: ['Fri, 01 Jul 2016 02:48:16 GMT']
+      expires: ['Thu, 07 Jul 2016 20:07:31 GMT']
       source-age: ['0']
       strict-transport-security: [max-age=31536000]
       vary: ['Authorization,Accept-Encoding']
       via: [1.1 varnish]
-      x-cache: [MISS]
-      x-cache-hits: ['0']
+      x-cache: [HIT]
+      x-cache-hits: ['1']
       x-content-type-options: [nosniff]
-      x-fastly-request-id: [045e2bcf1576f946cb921fb69841f1366cb50d75]
+      x-fastly-request-id: [6f17ae99437342f2b6b1d47001bd7705b7451021]
       x-frame-options: [deny]
       x-geo-block-list: ['']
-      x-github-request-id: ['17EB2F14:5AD3:1CB0E6F:5775D8C3']
-      x-served-by: [cache-sjc3633-SJC]
+      x-github-request-id: ['17EB2F14:5AD3:37F5586:577EB557']
+      x-served-by: [cache-sjc3631-SJC]
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -74,14 +74,78 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzM3NTY2LCJuYmYiOjE0NjczMzc1NjYsImV4cCI6MTQ2NzM0MTQ2NiwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.KoSZ-b851wnb9FP2udUwXgL5Rv608kcXLMwPrKyOATevK5AGvOxq_2ZUZI6AgHCMlQu0LhVvHb0K4z7rnVtyDXWzAnE2aYAVoVn7cFj4RfPFV2kpDb4OX07oHso3HV7Uu9VpUDrAmXuuGHqWdfwHdC9A2qt_J_VhwMNIAzt6da6FV0kzYohWOotJfOwOLDTPlleCY30J4H7X0GnwuKZnwahNQ8YBNwHgIEuYRiSRYgySuoXHvKJHNRXM7B6_jye8elAcKF1Cfx3TMGMRG8UN-KDa91YzrC4sa7PsZVSwhzF6GvpKv6HzToNuYOFj5ZubjCk1wZBBnduZRuLimzLxPw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bd0ee6cf-447d-11e6-aa99-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Network/virtualnetworks?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS97/+S/wdC6kBEDAAAAA==
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['133']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Jul 2016 20:02:31 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 storagemanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bd2a851e-447d-11e6-8288-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Storage/storageAccounts?api-version=2016-01-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS97/+S5P8BxWZBqg0AAAA=
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-type: [application/json]
+      date: ['Thu, 07 Jul 2016 20:02:31 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 resourcemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.32]
+          AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [8fa72011-3f35-11e6-bda9-001dd8b7c0ad]
+      x-ms-client-request-id: [bd500e80-447d-11e6-b058-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27cliTestRg_datadisk%27%20and%20name%20eq%20%27vm-datadisk-test%27%20and%20resourceType%20eq%20%27Microsoft.Compute%2FvirtualMachines%27
   response:
@@ -95,7 +159,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['133']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:43:15 GMT']
+      date: ['Thu, 07 Jul 2016 20:02:32 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -109,54 +173,54 @@ interactions:
       {"value": "none"}, "subnetIpAddressPrefix": {"value": "10.0.0.0/24"}, "adminUsername":
       {"value": "ubuntu"}, "networkInterfaceType": {"value": "new"}, "_artifactsLocation":
       {"value": "https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30"},
-      "osType": {"value": "Custom"}, "sshKeyValue": {"value": "C:\\Users\\burtbiel\\.ssh\\id_rsa.pub"},
-      "osVersion": {"value": "latest"}, "customOsDiskType": {"value": "windows"},
-      "virtualNetworkIpAddressPrefix": {"value": "10.0.0.0/16"}, "name": {"value":
-      "vm-datadisk-test"}, "storageCaching": {"value": "ReadWrite"}, "adminPassword":
-      {"value": "testPassword0"}, "networkSecurityGroupRule": {"value": "RDP"}, "storageContainerName":
-      {"value": "vhds"}, "osOffer": {"value": "UbuntuServer"}, "osPublisher": {"value":
-      "Canonical"}, "privateIpAddressAllocation": {"value": "dynamic"}, "size": {"value":
-      "Standard_DS1"}, "location": {"value": "westus"}}}}'
+      "osType": {"value": "Custom"}, "osVersion": {"value": "latest"}, "customOsDiskType":
+      {"value": "windows"}, "virtualNetworkIpAddressPrefix": {"value": "10.0.0.0/16"},
+      "name": {"value": "vm-datadisk-test"}, "storageCaching": {"value": "ReadWrite"},
+      "adminPassword": {"value": "testPassword0"}, "networkSecurityGroupRule": {"value":
+      "SSH"}, "storageContainerName": {"value": "vhds"}, "osOffer": {"value": "UbuntuServer"},
+      "osPublisher": {"value": "Canonical"}, "privateIpAddressAllocation": {"value":
+      "dynamic"}, "size": {"value": "Standard_DS1"}, "osDiskName": {"value": "osdisk1467921752"},
+      "location": {"value": "westus"}}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzM3NTY2LCJuYmYiOjE0NjczMzc1NjYsImV4cCI6MTQ2NzM0MTQ2NiwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.KoSZ-b851wnb9FP2udUwXgL5Rv608kcXLMwPrKyOATevK5AGvOxq_2ZUZI6AgHCMlQu0LhVvHb0K4z7rnVtyDXWzAnE2aYAVoVn7cFj4RfPFV2kpDb4OX07oHso3HV7Uu9VpUDrAmXuuGHqWdfwHdC9A2qt_J_VhwMNIAzt6da6FV0kzYohWOotJfOwOLDTPlleCY30J4H7X0GnwuKZnwahNQ8YBNwHgIEuYRiSRYgySuoXHvKJHNRXM7B6_jye8elAcKF1Cfx3TMGMRG8UN-KDa91YzrC4sa7PsZVSwhzF6GvpKv6HzToNuYOFj5ZubjCk1wZBBnduZRuLimzLxPw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
-      Content-Length: ['1303']
+      Content-Length: ['1281']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [8ffe67d1-3f35-11e6-a141-001dd8b7c0ad]
+      x-ms-client-request-id: [bd957bf0-447d-11e6-a3ac-001dd8b7c0ad]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/azurecli-test-datadisk","name":"azurecli-test-datadisk","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30"},"adminPassword":{"type":"SecureString"},"adminUsername":{"type":"String","value":"ubuntu"},"authenticationType":{"type":"String","value":"password"},"availabilitySet":{"type":"String","value":""},"availabilitySetType":{"type":"String","value":"none"},"customOsDiskType":{"type":"String","value":"windows"},"customOsDiskUri":{"type":"String","value":""},"dnsNameForPublicIP":{"type":"String","value":""},"dnsNameType":{"type":"String","value":"none"},"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"vm-datadisk-test"},"networkSecurityGroup":{"type":"String","value":"vm-datadisk-testNSG"},"networkSecurityGroupRule":{"type":"String","value":"RDP"},"networkSecurityGroupType":{"type":"String","value":"new"},"networkInterfaceIds":{"type":"Array","value":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Network/networkInterfaces/vm-datadisk-testVMNic"}]},"networkInterfaceType":{"type":"String","value":"new"},"osDiskName":{"type":"String","value":"osdiskimagez3nw6elgilixi"},"osDiskType":{"type":"String","value":"provided"},"osDiskUri":{"type":"String","value":"https://vhdstoragehunkvouhag56m.blob.core.windows.net/vhds/osdiskimagez3nw6elgilixi.vhd"},"osOffer":{"type":"String","value":"UbuntuServer"},"osPublisher":{"type":"String","value":"Canonical"},"osSKU":{"type":"String","value":"14.04.4-LTS"},"osType":{"type":"String","value":"Custom"},"osVersion":{"type":"String","value":"latest"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddress":{"type":"String","value":"vm-datadisk-testPublicIP"},"publicIpAddressType":{"type":"String","value":"new"},"size":{"type":"String","value":"Standard_DS1"},"sshDestKeyPath":{"type":"String","value":"/home/ubuntu/.ssh/authorized_keys"},"sshKeyValue":{"type":"String","value":"C:\\Users\\burtbiel\\.ssh\\id_rsa.pub"},"storageAccount":{"type":"String","value":"vhdstoragehunkvouhag56m"},"storageAccountType":{"type":"String","value":"new"},"storageCaching":{"type":"String","value":"ReadWrite"},"storageContainerName":{"type":"String","value":"vhds"},"storageType":{"type":"String","value":"Premium_LRS"},"subnetIpAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetName":{"type":"String","value":"vm-datadisk-testSubnet"},"virtualNetworkIpAddressPrefix":{"type":"String","value":"10.0.0.0/16"},"virtualNetwork":{"type":"String","value":"vm-datadisk-testVNET"},"virtualNetworkType":{"type":"String","value":"new"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-01T02:43:17.5747475Z","duration":"PT0.1670545S","correlationId":"c9c21b55-0d26-460d-a9d4-ba713fb71506","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/vm-datadisk-testVNet","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-datadisk-testVNet"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/vm-datadisk-testNSG","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-datadisk-testNSG"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/vm-datadisk-testNicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-datadisk-testNicIp"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/vm-datadisk-testpuofjg7li6dzo","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-datadisk-testpuofjg7li6dzo"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/vm-datadisk-testNicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-datadisk-testNicIp"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/vm-datadisk-testVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-datadisk-testVM"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/vm-datadisk-testVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-datadisk-testVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/vm-datadisk-test4kg7bxt3asdcmnew","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-datadisk-test4kg7bxt3asdcmnew"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/vm-datadisk-testVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-datadisk-testVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/vm-datadisk-test4kg7bxt3asdcmnewfqdn","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-datadisk-test4kg7bxt3asdcmnewfqdn"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/vm-datadisk-testVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-datadisk-testVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/vm-datadisk-testvm-datadisk-testVMNicmac","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-datadisk-testvm-datadisk-testVMNicmac"}]}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/azurecli-test-datadisk","name":"azurecli-test-datadisk","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30"},"adminPassword":{"type":"SecureString"},"adminUsername":{"type":"String","value":"ubuntu"},"authenticationType":{"type":"String","value":"password"},"availabilitySet":{"type":"String","value":""},"availabilitySetType":{"type":"String","value":"none"},"customOsDiskType":{"type":"String","value":"windows"},"customOsDiskUri":{"type":"String","value":""},"dnsNameForPublicIP":{"type":"String","value":""},"dnsNameType":{"type":"String","value":"none"},"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"vm-datadisk-test"},"networkSecurityGroup":{"type":"String","value":"vm-datadisk-testNSG"},"networkSecurityGroupRule":{"type":"String","value":"SSH"},"networkSecurityGroupType":{"type":"String","value":"new"},"networkInterfaceIds":{"type":"Array","value":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Network/networkInterfaces/vm-datadisk-testVMNic"}]},"networkInterfaceType":{"type":"String","value":"new"},"osDiskName":{"type":"String","value":"osdisk1467921752"},"osDiskType":{"type":"String","value":"provided"},"osDiskUri":{"type":"String","value":"https://vhdstoragehunkvouhag56m.blob.core.windows.net/vhds/osdisk1467921752.vhd"},"osOffer":{"type":"String","value":"UbuntuServer"},"osPublisher":{"type":"String","value":"Canonical"},"osSKU":{"type":"String","value":"14.04.4-LTS"},"osType":{"type":"String","value":"Custom"},"osVersion":{"type":"String","value":"latest"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddress":{"type":"String","value":"vm-datadisk-testPublicIP"},"publicIpAddressType":{"type":"String","value":"new"},"size":{"type":"String","value":"Standard_DS1"},"sshDestKeyPath":{"type":"String","value":"/home/ubuntu/.ssh/authorized_keys"},"sshKeyValue":{"type":"String","value":""},"storageAccount":{"type":"String","value":"vhdstoragehunkvouhag56m"},"storageAccountType":{"type":"String","value":"new"},"storageCaching":{"type":"String","value":"ReadWrite"},"storageContainerName":{"type":"String","value":"vhds"},"storageType":{"type":"String","value":"Premium_LRS"},"subnetIpAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetName":{"type":"String","value":"vm-datadisk-testSubnet"},"virtualNetworkIpAddressPrefix":{"type":"String","value":"10.0.0.0/16"},"virtualNetwork":{"type":"String","value":"vm-datadisk-testVNET"},"virtualNetworkType":{"type":"String","value":"new"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-07T20:02:33.300322Z","duration":"PT0.1197231S","correlationId":"f54e85e7-0069-4a73-adbf-582f7bde38f3","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/vm-datadisk-testVNet","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-datadisk-testVNet"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/vm-datadisk-testNSG","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-datadisk-testNSG"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/vm-datadisk-testNicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-datadisk-testNicIp"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/vm-datadisk-testpuofjg7li6dzo","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-datadisk-testpuofjg7li6dzo"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/vm-datadisk-testNicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-datadisk-testNicIp"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/vm-datadisk-testVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-datadisk-testVM"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/vm-datadisk-testVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-datadisk-testVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/vm-datadisk-test4kg7bxt3asdcmnew","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-datadisk-test4kg7bxt3asdcmnew"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/vm-datadisk-testVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-datadisk-testVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/vm-datadisk-test4kg7bxt3asdcmnewfqdn","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-datadisk-test4kg7bxt3asdcmnewfqdn"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/vm-datadisk-testVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-datadisk-testVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/vm-datadisk-testvm-datadisk-testVMNicmac","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-datadisk-testvm-datadisk-testVMNicmac"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/azurecli-test-datadisk/operationStatuses/08587342658880700331?api-version=2015-11-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/azurecli-test-datadisk/operationStatuses/08587336851322971080?api-version=2015-11-01']
       cache-control: [no-cache]
-      content-length: ['6513']
+      content-length: ['6459']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:43:17 GMT']
+      date: ['Thu, 07 Jul 2016 20:02:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzM3NTY2LCJuYmYiOjE0NjczMzc1NjYsImV4cCI6MTQ2NzM0MTQ2NiwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.KoSZ-b851wnb9FP2udUwXgL5Rv608kcXLMwPrKyOATevK5AGvOxq_2ZUZI6AgHCMlQu0LhVvHb0K4z7rnVtyDXWzAnE2aYAVoVn7cFj4RfPFV2kpDb4OX07oHso3HV7Uu9VpUDrAmXuuGHqWdfwHdC9A2qt_J_VhwMNIAzt6da6FV0kzYohWOotJfOwOLDTPlleCY30J4H7X0GnwuKZnwahNQ8YBNwHgIEuYRiSRYgySuoXHvKJHNRXM7B6_jye8elAcKF1Cfx3TMGMRG8UN-KDa91YzrC4sa7PsZVSwhzF6GvpKv6HzToNuYOFj5ZubjCk1wZBBnduZRuLimzLxPw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [8ffe67d1-3f35-11e6-a141-001dd8b7c0ad]
+      x-ms-client-request-id: [bd957bf0-447d-11e6-a3ac-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342658880700331?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336851322971080?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -168,7 +232,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['140']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:43:47 GMT']
+      date: ['Thu, 07 Jul 2016 20:03:02 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -179,15 +243,15 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzM3NTY2LCJuYmYiOjE0NjczMzc1NjYsImV4cCI6MTQ2NzM0MTQ2NiwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.KoSZ-b851wnb9FP2udUwXgL5Rv608kcXLMwPrKyOATevK5AGvOxq_2ZUZI6AgHCMlQu0LhVvHb0K4z7rnVtyDXWzAnE2aYAVoVn7cFj4RfPFV2kpDb4OX07oHso3HV7Uu9VpUDrAmXuuGHqWdfwHdC9A2qt_J_VhwMNIAzt6da6FV0kzYohWOotJfOwOLDTPlleCY30J4H7X0GnwuKZnwahNQ8YBNwHgIEuYRiSRYgySuoXHvKJHNRXM7B6_jye8elAcKF1Cfx3TMGMRG8UN-KDa91YzrC4sa7PsZVSwhzF6GvpKv6HzToNuYOFj5ZubjCk1wZBBnduZRuLimzLxPw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [8ffe67d1-3f35-11e6-a141-001dd8b7c0ad]
+      x-ms-client-request-id: [bd957bf0-447d-11e6-a3ac-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342658880700331?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336851322971080?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -199,7 +263,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['140']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:44:17 GMT']
+      date: ['Thu, 07 Jul 2016 20:03:32 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -210,15 +274,15 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzM3NTY2LCJuYmYiOjE0NjczMzc1NjYsImV4cCI6MTQ2NzM0MTQ2NiwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.KoSZ-b851wnb9FP2udUwXgL5Rv608kcXLMwPrKyOATevK5AGvOxq_2ZUZI6AgHCMlQu0LhVvHb0K4z7rnVtyDXWzAnE2aYAVoVn7cFj4RfPFV2kpDb4OX07oHso3HV7Uu9VpUDrAmXuuGHqWdfwHdC9A2qt_J_VhwMNIAzt6da6FV0kzYohWOotJfOwOLDTPlleCY30J4H7X0GnwuKZnwahNQ8YBNwHgIEuYRiSRYgySuoXHvKJHNRXM7B6_jye8elAcKF1Cfx3TMGMRG8UN-KDa91YzrC4sa7PsZVSwhzF6GvpKv6HzToNuYOFj5ZubjCk1wZBBnduZRuLimzLxPw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [8ffe67d1-3f35-11e6-a141-001dd8b7c0ad]
+      x-ms-client-request-id: [bd957bf0-447d-11e6-a3ac-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342658880700331?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336851322971080?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -230,7 +294,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['140']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:44:48 GMT']
+      date: ['Thu, 07 Jul 2016 20:04:03 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -241,15 +305,15 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzM3NTY2LCJuYmYiOjE0NjczMzc1NjYsImV4cCI6MTQ2NzM0MTQ2NiwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.KoSZ-b851wnb9FP2udUwXgL5Rv608kcXLMwPrKyOATevK5AGvOxq_2ZUZI6AgHCMlQu0LhVvHb0K4z7rnVtyDXWzAnE2aYAVoVn7cFj4RfPFV2kpDb4OX07oHso3HV7Uu9VpUDrAmXuuGHqWdfwHdC9A2qt_J_VhwMNIAzt6da6FV0kzYohWOotJfOwOLDTPlleCY30J4H7X0GnwuKZnwahNQ8YBNwHgIEuYRiSRYgySuoXHvKJHNRXM7B6_jye8elAcKF1Cfx3TMGMRG8UN-KDa91YzrC4sa7PsZVSwhzF6GvpKv6HzToNuYOFj5ZubjCk1wZBBnduZRuLimzLxPw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [8ffe67d1-3f35-11e6-a141-001dd8b7c0ad]
+      x-ms-client-request-id: [bd957bf0-447d-11e6-a3ac-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342658880700331?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336851322971080?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -261,7 +325,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['140']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:45:18 GMT']
+      date: ['Thu, 07 Jul 2016 20:04:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -272,15 +336,15 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzM3NTY2LCJuYmYiOjE0NjczMzc1NjYsImV4cCI6MTQ2NzM0MTQ2NiwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.KoSZ-b851wnb9FP2udUwXgL5Rv608kcXLMwPrKyOATevK5AGvOxq_2ZUZI6AgHCMlQu0LhVvHb0K4z7rnVtyDXWzAnE2aYAVoVn7cFj4RfPFV2kpDb4OX07oHso3HV7Uu9VpUDrAmXuuGHqWdfwHdC9A2qt_J_VhwMNIAzt6da6FV0kzYohWOotJfOwOLDTPlleCY30J4H7X0GnwuKZnwahNQ8YBNwHgIEuYRiSRYgySuoXHvKJHNRXM7B6_jye8elAcKF1Cfx3TMGMRG8UN-KDa91YzrC4sa7PsZVSwhzF6GvpKv6HzToNuYOFj5ZubjCk1wZBBnduZRuLimzLxPw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [8ffe67d1-3f35-11e6-a141-001dd8b7c0ad]
+      x-ms-client-request-id: [bd957bf0-447d-11e6-a3ac-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342658880700331?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336851322971080?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -292,7 +356,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['140']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:45:49 GMT']
+      date: ['Thu, 07 Jul 2016 20:05:03 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -303,15 +367,15 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [8ffe67d1-3f35-11e6-a141-001dd8b7c0ad]
+      x-ms-client-request-id: [bd957bf0-447d-11e6-a3ac-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342658880700331?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336851322971080?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -323,7 +387,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['140']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:46:21 GMT']
+      date: ['Thu, 07 Jul 2016 20:05:34 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -334,15 +398,15 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [8ffe67d1-3f35-11e6-a141-001dd8b7c0ad]
+      x-ms-client-request-id: [bd957bf0-447d-11e6-a3ac-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342658880700331?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336851322971080?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -354,7 +418,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['140']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:46:51 GMT']
+      date: ['Thu, 07 Jul 2016 20:06:04 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -365,15 +429,15 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [8ffe67d1-3f35-11e6-a141-001dd8b7c0ad]
+      x-ms-client-request-id: [bd957bf0-447d-11e6-a3ac-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342658880700331?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336851322971080?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -385,7 +449,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['140']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:47:22 GMT']
+      date: ['Thu, 07 Jul 2016 20:06:34 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -396,294 +460,15 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [8ffe67d1-3f35-11e6-a141-001dd8b7c0ad]
+      x-ms-client-request-id: [bd957bf0-447d-11e6-a3ac-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342658880700331?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:47:53 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [8ffe67d1-3f35-11e6-a141-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342658880700331?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:48:24 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [8ffe67d1-3f35-11e6-a141-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342658880700331?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:48:54 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [8ffe67d1-3f35-11e6-a141-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342658880700331?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:49:25 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [8ffe67d1-3f35-11e6-a141-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342658880700331?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:49:56 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [8ffe67d1-3f35-11e6-a141-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342658880700331?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:50:26 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [8ffe67d1-3f35-11e6-a141-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342658880700331?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:50:55 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [8ffe67d1-3f35-11e6-a141-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342658880700331?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:51:26 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [8ffe67d1-3f35-11e6-a141-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342658880700331?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:51:56 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [8ffe67d1-3f35-11e6-a141-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342658880700331?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336851322971080?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -695,7 +480,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['141']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:52:27 GMT']
+      date: ['Thu, 07 Jul 2016 20:07:05 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -706,13 +491,13 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [8ffe67d1-3f35-11e6-a141-001dd8b7c0ad]
+      x-ms-client-request-id: [bd957bf0-447d-11e6-a3ac-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_datadisk/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
@@ -728,32 +513,31 @@ interactions:
         vCB4l1m5xgffGNJAJJstiuXLrGmuqpqm2/WaTwm69m3afdXktZDdtZMWDrv1ZL1s1/zKup3T+AsZ
         0RtuP/zeyuCANy+zoswmRVm016/zdtNrkeY39bSsljlem66btlp82TwlfrnpHSVr97WvwEXDb6H5
         bNm8yBb5s6p+uZ6UxfTs5S3fuAklM4zyFixzRbKxZuxvmr7LhZUhlih+J29pZt4ySxCJWarfB8aL
-        158PgXm1LumNYVCvnr4cevVG+uRX3qtnJIs1iVh+NmOR07eO6zq7di9974eu9F4Iene7aDZ3u1T8
-        yS9eFNOPfsn3I2O6JSkq5lnw1qbGVYMui0V2kf/g3vLq07y8IMl6VzgIN3Wn42RRljdukBOj0S7n
-        M5Ktmnqer5dvL6v1PLu4/+liQL2h9d0hbMf0rfT/5fl5Xm/q/SvWWK/z+pLa8Sssqc2c/tzw2klG
-        EkjKrZR3Xv9eX21qvbs/3tkf728/f/Na2t9ExBNWM9LWmpDh5tDzIq2rurikP85Wx7MZ8aTP7b23
-        Yu2Py9tolNk1aRLwIwEAtabf2Pub3urKBE8UVGofzE30VZloih/QX8PNXrfZcpbVs9//6etdbt/M
-        n1LHv1d+/TJr55vevDuvFvldMYd3x/TeXRjEqqYOZ7//2/ya1TF9TKB+Ul4ZhnXy6Pf9fWF8m9/3
-        952s63ZS5OXv+/sC5u/7+xaz379usjGNnuGJ+BxPpxX1uwkkyYc2DmStD+S2hJSXTrLpHN9veOFV
-        ns2+S2qcrZd5jXylrFjm9U3aCWh7792E3Ms6XxTrxe///BWLHal10hyWR+jb8+Ldpvd3yV/Df3f3
-        9t37N+LY4dLX/Bbevyzqdp2VqvS/Dh67n/bhbHqxi8tPvjh904dwExl5jumtRTXDn2fLKdGVfDtS
-        fiR4UPfQT/QOiQvNK0FYT6c5+cMz+r4tFtRxtiCf4SNxPh9s7+y+2dl7dH/v0c7B+NNPd/Yefnrw
-        U9R0tq5Vc3z08s3BF/d3x3v39z7duXfwmr4kA1DnpOfo+zMY6enD6d7u5P797Z3Z3qdklXdm29nD
-        2T6Z5ge7984nD3bv73xKrzF6sLps3knr5M2KbCYBcFbYhh7UniaEfwdN5B3/E3pNvHwMH82NskPT
-        5bosv08W+vs0knyVL2f5csrxBwGRD5ovaWz01w/Zy7DjC0KrPm8Ql4YEICxvgOK9IHIRYTkC+0tG
-        /y8dNJxTN4RvasyACjb4f+eQYSa9MXxjg2a4mGl67f/tzL5aV+c/ffGgLD6d/aDyxvZNESOED6L8
-        v5IMMmduNN/U8AXu/2tF4Ce/8IbwTY2ZgGKe6Z3/tzM/YepG800O//+t873/9uLB5F17L2tm0wW8
-        GTeab2r4vS5+xAv/7xxwd6LOf9EM6VrT5TdFgmg3P+KJ/3cOuPs3J9sW2dQb1TdFhu7ftisQp1qT
-        40BQKBYDnYYjsrs/NAKeVAtCKb+rEeMXHODToLvjIN7u5mA2DWD33vjhvfHe3qfj3QNeiWD52PAC
-        2nRzVZvaa8jMcTuR9xZv7Oxs7zzdvndMSyPbu/vbe3sc88qU2Ml2Qvu1SNR7l4IjROC3TwDfCCLI
-        kvfBcGgyDESn8KXSK4KHl3QbhKKU0D/7MDQN0Xv/taR17mp6R1NQ9D6lfeSjTrbq+7/kl/w/00zW
-        AqkcAAA=
+        158PgXm1LumNYVCvX3976NUb6ZNfea+ekSzWJGL52YxFTt86ruvs2r30vR+60nsh6N3totnc7VLx
+        J794UUw/+iXfj4zplqSomGfBW5saVw263N3/9MHDvd0H9/fcmzd1o+NjEZY3bpAPo8ku5zOSqTq7
+        yOfr5dvLaj3PLu5/uhhQa2h9t4vlmD6Vfr88P8/rTb1+xRrqdV5fUjt+hSWzmdOfG147yUjiSJmV
+        8s7r3+urTa1398c7++P97edvXkv7m4h3wmpF2lqTMdwcel2kc1UXl/TH2ep4NiMe9Lm791as/XF5
+        Gw0yuybNAf4jAKDW9Bt7f9NbXRngiYIK7YO5ib4qA03xA/pruNnrNlvOsnr2+z99vcvtm/lT6vj3
+        yq9fZu1805t359Uivyvm7+6Y3rsLA1jV1OHs93+bX7P6pY8J1E/KK8OwuKlIxPF0WhHITa2J9bVx
+        ID59ILelkbx0kk3n+H7DC6/ybPZd0shsiMxr5PZkxTKvb1I0QNt77ybkXtb5olgvfv/nr1iiSEOT
+        MrDTT9+eF+82vb9Lrhf+u7u3796/EccOA77mt/D+ZVG366xU/f118Nj9tA9n04tdXH7yxembPoSb
+        yMhzTG8tqhn+PFtOia7kppFeI5mCBofqoXdIEmheCcJ6Os3JtZ3R922xoI6zBZn/j8SPfED/e7O3
+        82jn00f7++MH9z7d3X9w76eo6Wxdq1L46OWb/S92d8f36dk/2H9NX5JOr3NSYfT9Gezt+X0ysPdz
+        Arbz6cPt/ezBve1sNjnfvn+wd/5gMsvvHZzfo9cYPRhQttSkUPJmReaPADiDaqMIak8Twr+DJvKO
+        /wm9Jg47ho/mRo+h6XJdlt8nY/t9Gkm+ypezfDnlUIKAyAfNlzQ2+uuH7DDY8QVRUp83iEtDAhCW
+        N0DxXhC5iLAcgf0lo/+XDhp+phvCNzVmQAUb/L9zyLCA3hi+sUEzXMw0vfb/dmZfravzn754UBaf
+        zn5QeWP7pogRwgdR/l9JBpkzN5pvavgC9/+1IvCTX3hD+KbGTEAxz/TO/9uZnzB1o/kmh///1vne
+        f3vxYPKuvZc1s+kC3owbzTc1/F4XP+KF/3cOuDtR579ohsyr6fKbIkG0mx/xxP87B9z9m/Nmi2zq
+        jeqbIkP3b9sViFOtyXEgKBSLgU7DEdndHxoBT6oFoZTf1YjxCw7wadDdcRBvd9MrmwawvzM+uDfe
+        PdgZ7+3yogLLx4YX0KabhtrUXkNmjtuJvLd4Y2dne+fp9r3j7Xv7258+2T54xjGvTImdbCe0X4tE
+        vXcpOEIEfvtc7o0ggoR3HwyHJsNAdApfKr0ieHj5tEEoSgn9sw9D0xC9919LWueupnc0BUXvU9pH
+        Pupkq77/S37J/wOqE/wrdBwAAA==
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
-      content-length: ['1658']
+      content-length: ['1615']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:52:26 GMT']
+      date: ['Thu, 07 Jul 2016 20:07:05 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -764,14 +548,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.32]
+          AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [d89f9621-3f36-11e6-98af-001dd8b7c0ad]
+      x-ms-client-request-id: [60fde980-447e-11e6-9fe9-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Compute/virtualMachines/vm-datadisk-test?api-version=2016-03-30
   response:
@@ -779,24 +563,24 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UerulrldVvkzUePUv6IPrxcnM3oz4+y/fODh/nOw+2Hn9472N7Pd3e2J5/O6Ld7s0/v79y7dy/L
-        H3w00pfmWT27yur8ZV2dF2VO7ys4+u5y8br4AT766HWbLWfU8vd/+nr3I/n+lxgITVvV2UUUQLGg
-        L17l53mdL6fBV/Tlaj0pi2ae1/T5RyfZsloW06w0iOH5qDqnV/H1V5P1sl2/zutL+ttv0bxd4/vd
-        /fHO/nh/+/mb18HX1LwpqiWalFmbN60i79CnRlXztGjeUhsfu6p5c70Cyh89L5brdwHUZbbgb6pm
-        Ri/yIH9wb3n1aV5eFGXxrggaT+ucev5y1Soez+pqcYZXglaXc0ydhwB9tq4L+uyjeduumkd371IT
-        JfV8vXx7Wa3n2cX9TxfjSVlNxtOqzsdXxXJWXTXjZd5y67tDCI7pW0sJnxbU6zSbzovlBXp+lWez
-        79ZFm9u2ruVHs6zNQDdw4Pe+Lx+br4kyMXaYVovVus3rF0q/y8U2oADHbZ4cfZ2aZrNFsfyqyWtD
-        6zVzgNeixLScVMvz4mJdZ0pd2xc1ILDZpMxfZk1zVdWz43U7z5ct8Zi2Pc/KJjftDeb0XpPTlLXR
-        YRFhCdRbb2zmo7Mljes8m0Igv/eLPypoNj+626wnzbQueOqbu/d29vODhw8/3X7w4Hyyvf9pfrA9
-        yWbZ9v37Dz7d2b3/cH+S79+t86Za19P887par5q707J4Q4R5dfH7G0LdJdG/LGbE13e/KKZ11VTn
-        7fiFIHG3h8zdLol/8osXxfSjX/J9OyQGBxmhOScpp7kmYr9eT6d5PsuFSaQtjyn9IQ7qRLjl7mVR
-        t+us/IL5MjIk4QkrlANftyrNN8LX9mVlGeWjKwKzNl+02QXNseE0cNmqzK4NS/9kAEzI9xsnv+T/
-        AbUNp3e2BQAA
+        6UerulrldVvkzUePUv6IPrxcnM3oz4/uPzjfybLJbPvB3mRne39/dr492T14sL0/2dvPH3x67+He
+        pw8+GulL86yeXWV1/rKuzosyp/cVHH13uXhd/AAfffS6zZYzavn7P329+5F8/0sMhKat6uwiCqBY
+        0Bev8vO8zpfT4Cv6crWelEUzz2v6/KOTbFkti2lWGsTwfFSd06v4+qvJetmuX+f1Jf3tt2jervH9
+        7v54Z3+8v/38zevga2reFNUSTcqszZtWkXfoU6OqeVo0b6mNj13VvLleAeWPnhfL9bsA6jJb8DdV
+        M6MXd/c/ffBwb/fB/b2g0bTOqccvV632/6yuFmegR9Dqco4p8zqmz9Z1QZ99NG/bVfPo7l1qoiSe
+        r5dvL6v1PLu4/+liPCmryXha1fn4qljOqqtmvMxbbn23i9iYPrUj98dOvU2z6bxYXqDHV3k2+25d
+        tLlt61p+NMvaDHQCx33v+/Kx+ZooEZv+abVYrdu8fqH0ulxsAwpw2+bJ0NepaTZbFMuvmrw2tF3z
+        jHstSkzDSbU8Ly7WdaZUtX1RAwKbTcr8ZdY0V1U9O16383zZEk9p2/OsbHLT3mBO7zU5TVUbHRYR
+        lEC99cZmPjpb0rjOsykE8Hu/+KOCZvGju8160kzrgqe8uXtvZz8/ePjw0+0HD84n2/uf5gfbk2yW
+        bd+//+DTnd37D/cn+f7dOm+qdT3NP6+r9aq5Oy2LN0SYVxe/vyHUXRL1y2JGfHz3i2JaV0113o5f
+        CBJ3e8jc7ZL4J794UUw/+iXft0NicJAJmnOSapprIvbr9XSa57NcmETa8pjSH+KgToRb7l4WdbvO
+        yi+YLyNDEp6wQjjwdavSeyN8bV9WllE+uiIwa/NFm13QHBtOA5etyuzasPRPBsCEfL9x8kv+H1Ft
+        2CqmBQAA
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:52:27 GMT']
+      date: ['Thu, 07 Jul 2016 20:07:06 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -808,14 +592,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.32]
+          AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [d92a9811-3f36-11e6-80da-001dd8b7c0ad]
+      x-ms-client-request-id: [61310770-447e-11e6-be1b-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Compute/virtualMachines/vm-datadisk-test?api-version=2016-03-30
   response:
@@ -823,24 +607,24 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UerulrldVvkzUePUv6IPrxcnM3oz4+y/fODh/nOw+2Hn9472N7Pd3e2J5/O6Ld7s0/v79y7dy/L
-        H3w00pfmWT27yur8ZV2dF2VO7ys4+u5y8br4AT766HWbLWfU8vd/+nr3I/n+lxgITVvV2UUUQLGg
-        L17l53mdL6fBV/Tlaj0pi2ae1/T5RyfZsloW06w0iOH5qDqnV/H1V5P1sl2/zutL+ttv0bxd4/vd
-        /fHO/nh/+/mb18HX1LwpqiWalFmbN60i79CnRlXztGjeUhsfu6p5c70Cyh89L5brdwHUZbbgb6pm
-        Ri/yIH9wb3n1aV5eFGXxrggaT+ucev5y1Soez+pqcYZXglaXc0ydhwB9tq4L+uyjeduumkd371IT
-        JfV8vXx7Wa3n2cX9TxfjSVlNxtOqzsdXxXJWXTXjZd5y67tDCI7pW0sJnxbU6zSbzovlBXp+lWez
-        79ZFm9u2ruVHs6zNQDdw4Pe+Lx+br4kyMXaYVovVus3rF0q/y8U2oADHbZ4cfZ2aZrNFsfyqyWtD
-        6zVzgNeixLScVMvz4mJdZ0pd2xc1ILDZpMxfZk1zVdWz43U7z5ct8Zi2Pc/KJjftDeb0XpPTlLXR
-        YRFhCdRbb2zmo7Mljes8m0Igv/eLPypoNj+626wnzbQueOqbu/d29vODhw8/3X7w4Hyyvf9pfrA9
-        yWbZ9v37Dz7d2b3/cH+S79+t86Za19P887par5q707J4Q4R5dfH7G0LdJdG/LGbE13e/KKZ11VTn
-        7fiFIHG3h8zdLol/8osXxfSjX/J9OyQGBxmhOScpp7kmYr9eT6d5PsuFSaQtjyn9IQ7qRLjl7mVR
-        t+us/IL5MjIk4QkrlANftyrNN8LX9mVlGeWjKwKzNl+02QXNseE0cNmqzK4NS/9kAEzI9xsnv+T/
-        AbUNp3e2BQAA
+        6UerulrldVvkzUePUv6IPrxcnM3oz4/uPzjfybLJbPvB3mRne39/dr492T14sL0/2dvPH3x67+He
+        pw8+GulL86yeXWV1/rKuzosyp/cVHH13uXhd/AAfffS6zZYzavn7P329+5F8/0sMhKat6uwiCqBY
+        0Bev8vO8zpfT4Cv6crWelEUzz2v6/KOTbFkti2lWGsTwfFSd06v4+qvJetmuX+f1Jf3tt2jervH9
+        7v54Z3+8v/38zevga2reFNUSTcqszZtWkXfoU6OqeVo0b6mNj13VvLleAeWPnhfL9bsA6jJb8DdV
+        M6MXd/c/ffBwb/fB/b2g0bTOqccvV632/6yuFmegR9Dqco4p8zqmz9Z1QZ99NG/bVfPo7l1qoiSe
+        r5dvL6v1PLu4/+liPCmryXha1fn4qljOqqtmvMxbbn23i9iYPrUj98dOvU2z6bxYXqDHV3k2+25d
+        tLlt61p+NMvaDHQCx33v+/Kx+ZooEZv+abVYrdu8fqH0ulxsAwpw2+bJ0NepaTZbFMuvmrw2tF3z
+        jHstSkzDSbU8Ly7WdaZUtX1RAwKbTcr8ZdY0V1U9O16383zZEk9p2/OsbHLT3mBO7zU5TVUbHRYR
+        lEC99cZmPjpb0rjOsykE8Hu/+KOCZvGju8160kzrgqe8uXtvZz8/ePjw0+0HD84n2/uf5gfbk2yW
+        bd+//+DTnd37D/cn+f7dOm+qdT3NP6+r9aq5Oy2LN0SYVxe/vyHUXRL1y2JGfHz3i2JaV0113o5f
+        CBJ3e8jc7ZL4J794UUw/+iXft0NicJAJmnOSapprIvbr9XSa57NcmETa8pjSH+KgToRb7l4WdbvO
+        yi+YLyNDEp6wQjjwdavSeyN8bV9WllE+uiIwa/NFm13QHBtOA5etyuzasPRPBsCEfL9x8kv+H1Ft
+        2CqmBQAA
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:52:28 GMT']
+      date: ['Thu, 07 Jul 2016 20:07:06 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -854,24 +638,24 @@ interactions:
       {"networkInterfaces": [{"id": "/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Network/networkInterfaces/vm-datadisk-testVMNic"}]},
       "storageProfile": {"imageReference": {"sku": "14.04.4-LTS", "publisher": "Canonical",
       "version": "latest", "offer": "UbuntuServer"}, "osDisk": {"caching": "ReadWrite",
-      "vhd": {"uri": "https://vhdstoragehunkvouhag56m.blob.core.windows.net/vhds/osdiskimagez3nw6elgilixi.vhd"},
-      "createOption": "fromImage", "name": "osdiskimagez3nw6elgilixi", "osType": "Linux"},
+      "vhd": {"uri": "https://vhdstoragehunkvouhag56m.blob.core.windows.net/vhds/osdisk1467921752.vhd"},
+      "createOption": "fromImage", "name": "osdisk1467921752", "osType": "Linux"},
       "dataDisks": [{"diskSizeGB": 8, "createOption": "empty", "name": "d1", "caching":
-      "ReadWrite", "vhd": {"uri": "https://vhdstoragehunkvouhag56m.blob.core.windows.net/vhds/osdiskimagez3nw6elgilixi-datadisk.vhd"},
-      "lun": 1}]}, "vmId": "a4f89e09-9638-4e10-b6d8-43d650333ae7", "provisioningState":
+      "ReadWrite", "vhd": {"uri": "https://vhdstoragehunkvouhag56m.blob.core.windows.net/vhds/osdisk1467921752-datadisk.vhd"},
+      "lun": 1}]}, "vmId": "57f0aabd-72b0-44df-b187-4b24e7639267", "provisioningState":
       "Succeeded"}, "tags": {"displayName": "VirtualMachine"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
-      Content-Length: ['1159']
+      Content-Length: ['1135']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.32]
+          AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [d94e73c0-3f36-11e6-b61e-001dd8b7c0ad]
+      x-ms-client-request-id: [614b6d40-447e-11e6-86b2-001dd8b7c0ad]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Compute/virtualMachines/vm-datadisk-test?api-version=2016-03-30
   response:
@@ -879,509 +663,26 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UerulrldVvkzUePUv6IPrxcnM3oz4+y/fODh/nOw+2Hn9472N7Pd3e2J5/O6Ld7s0/v79y7dy/L
-        H3w00pfmWT27yur8ZV2dF2VO7ys4+u5y8br4AT766HWbLWfU8vd/+nr3I/n+lxgITVvV2UUUQLGg
-        L17l53mdL6fBV/Tlaj0pi2ae1/T5RyfZsloW06w0iOH5qDqnV/H1V5P1sl2/zutL+ttv0bxd4/vd
-        /fHO/nh/+/mb18HX1LwpqiWalFmbN60i79CnRlXztGjeUhsfu6p5c70Cyh89L5brdwHUZbbgb6pm
-        Ri/yIH9wb3n1aV5eFGXxrggaT+ucev5y1Soez+pqcYZXglaXc0ydhwB9tq4L+uyjeduumkd371IT
-        JfV8vXx7Wa3n2cX9TxfjSVlNxtOqzsdXxXJWXTXjZd5y67tDCI7pW0sJnxbU6zSbzovlBXp+lWez
-        79ZFm9u2ruVHs6zNQDdw4PfMp2lnCOUaY961b+Gx5Jvt+iSgL7qkOl2s2utOG2DeIRR9+rNHqm2M
-        E191aObTAk+cbmETgIFEff6EWh24r36J+fX78ouBTAwWk6pptVit27x+oXS8XFgkt5nH9XVqms0W
-        xfKrJq8NzdcsSF6LEtx9Ui3Pi4t1nSnlbV/UgMBmkzJ/mTXNVVXPjtftPF+2JKra9jwrm9y0N5jT
-        e01O09kyd3SHRUQnUG+9sZmPzpY0rvNsCr32vV/8UUFz/dHdZj1ppnXBbNHcvbeznx88fPjp9oMH
-        55Pt/U/zg+1JNsu2799/8OnO7v2H+5N8/26dN9W6nuaf19V61dydlsUbIsyri9/fEOouadDLYkbq
-        4e4XxbSumuq8Hb8QJO72kLnbJfFPfvGimH70S75vh8TgoGqIBUhZ0tQTsb9a0Uv0AbONNOUhpT/E
-        MZ0Is9y9LOp2nZVfMJdGRiQsYWVz4OtWdeKN8LV9WVk++eiKwKzNF212QVNsGA1Mtiqza8PRPxkA
-        E/L9xskv+X8AJrrDRvwGAAA=
+        6UerulrldVvkzUePUv6IPrxcnM3oz4/uPzjfybLJbPvB3mRne39/dr492T14sL0/2dvPH3x67+He
+        pw8+GulL86yeXWV1/rKuzosyp/cVHH13uXhd/AAfffS6zZYzavn7P329+5F8/0sMhKat6uwiCqBY
+        0Bev8vO8zpfT4Cv6crWelEUzz2v6/KOTbFkti2lWGsTwfFSd06v4+qvJetmuX+f1Jf3tt2jervH9
+        7v54Z3+8v/38zevga2reFNUSTcqszZtWkXfoU6OqeVo0b6mNj13VvLleAeWPnhfL9bsA6jJb8DdV
+        M6MXd/c/ffBwb/fB/b2g0bTOqccvV632/6yuFmegR9Dqco4p8zqmz9Z1QZ99NG/bVfPo7l1qoiSe
+        r5dvL6v1PLu4/+liPCmryXha1fn4qljOqqtmvMxbbn23i9iYPrUj98dOvU2z6bxYXqDHV3k2+25d
+        tLlt61p+NMvaDHQCx33PfJp2UC/XGOuufQuPJdds1x86fdEl0eli1V532gDzDoHo02+eRNsYHz7q
+        0MqnAZ44vcImAAPJ+fwJtTpwX/0S8+v35RcDmRgpJj3TarFat3n9Qul3ubBIbjMv6+vUNJstiuVX
+        TV4bWq9ZYLwWJbj4pFqeFxfrOlOK276oAYHNJmX+Mmuaq6qeHa/beb5sSSS17XlWNrlpbzCn95qc
+        prFlrugOi4hNoN56YzMfnS1pXOfZFPrre7/4o4Lm+KO7zXrSTOuC2aG5e29nPz94+PDT7QcPzifb
+        +5/mB9uTbJZt37//4NOd3fsP9yf5/t06b6p1Pc0/r6v1qrk7LYs3RJhXF7+/IdRd0pSXxYzUwN0v
+        imldNdV5O34hSNztIXO3S+Kf/OJFMf3ol3zfDonBQaUQC5BSpKknYn+1opfoA2YbacpDSn+IYzoR
+        Zrl7WdTtOiu/YC6NjEhYwsrkwNet6r4b4Wv7srJ88tEVgVmbL9rsgqbYMBqYbFVm14ajfzIAJuT7
+        jZNf8v8A3KmYR+QGAAA=
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/ae1104b7-06ab-4b58-ac0d-aafb12243dc5?api-version=2016-03-30']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/d0d4dbad-ecdd-4694-a3f5-f54a3e438cda?api-version=2016-03-30']
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:52:30 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [d94e73c0-3f36-11e6-b61e-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/ae1104b7-06ab-4b58-ac0d-aafb12243dc5?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H2zu7b3b2Ht3fe3RvZ/zgYG/n4c6DT3Z2Hu3sfDQyL7XrBm+c
-        LV/W1UWdN41+tcwEVJbv7u7sTwjWp9lke39y/2A7m+7MtrPsfLK7t7d/bza9/9FvnPyS/wcWS04T
-        hgAAAA==
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:53:00 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [d94e73c0-3f36-11e6-b61e-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/ae1104b7-06ab-4b58-ac0d-aafb12243dc5?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H2zu7b3b2Ht3fe3RvZ/zgYG/n4c6DT3Z2Hu3sfDTil/LlbOCV
-        e4/2Dsb3Htx/8OB+8AZ1064bvPB6PZ3m+Syf6TfLTABl+e7uzv6EIH2aTbb3J/cPtrPpzmw7y84n
-        u3t7+/dm0/sf/cbJL/l/AIuVFQW3AAAA
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:53:30 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [d94e73c0-3f36-11e6-b61e-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Compute/virtualMachines/vm-datadisk-test?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UerulrldVvkzUePUv6IPrxcnM3oz4+y/fODh/nOw+2Hn9472N7Pd3e2J5/O6Ld7s0/v79y7dy/L
-        H3w00pfmWT27yur8ZV2dF2VO7ys4+u5y8br4AT766HWbLWfU8vd/+nr3I/n+lxgITVvV2UUUQLGg
-        L17l53mdL6fBV/Tlaj0pi2ae1/T5RyfZsloW06w0iOH5qDqnV/H1V5P1sl2/zutL+ttv0bxd4/vd
-        /fHO/nh/+/mb18HX1LwpqiWalFmbN60i79CnRlXztGjeUhsfu6p5c70Cyh89L5brdwHUZbbgb6pm
-        Ri/yIH9wb3n1aV5eFGXxrggaT+ucev5y1Soez+pqcYZXglaXc0ydhwB9tq4L+uyjeduumkd371IT
-        JfV8vXx7Wa3n2cX9TxfjSVlNxtOqzsdXxXJWXTXjZd5y67tDCI7pW0sJnxbU6zSbzovlBXp+lWez
-        79ZFm9u2ruVHs6zNQDdw4PfMp2lnCOUaY961b+Gx5Jvt+iSgL7qkOl2s2utOG2DeIRR9+rNHqm2M
-        E191aObTAk+cbmETgIFEff6EWh24r36J+fX78ouBTAwWk6pptVit27x+oXS8XFgkt5nH9XVqms0W
-        xfKrJq8NzdcsSF6LEtx9Ui3Pi4t1nSnlbV/UgMBmkzJ/mTXNVVXPjtftPF+2JKra9jwrm9y0N5jT
-        e01O09kyd3SHRUQnUG+9sZmPzpY0rvNsCr32vV/8UUFz/dHdZj1ppnXBbNHcvbeznx88fPjp9oMH
-        55Pt/U/zg+1JNsu2799/8OnO7v2H+5N8/26dN9W6nuaf19V61dydlsUbIsyri9/fEOouadDLYkbq
-        4e4XxbSumuq8Hb8QJO72kLnbJfFPfvGimH70S75vh8TgoGqIBUhZ0tQTsV+vp9M8n+XCN9KWx5T+
-        EAd1Itxy97Ko23VWfsFsGhmS8IQVzoGvW1WKN8LX9mVlGeWjKwKzNl+02QXNseE0cNmqzK4NS/9k
-        AEzI9xsnv+T/Aeyc5Dn9BgAA
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:53:30 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [fef96580-3f36-11e6-882f-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Compute/virtualMachines/vm-datadisk-test?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UerulrldVvkzUePUv6IPrxcnM3oz4+y/fODh/nOw+2Hn9472N7Pd3e2J5/O6Ld7s0/v79y7dy/L
-        H3w00pfmWT27yur8ZV2dF2VO7ys4+u5y8br4AT766HWbLWfU8vd/+nr3I/n+lxgITVvV2UUUQLGg
-        L17l53mdL6fBV/Tlaj0pi2ae1/T5RyfZsloW06w0iOH5qDqnV/H1V5P1sl2/zutL+ttv0bxd4/vd
-        /fHO/nh/+/mb18HX1LwpqiWalFmbN60i79CnRlXztGjeUhsfu6p5c70Cyh89L5brdwHUZbbgb6pm
-        Ri/yIH9wb3n1aV5eFGXxrggaT+ucev5y1Soez+pqcYZXglaXc0ydhwB9tq4L+uyjeduumkd371IT
-        JfV8vXx7Wa3n2cX9TxfjSVlNxtOqzsdXxXJWXTXjZd5y67tDCI7pW0sJnxbU6zSbzovlBXp+lWez
-        79ZFm9u2ruVHs6zNQDdw4PfMp2lnCOUaY961b+Gx5Jvt+iSgL7qkOl2s2utOG2DeIRR9+rNHqm2M
-        E191aObTAk+cbmETgIFEff6EWh24r36J+fX78ouBTAwWk6pptVit27x+oXS8XFgkt5nH9XVqms0W
-        xfKrJq8NzdcsSF6LEtx9Ui3Pi4t1nSnlbV/UgMBmkzJ/mTXNVVXPjtftPF+2JKra9jwrm9y0N5jT
-        e01O09kyd3SHRUQnUG+9sZmPzpY0rvNsCr32vV/8UUFz/dHdZj1ppnXBbNHcvbeznx88fPjp9oMH
-        55Pt/U/zg+1JNsu2799/8OnO7v2H+5N8/26dN9W6nuaf19V61dydlsUbIsyri9/fEOouadDLYkbq
-        4e4XxbSumuq8Hb8QJO72kLnbJfFPfvGimH70S75vh8TgoGqIBUhZ0tQTsV+vp9M8n+XCN9KWx5T+
-        EAd1Itxy97Ko23VWfsFsGhmS8IQVzoGvW1WKN8LX9mVlGeWjKwKzNl+02QXNseE0cNmqzK4NS/9k
-        AEzI9xsnv+T/Aeyc5Dn9BgAA
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:53:32 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [ff381c30-3f36-11e6-ba1e-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Compute/virtualMachines/vm-datadisk-test?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UerulrldVvkzUePUv6IPrxcnM3oz4+y/fODh/nOw+2Hn9472N7Pd3e2J5/O6Ld7s0/v79y7dy/L
-        H3w00pfmWT27yur8ZV2dF2VO7ys4+u5y8br4AT766HWbLWfU8vd/+nr3I/n+lxgITVvV2UUUQLGg
-        L17l53mdL6fBV/Tlaj0pi2ae1/T5RyfZsloW06w0iOH5qDqnV/H1V5P1sl2/zutL+ttv0bxd4/vd
-        /fHO/nh/+/mb18HX1LwpqiWalFmbN60i79CnRlXztGjeUhsfu6p5c70Cyh89L5brdwHUZbbgb6pm
-        Ri/yIH9wb3n1aV5eFGXxrggaT+ucev5y1Soez+pqcYZXglaXc0ydhwB9tq4L+uyjeduumkd371IT
-        JfV8vXx7Wa3n2cX9TxfjSVlNxtOqzsdXxXJWXTXjZd5y67tDCI7pW0sJnxbU6zSbzovlBXp+lWez
-        79ZFm9u2ruVHs6zNQDdw4PfMp2lnCOUaY961b+Gx5Jvt+iSgL7qkOl2s2utOG2DeIRR9+rNHqm2M
-        E191aObTAk+cbmETgIFEff6EWh24r36J+fX78ouBTAwWk6pptVit27x+oXS8XFgkt5nH9XVqms0W
-        xfKrJq8NzdcsSF6LEtx9Ui3Pi4t1nSnlbV/UgMBmkzJ/mTXNVVXPjtftPF+2JKra9jwrm9y0N5jT
-        e01O09kyd3SHRUQnUG+9sZmPzpY0rvNsCr32vV/8UUFz/dHdZj1ppnXBbNHcvbeznx88fPjp9oMH
-        55Pt/U/zg+1JNsu2799/8OnO7v2H+5N8/26dN9W6nuaf19V61dydlsUbIsyri9/fEOouadDLYkbq
-        4e4XxbSumuq8Hb8QJO72kLnbJfFPfvGimH70S75vh8TgoGqIBUhZ0tQTsV+vp9M8n+XCN9KWx5T+
-        EAd1Itxy97Ko23VWfsFsGhmS8IQVzoGvW1WKN8LX9mVlGeWjKwKzNl+02QXNseE0cNmqzK4NS/9k
-        AEzI9xsnv+T/Aeyc5Dn9BgAA
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:53:31 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: '{"location": "westus", "properties": {"hardwareProfile": {"vmSize": "Standard_DS1"},
-      "osProfile": {"secrets": [], "adminUsername": "ubuntu", "computerName": "vm-datadisk-test",
-      "linuxConfiguration": {"disablePasswordAuthentication": false}}, "networkProfile":
-      {"networkInterfaces": [{"id": "/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Network/networkInterfaces/vm-datadisk-testVMNic"}]},
-      "storageProfile": {"imageReference": {"sku": "14.04.4-LTS", "publisher": "Canonical",
-      "version": "latest", "offer": "UbuntuServer"}, "osDisk": {"caching": "ReadWrite",
-      "vhd": {"uri": "https://vhdstoragehunkvouhag56m.blob.core.windows.net/vhds/osdiskimagez3nw6elgilixi.vhd"},
-      "createOption": "fromImage", "name": "osdiskimagez3nw6elgilixi", "osType": "Linux"},
-      "dataDisks": []}, "vmId": "a4f89e09-9638-4e10-b6d8-43d650333ae7", "provisioningState":
-      "Succeeded"}, "tags": {"displayName": "VirtualMachine"}}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
-      Connection: [keep-alive]
-      Content-Length: ['953']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [ff51e5c0-3f36-11e6-bd5a-001dd8b7c0ad]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Compute/virtualMachines/vm-datadisk-test?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UerulrldVvkzUePUv6IPrxcnM3oz4+y/fODh/nOw+2Hn9472N7Pd3e2J5/O6Ld7s0/v79y7dy/L
-        H3w00pfmWT27yur8ZV2dF2VO7ys4+u5y8br4AT766HWbLWfU8vd/+nr3I/n+lxgITVvV2UUUQLGg
-        L17l53mdL6fBV/Tlaj0pi2ae1/T5RyfZsloW06w0iOH5qDqnV/H1V5P1sl2/zutL+ttv0bxd4/vd
-        /fHO/nh/+/mb18HX1LwpqiWalFmbN60i79CnRlXztGjeUhsfu6p5c70Cyh89L5brdwHUZbbgb6pm
-        Ri/yIH9wb3n1aV5eFGXxrggaT+ucev5y1Soez+pqcYZXglaXc0ydhwB9tq4L+uyjeduumkd371IT
-        JfV8vXx7Wa3n2cX9TxfjSVlNxtOqzsdXxXJWXTXjZd5y67tDCI7pW0sJnxbU6zSbzovlBXp+lWez
-        79ZFm9u2ruVHs6zNQDdw4Pe+Lx+br4kyMXaYVovVus3rF0q/y8U2oADHbZ4cfZ2aZrNFsfyqyWtD
-        6zVzgNeixLScVMvz4mJdZ0pd2xc1ILDZpMxfZk1zVdWz43U7z5ct8Zi2Pc/KJjftDeb0XpPTlLXR
-        YRFhCdRbb2zmo7Mljes8m0Igv/eLPypoNj+626wnzbQueOqbu/d29vODhw8/3X7w4Hyyvf9pfrA9
-        yWbZ9v37Dz7d2b3/cH+S79+t86Za19P887par5q707J4Q4R5dfH7G0LdJdG/LGbE13e/KKZ11VTn
-        7fiFIHG3h8zdLol/8osXxfSjX/J9OyQGBxmhOScpp7kmYn+1opfoA553acpDSn+IYzoRZrl7WdTt
-        Oiu/YLaMjEhYwsrkwNetCvON8LV9WVk++eiKwKzNF212QVNsGA1Mtiqza8PRPxkAE/L9xskv+X8A
-        xLfRAbUFAAA=
-    headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/96af952f-6965-40c9-a8dc-ec74e715e836?api-version=2016-03-30']
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:53:33 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [ff51e5c0-3f36-11e6-bd5a-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/96af952f-6965-40c9-a8dc-ec74e715e836?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H2zu7b3b2Ht2/9+jevfHDg/u7n95/+MnOzqOdnY9G/FK+nA28
-        sv9oh165v79zf+d+8Ar1064bvPF6PZ3m+Syf6TfLTCA9/DQ7f3h/73z704ef3t/e35k+3M4OZtPt
-        fPpgP3+wez8/uPfpR79x8kv+HyIYAwO4AAAA
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:54:03 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [ff51e5c0-3f36-11e6-bd5a-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Compute/virtualMachines/vm-datadisk-test?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UerulrldVvkzUePUv6IPrxcnM3oz4+y/fODh/nOw+2Hn9472N7Pd3e2J5/O6Ld7s0/v79y7dy/L
-        H3w00pfmWT27yur8ZV2dF2VO7ys4+u5y8br4AT766HWbLWfU8vd/+nr3I/n+lxgITVvV2UUUQLGg
-        L17l53mdL6fBV/Tlaj0pi2ae1/T5RyfZsloW06w0iOH5qDqnV/H1V5P1sl2/zutL+ttv0bxd4/vd
-        /fHO/nh/+/mb18HX1LwpqiWalFmbN60i79CnRlXztGjeUhsfu6p5c70Cyh89L5brdwHUZbbgb6pm
-        Ri/yIH9wb3n1aV5eFGXxrggaT+ucev5y1Soez+pqcYZXglaXc0ydhwB9tq4L+uyjeduumkd371IT
-        JfV8vXx7Wa3n2cX9TxfjSVlNxtOqzsdXxXJWXTXjZd5y67tDCI7pW0sJnxbU6zSbzovlBXp+lWez
-        79ZFm9u2ruVHs6zNQDdw4Pe+Lx+br4kyMXaYVovVus3rF0q/y8U2oADHbZ4cfZ2aZrNFsfyqyWtD
-        6zVzgNeixLScVMvz4mJdZ0pd2xc1ILDZpMxfZk1zVdWz43U7z5ct8Zi2Pc/KJjftDeb0XpPTlLXR
-        YRFhCdRbb2zmo7Mljes8m0Igv/eLPypoNj+626wnzbQueOqbu/d29vODhw8/3X7w4Hyyvf9pfrA9
-        yWbZ9v37Dz7d2b3/cH+S79+t86Za19P887par5q707J4Q4R5dfH7G0LdJdG/LGbE13e/KKZ11VTn
-        7fiFIHG3h8zdLol/8osXxfSjX/J9OyQGBxmhOScpp7kmYr9eT6d5PsuFSaQtjyn9IQ7qRLjl7mVR
-        t+us/IL5MjIk4QkrlANftyrNN8LX9mVlGeWjKwKzNl+02QXNseE0cNmqzK4NS/9kAEzI9xsnv+T/
-        AbUNp3e2BQAA
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:54:03 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [11f0490f-3f37-11e6-92a7-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Compute/virtualMachines/vm-datadisk-test?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UerulrldVvkzUePUv6IPrxcnM3oz4+y/fODh/nOw+2Hn9472N7Pd3e2J5/O6Ld7s0/v79y7dy/L
-        H3w00pfmWT27yur8ZV2dF2VO7ys4+u5y8br4AT766HWbLWfU8vd/+nr3I/n+lxgITVvV2UUUQLGg
-        L17l53mdL6fBV/Tlaj0pi2ae1/T5RyfZsloW06w0iOH5qDqnV/H1V5P1sl2/zutL+ttv0bxd4/vd
-        /fHO/nh/+/mb18HX1LwpqiWalFmbN60i79CnRlXztGjeUhsfu6p5c70Cyh89L5brdwHUZbbgb6pm
-        Ri/yIH9wb3n1aV5eFGXxrggaT+ucev5y1Soez+pqcYZXglaXc0ydhwB9tq4L+uyjeduumkd371IT
-        JfV8vXx7Wa3n2cX9TxfjSVlNxtOqzsdXxXJWXTXjZd5y67tDCI7pW0sJnxbU6zSbzovlBXp+lWez
-        79ZFm9u2ruVHs6zNQDdw4Pe+Lx+br4kyMXaYVovVus3rF0q/y8U2oADHbZ4cfZ2aZrNFsfyqyWtD
-        6zVzgNeixLScVMvz4mJdZ0pd2xc1ILDZpMxfZk1zVdWz43U7z5ct8Zi2Pc/KJjftDeb0XpPTlLXR
-        YRFhCdRbb2zmo7Mljes8m0Igv/eLPypoNj+626wnzbQueOqbu/d29vODhw8/3X7w4Hyyvf9pfrA9
-        yWbZ9v37Dz7d2b3/cH+S79+t86Za19P887par5q707J4Q4R5dfH7G0LdJdG/LGbE13e/KKZ11VTn
-        7fiFIHG3h8zdLol/8osXxfSjX/J9OyQGBxmhOScpp7kmYr9eT6d5PsuFSaQtjyn9IQ7qRLjl7mVR
-        t+us/IL5MjIk4QkrlANftyrNN8LX9mVlGeWjKwKzNl+02QXNseE0cNmqzK4NS/9kAEzI9xsnv+T/
-        AbUNp3e2BQAA
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:54:04 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [1225ff0f-3f37-11e6-97d7-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Compute/virtualMachines/vm-datadisk-test?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UerulrldVvkzUePUv6IPrxcnM3oz4+y/fODh/nOw+2Hn9472N7Pd3e2J5/O6Ld7s0/v79y7dy/L
-        H3w00pfmWT27yur8ZV2dF2VO7ys4+u5y8br4AT766HWbLWfU8vd/+nr3I/n+lxgITVvV2UUUQLGg
-        L17l53mdL6fBV/Tlaj0pi2ae1/T5RyfZsloW06w0iOH5qDqnV/H1V5P1sl2/zutL+ttv0bxd4/vd
-        /fHO/nh/+/mb18HX1LwpqiWalFmbN60i79CnRlXztGjeUhsfu6p5c70Cyh89L5brdwHUZbbgb6pm
-        Ri/yIH9wb3n1aV5eFGXxrggaT+ucev5y1Soez+pqcYZXglaXc0ydhwB9tq4L+uyjeduumkd371IT
-        JfV8vXx7Wa3n2cX9TxfjSVlNxtOqzsdXxXJWXTXjZd5y67tDCI7pW0sJnxbU6zSbzovlBXp+lWez
-        79ZFm9u2ruVHs6zNQDdw4Pe+Lx+br4kyMXaYVovVus3rF0q/y8U2oADHbZ4cfZ2aZrNFsfyqyWtD
-        6zVzgNeixLScVMvz4mJdZ0pd2xc1ILDZpMxfZk1zVdWz43U7z5ct8Zi2Pc/KJjftDeb0XpPTlLXR
-        YRFhCdRbb2zmo7Mljes8m0Igv/eLPypoNj+626wnzbQueOqbu/d29vODhw8/3X7w4Hyyvf9pfrA9
-        yWbZ9v37Dz7d2b3/cH+S79+t86Za19P887par5q707J4Q4R5dfH7G0LdJdG/LGbE13e/KKZ11VTn
-        7fiFIHG3h8zdLol/8osXxfSjX/J9OyQGBxmhOScpp7kmYr9eT6d5PsuFSaQtjyn9IQ7qRLjl7mVR
-        t+us/IL5MjIk4QkrlANftyrNN8LX9mVlGeWjKwKzNl+02QXNseE0cNmqzK4NS/9kAEzI9xsnv+T/
-        AbUNp3e2BQAA
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:54:04 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: '{"location": "westus", "properties": {"hardwareProfile": {"vmSize": "Standard_DS1"},
-      "osProfile": {"secrets": [], "adminUsername": "ubuntu", "computerName": "vm-datadisk-test",
-      "linuxConfiguration": {"disablePasswordAuthentication": false}}, "networkProfile":
-      {"networkInterfaces": [{"id": "/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Network/networkInterfaces/vm-datadisk-testVMNic"}]},
-      "storageProfile": {"imageReference": {"sku": "14.04.4-LTS", "publisher": "Canonical",
-      "version": "latest", "offer": "UbuntuServer"}, "osDisk": {"caching": "ReadWrite",
-      "vhd": {"uri": "https://vhdstoragehunkvouhag56m.blob.core.windows.net/vhds/osdiskimagez3nw6elgilixi.vhd"},
-      "createOption": "fromImage", "name": "osdiskimagez3nw6elgilixi", "osType": "Linux"},
-      "dataDisks": [{"caching": "ReadOnly", "vhd": {"uri": "https://vhdstoragehunkvouhag56m.blob.core.windows.net/vhds/osdiskimagez3nw6elgilixi-datadisk.vhd"},
-      "createOption": "attach", "name": "d1", "lun": 0}]}, "vmId": "a4f89e09-9638-4e10-b6d8-43d650333ae7",
-      "provisioningState": "Succeeded"}, "tags": {"displayName": "VirtualMachine"}}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
-      Connection: [keep-alive]
-      Content-Length: ['1142']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [1242d5de-3f37-11e6-b26f-001dd8b7c0ad]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Compute/virtualMachines/vm-datadisk-test?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UerulrldVvkzUePUv6IPrxcnM3oz4+y/fODh/nOw+2Hn9472N7Pd3e2J5/O6Ld7s0/v79y7dy/L
-        H3w00pfmWT27yur8ZV2dF2VO7ys4+u5y8br4AT766HWbLWfU8vd/+nr3I/n+lxgITVvV2UUUQLGg
-        L17l53mdL6fBV/Tlaj0pi2ae1/T5RyfZsloW06w0iOH5qDqnV/H1V5P1sl2/zutL+ttv0bxd4/vd
-        /fHO/nh/+/mb18HX1LwpqiWalFmbN60i79CnRlXztGjeUhsfu6p5c70Cyh89L5brdwHUZbbgb6pm
-        Ri/yIH9wb3n1aV5eFGXxrggaT+ucev5y1Soez+pqcYZXglaXc0ydhwB9tq4L+uyjeduumkd371IT
-        JfV8vXx7Wa3n2cX9TxfjSVlNxtOqzsdXxXJWXTXjZd5y67tDCI7pW0sJnxbU6zSbzovlBXp+lWez
-        79ZFm9u2ruVHs6zNQDdw4PfMp2lnCOUaY96xb+Gx5Jvt+iSgL7qkOm5bQqbTCKh3KEWf/uzRahsD
-        xVcdovnEwNMl3JfL8tpr/kvMr9+XX8zLxEQxyZlWi9W6zesXSqvLhcVjm/lYX6em2WxRLL9q8trQ
-        dc3C4rUowcEn1fK8uFjXmVLX9kUNCGw2KfOXWdNcVfXseN3O82VL4qhtz7OyyU17gzm91+Q0ZS1z
-        QHdYRFcC9dYbm/nobEnjOs+m0F3f+8UfFTSdH91t1pNmWhc89c3dezv7+cHDh59uP3hwPtne/zQ/
-        2J5ks2z7/v0Hn+7s3n+4P8n379Z5U63raf55Xa1Xzd1pWbwhwry6+P0Noe6SlrwsZqQC7n5RTOuq
-        qc7b8QtB4m4PmbtdEv/kFy+K6Ue/5Pt2SAwO6oRmmRQiiQUR+6sVvUQf8FRLUx5S+kMc04kwy93L
-        om7XWfkFM2JkRMISVv4Gvm5V790IX9uXleWTj64IzNp80WYXNMWG0cBkqzK7Nhz9kwEwId9vnPyS
-        /wd4x+wY4AYAAA==
-    headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/edb99b01-ce07-4f2d-91be-401ceae62894?api-version=2016-03-30']
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:54:04 GMT']
+      date: ['Thu, 07 Jul 2016 20:07:07 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1394,29 +695,29 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.32]
+          AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [1242d5de-3f37-11e6-b26f-001dd8b7c0ad]
+      x-ms-client-request-id: [614b6d40-447e-11e6-86b2-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/edb99b01-ce07-4f2d-91be-401ceae62894?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/d0d4dbad-ecdd-4694-a3f5-f54a3e438cda?api-version=2016-03-30
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H2zu7b3b2Ht3ff7Rzf3ywd/Dw3v6DT3Z2Hu3sfDTil/LlbPCV
-        e7vjTw8O7t2792nwCvXTrhu88Xo9neb5LJ/pN8tMIOWzycOHk53d7WlO8PbP92bbD3cn+fb+zu40
-        z/JPCY/9j37j5Jf8P/E1Ojy4AAAA
+        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H9L83ezuPdh482jkYf3pw//6nD/Y/2aEPdj4amZfadYM3zpYv
+        6+qizptGv1pmAmq2M9ufTbLZdj6dzbb3P324v53dO7+/fX5/P7uX7987mM6yj37j5Jf8PyrmQXeG
+        AAAA
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:54:35 GMT']
+      date: ['Thu, 07 Jul 2016 20:07:37 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1428,40 +729,29 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.32]
+          AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [1242d5de-3f37-11e6-b26f-001dd8b7c0ad]
+      x-ms-client-request-id: [614b6d40-447e-11e6-86b2-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Compute/virtualMachines/vm-datadisk-test?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/d0d4dbad-ecdd-4694-a3f5-f54a3e438cda?api-version=2016-03-30
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UerulrldVvkzUePUv6IPrxcnM3oz4+y/fODh/nOw+2Hn9472N7Pd3e2J5/O6Ld7s0/v79y7dy/L
-        H3w00pfmWT27yur8ZV2dF2VO7ys4+u5y8br4AT766HWbLWfU8vd/+nr3I/n+lxgITVvV2UUUQLGg
-        L17l53mdL6fBV/Tlaj0pi2ae1/T5RyfZsloW06w0iOH5qDqnV/H1V5P1sl2/zutL+ttv0bxd4/vd
-        /fHO/nh/+/mb18HX1LwpqiWalFmbN60i79CnRlXztGjeUhsfu6p5c70Cyh89L5brdwHUZbbgb6pm
-        Ri/yIH9wb3n1aV5eFGXxrggaT+ucev5y1Soez+pqcYZXglaXc0ydhwB9tq4L+uyjeduumkd371IT
-        JfV8vXx7Wa3n2cX9TxfjSVlNxtOqzsdXxXJWXTXjZd5y67tDCI7pW0sJnxbU6zSbzovlBXp+lWez
-        79ZFm9u2ruVHs6zNQDdw4PfMp2lnCOUaY96xb+Gx5Jvt+iSgL7qkOm5bQqbTCKh3KEWf/uzRahsD
-        xVcdovnEwNMl3JfL8tpr/kvMr9+XX8zLxEQxyZlWi9W6zesXSqvLhcVjm/lYX6em2WxRLL9q8trQ
-        dc3C4rUowcEn1fK8uFjXmVLX9kUNCGw2KfOXWdNcVfXseN3O82VL4qhtz7OyyU17gzm91+Q0ZS1z
-        QHdYRFcC9dYbm/nobEnjOs+m0F3f+8UfFTSdH91t1pNmWhc89c3dezv7+cHDh59uP3hwPtne/zQ/
-        2J5ks2z7/v0Hn+7s3n+4P8n379Z5U63raf55Xa1Xzd1pWbwhwry6+P0Noe6SlrwsZqQC7n5RTOuq
-        qc7b8QtB4m4PmbtdEv/kFy+K6Ue/5Pt2SAwO6oRmmRQiiQUR+/V6Os3zWS6sIW15TOkPcVAnwi13
-        L4u6XWflF8yJkSEJT1gBHPi6VcV3I3xtX1aWUT66IjBr80WbXdAcG04Dl63K7Nqw9E8GwIR8v3Hy
-        S/4fYs9pteEGAAA=
+        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H9L83ezuPdh482jkYf3pw//6nD/Y/2aEPdj4a8Uv5cjbwygG9
+        NX7wcP/hfucV6qddN3jj9Xo6zfNZPtNvlplAmu3M9meTbLadT2ez7f1PH+5vZ/fO72+f39/P7uX7
+        9w6ms+yj3zj5Jf8PA97v5rgAAAA=
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:54:35 GMT']
+      date: ['Thu, 07 Jul 2016 20:08:08 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1473,14 +763,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.32]
+          AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [25736711-3f37-11e6-a796-001dd8b7c0ad]
+      x-ms-client-request-id: [614b6d40-447e-11e6-86b2-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Compute/virtualMachines/vm-datadisk-test?api-version=2016-03-30
   response:
@@ -1488,25 +778,587 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UerulrldVvkzUePUv6IPrxcnM3oz4+y/fODh/nOw+2Hn9472N7Pd3e2J5/O6Ld7s0/v79y7dy/L
-        H3w00pfmWT27yur8ZV2dF2VO7ys4+u5y8br4AT766HWbLWfU8vd/+nr3I/n+lxgITVvV2UUUQLGg
-        L17l53mdL6fBV/Tlaj0pi2ae1/T5RyfZsloW06w0iOH5qDqnV/H1V5P1sl2/zutL+ttv0bxd4/vd
-        /fHO/nh/+/mb18HX1LwpqiWalFmbN60i79CnRlXztGjeUhsfu6p5c70Cyh89L5brdwHUZbbgb6pm
-        Ri/yIH9wb3n1aV5eFGXxrggaT+ucev5y1Soez+pqcYZXglaXc0ydhwB9tq4L+uyjeduumkd371IT
-        JfV8vXx7Wa3n2cX9TxfjSVlNxtOqzsdXxXJWXTXjZd5y67tDCI7pW0sJnxbU6zSbzovlBXp+lWez
-        79ZFm9u2ruVHs6zNQDdw4PfMp2lnCOUaY96xb+Gx5Jvt+iSgL7qkOm5bQqbTCKh3KEWf/uzRahsD
-        xVcdovnEwNMl3JfL8tpr/kvMr9+XX8zLxEQxyZlWi9W6zesXSqvLhcVjm/lYX6em2WxRLL9q8trQ
-        dc3C4rUowcEn1fK8uFjXmVLX9kUNCGw2KfOXWdNcVfXseN3O82VL4qhtz7OyyU17gzm91+Q0ZS1z
-        QHdYRFcC9dYbm/nobEnjOs+m0F3f+8UfFTSdH91t1pNmWhc89c3dezv7+cHDh59uP3hwPtne/zQ/
-        2J5ks2z7/v0Hn+7s3n+4P8n379Z5U63raf55Xa1Xzd1pWbwhwry6+P0Noe6SlrwsZqQC7n5RTOuq
-        qc7b8QtB4m4PmbtdEv/kFy+K6Ue/5Pt2SAwO6oRmmRQiiQUR+/V6Os3zWS6sIW15TOkPcVAnwi13
-        L4u6XWflF8yJkSEJT1gBHPi6VcV3I3xtX1aWUT66IjBr80WbXdAcG04Dl63K7Nqw9E8GwIR8v3Hy
-        S/4fYs9pteEGAAA=
+        6UerulrldVvkzUePUv6IPrxcnM3oz4/uPzjfybLJbPvB3mRne39/dr492T14sL0/2dvPH3x67+He
+        pw8+GulL86yeXWV1/rKuzosyp/cVHH13uXhd/AAfffS6zZYzavn7P329+5F8/0sMhKat6uwiCqBY
+        0Bev8vO8zpfT4Cv6crWelEUzz2v6/KOTbFkti2lWGsTwfFSd06v4+qvJetmuX+f1Jf3tt2jervH9
+        7v54Z3+8v/38zevga2reFNUSTcqszZtWkXfoU6OqeVo0b6mNj13VvLleAeWPnhfL9bsA6jJb8DdV
+        M6MXd/c/ffBwb/fB/b2g0bTOqccvV632/6yuFmegR9Dqco4p8zqmz9Z1QZ99NG/bVfPo7l1qoiSe
+        r5dvL6v1PLu4/+liPCmryXha1fn4qljOqqtmvMxbbn23i9iYPrUj98dOvU2z6bxYXqDHV3k2+25d
+        tLlt61p+NMvaDHQCx33PfJp2UC/XGOuufQuPJdds1x86fdEl0eli1V532gDzDoHo02+eRNsYHz7q
+        0MqnAZ44vcImAAPJ+fwJtTpwX/0S8+v35RcDmRgpJj3TarFat3n9Qul3ubBIbjMv6+vUNJstiuVX
+        TV4bWq9ZYLwWJbj4pFqeFxfrOlOK276oAYHNJmX+Mmuaq6qeHa/beb5sSSS17XlWNrlpbzCn95qc
+        prFlrugOi4hNoN56YzMfnS1pXOfZFPrre7/4o4Lm+KO7zXrSTOuC2aG5e29nPz94+PDT7QcPzifb
+        +5/mB9uTbJZt37//4NOd3fsP9yf5/t06b6p1Pc0/r6v1qrk7LYs3RJhXF7+/IdRd0pSXxYzUwN0v
+        imldNdV5O34hSNztIXO3S+Kf/OJFMf3ol3zfDonBQaUQC5BSpKknYr9eT6d5PsuFb6Qtjyn9IQ7q
+        RLjl7mVRt+us/ILZNDIk4QkrlANft6r8boSv7cvKMspHVwRmbb5oswuaY8Np4LJVmV0blv7JAJiQ
+        7zdOfsn/A/3cjWTlBgAA
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:54:36 GMT']
+      date: ['Thu, 07 Jul 2016 20:08:08 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [864c1540-447e-11e6-a49d-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Compute/virtualMachines/vm-datadisk-test?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UerulrldVvkzUePUv6IPrxcnM3oz4/uPzjfybLJbPvB3mRne39/dr492T14sL0/2dvPH3x67+He
+        pw8+GulL86yeXWV1/rKuzosyp/cVHH13uXhd/AAfffS6zZYzavn7P329+5F8/0sMhKat6uwiCqBY
+        0Bev8vO8zpfT4Cv6crWelEUzz2v6/KOTbFkti2lWGsTwfFSd06v4+qvJetmuX+f1Jf3tt2jervH9
+        7v54Z3+8v/38zevga2reFNUSTcqszZtWkXfoU6OqeVo0b6mNj13VvLleAeWPnhfL9bsA6jJb8DdV
+        M6MXd/c/ffBwb/fB/b2g0bTOqccvV632/6yuFmegR9Dqco4p8zqmz9Z1QZ99NG/bVfPo7l1qoiSe
+        r5dvL6v1PLu4/+liPCmryXha1fn4qljOqqtmvMxbbn23i9iYPrUj98dOvU2z6bxYXqDHV3k2+25d
+        tLlt61p+NMvaDHQCx33PfJp2UC/XGOuufQuPJdds1x86fdEl0eli1V532gDzDoHo02+eRNsYHz7q
+        0MqnAZ44vcImAAPJ+fwJtTpwX/0S8+v35RcDmRgpJj3TarFat3n9Qul3ubBIbjMv6+vUNJstiuVX
+        TV4bWq9ZYLwWJbj4pFqeFxfrOlOK276oAYHNJmX+Mmuaq6qeHa/beb5sSSS17XlWNrlpbzCn95qc
+        prFlrugOi4hNoN56YzMfnS1pXOfZFPrre7/4o4Lm+KO7zXrSTOuC2aG5e29nPz94+PDT7QcPzifb
+        +5/mB9uTbJZt37//4NOd3fsP9yf5/t06b6p1Pc0/r6v1qrk7LYs3RJhXF7+/IdRd0pSXxYzUwN0v
+        imldNdV5O34hSNztIXO3S+Kf/OJFMf3ol3zfDonBQaUQC5BSpKknYr9eT6d5PsuFb6Qtjyn9IQ7q
+        RLjl7mVRt+us/ILZNDIk4QkrlANft6r8boSv7cvKMspHVwRmbb5oswuaY8Np4LJVmV0blv7JAJiQ
+        7zdOfsn/A/3cjWTlBgAA
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Jul 2016 20:08:09 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [86a1d661-447e-11e6-9073-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Compute/virtualMachines/vm-datadisk-test?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UerulrldVvkzUePUv6IPrxcnM3oz4/uPzjfybLJbPvB3mRne39/dr492T14sL0/2dvPH3x67+He
+        pw8+GulL86yeXWV1/rKuzosyp/cVHH13uXhd/AAfffS6zZYzavn7P329+5F8/0sMhKat6uwiCqBY
+        0Bev8vO8zpfT4Cv6crWelEUzz2v6/KOTbFkti2lWGsTwfFSd06v4+qvJetmuX+f1Jf3tt2jervH9
+        7v54Z3+8v/38zevga2reFNUSTcqszZtWkXfoU6OqeVo0b6mNj13VvLleAeWPnhfL9bsA6jJb8DdV
+        M6MXd/c/ffBwb/fB/b2g0bTOqccvV632/6yuFmegR9Dqco4p8zqmz9Z1QZ99NG/bVfPo7l1qoiSe
+        r5dvL6v1PLu4/+liPCmryXha1fn4qljOqqtmvMxbbn23i9iYPrUj98dOvU2z6bxYXqDHV3k2+25d
+        tLlt61p+NMvaDHQCx33PfJp2UC/XGOuufQuPJdds1x86fdEl0eli1V532gDzDoHo02+eRNsYHz7q
+        0MqnAZ44vcImAAPJ+fwJtTpwX/0S8+v35RcDmRgpJj3TarFat3n9Qul3ubBIbjMv6+vUNJstiuVX
+        TV4bWq9ZYLwWJbj4pFqeFxfrOlOK276oAYHNJmX+Mmuaq6qeHa/beb5sSSS17XlWNrlpbzCn95qc
+        prFlrugOi4hNoN56YzMfnS1pXOfZFPrre7/4o4Lm+KO7zXrSTOuC2aG5e29nPz94+PDT7QcPzifb
+        +5/mB9uTbJZt37//4NOd3fsP9yf5/t06b6p1Pc0/r6v1qrk7LYs3RJhXF7+/IdRd0pSXxYzUwN0v
+        imldNdV5O34hSNztIXO3S+Kf/OJFMf3ol3zfDonBQaUQC5BSpKknYr9eT6d5PsuFb6Qtjyn9IQ7q
+        RLjl7mVRt+us/ILZNDIk4QkrlANft6r8boSv7cvKMspHVwRmbb5oswuaY8Np4LJVmV0blv7JAJiQ
+        7zdOfsn/A/3cjWTlBgAA
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Jul 2016 20:08:10 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"location": "westus", "properties": {"hardwareProfile": {"vmSize": "Standard_DS1"},
+      "osProfile": {"secrets": [], "adminUsername": "ubuntu", "computerName": "vm-datadisk-test",
+      "linuxConfiguration": {"disablePasswordAuthentication": false}}, "networkProfile":
+      {"networkInterfaces": [{"id": "/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Network/networkInterfaces/vm-datadisk-testVMNic"}]},
+      "storageProfile": {"imageReference": {"sku": "14.04.4-LTS", "publisher": "Canonical",
+      "version": "latest", "offer": "UbuntuServer"}, "osDisk": {"caching": "ReadWrite",
+      "vhd": {"uri": "https://vhdstoragehunkvouhag56m.blob.core.windows.net/vhds/osdisk1467921752.vhd"},
+      "createOption": "fromImage", "name": "osdisk1467921752", "osType": "Linux"},
+      "dataDisks": []}, "vmId": "57f0aabd-72b0-44df-b187-4b24e7639267", "provisioningState":
+      "Succeeded"}, "tags": {"displayName": "VirtualMachine"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Length: ['937']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [87369c4f-447e-11e6-b7fb-001dd8b7c0ad]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Compute/virtualMachines/vm-datadisk-test?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UerulrldVvkzUePUv6IPrxcnM3oz4/uPzjfybLJbPvB3mRne39/dr492T14sL0/2dvPH3x67+He
+        pw8+GulL86yeXWV1/rKuzosyp/cVHH13uXhd/AAfffS6zZYzavn7P329+5F8/0sMhKat6uwiCqBY
+        0Bev8vO8zpfT4Cv6crWelEUzz2v6/KOTbFkti2lWGsTwfFSd06v4+qvJetmuX+f1Jf3tt2jervH9
+        7v54Z3+8v/38zevga2reFNUSTcqszZtWkXfoU6OqeVo0b6mNj13VvLleAeWPnhfL9bsA6jJb8DdV
+        M6MXd/c/ffBwb/fB/b2g0bTOqccvV632/6yuFmegR9Dqco4p8zqmz9Z1QZ99NG/bVfPo7l1qoiSe
+        r5dvL6v1PLu4/+liPCmryXha1fn4qljOqqtmvMxbbn23i9iYPrUj98dOvU2z6bxYXqDHV3k2+25d
+        tLlt61p+NMvaDHQCx33v+/Kx+ZooEZv+abVYrdu8fqH0ulxsAwpw2+bJ0NepaTZbFMuvmrw2tF3z
+        jHstSkzDSbU8Ly7WdaZUtX1RAwKbTcr8ZdY0V1U9O16383zZEk9p2/OsbHLT3mBO7zU5TVUbHRYR
+        lEC99cZmPjpb0rjOsykE8Hu/+KOCZvGju8160kzrgqe8uXtvZz8/ePjw0+0HD84n2/uf5gfbk2yW
+        bd+//+DTnd37D/cn+f7dOm+qdT3NP6+r9aq5Oy2LN0SYVxe/vyHUXRL1y2JGfHz3i2JaV0113o5f
+        CBJ3e8jc7ZL4J794UUw/+iXft0NicJAJmnOSapprIvZXK3qJPuB5l6Y8pPSHOKYTYZa7l0XdrrPy
+        C2bLyIiEJawMDnzdqvDeCF/bl5Xlk4+uCMzafNFmFzTFhtHAZKsyuzYc/ZMBMCHfb5z8kv8HPlGq
+        FqUFAAA=
+    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/64992b95-f2f4-4fcd-9767-77493dd6c4c9?api-version=2016-03-30']
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Jul 2016 20:08:11 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [87369c4f-447e-11e6-b7fb-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/64992b95-f2f4-4fcd-9767-77493dd6c4c9?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H9L83ezuPdg4e7d4b7+zee7C3+8kO/b3z0ci8064bvHC2fFlX
+        F3XeNPrVMhNIn+4/fLg3eXh/+3zvfH97/3w623744NMH2w8e7D+8N5t9Ot2fPvzoN05+yf8DRV71
+        BoUAAAA=
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Jul 2016 20:08:42 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [87369c4f-447e-11e6-b7fb-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/64992b95-f2f4-4fcd-9767-77493dd6c4c9?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H9L83ezuPdg4e7d4b7+zee7C3+8kO/b3z0YjfyZezwTfuPxw/
+        2P304P5e8Ab10q4bvPB6PZ3m+Syf6TfLTAB9uv/w4d7k4f3t873z/e398+ls++GDTx9sP3iw//De
+        bPbpdH/68KPfOPkl/w8k7eYZtgAAAA==
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Jul 2016 20:09:12 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [87369c4f-447e-11e6-b7fb-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Compute/virtualMachines/vm-datadisk-test?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UerulrldVvkzUePUv6IPrxcnM3oz4/uPzjfybLJbPvB3mRne39/dr492T14sL0/2dvPH3x67+He
+        pw8+GulL86yeXWV1/rKuzosyp/cVHH13uXhd/AAfffS6zZYzavn7P329+5F8/0sMhKat6uwiCqBY
+        0Bev8vO8zpfT4Cv6crWelEUzz2v6/KOTbFkti2lWGsTwfFSd06v4+qvJetmuX+f1Jf3tt2jervH9
+        7v54Z3+8v/38zevga2reFNUSTcqszZtWkXfoU6OqeVo0b6mNj13VvLleAeWPnhfL9bsA6jJb8DdV
+        M6MXd/c/ffBwb/fB/b2g0bTOqccvV632/6yuFmegR9Dqco4p8zqmz9Z1QZ99NG/bVfPo7l1qoiSe
+        r5dvL6v1PLu4/+liPCmryXha1fn4qljOqqtmvMxbbn23i9iYPrUj98dOvU2z6bxYXqDHV3k2+25d
+        tLlt61p+NMvaDHQCx33v+/Kx+ZooEZv+abVYrdu8fqH0ulxsAwpw2+bJ0NepaTZbFMuvmrw2tF3z
+        jHstSkzDSbU8Ly7WdaZUtX1RAwKbTcr8ZdY0V1U9O16383zZEk9p2/OsbHLT3mBO7zU5TVUbHRYR
+        lEC99cZmPjpb0rjOsykE8Hu/+KOCZvGju8160kzrgqe8uXtvZz8/ePjw0+0HD84n2/uf5gfbk2yW
+        bd+//+DTnd37D/cn+f7dOm+qdT3NP6+r9aq5Oy2LN0SYVxe/vyHUXRL1y2JGfHz3i2JaV0113o5f
+        CBJ3e8jc7ZL4J794UUw/+iXft0NicJAJmnOSapprIvbr9XSa57NcmETa8pjSH+KgToRb7l4WdbvO
+        yi+YLyNDEp6wQjjwdavSeyN8bV9WllE+uiIwa/NFm13QHBtOA5etyuzasPRPBsCEfL9x8kv+H1Ft
+        2CqmBQAA
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Jul 2016 20:09:12 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [accf659e-447e-11e6-8030-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Compute/virtualMachines/vm-datadisk-test?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UerulrldVvkzUePUv6IPrxcnM3oz4/uPzjfybLJbPvB3mRne39/dr492T14sL0/2dvPH3x67+He
+        pw8+GulL86yeXWV1/rKuzosyp/cVHH13uXhd/AAfffS6zZYzavn7P329+5F8/0sMhKat6uwiCqBY
+        0Bev8vO8zpfT4Cv6crWelEUzz2v6/KOTbFkti2lWGsTwfFSd06v4+qvJetmuX+f1Jf3tt2jervH9
+        7v54Z3+8v/38zevga2reFNUSTcqszZtWkXfoU6OqeVo0b6mNj13VvLleAeWPnhfL9bsA6jJb8DdV
+        M6MXd/c/ffBwb/fB/b2g0bTOqccvV632/6yuFmegR9Dqco4p8zqmz9Z1QZ99NG/bVfPo7l1qoiSe
+        r5dvL6v1PLu4/+liPCmryXha1fn4qljOqqtmvMxbbn23i9iYPrUj98dOvU2z6bxYXqDHV3k2+25d
+        tLlt61p+NMvaDHQCx33v+/Kx+ZooEZv+abVYrdu8fqH0ulxsAwpw2+bJ0NepaTZbFMuvmrw2tF3z
+        jHstSkzDSbU8Ly7WdaZUtX1RAwKbTcr8ZdY0V1U9O16383zZEk9p2/OsbHLT3mBO7zU5TVUbHRYR
+        lEC99cZmPjpb0rjOsykE8Hu/+KOCZvGju8160kzrgqe8uXtvZz8/ePjw0+0HD84n2/uf5gfbk2yW
+        bd+//+DTnd37D/cn+f7dOm+qdT3NP6+r9aq5Oy2LN0SYVxe/vyHUXRL1y2JGfHz3i2JaV0113o5f
+        CBJ3e8jc7ZL4J794UUw/+iXft0NicJAJmnOSapprIvbr9XSa57NcmETa8pjSH+KgToRb7l4WdbvO
+        yi+YLyNDEp6wQjjwdavSeyN8bV9WllE+uiIwa/NFm13QHBtOA5etyuzasPRPBsCEfL9x8kv+H1Ft
+        2CqmBQAA
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Jul 2016 20:09:13 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [acee3840-447e-11e6-8ec9-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Compute/virtualMachines/vm-datadisk-test?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UerulrldVvkzUePUv6IPrxcnM3oz4/uPzjfybLJbPvB3mRne39/dr492T14sL0/2dvPH3x67+He
+        pw8+GulL86yeXWV1/rKuzosyp/cVHH13uXhd/AAfffS6zZYzavn7P329+5F8/0sMhKat6uwiCqBY
+        0Bev8vO8zpfT4Cv6crWelEUzz2v6/KOTbFkti2lWGsTwfFSd06v4+qvJetmuX+f1Jf3tt2jervH9
+        7v54Z3+8v/38zevga2reFNUSTcqszZtWkXfoU6OqeVo0b6mNj13VvLleAeWPnhfL9bsA6jJb8DdV
+        M6MXd/c/ffBwb/fB/b2g0bTOqccvV632/6yuFmegR9Dqco4p8zqmz9Z1QZ99NG/bVfPo7l1qoiSe
+        r5dvL6v1PLu4/+liPCmryXha1fn4qljOqqtmvMxbbn23i9iYPrUj98dOvU2z6bxYXqDHV3k2+25d
+        tLlt61p+NMvaDHQCx33v+/Kx+ZooEZv+abVYrdu8fqH0ulxsAwpw2+bJ0NepaTZbFMuvmrw2tF3z
+        jHstSkzDSbU8Ly7WdaZUtX1RAwKbTcr8ZdY0V1U9O16383zZEk9p2/OsbHLT3mBO7zU5TVUbHRYR
+        lEC99cZmPjpb0rjOsykE8Hu/+KOCZvGju8160kzrgqe8uXtvZz8/ePjw0+0HD84n2/uf5gfbk2yW
+        bd+//+DTnd37D/cn+f7dOm+qdT3NP6+r9aq5Oy2LN0SYVxe/vyHUXRL1y2JGfHz3i2JaV0113o5f
+        CBJ3e8jc7ZL4J794UUw/+iXft0NicJAJmnOSapprIvbr9XSa57NcmETa8pjSH+KgToRb7l4WdbvO
+        yi+YLyNDEp6wQjjwdavSeyN8bV9WllE+uiIwa/NFm13QHBtOA5etyuzasPRPBsCEfL9x8kv+H1Ft
+        2CqmBQAA
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Jul 2016 20:09:13 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"location": "westus", "properties": {"hardwareProfile": {"vmSize": "Standard_DS1"},
+      "osProfile": {"secrets": [], "adminUsername": "ubuntu", "computerName": "vm-datadisk-test",
+      "linuxConfiguration": {"disablePasswordAuthentication": false}}, "networkProfile":
+      {"networkInterfaces": [{"id": "/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Network/networkInterfaces/vm-datadisk-testVMNic"}]},
+      "storageProfile": {"imageReference": {"sku": "14.04.4-LTS", "publisher": "Canonical",
+      "version": "latest", "offer": "UbuntuServer"}, "osDisk": {"caching": "ReadWrite",
+      "vhd": {"uri": "https://vhdstoragehunkvouhag56m.blob.core.windows.net/vhds/osdisk1467921752.vhd"},
+      "createOption": "fromImage", "name": "osdisk1467921752", "osType": "Linux"},
+      "dataDisks": [{"caching": "ReadOnly", "vhd": {"uri": "https://vhdstoragehunkvouhag56m.blob.core.windows.net/vhds/osdisk1467921752-datadisk.vhd"},
+      "createOption": "attach", "name": "d1", "lun": 0}]}, "vmId": "57f0aabd-72b0-44df-b187-4b24e7639267",
+      "provisioningState": "Succeeded"}, "tags": {"displayName": "VirtualMachine"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Length: ['1118']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [ad067b30-447e-11e6-8985-001dd8b7c0ad]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Compute/virtualMachines/vm-datadisk-test?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UerulrldVvkzUePUv6IPrxcnM3oz4/uPzjfybLJbPvB3mRne39/dr492T14sL0/2dvPH3x67+He
+        pw8+GulL86yeXWV1/rKuzosyp/cVHH13uXhd/AAfffS6zZYzavn7P329+5F8/0sMhKat6uwiCqBY
+        0Bev8vO8zpfT4Cv6crWelEUzz2v6/KOTbFkti2lWGsTwfFSd06v4+qvJetmuX+f1Jf3tt2jervH9
+        7v54Z3+8v/38zevga2reFNUSTcqszZtWkXfoU6OqeVo0b6mNj13VvLleAeWPnhfL9bsA6jJb8DdV
+        M6MXd/c/ffBwb/fB/b2g0bTOqccvV632/6yuFmegR9Dqco4p8zqmz9Z1QZ99NG/bVfPo7l1qoiSe
+        r5dvL6v1PLu4/+liPCmryXha1fn4qljOqqtmvMxbbn23i9iYPrUj98dOvU2z6bxYXqDHV3k2+25d
+        tLlt61p+NMvaDHQCx33PfJp2UC/XGOuOfQuPJdds1x86fdEl0XHbEjKdRkC9QyH69Jun0TYGiI86
+        xPKJgKdLsC+X5bXX/JeYX78vv5iXiVliEjKtFqt1m9cvlEaXC4vHNvOrvk5Ns9miWH7V5LWh55qF
+        wmtRglNPquV5cbGuM6Wq7YsaENhsUuYvs6a5qurZ8bqd58uWxE7bnmdlk5v2BnN6r8lpqlqe+e6w
+        iJ4E6q03NvPR2ZLGdZ5NoaO+94s/KmgaP7rbrCfNtC54ypu793b284OHDz/dfvDgfLK9/2l+sD3J
+        Ztn2/fsPPt3Zvf9wf5Lv363zplrX0/zzulqvmrvTsnhDhHl18fsbQt0lbXhZzEjU735RTOuqqc7b
+        8QtB4m4PmbtdEv/kFy+K6Ue/5Pt2SAwOaoNmmRQfiQMR+6sVvUQf8FRLUx5S+kMc04kwy93Lom7X
+        WfkFM2JkRMISVu4Gvm5Vv90IX9uXleWTj64IzNp80WYXNMWG0cBkqzK7Nhz9kwEwId9vnPyS/wcp
+        rViZyAYAAA==
+    headers:
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/8522ac2a-ae22-451a-b909-4afd9f1f352f?api-version=2016-03-30']
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Jul 2016 20:09:14 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1190']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [ad067b30-447e-11e6-8985-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/8522ac2a-ae22-451a-b909-4afd9f1f352f?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H9L83ezuPdh4+2r0/PtjfPdh/sPfJDn2w89HIvNSuG7xxtnxZ
+        Vxd13jT61TITUAf39/ay6V62neV7e9v793ez7cnDnYfb+9n57OH57vm9+3vnH/3GyS/5fwCOzN9G
+        hgAAAA==
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Jul 2016 20:09:45 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [ad067b30-447e-11e6-8985-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/8522ac2a-ae22-451a-b909-4afd9f1f352f?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H9L83ezuPdh4+2r0/PtjfPdh/sPfJDn2w89GIX8qXs8FX9h+M
+        H97f3dt78DB4hfpp1w3eeL2eTvN8ls/0m2UmkA7u7+1l071sO8v39rb37+9m25OHOw+397Pz2cPz
+        3fN79/fOP/qNk1/y/wBBXBAuuAAAAA==
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Jul 2016 20:10:15 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [ad067b30-447e-11e6-8985-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Compute/virtualMachines/vm-datadisk-test?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UerulrldVvkzUePUv6IPrxcnM3oz4/uPzjfybLJbPvB3mRne39/dr492T14sL0/2dvPH3x67+He
+        pw8+GulL86yeXWV1/rKuzosyp/cVHH13uXhd/AAfffS6zZYzavn7P329+5F8/0sMhKat6uwiCqBY
+        0Bev8vO8zpfT4Cv6crWelEUzz2v6/KOTbFkti2lWGsTwfFSd06v4+qvJetmuX+f1Jf3tt2jervH9
+        7v54Z3+8v/38zevga2reFNUSTcqszZtWkXfoU6OqeVo0b6mNj13VvLleAeWPnhfL9bsA6jJb8DdV
+        M6MXd/c/ffBwb/fB/b2g0bTOqccvV632/6yuFmegR9Dqco4p8zqmz9Z1QZ99NG/bVfPo7l1qoiSe
+        r5dvL6v1PLu4/+liPCmryXha1fn4qljOqqtmvMxbbn23i9iYPrUj98dOvU2z6bxYXqDHV3k2+25d
+        tLlt61p+NMvaDHQCx33PfJp2UC/XGOuOfQuPJdds1x86fdEl0XHbEjKdRkC9QyH69Jun0TYGiI86
+        xPKJgKdLsC+X5bXX/JeYX78vv5iXiVliEjKtFqt1m9cvlEaXC4vHNvOrvk5Ns9miWH7V5LWh55qF
+        wmtRglNPquV5cbGuM6Wq7YsaENhsUuYvs6a5qurZ8bqd58uWxE7bnmdlk5v2BnN6r8lpqlqe+e6w
+        iJ4E6q03NvPR2ZLGdZ5NoaO+94s/KmgaP7rbrCfNtC54ypu793b284OHDz/dfvDgfLK9/2l+sD3J
+        Ztn2/fsPPt3Zvf9wf5Lv363zplrX0/zzulqvmrvTsnhDhHl18fsbQt0lbXhZzEjU735RTOuqqc7b
+        8QtB4m4PmbtdEv/kFy+K6Ue/5Pt2SAwOaoNmmRQfiQMR+/V6Os3zWS6sIW15TOkPcVAnwi13L4u6
+        XWflF8yJkSEJT1jBG/i6VQV3I3xtX1aWUT66IjBr80WbXdAcG04Dl63K7Nqw9E8GwIR8v3HyS/4f
+        ahqEqckGAAA=
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Jul 2016 20:10:15 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [d2080d8f-447e-11e6-93f1-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Compute/virtualMachines/vm-datadisk-test?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UerulrldVvkzUePUv6IPrxcnM3oz4/uPzjfybLJbPvB3mRne39/dr492T14sL0/2dvPH3x67+He
+        pw8+GulL86yeXWV1/rKuzosyp/cVHH13uXhd/AAfffS6zZYzavn7P329+5F8/0sMhKat6uwiCqBY
+        0Bev8vO8zpfT4Cv6crWelEUzz2v6/KOTbFkti2lWGsTwfFSd06v4+qvJetmuX+f1Jf3tt2jervH9
+        7v54Z3+8v/38zevga2reFNUSTcqszZtWkXfoU6OqeVo0b6mNj13VvLleAeWPnhfL9bsA6jJb8DdV
+        M6MXd/c/ffBwb/fB/b2g0bTOqccvV632/6yuFmegR9Dqco4p8zqmz9Z1QZ99NG/bVfPo7l1qoiSe
+        r5dvL6v1PLu4/+liPCmryXha1fn4qljOqqtmvMxbbn23i9iYPrUj98dOvU2z6bxYXqDHV3k2+25d
+        tLlt61p+NMvaDHQCx33PfJp2UC/XGOuOfQuPJdds1x86fdEl0XHbEjKdRkC9QyH69Jun0TYGiI86
+        xPKJgKdLsC+X5bXX/JeYX78vv5iXiVliEjKtFqt1m9cvlEaXC4vHNvOrvk5Ns9miWH7V5LWh55qF
+        wmtRglNPquV5cbGuM6Wq7YsaENhsUuYvs6a5qurZ8bqd58uWxE7bnmdlk5v2BnN6r8lpqlqe+e6w
+        iJ4E6q03NvPR2ZLGdZ5NoaO+94s/KmgaP7rbrCfNtC54ypu793b284OHDz/dfvDgfLK9/2l+sD3J
+        Ztn2/fsPPt3Zvf9wf5Lv363zplrX0/zzulqvmrvTsnhDhHl18fsbQt0lbXhZzEjU735RTOuqqc7b
+        8QtB4m4PmbtdEv/kFy+K6Ue/5Pt2SAwOaoNmmRQfiQMR+/V6Os3zWS6sIW15TOkPcVAnwi13L4u6
+        XWflF8yJkSEJT1jBG/i6VQV3I3xtX1aWUT66IjBr80WbXdAcG04Dl63K7Nqw9E8GwIR8v3HyS/4f
+        ahqEqckGAAA=
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Jul 2016 20:10:15 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_generalize.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_generalize.yaml
@@ -52,21 +52,21 @@ interactions:
       content-length: ['2297']
       content-security-policy: [default-src 'none'; style-src 'unsafe-inline']
       content-type: [text/plain; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:54:41 GMT']
+      date: ['Thu, 07 Jul 2016 20:02:31 GMT']
       etag: ['"db78eb36618a060181b32ac2de91b1733f382e01"']
-      expires: ['Fri, 01 Jul 2016 02:59:41 GMT']
+      expires: ['Thu, 07 Jul 2016 20:07:31 GMT']
       source-age: ['0']
       strict-transport-security: [max-age=31536000]
       vary: ['Authorization,Accept-Encoding']
       via: [1.1 varnish]
-      x-cache: [MISS]
-      x-cache-hits: ['0']
+      x-cache: [HIT]
+      x-cache-hits: ['1']
       x-content-type-options: [nosniff]
-      x-fastly-request-id: [4fe168630b68dbc5c5d6eeb095a332d6a996e93a]
+      x-fastly-request-id: [b84c53dff2fb5cc8d46b0e7ff7e9533fbbe88a8c]
       x-frame-options: [deny]
       x-geo-block-list: ['']
-      x-github-request-id: ['C71B4F14:5AD1:5C44E7:5775DB70']
-      x-served-by: [cache-lax1437-LAX]
+      x-github-request-id: ['17EB2F14:5AD3:37F5586:577EB557']
+      x-served-by: [cache-sjc3129-SJC]
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
@@ -74,14 +74,78 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bd0ee6cf-447d-11e6-9abc-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Network/virtualnetworks?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS97/+S/wdC6kBEDAAAAA==
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['133']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Jul 2016 20:02:31 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 storagemanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bd2a0ff0-447d-11e6-b81f-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Storage/storageAccounts?api-version=2016-01-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS97/+S5P8BxWZBqg0AAAA=
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-type: [application/json]
+      date: ['Thu, 07 Jul 2016 20:02:31 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 resourcemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.32]
+          AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [2809f070-3f37-11e6-b28e-001dd8b7c0ad]
+      x-ms-client-request-id: [bd4fe770-447d-11e6-b22b-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27cliTestRg_VmGeneralize%27%20and%20name%20eq%20%27vm-generalize%27%20and%20resourceType%20eq%20%27Microsoft.Compute%2FvirtualMachines%27
   response:
@@ -95,7 +159,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['133']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:54:41 GMT']
+      date: ['Thu, 07 Jul 2016 20:02:31 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -109,54 +173,54 @@ interactions:
       {"value": "none"}, "subnetIpAddressPrefix": {"value": "10.0.0.0/24"}, "adminUsername":
       {"value": "ubuntu"}, "networkInterfaceType": {"value": "new"}, "_artifactsLocation":
       {"value": "https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30"},
-      "osType": {"value": "Custom"}, "sshKeyValue": {"value": "C:\\Users\\burtbiel\\.ssh\\id_rsa.pub"},
-      "osVersion": {"value": "latest"}, "customOsDiskType": {"value": "windows"},
-      "virtualNetworkIpAddressPrefix": {"value": "10.0.0.0/16"}, "name": {"value":
-      "vm-generalize"}, "storageCaching": {"value": "ReadWrite"}, "adminPassword":
-      {"value": "testPassword0"}, "networkSecurityGroupRule": {"value": "RDP"}, "storageContainerName":
-      {"value": "vhds"}, "osOffer": {"value": "UbuntuServer"}, "osPublisher": {"value":
-      "Canonical"}, "privateIpAddressAllocation": {"value": "dynamic"}, "size": {"value":
-      "Standard_DS1"}, "location": {"value": "westus"}}}}'
+      "osType": {"value": "Custom"}, "osVersion": {"value": "latest"}, "customOsDiskType":
+      {"value": "windows"}, "virtualNetworkIpAddressPrefix": {"value": "10.0.0.0/16"},
+      "name": {"value": "vm-generalize"}, "storageCaching": {"value": "ReadWrite"},
+      "adminPassword": {"value": "testPassword0"}, "networkSecurityGroupRule": {"value":
+      "SSH"}, "storageContainerName": {"value": "vhds"}, "osOffer": {"value": "UbuntuServer"},
+      "osPublisher": {"value": "Canonical"}, "privateIpAddressAllocation": {"value":
+      "dynamic"}, "size": {"value": "Standard_DS1"}, "osDiskName": {"value": "osdisk1467921752"},
+      "location": {"value": "westus"}}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
-      Content-Length: ['1300']
+      Content-Length: ['1278']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [285d67a1-3f37-11e6-8e8b-001dd8b7c0ad]
+      x-ms-client-request-id: [bd8ca24f-447d-11e6-adcc-001dd8b7c0ad]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/azurecli-test-deployment-vm-generalize","name":"azurecli-test-deployment-vm-generalize","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30"},"adminPassword":{"type":"SecureString"},"adminUsername":{"type":"String","value":"ubuntu"},"authenticationType":{"type":"String","value":"password"},"availabilitySet":{"type":"String","value":""},"availabilitySetType":{"type":"String","value":"none"},"customOsDiskType":{"type":"String","value":"windows"},"customOsDiskUri":{"type":"String","value":""},"dnsNameForPublicIP":{"type":"String","value":""},"dnsNameType":{"type":"String","value":"none"},"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"vm-generalize"},"networkSecurityGroup":{"type":"String","value":"vm-generalizeNSG"},"networkSecurityGroupRule":{"type":"String","value":"RDP"},"networkSecurityGroupType":{"type":"String","value":"new"},"networkInterfaceIds":{"type":"Array","value":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Network/networkInterfaces/vm-generalizeVMNic"}]},"networkInterfaceType":{"type":"String","value":"new"},"osDiskName":{"type":"String","value":"osdiskimagel7uc3pwjbshvm"},"osDiskType":{"type":"String","value":"provided"},"osDiskUri":{"type":"String","value":"https://vhdstorageg4srpskjqsssw.blob.core.windows.net/vhds/osdiskimagel7uc3pwjbshvm.vhd"},"osOffer":{"type":"String","value":"UbuntuServer"},"osPublisher":{"type":"String","value":"Canonical"},"osSKU":{"type":"String","value":"14.04.4-LTS"},"osType":{"type":"String","value":"Custom"},"osVersion":{"type":"String","value":"latest"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddress":{"type":"String","value":"vm-generalizePublicIP"},"publicIpAddressType":{"type":"String","value":"new"},"size":{"type":"String","value":"Standard_DS1"},"sshDestKeyPath":{"type":"String","value":"/home/ubuntu/.ssh/authorized_keys"},"sshKeyValue":{"type":"String","value":"C:\\Users\\burtbiel\\.ssh\\id_rsa.pub"},"storageAccount":{"type":"String","value":"vhdstorageg4srpskjqsssw"},"storageAccountType":{"type":"String","value":"new"},"storageCaching":{"type":"String","value":"ReadWrite"},"storageContainerName":{"type":"String","value":"vhds"},"storageType":{"type":"String","value":"Premium_LRS"},"subnetIpAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetName":{"type":"String","value":"vm-generalizeSubnet"},"virtualNetworkIpAddressPrefix":{"type":"String","value":"10.0.0.0/16"},"virtualNetwork":{"type":"String","value":"vm-generalizeVNET"},"virtualNetworkType":{"type":"String","value":"new"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-01T02:54:42.6230884Z","duration":"PT0.1121394S","correlationId":"d0f9ab40-77e8-4c3c-b38d-09ce18ea560c","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/vm-generalizeVNet","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-generalizeVNet"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/vm-generalizeNSG","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-generalizeNSG"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/vm-generalizeNicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-generalizeNicIp"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/vm-generalize5oecvh744x6pa","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-generalize5oecvh744x6pa"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/vm-generalizeNicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-generalizeNicIp"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/vm-generalizeVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-generalizeVM"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/vm-generalizeVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-generalizeVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/vm-generalizetrfsvzxkksilenew","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-generalizetrfsvzxkksilenew"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/vm-generalizeVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-generalizeVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/vm-generalizetrfsvzxkksilenewfqdn","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-generalizetrfsvzxkksilenewfqdn"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/vm-generalizeVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-generalizeVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/vm-generalizevm-generalizeVMNicmac","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-generalizevm-generalizeVMNicmac"}]}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/azurecli-test-deployment-vm-generalize","name":"azurecli-test-deployment-vm-generalize","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30"},"adminPassword":{"type":"SecureString"},"adminUsername":{"type":"String","value":"ubuntu"},"authenticationType":{"type":"String","value":"password"},"availabilitySet":{"type":"String","value":""},"availabilitySetType":{"type":"String","value":"none"},"customOsDiskType":{"type":"String","value":"windows"},"customOsDiskUri":{"type":"String","value":""},"dnsNameForPublicIP":{"type":"String","value":""},"dnsNameType":{"type":"String","value":"none"},"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"vm-generalize"},"networkSecurityGroup":{"type":"String","value":"vm-generalizeNSG"},"networkSecurityGroupRule":{"type":"String","value":"SSH"},"networkSecurityGroupType":{"type":"String","value":"new"},"networkInterfaceIds":{"type":"Array","value":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Network/networkInterfaces/vm-generalizeVMNic"}]},"networkInterfaceType":{"type":"String","value":"new"},"osDiskName":{"type":"String","value":"osdisk1467921752"},"osDiskType":{"type":"String","value":"provided"},"osDiskUri":{"type":"String","value":"https://vhdstorageg4srpskjqsssw.blob.core.windows.net/vhds/osdisk1467921752.vhd"},"osOffer":{"type":"String","value":"UbuntuServer"},"osPublisher":{"type":"String","value":"Canonical"},"osSKU":{"type":"String","value":"14.04.4-LTS"},"osType":{"type":"String","value":"Custom"},"osVersion":{"type":"String","value":"latest"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddress":{"type":"String","value":"vm-generalizePublicIP"},"publicIpAddressType":{"type":"String","value":"new"},"size":{"type":"String","value":"Standard_DS1"},"sshDestKeyPath":{"type":"String","value":"/home/ubuntu/.ssh/authorized_keys"},"sshKeyValue":{"type":"String","value":""},"storageAccount":{"type":"String","value":"vhdstorageg4srpskjqsssw"},"storageAccountType":{"type":"String","value":"new"},"storageCaching":{"type":"String","value":"ReadWrite"},"storageContainerName":{"type":"String","value":"vhds"},"storageType":{"type":"String","value":"Premium_LRS"},"subnetIpAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetName":{"type":"String","value":"vm-generalizeSubnet"},"virtualNetworkIpAddressPrefix":{"type":"String","value":"10.0.0.0/16"},"virtualNetwork":{"type":"String","value":"vm-generalizeVNET"},"virtualNetworkType":{"type":"String","value":"new"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-07T20:02:33.220835Z","duration":"PT0.1422725S","correlationId":"33d41009-b552-4de0-9603-aea77e5f1607","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/vm-generalizeVNet","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-generalizeVNet"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/vm-generalizeNSG","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-generalizeNSG"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/vm-generalizeNicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-generalizeNicIp"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/vm-generalize5oecvh744x6pa","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-generalize5oecvh744x6pa"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/vm-generalizeNicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-generalizeNicIp"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/vm-generalizeVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-generalizeVM"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/vm-generalizeVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-generalizeVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/vm-generalizetrfsvzxkksilenew","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-generalizetrfsvzxkksilenew"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/vm-generalizeVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-generalizeVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/vm-generalizetrfsvzxkksilenewfqdn","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-generalizetrfsvzxkksilenewfqdn"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/vm-generalizeVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-generalizeVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/vm-generalizevm-generalizeVMNicmac","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-generalizevm-generalizeVMNicmac"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/azurecli-test-deployment-vm-generalize/operationStatuses/08587342652029667512?api-version=2015-11-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/azurecli-test-deployment-vm-generalize/operationStatuses/08587336851323991431?api-version=2015-11-01']
       cache-control: [no-cache]
-      content-length: ['6505']
+      content-length: ['6451']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:54:42 GMT']
+      date: ['Thu, 07 Jul 2016 20:02:32 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      x-ms-ratelimit-remaining-subscription-writes: ['1189']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [285d67a1-3f37-11e6-8e8b-001dd8b7c0ad]
+      x-ms-client-request-id: [bd8ca24f-447d-11e6-adcc-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342652029667512?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336851323991431?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -168,7 +232,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['140']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:55:11 GMT']
+      date: ['Thu, 07 Jul 2016 20:03:02 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -179,15 +243,15 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [285d67a1-3f37-11e6-8e8b-001dd8b7c0ad]
+      x-ms-client-request-id: [bd8ca24f-447d-11e6-adcc-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342652029667512?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336851323991431?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -199,7 +263,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['140']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:55:42 GMT']
+      date: ['Thu, 07 Jul 2016 20:03:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -210,15 +274,15 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [285d67a1-3f37-11e6-8e8b-001dd8b7c0ad]
+      x-ms-client-request-id: [bd8ca24f-447d-11e6-adcc-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342652029667512?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336851323991431?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -230,7 +294,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['140']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:56:12 GMT']
+      date: ['Thu, 07 Jul 2016 20:04:04 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -241,15 +305,15 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [285d67a1-3f37-11e6-8e8b-001dd8b7c0ad]
+      x-ms-client-request-id: [bd8ca24f-447d-11e6-adcc-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342652029667512?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336851323991431?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -261,7 +325,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['140']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:56:43 GMT']
+      date: ['Thu, 07 Jul 2016 20:04:34 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -272,15 +336,15 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [285d67a1-3f37-11e6-8e8b-001dd8b7c0ad]
+      x-ms-client-request-id: [bd8ca24f-447d-11e6-adcc-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342652029667512?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336851323991431?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -292,7 +356,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['140']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:57:13 GMT']
+      date: ['Thu, 07 Jul 2016 20:05:05 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -303,15 +367,15 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [285d67a1-3f37-11e6-8e8b-001dd8b7c0ad]
+      x-ms-client-request-id: [bd8ca24f-447d-11e6-adcc-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342652029667512?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336851323991431?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -323,7 +387,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['140']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:57:43 GMT']
+      date: ['Thu, 07 Jul 2016 20:05:35 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -334,15 +398,15 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [285d67a1-3f37-11e6-8e8b-001dd8b7c0ad]
+      x-ms-client-request-id: [bd8ca24f-447d-11e6-adcc-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342652029667512?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336851323991431?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -354,7 +418,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['140']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:58:13 GMT']
+      date: ['Thu, 07 Jul 2016 20:06:05 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -365,139 +429,15 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [285d67a1-3f37-11e6-8e8b-001dd8b7c0ad]
+      x-ms-client-request-id: [bd8ca24f-447d-11e6-adcc-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342652029667512?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:58:44 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [285d67a1-3f37-11e6-8e8b-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342652029667512?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:59:15 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [285d67a1-3f37-11e6-8e8b-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342652029667512?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 02:59:46 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [285d67a1-3f37-11e6-8e8b-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342652029667512?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 03:00:16 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [285d67a1-3f37-11e6-8e8b-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342652029667512?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336851323991431?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -509,7 +449,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['141']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 03:00:46 GMT']
+      date: ['Thu, 07 Jul 2016 20:06:35 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -520,13 +460,13 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [285d67a1-3f37-11e6-8e8b-001dd8b7c0ad]
+      x-ms-client-request-id: [bd8ca24f-447d-11e6-adcc-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmGeneralize/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
@@ -542,32 +482,31 @@ interactions:
         JgOfttcrDPh1WxfLC4J3mZVrfPCNIQ1EstmiWL7MmuaqqoklXK/5lKBr36bdV01eyzS4dtLCYbee
         rJftml9Zt3MafyEjesPth99bGRzw5mVWlNmkKIv2+nXebnot0vymnpbVMsdr03XTVosvm6dF8/am
         d5Ss3de+AhcNv4Xms2XzIlvkz6r65XpSFtOzl7d84yaUzDDKW7DMFcnKmrG/afpCKcILeUvT8pb5
-        gejLYn9rAC9efz4E49W6pObDcF49fTn06o2Uya+8V89ICmsSrvxsxsKmbx3XdXbtXvrez4lKfCEo
-        3u2i2twNyPiTX7woph/9ku9HBnVLWlTMrmCrTY2rZkatikV2kZcP1tN7q6ufnjTzy4WDcFN3OkiW
-        YnnjBhExyuxyPiOxqqnni/2mXjVvf/oXNaQQBjQbWt8dwnZM30r/X56f5/Wm3r9iZfU6ry+pHb/C
-        QtrM6c8Nr51kJHyk10p55/Xv9dWm1rv745398f728zevpf1NRDxhDSNtrfUYbg4V37RovqqLS/rj
-        bHU8mxFT+uzeeyvW/ri8jTKZXZMSAT8SAFBr+o29v+mtQCB4lqBK+zBuIq4KRENQNjV73WbLWVbP
-        fv+nr3e5fTN/SlT+vfLrl1k73/Tm3Xm1yO+KGbw7pvfuwhBWNXU4+/3f5teshuljAvWT8sowrJNH
-        v+/vC6Pb/L6/72Rdt5MiL3/f3xcwf9/ft5j9/nWTjWn0DE9k53g6rajfTSBJOLRxIGh9ILclpLx0
-        kk3n+H7DC6/ybPZdUuJsVsxr5CNlBU3rTaoJaHvv3YTcyzpfFOvF7//8FcscKXVSG5ZH6Nvz4t2m
-        93fJT8N/d/f23fs34uiz6Gt+BS9fFnW7zkrV9V8Hid1P+3A2vRgg8pMvTt/0X7+JgDy79NaimuHP
-        s+WUKEreHOk8EjloeagleocEhWaUIKyn05w84Bl93xYLkpVsQY7CR+JuPtje2X2zc+/Rzs6jvYfj
-        3d2d3b17+z9FTWfrWhXGRy/f3P9i/9Px/YcPdx/s77+mL0nv1zmpN/r+DMZ5tnP+MJvs75A1JkO8
-        P7033Z7cO5ht7zyc5rsHeXb/050pvcbowdKyWSdlkzcrMpUEwFleG4xQe5oN/h00kXf8T+g18esx
-        fDQ3Og5Nl+uy/D4Z5u/TSPJVvpzlyylHHAREPmi+pLHRXz8H3oUdYxBwdZiDeDSkAKF5AwjvBRGJ
-        LsMRzF8y+n/rkOGTugF8IyMGSLDA/0sHDOvojeCbGTIDxSzTO/+vZ/P7VT69nJNWeffpKvNG9o2Q
-        IgQOkvy/kwgyZW4s38jgBej/e5n/J7/wBvCNjJggYo7phf/Xsz2h6sbyjQ3+/7Vz3dbnzeUP3r19
-        2xQlfXjljeUbGXwP/o/44P+Vw+3O0/kvmiEfa/r8RggQ7eNH/PD/yuEGf3AubZEhTjCdfiMUCP6w
-        nYAo1bpdrel9irZAn+GY6+4PlXAn1YLQyu9qXPgFB/A05GAgxNLdBMumEezeGz/cHd//dLx3bw+v
-        slRsaI823STUpvYaEXNMTuS9xRs7O9s7T7fvHW/f291+Rv97wlGtTImdZieq70+e3osU/SDAvmVO
-        98b3g8x3BwbHHcMQdOJeKpm6GHhJtEEQOnr9swNAMwu9l19Ljuau5mo0n0QvUw5HPuqknr7/S37J
-        /wNK7hokkhwAAA==
+        gejLYn9rAC9efz4E49W6pObDcF6//vbQqzdSJr/yXj0jKaxJuPKzGQubvnVc19m1e+l7Pycq8YWg
+        eLeLanM3IONPfvGimH70S74fGdQtaVExu4KtNjWumhm12t3/9MHDvd0H9/fcmzd1o4Nj6ZU3bhAN
+        o8Qu5zMSpzq7yC/2m3rVvP3pX9SQIhjQaGh9t4vlmD6Vfr88P8/rTb1+xcrpdV5fUjt+hYWymdOf
+        G147yUjYSI+V8s7r3+urTa1398c7++P97edvXkv7m4h3whpF2lprMdwcKr1p0XxVF5f0x9nqeDYj
+        JvTZu/dWrP1xeRvlMbsmpQH+IwCg1vQbe3/TW4EA8CxBdfZh3ERcFYCGoGxq9rrNlrOsnv3+T1/v
+        cvtm/pSo/Hvl1y+zdr7pzbvzapHfFbN3d0zv3YXhq2rqcPb7v82vWe3SxwTqJ+WVYVjcVMTheDqt
+        COSm1sT32jiQnT6Q29JIXjrJpnN8v+GFV3k2+y7pY7YQ5jVyd7KCZuwmLQO0vfduQu5lnS+K9eL3
+        f/6KxYn0M2kCO/307XnxbtP7u+Ry4b+7e/vu/Rtx9LnvNb+Cly+Lul1npartr4PE7qd9OJteDBD5
+        yRenb/qv30RAnl16a1HN8OfZckoUJceM1BlJExQ3NA69QzJAM0oQ1tNpTs7sjL5viwWJQbYgm/+R
+        eI4P6H9v9nYe7Xz6aO9gfHD/3r37e5/+FDWdrWvVBR+9fHPvi/v3xw8e7D94uLP7mr4kVV7npLno
+        +zPY2Xv3Zvu7OzsPtyf37+9t78/yne2Hn+7c287y7MGD/P757qc7D+g1Rg9Gky006ZG8WZHVIwDO
+        iNq4gtrTbPDvoIm8439Cr4mLjuGjuVFfaLpcl+X3ycZ+n0aSr/LlLF9OOXggIPJB8yWNjf76OXAU
+        7BiD2KnDHMSjIQUIzRtAeC+ISHQZjmD+ktH/W4cM99IN4BsZMUCCBf5fOmAYPm8E38yQGShmmd75
+        fz2b36/y6eX8wf7+u09XmTeyb4QUIXCQ5P+dRJApc2P5RgYvQP/fy/w/+YU3gG9kxAQRc0wv/L+e
+        7QlVN5ZvbPD/r53rtj5vLn/w7u3bpijpwytvLN/I4Hvwf8QH/68cbneezn/RDKlV0+c3QoBoHz/i
+        h/9XDjf4g9Nii2zqDegboUDwh+0ERKnW7WpN71O0BfoMx1x3f6iEO6kWhFZ+V+PCLziApyEHAyGW
+        7uZONo1gf2d8cG+8++DhePc+XmWp2NAebbr5pU3tNSLmmJzIe4s3dna2d55u3zvevndve+/B9sFT
+        jmplSuw0O1F9f/L0XqToBwH2LdOzN74fJLE7MDjuGIagE/dSydTFwMuPDYLQ0eufHQCaWei9/Fpy
+        NHc1V6P5JHqZcjjyUSf19P1f8kv+HyMy5LhdHAAA
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
-      content-length: ['1663']
+      content-length: ['1626']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 03:00:46 GMT']
+      date: ['Thu, 07 Jul 2016 20:06:35 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -578,59 +517,59 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.32]
+          AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [02ad504f-3f38-11e6-ac3b-001dd8b7c0ad]
+      x-ms-client-request-id: [4f119821-447e-11e6-9eec-001dd8b7c0ad]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Compute/virtualMachines/vm-generalize/powerOff?api-version=2016-03-30
   response:
     body: {string: !!python/unicode ''}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/27c73916-18f8-4775-a0b5-1cda5fc2690f?api-version=2016-03-30']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/2e8edfd0-4979-48e7-b637-790eb656a59b?api-version=2016-03-30']
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Fri, 01 Jul 2016 03:00:47 GMT']
+      date: ['Thu, 07 Jul 2016 20:06:36 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/27c73916-18f8-4775-a0b5-1cda5fc2690f?monitor=true&api-version=2016-03-30']
+      location: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/2e8edfd0-4979-48e7-b637-790eb656a59b?monitor=true&api-version=2016-03-30']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1193']
     status: {code: 202, message: Accepted}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.32]
+          AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [02ad504f-3f38-11e6-ac3b-001dd8b7c0ad]
+      x-ms-client-request-id: [4f119821-447e-11e6-9eec-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/27c73916-18f8-4775-a0b5-1cda5fc2690f?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/2e8edfd0-4979-48e7-b637-790eb656a59b?api-version=2016-03-30
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H2zu7b3buPdrZebT/cLy7d/9g/96nn9BfOzsfjfilfDkbeGX3
-        0c698f2dnYN7D+4Hr1A/7brBG6/X02mez/KZfrPMFNKD6YN7Dwna7sH5wfb+gwf3t7Odyf3t3eks
-        u38+3fv04c75R79x8kv+H51MooC4AAAA
+        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H9L83ezuPdj59dO9gvPvpw4cP9vc+2aEPdj4a8Uv5cjb4yv2H
+        4/sPPt09uL8bvEL9tOsGb7xeT6d5Pstn+s0yU0j5QT47n+1s7z988HB7/yB/sD359N6D7QcPd/LJ
+        p/c/ze4/nHz0Gye/5P8B41uPY7gAAAA=
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 03:01:18 GMT']
+      date: ['Thu, 07 Jul 2016 20:07:06 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -642,15 +581,15 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.32]
+          AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [1543010f-3f38-11e6-bac3-001dd8b7c0ad]
+      x-ms-client-request-id: [619658f0-447e-11e6-8e15-001dd8b7c0ad]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Compute/virtualMachines/vm-generalize/generalize?api-version=2016-03-30
   response:
@@ -658,12 +597,12 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Fri, 01 Jul 2016 03:01:19 GMT']
+      date: ['Thu, 07 Jul 2016 20:07:07 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1193']
     status: {code: 200, message: OK}
 - request:
     body: '{"overwriteVhds": true, "destinationContainerName": "vhds", "vhdPrefix":
@@ -671,71 +610,71 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Length: ['82']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.32]
+          AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [1593920f-3f38-11e6-b918-001dd8b7c0ad]
+      x-ms-client-request-id: [61d92e4f-447e-11e6-8494-001dd8b7c0ad]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Compute/virtualMachines/vm-generalize/capture?api-version=2016-03-30
   response:
     body: {string: !!python/unicode ''}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/f6247f50-6b69-4225-b714-c3f84dbdea48?api-version=2016-03-30']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/3ed2ee26-14b5-4905-b200-301ad7485a46?api-version=2016-03-30']
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Fri, 01 Jul 2016 03:01:19 GMT']
+      date: ['Thu, 07 Jul 2016 20:07:07 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/f6247f50-6b69-4225-b714-c3f84dbdea48?monitor=true&api-version=2016-03-30']
+      location: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/providers/Microsoft.Compute/locations/westus/operations/3ed2ee26-14b5-4905-b200-301ad7485a46?monitor=true&api-version=2016-03-30']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 202, message: Accepted}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.32]
+          AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [1593920f-3f38-11e6-b918-001dd8b7c0ad]
+      x-ms-client-request-id: [61d92e4f-447e-11e6-8494-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/f6247f50-6b69-4225-b714-c3f84dbdea48?api-version=2016-03-30
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/operations/3ed2ee26-14b5-4905-b200-301ad7485a46?api-version=2016-03-30
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H2zu7b3buPdrZfbS3Mz54uLv/4MG9T3Z2Hu3sfDTil/LlbPiV
-        3fG9T3d29w8eBq9QP+26wRuv19Npns/ymX6zqqtVXrdFjm8ZKfqwWrerdWs++Oh3a6bzfJHR3x/N
-        23b16O5d+WC8yJbZRb7Il+04+8G6zsfTaqHfNXcJt/3tHfrf7vaqzi+L/OruT37x+5+9HP90Uy21
-        92m1bOntn8zrpqAPqYPd8Q7+0+9XWZ0t8pa+pu8YGfrwcvGCPnQf0Eft9Qof0DjrYnnxkXz+SxgG
-        fXu5eF38AN8PvqAt6YtZfp6ty/Yns3LNDV632XKW1bPf/+nr3S7cbLYoll81ef2e+PB7L7Omuarq
-        GTWLvJdPiZzxt5d5S++9PSPK1efZND8bABG8jB8C4SOCW63rKU/49/BJ6r2drQpvMmgKib3ubd/T
-        +cAT5Rg8H82JTFdZnb+sq/OiBBLet/S9nYaPvufmdetj+fjjO99XXPEIqvLQSKqa2GwIbNU8LZq3
-        3Y/5izdKi+fFcv3ODUGej5aEAr69XLRE6m2BM/50+un5/s5ssv1pPtnZ3gcFHk537m9/Oj14kD/M
-        7u3kuw/Hl3OVH/d8NK3zrM2/XLVKvGd1tThbEOK9lgV/2kOYvlnXBX3OUtaQmFE3OviL/aZeNW9/
-        +hc1xDXjSVlNSNZI4K6K5ay6asbEFHeb66bNF3e/KKZ11VTn7fikWpAY53cZi4ah3f2agw0x9acH
-        z0do8o2P53IB9ZAVy7zOHz54sHNvb7L98Hz/4fb+vezT7cn9h/vbe7t759Od7Dw/OM/v6phu0/Y2
-        Y5pm0zkkiPB/lWez79ZFmwfvsFDJ479MfDfEqqQeMSFGX3TlAB9DDjxg9BJrC2gZw6/BW8G3Ay97
-        qibysvkWL7t3gxHRbFCLt96wzEdWC5Ey+N4v/qigPsIuuu3OuJ9f8v0APqmUywJKh+hNCpfo/Cjd
-        Md+7llZigx4idLNKsC8Ll0XdrrPyC55cwtq9U1bTzMjuFckI2Uv5juf5+79xwj8FG4vJ+ad7+w/O
-        7+9sfzr5lJhtb+/+9uQB2b3pvfOD/dlklmf7BwTml/w/SfG7Ve8HAAA=
+        6UdNm9Xtm2KRf/Qo/WhvZ/fT7Z0H9L83ezuPdh482nk4/nTv3s7BwcNPduiDnY9G/FK+nA2+srsz
+        3nm4S//tB69QP+26wRuv19Npns/ymX6zqqtVXrdFjm8ZKfqwWrerdWs++Oh3a6bzfJHR3x/N23b1
+        6O5d+WC8yJbZRb7Il+04+8G6zsfTaqHfNXcJt/3tHfrf7vaqzi+L/OruT37x+5+9HP90Uy2192m1
+        bOntn8zrpqAPqYPdMY1gbPBeZXW2yFv6mr5jZOjDy8UL+tB9QB+11yt8QOOsi+XFR/L5L2EY9O3l
+        4nXxA3w/+IK2pC9m+Xm2LtufzMo1N3jdZstZVs9+/6evd7tws9miWH7V5PV74sPvvcya5qqqZ9Qs
+        8l4+JXLG317mLb339owoV59n0/xsAETwMn4IhI8IbrWupzzh38Mnqfd2tiq8yaApJPa6t31P5wNP
+        lGPwfDQnMl1ldf6yrs6LEkh439L3dho++p6b162P5eOP73xfccUjqMpDI6lqYrMhsFXztGjedj/m
+        L94oLZ4Xy/U7NwR5PloSCvj2ctESqbcFznjn/vmn091ptr3/6YMD+mdvf/vgwc7D7fPzB/fPJw8P
+        sr3JZHw5V/lxz0fTOs/a/MtVq8R7VleLswUh3mtZ8Kc9hOmbdV3Q5yxlDYkZdaODv9hv6lXz9qd/
+        UUNcM56U1YRkjQTuqljOqqtmTExxt7lu2nxx94tiWldNdd6OT6oFiXF+l7FoGNrdrznYEFN/evB8
+        hCbf+HguF1APWbHM6wcH9+7PDs6n2/d3Pz3f3s/2z7ez2cH+9t5uvjObzj6d3d//9K6O6TZtbzOm
+        aTadQ4II/1d5NvtuXbR58A4LlTz+y8R3Q6xK6hETYvRFVw7wMeTAA0YvsbaAljH8GrwVfDvwsqdq
+        Ii+bb/GyezcYEc0GtXjrDct8ZLUQKYPv/eKPCuoj7KLb7oz7+SXfD+CTSrksoHSI3qRwic6P0h3z
+        vWtpJTboIUI3qwT7snBZ1O06K7/gySWs3TtlNc2M7F6RjJC9lO94nr//Gyf8U7CxmNzLZ3t5vvfp
+        9u7+5P72/sOd+9uTvZ0d0pi72ezB/sH9bP9TAvNL/h8jERcF7wcAAA==
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 03:01:49 GMT']
+      date: ['Thu, 07 Jul 2016 20:07:38 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_scaleset_create_existing_options.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_scaleset_create_existing_options.yaml
@@ -1,51 +1,54 @@
 interactions:
 - request:
-    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateVNet/azuredeploy.json"},
-      "mode": "Incremental", "parameters": {"subnetName": {"value": "vrfsubnet"},
-      "virtualNetworkPrefix": {"value": "10.0.0.0/16"}, "virtualNetworkName": {"value":
-      "vrfvnet"}, "subnetPrefix": {"value": "10.0.0.0/24"}}}}'
+    body: !!binary |
+      eyJwcm9wZXJ0aWVzIjogeyJ0ZW1wbGF0ZUxpbmsiOiB7InVyaSI6ICJodHRwczovL2F6dXJlc2Rr
+      Y2kuYmxvYi5jb3JlLndpbmRvd3MubmV0L3RlbXBsYXRlaG9zdC9DcmVhdGVWTmV0L2F6dXJlZGVw
+      bG95Lmpzb24ifSwgInBhcmFtZXRlcnMiOiB7InN1Ym5ldE5hbWUiOiB7InZhbHVlIjogInZyZnN1
+      Ym5ldCJ9LCAidmlydHVhbE5ldHdvcmtOYW1lIjogeyJ2YWx1ZSI6ICJ2cmZ2bmV0In0sICJ2aXJ0
+      dWFsTmV0d29ya1ByZWZpeCI6IHsidmFsdWUiOiAiMTAuMC4wLjAvMTYifSwgInN1Ym5ldFByZWZp
+      eCI6IHsidmFsdWUiOiAiMTAuMC4wLjAvMjQifX0sICJtb2RlIjogIkluY3JlbWVudGFsIn19
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODQyMDg1LCJuYmYiOjE0Njc4NDIwODUsImV4cCI6MTQ2Nzg0NTk4NSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.Z2u8kAFY80MT1Bnb3VqQ2mkOohYGTbV1DT1--aeCXTkaSCSpmy4lSEhz0aO5iotrkbvOyjw0rMGGZiUCRMS_xletuxBim9UYLpzuAC5Ef0KvG8d7XAURuFQ8cQ7e0-w70EO4pzZJX84YovpNsUsSC8f0UmuVeEuYfPGIEvWUlSLW_1XmE1JQruGd3_li2XGYBjRqqpRLC2Uvic2Hg-V00-m8iUg7UI5ZdMwjJMh4MGNmPS6fau_yWU-EjANwA_iwtq9w7D5x6BhewhWwF-lMtRwG4L72CwAombkHhyaF0_0NLnuiYN9cifTcIWd3GoCWAYJ5nEQEH3oc85FT--ipGQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Length: ['339']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 resourcemanagementclient/2015-11-01 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [503f08c0-43c7-11e6-b811-001dd8b7c0ad]
+      x-ms-client-request-id: [e5b3d62c-447a-11e6-8840-001dd8b7c0ad]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_existing_options_rg2/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_existing_options_rg2/providers/Microsoft.Resources/deployments/azurecli1467843400.5281568","name":"azurecli1467843400.5281568","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVNet/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"virtualNetworkName":{"type":"String","value":"vrfvnet"},"virtualNetworkPrefix":{"type":"String","value":"10.0.0.0/16"},"subnetName":{"type":"String","value":"vrfsubnet"},"subnetPrefix":{"type":"String","value":"10.0.0.0/24"},"location":{"type":"String","value":"westus"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-06T22:16:41.8828105Z","duration":"PT0.211595S","correlationId":"7451b657-d0b5-43de-b7a4-54c05cd1597e","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]}]}],"dependencies":[]}}'}
+    body: {string: '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_existing_options_rg2/providers/Microsoft.Resources/deployments/azurecli1467920531.175594855043","name":"azurecli1467920531.175594855043","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVNet/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"virtualNetworkName":{"type":"String","value":"vrfvnet"},"virtualNetworkPrefix":{"type":"String","value":"10.0.0.0/16"},"subnetName":{"type":"String","value":"vrfsubnet"},"subnetPrefix":{"type":"String","value":"10.0.0.0/24"},"location":{"type":"String","value":"westus"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-07T19:42:14.2881819Z","duration":"PT0.229198S","correlationId":"d05504da-67c7-4f26-93de-cde8a4386d11","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]}]}],"dependencies":[]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/scaleset_create_existing_options_rg2/providers/Microsoft.Resources/deployments/azurecli1467843400.5281568/operationStatuses/08587337634838064174?api-version=2015-11-01']
-      cache-control: [no-cache]
-      content-length: ['970']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 22:16:40 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/scaleset_create_existing_options_rg2/providers/Microsoft.Resources/deployments/azurecli1467920531.175594855043/operationStatuses/08587336863514186545?api-version=2015-11-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['980']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:42:13 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1194']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODQyMDg1LCJuYmYiOjE0Njc4NDIwODUsImV4cCI6MTQ2Nzg0NTk4NSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.Z2u8kAFY80MT1Bnb3VqQ2mkOohYGTbV1DT1--aeCXTkaSCSpmy4lSEhz0aO5iotrkbvOyjw0rMGGZiUCRMS_xletuxBim9UYLpzuAC5Ef0KvG8d7XAURuFQ8cQ7e0-w70EO4pzZJX84YovpNsUsSC8f0UmuVeEuYfPGIEvWUlSLW_1XmE1JQruGd3_li2XGYBjRqqpRLC2Uvic2Hg-V00-m8iUg7UI5ZdMwjJMh4MGNmPS6fau_yWU-EjANwA_iwtq9w7D5x6BhewhWwF-lMtRwG4L72CwAombkHhyaF0_0NLnuiYN9cifTcIWd3GoCWAYJ5nEQEH3oc85FT--ipGQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 resourcemanagementclient/2015-11-01 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [503f08c0-43c7-11e6-b811-001dd8b7c0ad]
+      x-ms-client-request-id: [e5b3d62c-447a-11e6-8840-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_existing_options_rg2/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337634838064174?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_existing_options_rg2/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863514186545?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -53,29 +56,29 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['141']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 22:17:11 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['141']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:42:44 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODQyMDg1LCJuYmYiOjE0Njc4NDIwODUsImV4cCI6MTQ2Nzg0NTk4NSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.Z2u8kAFY80MT1Bnb3VqQ2mkOohYGTbV1DT1--aeCXTkaSCSpmy4lSEhz0aO5iotrkbvOyjw0rMGGZiUCRMS_xletuxBim9UYLpzuAC5Ef0KvG8d7XAURuFQ8cQ7e0-w70EO4pzZJX84YovpNsUsSC8f0UmuVeEuYfPGIEvWUlSLW_1XmE1JQruGd3_li2XGYBjRqqpRLC2Uvic2Hg-V00-m8iUg7UI5ZdMwjJMh4MGNmPS6fau_yWU-EjANwA_iwtq9w7D5x6BhewhWwF-lMtRwG4L72CwAombkHhyaF0_0NLnuiYN9cifTcIWd3GoCWAYJ5nEQEH3oc85FT--ipGQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 resourcemanagementclient/2015-11-01 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [503f08c0-43c7-11e6-b811-001dd8b7c0ad]
+      x-ms-client-request-id: [e5b3d62c-447a-11e6-8840-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_existing_options_rg2/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
@@ -85,77 +88,82 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
         o0cf3W3Wk2ZaF6u2qJbN3Xs7+/nBw4efbj94cD7Z3v80P9ieZLNs+/79B5/u7N5/uD/J9+/WeVOt
         62n+eV2tV83dZpqVeZO3v/+0zrM2//3zd0XTFsuL378SoL9/fbF3d1VXl8Usr5u7XxTTumqq83b8
-        SuE0d2f5qqyuF/mybe5mP1jX+bQsdvc/fXCwf29/Z2d8f+9g9/6nBx+NPlpmi5yw3tiGulrldVvk
-        zUePfvFHbb5YlYTW82L5Fn+v64IAzNt21Ty6K501s7fTYjwpq8l4WtX5+KpYzqqrZrzM27vm9XnV
-        tHdPeIA/+YI+5xcF7fFPN9WS+p1Wy5ZG8JM0SBo2dbI73sF/H/0SwimrCfOWvgIOl0XdrrOS4FxV
-        9dsX9A0+ba9X9POj121NxCN4l1m5xgeX9fkloQIw4Ysv6/y8eLfp1V3qHv/d3f0Ur9NcE6Bb9CcN
-        3Svv0dPePl4rq2mGyd/0ylXetOvmo19CzRfVDJ+cLYmFwAVZSe1oHi8LkJJee90S4anF6/V0mhPd
-        Z/R9WywIQrZY0ed7O7ufbu882N759M3e3qPdB492dscHn97b2d19+FPUdLauFZ2PXr7Z2xnvPtx9
-        8PDT/df0Fc14ndMM07dnEIgH+/d3J5/ef7A925nc396/N8u3Jw+y/e37+9Od+9MZycCDnF5j5MDP
-        Hz363i9mtmxW2RQoOv7WaaLWxGPM6W+IFPKG/wm9FE5sQ68YCqK5IdX3fwn9R6PJV/lyli+nzOLf
-        o0+qdbtat/QHoZJfgUHxqxL+y8lP59OWQCrhf7Egv4GyBrnP16wjdqb5wYzosp1NJg+393fv729P
-        dvY+3c7vnU8mu/n5pw8nn9Jb2WxGLzavhQ6/2PwtvMOYOi4hfvw+zbtwF74ixDOwpcd9o4+497v0
-        58+VhiJCYj7udqbnLiEJkbxLqNEP/lt+JaTzNrsgtL979/f96OHDe5O9vUm2fb4/mW3v78/Otx/u
-        Z7vb+YP92cFkP3uYZw9/34/oHerbU1n018bpCQhL31mqQvaIRSBRwhFWwzKFmZy3HtxHgPT/AGpI
-        +20mBgAA
+        SuE0d2f5qqyuF/mybe5mP1jX+bQsdvc/ffBwb+f+vd3x7oP71PXB/fs7+/c+Gn20zBY5oX5zQ+p0
+        lddtkTcfPfrFH7X5YlUSgs+L5Vv8va4LgjJv21Xz6K5028zeTovxpKwm42lV5+OrYjmrrprxMm/v
+        mtfnVdPePeGh/uQL+pxflAGMf7qpltTvtFq2NJafpOESAaiT3fEO/vvolxBOWU3ot/QVcLgs6nad
+        lQTnqqrfvqBv8Gl7vaKfH71uayIjwbvMyjU+uKzPLwkVgAlffFnn58W7Ta/uUvf47+7up3idZp0A
+        3aI/aeheeY+e9vbxWllNM7DBpleu8qZdNx/9Emq+qGb45GxJzAR+yEpqR/N4WYCU9NrrlghPLV6v
+        p9Oc6D6j79tiQRCyxYo+39vZ/XR75wH9783uw0f7e4/u7Y0/Pdi7v3P/4Keo6WxdKzofvXyzezD+
+        dO/e/b3dh6/pK5rxOqcZpm/PIBqzHfARMf+nD6YPtvfP9z7dfnhvlm9PZ/lBtn/v4NPZ7i69xsiB
+        sz969L1fzLzZrLIpUHScrtNErYnHmOffECnkDf8Teimc2IZeMRREc0Oq7/8S+o9Gk6/y5SxfTpnF
+        v0efVOt2tW7pD0IlvwKD4lcl/JeTn86nLYFUwv9iQX4DZQ1yn69ZWxxkn+4dTHZJH+yd72zv398/
+        3364d/Bwe39n79NP9+7n+fnefXorm83oxea10OEXm7+FdxhTxyXEj9+neRfuwleEeAa29Lhv9BH3
+        fpf+/LnSVURIzMfdzvTcJSQhkncJNfrBf8uvhHTeZheE9nfv/r4f7T0kjHY/3dueTif3iZcOdsBL
+        D7bvZ5MdYq9P72Wzh7/vR/QO9e2pLPpr4/QEhKXvLFUhe8QikCjhCKtrmcJMzlsP7iNA+n8ANbLg
+        tjAGAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['918']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 22:17:12 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['917']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:42:44 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-06-20/azuredeploy.json"},
-      "mode": "Incremental", "parameters": {"dnsNameType": {"value": "none"}, "publicIpAddressAllocation":
-      {"value": "dynamic"}, "loadBalancerName": {"value": "vrflb"}, "privateIpAddressAllocation":
-      {"value": "dynamic"}, "_artifactsLocation": {"value": "https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-06-20"},
-      "vnetAddressPrefix": {"value": "10.0.0.0/16"}, "subnetAddressPrefix": {"value":
-      "10.0.0.0/24"}}}}'
+    body: !!binary |
+      eyJwcm9wZXJ0aWVzIjogeyJ0ZW1wbGF0ZUxpbmsiOiB7InVyaSI6ICJodHRwczovL2F6dXJlc2Rr
+      Y2kuYmxvYi5jb3JlLndpbmRvd3MubmV0L3RlbXBsYXRlaG9zdC9DcmVhdGVMYl8yMDE2LTA2LTIw
+      L2F6dXJlZGVwbG95Lmpzb24ifSwgInBhcmFtZXRlcnMiOiB7ImRuc05hbWVUeXBlIjogeyJ2YWx1
+      ZSI6ICJub25lIn0sICJwcml2YXRlSXBBZGRyZXNzQWxsb2NhdGlvbiI6IHsidmFsdWUiOiAiZHlu
+      YW1pYyJ9LCAiX2FydGlmYWN0c0xvY2F0aW9uIjogeyJ2YWx1ZSI6ICJodHRwczovL2F6dXJlc2Rr
+      Y2kuYmxvYi5jb3JlLndpbmRvd3MubmV0L3RlbXBsYXRlaG9zdC9DcmVhdGVMYl8yMDE2LTA2LTIw
+      In0sICJsb2FkQmFsYW5jZXJOYW1lIjogeyJ2YWx1ZSI6ICJ2cmZsYiJ9LCAicHVibGljSXBBZGRy
+      ZXNzQWxsb2NhdGlvbiI6IHsidmFsdWUiOiAiZHluYW1pYyJ9LCAidm5ldEFkZHJlc3NQcmVmaXgi
+      OiB7InZhbHVlIjogIjEwLjAuMC4wLzE2In0sICJzdWJuZXRBZGRyZXNzUHJlZml4IjogeyJ2YWx1
+      ZSI6ICIxMC4wLjAuMC8yNCJ9fSwgIm1vZGUiOiAiSW5jcmVtZW50YWwifX0=
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODQyMDg1LCJuYmYiOjE0Njc4NDIwODUsImV4cCI6MTQ2Nzg0NTk4NSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.Z2u8kAFY80MT1Bnb3VqQ2mkOohYGTbV1DT1--aeCXTkaSCSpmy4lSEhz0aO5iotrkbvOyjw0rMGGZiUCRMS_xletuxBim9UYLpzuAC5Ef0KvG8d7XAURuFQ8cQ7e0-w70EO4pzZJX84YovpNsUsSC8f0UmuVeEuYfPGIEvWUlSLW_1XmE1JQruGd3_li2XGYBjRqqpRLC2Uvic2Hg-V00-m8iUg7UI5ZdMwjJMh4MGNmPS6fau_yWU-EjANwA_iwtq9w7D5x6BhewhWwF-lMtRwG4L72CwAombkHhyaF0_0NLnuiYN9cifTcIWd3GoCWAYJ5nEQEH3oc85FT--ipGQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Length: ['557']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 lbcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [63644f4f-43c7-11e6-ab64-001dd8b7c0ad]
+      x-ms-client-request-id: [fa09d128-447a-11e6-ae41-001dd8b7c0ad]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_existing_options_rg2/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_existing_options_rg2/providers/Microsoft.Resources/deployments/azurecli1467843432.6477207","name":"azurecli1467843432.6477207","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-06-20/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-06-20"},"backendPoolName":{"type":"String","value":"vrflbbepool"},"dnsNameType":{"type":"String","value":"none"},"loadBalancerName":{"type":"String","value":"vrflb"},"location":{"type":"String","value":"westus"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddress":{"type":"String","value":"PublicIPvrflb"},"publicIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddressType":{"type":"String","value":"new"},"publicIpDnsName":{"type":"String","value":""},"subnet":{"type":"String","value":""},"subnetAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetType":{"type":"String","value":"none"},"virtualNetworkName":{"type":"String","value":""},"vnetAddressPrefix":{"type":"String","value":"10.0.0.0/16"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-06T22:17:13.5917861Z","duration":"PT0.2384996S","correlationId":"a9c17800-90cc-4279-9da1-55ee08621862","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_existing_options_rg2/providers/Microsoft.Resources/deployments/IPvrflb","resourceType":"Microsoft.Resources/deployments","resourceName":"IPvrflb"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_existing_options_rg2/providers/Microsoft.Resources/deployments/Subnetvrflb","resourceType":"Microsoft.Resources/deployments","resourceName":"Subnetvrflb"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_existing_options_rg2/providers/Microsoft.Network/loadBalancers/vrflb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vrflb"}]}}'}
+    body: {string: '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_existing_options_rg2/providers/Microsoft.Resources/deployments/azurecli1467920565.293505778636","name":"azurecli1467920565.293505778636","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-06-20/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-06-20"},"backendPoolName":{"type":"String","value":"vrflbbepool"},"dnsNameType":{"type":"String","value":"none"},"loadBalancerName":{"type":"String","value":"vrflb"},"location":{"type":"String","value":"westus"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddress":{"type":"String","value":"PublicIPvrflb"},"publicIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddressType":{"type":"String","value":"new"},"publicIpDnsName":{"type":"String","value":""},"subnet":{"type":"String","value":""},"subnetAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetType":{"type":"String","value":"none"},"virtualNetworkName":{"type":"String","value":""},"vnetAddressPrefix":{"type":"String","value":"10.0.0.0/16"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-07T19:42:46.1278024Z","duration":"PT0.1882781S","correlationId":"9941e69b-f69c-465d-8a99-37b79b7065af","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_existing_options_rg2/providers/Microsoft.Resources/deployments/IPvrflb","resourceType":"Microsoft.Resources/deployments","resourceName":"IPvrflb"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_existing_options_rg2/providers/Microsoft.Resources/deployments/Subnetvrflb","resourceType":"Microsoft.Resources/deployments","resourceName":"Subnetvrflb"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_existing_options_rg2/providers/Microsoft.Network/loadBalancers/vrflb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vrflb"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/scaleset_create_existing_options_rg2/providers/Microsoft.Resources/deployments/azurecli1467843432.6477207/operationStatuses/08587337634521243674?api-version=2015-11-01']
-      cache-control: [no-cache]
-      content-length: ['2459']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 22:17:12 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/scaleset_create_existing_options_rg2/providers/Microsoft.Resources/deployments/azurecli1467920565.293505778636/operationStatuses/08587336863195381326?api-version=2015-11-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['2469']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:42:46 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODQyMDg1LCJuYmYiOjE0Njc4NDIwODUsImV4cCI6MTQ2Nzg0NTk4NSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.Z2u8kAFY80MT1Bnb3VqQ2mkOohYGTbV1DT1--aeCXTkaSCSpmy4lSEhz0aO5iotrkbvOyjw0rMGGZiUCRMS_xletuxBim9UYLpzuAC5Ef0KvG8d7XAURuFQ8cQ7e0-w70EO4pzZJX84YovpNsUsSC8f0UmuVeEuYfPGIEvWUlSLW_1XmE1JQruGd3_li2XGYBjRqqpRLC2Uvic2Hg-V00-m8iUg7UI5ZdMwjJMh4MGNmPS6fau_yWU-EjANwA_iwtq9w7D5x6BhewhWwF-lMtRwG4L72CwAombkHhyaF0_0NLnuiYN9cifTcIWd3GoCWAYJ5nEQEH3oc85FT--ipGQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 lbcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [63644f4f-43c7-11e6-ab64-001dd8b7c0ad]
+      x-ms-client-request-id: [fa09d128-447a-11e6-ae41-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_existing_options_rg2/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337634521243674?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_existing_options_rg2/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863195381326?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -163,28 +171,28 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['141']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 22:17:44 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['141']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:43:16 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODQyMDg1LCJuYmYiOjE0Njc4NDIwODUsImV4cCI6MTQ2Nzg0NTk4NSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.Z2u8kAFY80MT1Bnb3VqQ2mkOohYGTbV1DT1--aeCXTkaSCSpmy4lSEhz0aO5iotrkbvOyjw0rMGGZiUCRMS_xletuxBim9UYLpzuAC5Ef0KvG8d7XAURuFQ8cQ7e0-w70EO4pzZJX84YovpNsUsSC8f0UmuVeEuYfPGIEvWUlSLW_1XmE1JQruGd3_li2XGYBjRqqpRLC2Uvic2Hg-V00-m8iUg7UI5ZdMwjJMh4MGNmPS6fau_yWU-EjANwA_iwtq9w7D5x6BhewhWwF-lMtRwG4L72CwAombkHhyaF0_0NLnuiYN9cifTcIWd3GoCWAYJ5nEQEH3oc85FT--ipGQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 lbcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [63644f4f-43c7-11e6-ab64-001dd8b7c0ad]
+      x-ms-client-request-id: [fa09d128-447a-11e6-ae41-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_existing_options_rg2/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
@@ -194,33 +202,33 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
         o0cf3W3Wk2ZaF6u2qJbN3Xs7+/nBw4efbj94cD7Z3v80P9ieZLNs+/79B5/u7N5/uD/J9+/WeVOt
         62n+eV2tV83dZpqVeZO3v/+0zrM2//3zd0XTFsuL378SoL9/fbF3d1VXl8Usr5u7XxTTumqq83b8
-        SuE0d2f5qqyuF/mybe5mP1jX+bQsdvc/fXCwf2//3t740/0HD/Z2Hnw0+miZLXLCemMb6mqV122R
-        Nx89+sUftfliVRJaz4vlW/y9rgsCMG/bVfPornTWzN5Oi/GkrCbjaVXn46tiOauumvEyb++a1+dV
-        09494QE+n/z+ezu7n27vfLq9tyMQBP/xTzfVkhCYVsuWhvKTNFoaP/W2O97Bfx/9EkIuq2kILX0F
-        ZH7/jPA8z6Zt87yaZqAWPm2vVxjk67YmKhK8y6xc44NvDGkgMsmmb/Pl7GVVlS8yEHW438v6vJxM
-        8hU1xZuzZYM33nDr4beW1TJH87LKZk+yMltO8xrvbXqHe5KXbibHVd606watV3VxSWM8Wx3PZkQZ
-        Ju3QW7H2x+Vt+ptdE/cVUwawnpTF1L6/6a2X0vSlHVrn3Q/t+8ZpyK/8t57K5G16A81JKxAj3a6V
-        IvKyzs+Ld5te2SUZwH939/bd2zfir2x0WdTtOitf5O1VVb+9zRguCfr747b76Ue/hF5eVDN8fLYk
-        pQa9lJXUmDTLZQGZpndft8RB1OL1ejrNSQHM6Pu2WBBPZosVfS7S9oAE7s3e3qPdB4/ufTq+9/Dg
-        3oO9n6KWs3Wtc/7Ryzd798Y7+/d3Du7ff01fkTTXOUkvfXsGDZ09nO4+ONjZ2X64M51u7+89eLj9
-        cJbtkkrO852DT/d26f/0GuMGBfvRo+/9YtaTzSqbAkOncJV41JqIwqoX1Jc3/E/oJV9qG3rBMCka
-        G8n7/i/5/i8ZDfVllTu97MMGgF5voj9BZzT3+1quyxL9fJ9olq9IYeXLKWt2AiIfNF8SFemv/5ea
-        MyP5IRUI1Rte9F4QZv/IQALN/1862Ncs0oKmw//rDtiHBgb4OR+0ys/dQDjuCoIO+95wo695L+hw
-        BQ4GWq3b1bolJv/FJAvuHfyt+uvLyU/n05ZgqP76xSL/G3ST6ezzNZPx4MH5zu75/fPt7N5sf3v/
-        4afT7cnu3t72wcH0YHp/b7L38By+1HnNvszs7OVJtTwvLlRtEWokcRB8AvXcQ/EZ2p8u0SF3c/f/
-        nbN1d2hcdwcGk7fZBQ3nu3d/348O9u/v5Q/2P92+N81JHxPO29nk/nT74OHubOc+je78YO/3/Yje
-        IZw8P5T+2jg/xid56RyCL/J2XoGKT9X6Uysx4y/VrgHw/2vo3MEtb+52fJ9fAt5Wv1Mbwf2kUThm
-        4qbqa/6/nIciI5FvLPo/21zDBHWoUZtXaxon0ZM+p1cn5vdiOanWy9mLrPUakJaJfOqa8ojwIU0c
-        tyadZDU3fa6sdytiOaPVb34j33z/l/yS/weF2tN5rg4AAA==
+        SuE0d2f5qqyuF/mybe5mP1jX+bQsdvc/ffBwb+f+p/fHew/v3d+5/+DBwaf3Pv1o9NEyW+SE+s0N
+        qdNVXrdF3nz06Bd/1OaLVUkIPi+Wb/H3ui4IyrxtV82ju9JtM3s7LcaTspqMp1Wdj6+K5ay6asbL
+        vL1rXp9XTXv3hIf6fPL77+3sfrq98+n23o5AkJGMf7qploTAtFq2NKifpHETJai33fEO/vvolxBy
+        WU3jaOkrIPP7Z4TneTZtm+fVNAPd8Gl7vcJIX7c10ZPgXWblGh98Y0gDkUk2fZsvZy+rqnyRgbLD
+        /V7W5+Vkkq+oKd6cLRu88YZbD7+1rJY5mpdVNnuSldlymtd4b9M73JO8dDM5rvKmXTdovaqLSxrj
+        2ep4NiPKMGmH3oq1Py5v09/smliwmDKA9aQspvb9TW+9lKYv7dA6735o3zdOQ37lv/VUJm/TG2hO
+        +oEY6XatFJGXdX5evNv0yi7JAP67u7fv3r4Rf2Wjy6Ju11n5Im+vqvrtbcZwSdDfH7fdTz/6JfTy
+        oprh47MlqTdoqKykxqRZLgvINL37uiUOohav19NpTgpgRt+3xYJ4Mlus6HORtgf0vze7Dx/t33u0
+        uz++t3Pv3v3d/Z+iprN1rZP+0cs3ewfje5/eO9h7sPuaviJxrnMSX/r2DMr64cP93fzTh5Pt808f
+        Tkk7359tH2QPH27fezB58HDyYOfT+9k5vcbIQdd+9Oh7v5i1ZbPKpkDR6V6lHrUmqrAWBvnlDf8T
+        eskX24ZeMFyKxkb0vv9Lvv9LRkN9WT1PL/uwAaDXmyhQEBrN/b6W67JEP98nmuUr0lj5csqqnYDI
+        B82XREX66/+lls2IfkgFQvWGF70XhNs/MpBA8/+XDvY1y7Sg6fD/ugP2oYEBfs4HrfJzNxCOu4Kg
+        w7433Ohr3gs6XIGDgVbrdrVuicl/McmCewd/qwL7cvLT+bQlGKrAfrHI/wblZDr7fM1k/HR3spfv
+        Tva3dx/mRLe9e7vb2aez3e17E6Lb/uzB7OGDh/TWec3OzOzs5Um1PC8uVG0RaiRxEHwC9dxD8Rna
+        ny7RIXdz9/+ds3V3aFx3BwaTt9kFDee7d3/fjyazPLt//3x/e3/3/AFR7uHO9sHBwYPt3Xwnm01o
+        TPf2P/19P6J3CCfPEaW/Ns6PcUpeOo/gi7ydV6DiUzX/1Ers+Es1bAD8/xo6d3DLm7sd5+eXgLfV
+        8dRG8D9pFI6ZuKk6m/8v56HISOQbi/7PNtcwQR1q1ObVmsZJ9KTP6dWJ+b1YTqr1cvYia70GpGUi
+        n7qmPCJ8SBPHrUknWc1Nnyvr3YpYzmj1m9/IN9//Jb/k/wFfLUpruQ4AAA==
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['1231']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 22:17:44 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['1240']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:43:16 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_scaleset_create_options.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_scaleset_create_options.yaml
@@ -1,51 +1,56 @@
 interactions:
 - request:
-    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreatePublicIp_2016-06-06/azuredeploy.json"},
-      "mode": "Incremental", "parameters": {"allocationMethod": {"value": "dynamic"},
-      "publicIpAddressType": {"value": "noDns"}, "name": {"value": "vrfpubip"}, "_artifactsLocation":
-      {"value": "https://azuresdkci.blob.core.windows.net/templatehost/Createpublic_ip_2016-06-06"}}}}'
+    body: !!binary |
+      eyJwcm9wZXJ0aWVzIjogeyJtb2RlIjogIkluY3JlbWVudGFsIiwgInBhcmFtZXRlcnMiOiB7Il9h
+      cnRpZmFjdHNMb2NhdGlvbiI6IHsidmFsdWUiOiAiaHR0cHM6Ly9henVyZXNka2NpLmJsb2IuY29y
+      ZS53aW5kb3dzLm5ldC90ZW1wbGF0ZWhvc3QvQ3JlYXRlcHVibGljX2lwXzIwMTYtMDYtMDYifSwg
+      InB1YmxpY0lwQWRkcmVzc1R5cGUiOiB7InZhbHVlIjogIm5vRG5zIn0sICJuYW1lIjogeyJ2YWx1
+      ZSI6ICJ2cmZwdWJpcCJ9LCAiYWxsb2NhdGlvbk1ldGhvZCI6IHsidmFsdWUiOiAiZHluYW1pYyJ9
+      fSwgInRlbXBsYXRlTGluayI6IHsidXJpIjogImh0dHBzOi8vYXp1cmVzZGtjaS5ibG9iLmNvcmUu
+      d2luZG93cy5uZXQvdGVtcGxhdGVob3N0L0NyZWF0ZVB1YmxpY0lwXzIwMTYtMDYtMDYvYXp1cmVk
+      ZXBsb3kuanNvbiJ9fX0=
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI2MTE1LCJuYmYiOjE0Njc4MjYxMTUsImV4cCI6MTQ2NzgzMDAxNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.BsXPjbpDDitiOiqCh89LqEkRNwGth9IsXslnNhFEHJBysUJjzEBeOZaEwQCAZtLOO2DLZkoTvDZ2ddXEfZ3XNXS4wSAj2Hf0L0-d3gbP7mvzGpcZIsAH4eUlfX8LoGuQt4MyBNPH1pfTfNJYTMOFAsnsy3vPjr6qVj8butsv2XpDhPrDGRTE7WrgCBF-I7OfWqeiej_zc3ZKEXneOgxc6IbWGBqmUfM8SyLh48O2a_hoEs1KciA4AKt77zbsCbqrnbHdNadvVTDvkM-ToYNzgjWXp6kcW13cwS_roFV3Afz3YNB61ICCYog45D3uATmoKVE9BCZkrwCGrljteh9djw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Length: ['413']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 publicipcreationclient/2015-11-01 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [69651351-43a7-11e6-b86d-001dd8b7c0ad]
+      x-ms-client-request-id: [e7351cc6-447a-11e6-aec2-001dd8b7c0ad]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/azurecli1467829698.8145669","name":"azurecli1467829698.8145669","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreatePublicIp_2016-06-06/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/Createpublic_ip_2016-06-06"},"allocationMethod":{"type":"String","value":"dynamic"},"dnsName":{"type":"String","value":""},"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"vrfpubip"},"publicIpAddressType":{"type":"String","value":"noDns"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-06T18:28:19.8307654Z","duration":"PT0.2151484S","correlationId":"afa1a1eb-e5e8-4149-8b5c-4401e34cbee0","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]}]}],"dependencies":[]}}'}
+    body: {string: '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/azurecli1467920533.701532695458","name":"azurecli1467920533.701532695458","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreatePublicIp_2016-06-06/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/Createpublic_ip_2016-06-06"},"allocationMethod":{"type":"String","value":"dynamic"},"dnsName":{"type":"String","value":""},"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"vrfpubip"},"publicIpAddressType":{"type":"String","value":"noDns"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-07T19:42:17.2816758Z","duration":"PT1.3740972S","correlationId":"783dcfd0-6a96-40d5-8f88-db70f9819794","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]}]}],"dependencies":[]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/azurecli1467829698.8145669/operationStatuses/08587337771858620129?api-version=2015-11-01']
-      cache-control: [no-cache]
-      content-length: ['1076']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:28:19 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/azurecli1467920533.701532695458/operationStatuses/08587336863495700792?api-version=2015-11-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['1086']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:42:16 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1193']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 publicipcreationclient/2015-11-01 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [69651351-43a7-11e6-b86d-001dd8b7c0ad]
+      x-ms-client-request-id: [e7351cc6-447a-11e6-aec2-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771858620129?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863495700792?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -53,29 +58,29 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['141']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:28:50 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['141']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:42:46 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 publicipcreationclient/2015-11-01 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [69651351-43a7-11e6-b86d-001dd8b7c0ad]
+      x-ms-client-request-id: [e7351cc6-447a-11e6-aec2-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
@@ -85,39 +90,39 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
         o0cf3W3Wk2ZaF6u2qJbN3Xs7+/nBw4efbj94cD7Z3v80P9ieZLNs+/79B5/u7N5/uD/J9+/WeVOt
         62n+eV2tV83dZpqVeZO3v/+0zrM2//0rgfX71xd3V3V1Wczyurn7RTGtq6Y6b8ev9O3m7ixfldX1
-        Il+2zd3sB+s6n5bF7v6nDw72Hn768GB8sLt//9NPH340+miZLXLCdWMb6mqV122RNx89+sUftfli
-        VRIyz4vlW/y9rgsCMG/bVfPornTWzN5Oi/GkrCbjaVXn46tiOauumvEyb++a1+dV09494WG9XE/K
-        Ynq2+v33dnY/3d7B/wSOjGL80021JDSm1bKlAf0kjZmIQH3ujnfw30e/hFDMahpIS18Bpd8/I2zP
-        s2nbPK+mGUiGT9vrFYb6uq2L5QXBu8zKNT74ENRXjPrvX/i4A5+sLLXnL/J2XhE7DPc/u6ZJKKZ4
-        bbZsXmSYkOHWaGZgb2p3lTftukFrgk4fDLe8rM9pGMUKbekXGs/Z6ng2I1o0b/iV4VeX1dMl9UEv
-        LqoZPjhbEqeC7bKSmhHjXBaYLHrrdUvkohav19NpTjM7o+/bYkFYZosVfS70e0D0e7N78Gjv4NG9
-        h+MHJBoH9w9+iprO1rUO+aOXb/Z2xrv7ezufHhy8pq9onuqc5oW+PSNCf5SdZ7vZbj7Zzu+TjO3v
-        7j/cPpjcn27v7+/s5vf2p5M836HXGDkI0EePvveLmUjNKpsCRSdQL/L2qqrfUmuiBosWKCJv+J/Q
-        S0q5l0o5auTmCS+YCfn+L6H/aDz5Kl/O8uWUpep79Em1blfrlv74xQYWkcWS/svJT+fTlmAq6akR
-        8N9AXMKC8ft8zdpoOpllD+/vTrbP7+/k2/vnpIMOZnuT7QeTaXZvdnDwcO+AZV26fnncY+CPniqf
-        jj4qZmX+huaOUD5bflEs1y0Gsf9LwAj0GQ3DaiIam6rDHlXv2r4Mye46Vvz+L/kl/w9N4ZpGRwUA
-        AA==
+        Il+2zd3sB+s6n5bF7v6nDx7u7dy/d2/8gDq8t/fpw/v79w8+Gn20zBY5IXxzQ+p0lddtkTcfPfrF
+        H7X5YlUSWs+L5Vv8va4LgjJv21Xz6K5028zeTovxpKwm42lV5+OrYjmrrprxMm/vmtfnVdPePeEB
+        vlxPymJ6tvr993Z2P93ewf8Ejoxn/NNNtSQ0ptWypaH9JI2eyEF97o538N9Hv4RQzGoaTUtfAaXf
+        PyNsz7Np2zyvphmIh0/b6xXG+7qti+UFwbvMyjU++BDUV4z671/4uAOfrCy15y/ydl4RYwz3P7um
+        mSimeG22bF5kmJXh1mhmYG9qd5U37bpBa4JOHwy3vKzPaRjFCm3pFxrP2ep4NiNaNG/4leFXl9XT
+        JfVBLy6qGT44WxLPggGzkpoR41wWmCx663VL5KIWr9fTaU4zO6Pv22JBWGaLFX0u9HtA/3uz+/DR
+        /t6je/fH9+7v3T/YOfgpajpb1zrkj15Sg/H+/v2dnb291/QVzVOd07zQt2dE6I8eHNybTc9nO9uf
+        ZiR3+zuz+9sH5wcH27PJg53zhwe7Dx883KfXGDmI0kePvveLmUjNKpsCRSdaL/L2qqrfUmuiBgsZ
+        KCJv+J/QS0q5l0o5auTmCS+YCfn+L6H/aDz5Kl/O8uWUpep79Em1blfrlv74xQYWkcWS/svJT+fT
+        lmAq6akR8N9AXMKC8ft8zXppP3v48P7DPSLI/Qe72/vTbLZ9MMl2th/sPNx/cEC03Mkf0lva9cvj
+        HgN/9FT5dPRRMSvzNzR3hPLZ8otiuW4xiP1fAkagz2gYVifR2FQx9qh61/ZlSHbXseL3f8kv+X8A
+        np+KB1EFAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['856']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:28:51 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['863']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:42:47 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [close]
       Host: [raw.githubusercontent.com]
-      User-Agent: [Python-urllib/2.7]
+      User-Agent: [Python-urllib/3.5]
     method: GET
     uri: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json
   response:
-    body: {string: !!python/unicode "{\n  \"$schema\":\"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json\"\
+    body: {string: "{\n  \"$schema\":\"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json\"\
         ,\n  \"contentVersion\":\"1.0.0.0\",\n  \"parameters\":{},\n  \"variables\"\
         :{},\n  \"resources\":[],\n\n  \"outputs\":{\n    \"aliases\":{\n      \"\
         metadata\":{\n        \"description\":\"This list of aliases is used by Azure\
@@ -154,45 +159,45 @@ interactions:
         \     \"version\":\"latest\"\n          }\n        }\n      }\n    }\n  }\n\
         }\n"}
     headers:
-      accept-ranges: [bytes]
-      access-control-allow-origin: ['*']
-      cache-control: [max-age=300]
-      connection: [close]
-      content-length: ['2297']
-      content-security-policy: [default-src 'none'; style-src 'unsafe-inline']
-      content-type: [text/plain; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:28:52 GMT']
-      etag: ['"db78eb36618a060181b32ac2de91b1733f382e01"']
-      expires: ['Wed, 06 Jul 2016 18:33:52 GMT']
-      source-age: ['0']
-      strict-transport-security: [max-age=31536000]
-      vary: ['Authorization,Accept-Encoding']
-      via: [1.1 varnish]
-      x-cache: [MISS]
-      x-cache-hits: ['0']
-      x-content-type-options: [nosniff]
-      x-fastly-request-id: [df5dd6a7d16fd2b762f58393c4a541a3a64255fb]
-      x-frame-options: [deny]
-      x-geo-block-list: ['']
-      x-github-request-id: ['17EB2F14:5AD3:33797ED:577D4DE3']
-      x-served-by: [cache-sjc3621-SJC]
-      x-xss-protection: [1; mode=block]
+      Accept-Ranges: [bytes]
+      Access-Control-Allow-Origin: ['*']
+      Cache-Control: [max-age=300]
+      Connection: [close]
+      Content-Length: ['2297']
+      Content-Security-Policy: [default-src 'none'; style-src 'unsafe-inline']
+      Content-Type: [text/plain; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:42:48 GMT']
+      ETag: ['"db78eb36618a060181b32ac2de91b1733f382e01"']
+      Expires: ['Thu, 07 Jul 2016 19:47:48 GMT']
+      Source-Age: ['200']
+      Strict-Transport-Security: [max-age=31536000]
+      Vary: ['Authorization,Accept-Encoding']
+      Via: [1.1 varnish]
+      X-Cache: [HIT]
+      X-Cache-Hits: ['1']
+      X-Content-Type-Options: [nosniff]
+      X-Fastly-Request-ID: [3fd66eb5d4da83de8fada04b585012f285daccd6]
+      X-Frame-Options: [deny]
+      X-Geo-Block-List: ['']
+      X-GitHub-Request-Id: ['C71B4F15:2F46:3987E58:577EAFEF']
+      X-Served-By: [cache-lax1424-LAX]
+      X-XSS-Protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 resourcemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [7d666200-43a7-11e6-81da-001dd8b7c0ad]
+      x-ms-client-request-id: [fbb3417a-447a-11e6-8514-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27scaleset_create_options_rg%27%20and%20name%20eq%20%27vrfvmss%27%20and%20resourceType%20eq%20%27Microsoft.Compute%2FvirtualMachineScaleSets%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?$filter=resourceGroup%20eq%20%27scaleset_create_options_rg%27%20and%20name%20eq%20%27vrfvmss%27%20and%20resourceType%20eq%20%27Microsoft.Compute%2FvirtualMachineScaleSets%27&api-version=2016-02-01
   response:
     body:
       string: !!binary |
@@ -200,76 +205,87 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
         uc4/evS97/+S/wdC6kBEDAAAAA==
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['133']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:28:52 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['133']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:42:47 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateVMSS_2016-06-01/azuredeploy.json"},
-      "mode": "Incremental", "parameters": {"osSKU": {"value": "2012-R2-Datacenter"},
-      "publicIpAddressAllocation": {"value": "dynamic"}, "instanceCount": {"value":
-      "4"}, "authenticationType": {"value": "password"}, "osDiskType": {"value": "provided"},
-      "publicIpAddressName": {"value": "vrfpubip"}, "_artifactsLocation": {"value":
-      "https://azuresdkci.blob.core.windows.net/templatehost/CreateVMSS_2016-06-01"},
-      "subnetIpAddressPrefix": {"value": "10.0.0.0/24"}, "upgradePolicyMode": {"value":
-      "automatic"}, "adminUsername": {"value": "myadmin"}, "overprovision": {"value":
-      "False"}, "vmSku": {"value": "Standard_D1_v2"}, "natBackendPort": {"value":
-      "3389"}, "dnsNameType": {"value": "none"}, "osType": {"value": "Custom"}, "osVersion":
-      {"value": "latest"}, "customOsDiskType": {"value": "windows"}, "natStartPort":
-      {"value": "50000"}, "virtualNetworkIpAddressPrefix": {"value": "10.0.0.0/16"},
-      "storageRedundancyType": {"value": "Standard_LRS"}, "name": {"value": "vrfvmss"},
-      "storageCaching": {"value": "ReadWrite"}, "adminPassword": {"value": "Test1234@!"},
-      "osOffer": {"value": "WindowsServer"}, "storageContainerName": {"value": "vhds"},
-      "loadBalancerType": {"value": "new"}, "publicIpAddressType": {"value": "existing"},
-      "location": {"value": "westus"}, "natEndPort": {"value": "50099"}, "privateIpAddressAllocation":
-      {"value": "static"}, "privateIpAddress": {"value": "10.0.0.5"}, "osDiskName":
-      {"value": "osdiskimage"}, "osPublisher": {"value": "MicrosoftWindowsServer"}}}}'
+    body: !!binary |
+      eyJwcm9wZXJ0aWVzIjogeyJtb2RlIjogIkluY3JlbWVudGFsIiwgInRlbXBsYXRlTGluayI6IHsi
+      dXJpIjogImh0dHBzOi8vYXp1cmVzZGtjaS5ibG9iLmNvcmUud2luZG93cy5uZXQvdGVtcGxhdGVo
+      b3N0L0NyZWF0ZVZNU1NfMjAxNi0wNi0wMS9henVyZWRlcGxveS5qc29uIn0sICJwYXJhbWV0ZXJz
+      IjogeyJvc1NLVSI6IHsidmFsdWUiOiAiMjAxMi1SMi1EYXRhY2VudGVyIn0sICJvc1ZlcnNpb24i
+      OiB7InZhbHVlIjogImxhdGVzdCJ9LCAidm1Ta3UiOiB7InZhbHVlIjogIlN0YW5kYXJkX0QxX3Yy
+      In0sICJuYXRFbmRQb3J0IjogeyJ2YWx1ZSI6ICI1MDA5OSJ9LCAiX2FydGlmYWN0c0xvY2F0aW9u
+      IjogeyJ2YWx1ZSI6ICJodHRwczovL2F6dXJlc2RrY2kuYmxvYi5jb3JlLndpbmRvd3MubmV0L3Rl
+      bXBsYXRlaG9zdC9DcmVhdGVWTVNTXzIwMTYtMDYtMDEifSwgInByaXZhdGVJcEFkZHJlc3NBbGxv
+      Y2F0aW9uIjogeyJ2YWx1ZSI6ICJzdGF0aWMifSwgInB1YmxpY0lwQWRkcmVzc0FsbG9jYXRpb24i
+      OiB7InZhbHVlIjogImR5bmFtaWMifSwgIm9zT2ZmZXIiOiB7InZhbHVlIjogIldpbmRvd3NTZXJ2
+      ZXIifSwgImF1dGhlbnRpY2F0aW9uVHlwZSI6IHsidmFsdWUiOiAicGFzc3dvcmQifSwgIm9zUHVi
+      bGlzaGVyIjogeyJ2YWx1ZSI6ICJNaWNyb3NvZnRXaW5kb3dzU2VydmVyIn0sICJjdXN0b21Pc0Rp
+      c2tUeXBlIjogeyJ2YWx1ZSI6ICJ3aW5kb3dzIn0sICJvc1R5cGUiOiB7InZhbHVlIjogIkN1c3Rv
+      bSJ9LCAibmFtZSI6IHsidmFsdWUiOiAidnJmdm1zcyJ9LCAic3RvcmFnZUNhY2hpbmciOiB7InZh
+      bHVlIjogIlJlYWRXcml0ZSJ9LCAicHVibGljSXBBZGRyZXNzVHlwZSI6IHsidmFsdWUiOiAiZXhp
+      c3RpbmcifSwgInN0b3JhZ2VSZWR1bmRhbmN5VHlwZSI6IHsidmFsdWUiOiAiU3RhbmRhcmRfTFJT
+      In0sICJzdG9yYWdlQ29udGFpbmVyTmFtZSI6IHsidmFsdWUiOiAidmhkcyJ9LCAicHJpdmF0ZUlw
+      QWRkcmVzcyI6IHsidmFsdWUiOiAiMTAuMC4wLjUifSwgImRuc05hbWVUeXBlIjogeyJ2YWx1ZSI6
+      ICJub25lIn0sICJsb2FkQmFsYW5jZXJUeXBlIjogeyJ2YWx1ZSI6ICJuZXcifSwgIm5hdEJhY2tl
+      bmRQb3J0IjogeyJ2YWx1ZSI6ICIzMzg5In0sICJsb2NhdGlvbiI6IHsidmFsdWUiOiAid2VzdHVz
+      In0sICJhZG1pblVzZXJuYW1lIjogeyJ2YWx1ZSI6ICJteWFkbWluIn0sICJvdmVycHJvdmlzaW9u
+      IjogeyJ2YWx1ZSI6ICJGYWxzZSJ9LCAib3NEaXNrVHlwZSI6IHsidmFsdWUiOiAicHJvdmlkZWQi
+      fSwgInN1Ym5ldElwQWRkcmVzc1ByZWZpeCI6IHsidmFsdWUiOiAiMTAuMC4wLjAvMjQifSwgIm5h
+      dFN0YXJ0UG9ydCI6IHsidmFsdWUiOiAiNTAwMDAifSwgInZpcnR1YWxOZXR3b3JrSXBBZGRyZXNz
+      UHJlZml4IjogeyJ2YWx1ZSI6ICIxMC4wLjAuMC8xNiJ9LCAiaW5zdGFuY2VDb3VudCI6IHsidmFs
+      dWUiOiAiNCJ9LCAiYWRtaW5QYXNzd29yZCI6IHsidmFsdWUiOiAiVGVzdDEyMzRAISJ9LCAicHVi
+      bGljSXBBZGRyZXNzTmFtZSI6IHsidmFsdWUiOiAidnJmcHViaXAifSwgInVwZ3JhZGVQb2xpY3lN
+      b2RlIjogeyJ2YWx1ZSI6ICJhdXRvbWF0aWMifSwgIm9zRGlza05hbWUiOiB7InZhbHVlIjogIm9z
+      ZGlza2ltYWdlIn19fX0=
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Length: ['1610']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
+      x-ms-client-request-id: [fbdd8aee-447a-11e6-b285-001dd8b7c0ad]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/azurecli1467829732.3783494","name":"azurecli1467829732.3783494","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVMSS_2016-06-01/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVMSS_2016-06-01"},"adminPassword":{"type":"SecureString"},"adminUsername":{"type":"String","value":"myadmin"},"authenticationType":{"type":"String","value":"password"},"customOsDiskType":{"type":"String","value":"windows"},"customOsDiskUri":{"type":"String","value":""},"dnsNameForPublicIP":{"type":"String","value":""},"dnsNameType":{"type":"String","value":"none"},"instanceCount":{"type":"String","value":"4"},"loadBalancerBackendPoolName":{"type":"String","value":"vrfvmssbepool"},"loadBalancerName":{"type":"String","value":"vrfvmsslb"},"loadBalancerNatPoolName":{"type":"String","value":"vrfvmssnatpool"},"loadBalancerType":{"type":"String","value":"new"},"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"vrfvmss"},"natBackendPort":{"type":"String","value":"3389"},"natEndPort":{"type":"String","value":"50099"},"natStartPort":{"type":"String","value":"50000"},"osDiskName":{"type":"String","value":"osdiskimage"},"osDiskType":{"type":"String","value":"provided"},"osOffer":{"type":"String","value":"WindowsServer"},"osPublisher":{"type":"String","value":"MicrosoftWindowsServer"},"osSKU":{"type":"String","value":"2012-R2-Datacenter"},"osType":{"type":"String","value":"Custom"},"osVersion":{"type":"String","value":"latest"},"overprovision":{"type":"String","value":"False"},"privateIpAddress":{"type":"String","value":"10.0.0.5"},"privateIpAddressAllocation":{"type":"String","value":"static"},"publicIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddressName":{"type":"String","value":"vrfpubip"},"publicIpAddressType":{"type":"String","value":"existing"},"sshDestKeyPath":{"type":"String","value":"/home/myadmin/.ssh/authorized_keys"},"sshKeyValue":{"type":"String","value":""},"storageCaching":{"type":"String","value":"ReadWrite"},"storageContainerName":{"type":"String","value":"vhds"},"storageRedundancyType":{"type":"String","value":"Standard_LRS"},"subnetIpAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetName":{"type":"String","value":"vrfvmssSubnet"},"upgradePolicyMode":{"type":"String","value":"automatic"},"virtualNetworkIpAddressPrefix":{"type":"String","value":"10.0.0.0/16"},"virtualNetworkName":{"type":"String","value":"vrfvmssVNET"},"virtualNetworkType":{"type":"String","value":"new"},"vmSku":{"type":"String","value":"Standard_D1_v2"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-06T18:28:53.5976284Z","duration":"PT0.172073S","correlationId":"77f56bd7-f324-4ffc-99d1-32773fb4be9d","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/vrfvmssIP","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmssIP"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/vrfvmssLB","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmssLB"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_options_rg/providers/Microsoft.Storage/storageAccounts/ipqnf2e3g2c26vrfvmssqrsa","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"ipqnf2e3g2c26vrfvmssqrsa"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_options_rg/providers/Microsoft.Storage/storageAccounts/57xchgbn4zn6uvrfvmssqrsa","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"57xchgbn4zn6uvrfvmssqrsa"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_options_rg/providers/Microsoft.Storage/storageAccounts/btak5md4oc3p6vrfvmssqrsa","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"btak5md4oc3p6vrfvmssqrsa"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_options_rg/providers/Microsoft.Storage/storageAccounts/kvlyj44hwaf3uvrfvmssqrsa","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"kvlyj44hwaf3uvrfvmssqrsa"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_options_rg/providers/Microsoft.Storage/storageAccounts/z7tarv5igr4muvrfvmssqrsa","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"z7tarv5igr4muvrfvmssqrsa"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/vrfvmssLB","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmssLB"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/vrfvmssVNet","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmssVNet"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_options_rg/providers/Microsoft.Compute/virtualMachineScaleSets/vrfvmss","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vrfvmss"}]}}'}
+    body: {string: '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/azurecli1467920568.35979389588","name":"azurecli1467920568.35979389588","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVMSS_2016-06-01/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVMSS_2016-06-01"},"adminPassword":{"type":"SecureString"},"adminUsername":{"type":"String","value":"myadmin"},"authenticationType":{"type":"String","value":"password"},"customOsDiskType":{"type":"String","value":"windows"},"customOsDiskUri":{"type":"String","value":""},"dnsNameForPublicIP":{"type":"String","value":""},"dnsNameType":{"type":"String","value":"none"},"instanceCount":{"type":"String","value":"4"},"loadBalancerBackendPoolName":{"type":"String","value":"vrfvmssbepool"},"loadBalancerName":{"type":"String","value":"vrfvmsslb"},"loadBalancerNatPoolName":{"type":"String","value":"vrfvmssnatpool"},"loadBalancerType":{"type":"String","value":"new"},"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"vrfvmss"},"natBackendPort":{"type":"String","value":"3389"},"natEndPort":{"type":"String","value":"50099"},"natStartPort":{"type":"String","value":"50000"},"osDiskName":{"type":"String","value":"osdiskimage"},"osDiskType":{"type":"String","value":"provided"},"osOffer":{"type":"String","value":"WindowsServer"},"osPublisher":{"type":"String","value":"MicrosoftWindowsServer"},"osSKU":{"type":"String","value":"2012-R2-Datacenter"},"osType":{"type":"String","value":"Custom"},"osVersion":{"type":"String","value":"latest"},"overprovision":{"type":"String","value":"False"},"privateIpAddress":{"type":"String","value":"10.0.0.5"},"privateIpAddressAllocation":{"type":"String","value":"static"},"publicIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddressName":{"type":"String","value":"vrfpubip"},"publicIpAddressType":{"type":"String","value":"existing"},"sshDestKeyPath":{"type":"String","value":"/home/myadmin/.ssh/authorized_keys"},"sshKeyValue":{"type":"String","value":""},"storageCaching":{"type":"String","value":"ReadWrite"},"storageContainerName":{"type":"String","value":"vhds"},"storageRedundancyType":{"type":"String","value":"Standard_LRS"},"subnetIpAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetName":{"type":"String","value":"vrfvmssSubnet"},"upgradePolicyMode":{"type":"String","value":"automatic"},"virtualNetworkIpAddressPrefix":{"type":"String","value":"10.0.0.0/16"},"virtualNetworkName":{"type":"String","value":"vrfvmssVNET"},"virtualNetworkType":{"type":"String","value":"new"},"vmSku":{"type":"String","value":"Standard_D1_v2"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-07T19:42:49.0673604Z","duration":"PT0.1102132S","correlationId":"4b0213c3-19fd-4904-a036-46964fdd39ed","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/vrfvmssIP","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmssIP"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/vrfvmssLB","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmssLB"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_options_rg/providers/Microsoft.Storage/storageAccounts/ipqnf2e3g2c26vrfvmssqrsa","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"ipqnf2e3g2c26vrfvmssqrsa"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_options_rg/providers/Microsoft.Storage/storageAccounts/57xchgbn4zn6uvrfvmssqrsa","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"57xchgbn4zn6uvrfvmssqrsa"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_options_rg/providers/Microsoft.Storage/storageAccounts/btak5md4oc3p6vrfvmssqrsa","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"btak5md4oc3p6vrfvmssqrsa"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_options_rg/providers/Microsoft.Storage/storageAccounts/kvlyj44hwaf3uvrfvmssqrsa","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"kvlyj44hwaf3uvrfvmssqrsa"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_options_rg/providers/Microsoft.Storage/storageAccounts/z7tarv5igr4muvrfvmssqrsa","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"z7tarv5igr4muvrfvmssqrsa"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/vrfvmssLB","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmssLB"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/vrfvmssVNet","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmssVNet"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_options_rg/providers/Microsoft.Compute/virtualMachineScaleSets/vrfvmss","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vrfvmss"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/azurecli1467829732.3783494/operationStatuses/08587337771520521797?api-version=2015-11-01']
-      cache-control: [no-cache]
-      content-length: ['5883']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:28:52 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/azurecli1467920568.35979389588/operationStatuses/08587336863165205759?api-version=2015-11-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['5892']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:42:48 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
+      x-ms-client-request-id: [fbdd8aee-447a-11e6-b285-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771520521797?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863165205759?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -277,30 +293,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:29:23 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:43:18 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
+      x-ms-client-request-id: [fbdd8aee-447a-11e6-b285-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771520521797?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863165205759?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -308,30 +324,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:29:53 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:43:48 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
+      x-ms-client-request-id: [fbdd8aee-447a-11e6-b285-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771520521797?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863165205759?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -339,30 +355,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:30:23 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:44:18 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
+      x-ms-client-request-id: [fbdd8aee-447a-11e6-b285-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771520521797?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863165205759?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -370,30 +386,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:30:54 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:44:49 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
+      x-ms-client-request-id: [fbdd8aee-447a-11e6-b285-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771520521797?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863165205759?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -401,30 +417,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:31:25 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:45:19 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
+      x-ms-client-request-id: [fbdd8aee-447a-11e6-b285-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771520521797?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863165205759?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -432,30 +448,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:31:55 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:45:49 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
+      x-ms-client-request-id: [fbdd8aee-447a-11e6-b285-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771520521797?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863165205759?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -463,30 +479,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:32:26 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:46:19 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
+      x-ms-client-request-id: [fbdd8aee-447a-11e6-b285-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771520521797?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863165205759?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -494,30 +510,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:32:56 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:46:50 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
+      x-ms-client-request-id: [fbdd8aee-447a-11e6-b285-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771520521797?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863165205759?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -525,30 +541,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:33:26 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:47:19 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
+      x-ms-client-request-id: [fbdd8aee-447a-11e6-b285-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771520521797?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863165205759?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -556,650 +572,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:33:56 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:47:49 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
+      x-ms-client-request-id: [fbdd8aee-447a-11e6-b285-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771520521797?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:34:27 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771520521797?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:34:57 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771520521797?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:35:27 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771520521797?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:35:58 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771520521797?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:36:28 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771520521797?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:36:58 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771520521797?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:37:29 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771520521797?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:37:59 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771520521797?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:38:29 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771520521797?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:38:59 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771520521797?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:39:29 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771520521797?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:40:00 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771520521797?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:40:30 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771520521797?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:41:00 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771520521797?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:41:30 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771520521797?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:42:01 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771520521797?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:42:30 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771520521797?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:43:01 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771520521797?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:43:31 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771520521797?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:44:01 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771520521797?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863165205759?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -1207,28 +603,28 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['141']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:44:31 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['141']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:48:20 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [7d89ef91-43a7-11e6-adcd-001dd8b7c0ad]
+      x-ms-client-request-id: [fbdd8aee-447a-11e6-b285-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_options_rg/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
@@ -1238,55 +634,55 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
         o0cf3W3Wk2ZaF6u2qJbN3Xs7+/nBw4efbj94cD7Z3v80P9ieZLNs+/79B5/u7N5/uD/J9+/WeVOt
         62n+eV2tV83dZpqVeZO3v/+0zrM2//0rgfX71xd3V3V1Wczyurn7RTGtq6Y6b8ev9O3m7ixfldX1
-        Il+2zd3sB+s6n5bF7v6nDw72Hj64tze+9+Dg3v7D/Y9GHy2zRU64bmxDXa3yui3y5qNHv/ijNl+s
-        SkLmebF8i7/XdUEA5m27ah7dlc6a2dtpMZ6U1WQ8rep8fFUsZ9VVM17m7V3z+rxq2rsnPKyf/OL1
-        699/b2f30+0d+t+uwJARjH+6qZaEwrRatjSYn6TxEgGov93xDv776JcQellNg2jpK6Dz+2eE6Xk2
-        bZvn1TQDufBpe73CMF+3dbG8IHiXWbnGB98g2kAlmy2K5cusaa6qmljA9ZtPCb72btp91eS1kN+1
-        kxYOv8U1N+V31u2cSFDIoN7wC8MvrgwS9OZ03bTV4svmadG8vek9HXP3ta8wycNvofls2bzIFvmz
-        qn65npTF9OzlLd+4CaVltczRvFg2bbac5ifVetluemEfrcsqmz3JSrxQP8mmb/Pl7GVVlehw07uX
-        9fnlomkm+Yoad+Hc8uVy0n+xfY/Ol1kb6/1GOuVX8opwyKamV3nTrnmSb2JARUmatpaQ9cYJuHfv
-        4KG+cXpz6/s7Ow9N89ctie8tXthhya+YN2+iatXMqFWxyC6YjeSlm4hJOg/qleWnar48P8/rTc2/
-        K2LzOq8vqSG/w1LQzOnPDe9Z3R0B8Pr3+mrTq6R59rZf7W0/zdpsSorBvHbTyE5YrKWt1afDzaH0
-        mpabE2ZMlpteeZaVDZN6VReX9PrZ6ng2I/XK+nnopV3S5vTf/dh7x+VtmJq0A2lHfh+kn77n67Nr
-        koXo+zcxGMkIvVGsIq/eNBn5u6Jp8RG92jTzp0Tq3yu/fpm1801v3Z1Xi/yu2oa7Y3rxLqxDVRc/
-        yGe//9v8muWVPiZYPynvDAPjpm1Vk3icZNM5vtzQ+lWezb5bFy3Pr3mNjHNWLKHmbiDUfCaYyXuv
-        8tl6OSPddn0TmUgtUMN69vs/f/WaAawnZJQtlV/W+XnxbhMA5a6du3tsHOT9G9EV3feaG+O19eqi
-        zmb5y4qm+PqLakaNht+mGakWxHXMUZdF3a6z8kXeklF++3UQ3/20D+eWA/jJF6dv+i/fRHM1J5eL
-        12/Xm9rZuXm6+/tf7n30S+idBZPmo7Mlua3wQbOS2lvVQa/TO8RB9O56Os3J1ZvR922xIO7PFiv6
-        nHQbuVQPyLF6s3vwaH//0c7+eO9gb+f+/sFPUdPZuibCQpw/evlm9/4XRKSD+5/uP3y4/5q+Jd+t
-        zkltUYMzcsI+In/7/qeT2YPt83t7+9v75+fT7YcPZ7vb9/YePLh3PiG/+yH6Z/zgUH/06Hu/mGwR
-        YbMixUoArJJ2Dja1p/nj30FHecf/hF4TDxbjR3OjgtB0uS7L7/+S7/+S0VA/J9VitSYK3aIXndQv
-        WHTz1wgYXue9Ho3F39jraxFLetXvA6/3elUJPp5O4Yxt6u37NF35ipyGfDnlCIKAyQfNlzSB9Nf/
-        q4IlFRlyXkMqEIo3vOq9IHJpxI9ggQr/bxzm8yce1h84TIIF1qKmP/dzq5x8t8Omd4vVL1qe7+X3
-        Lvame58q3r+objJvUD0qDMDyXlE6DAIHWf5fRoj7D95N5xeT5f4Plp+ufVzdqL4+IQaB/7+QEJM2
-        e3t/MduvpvdWwaS5UX19QgwC/38hId5eltc/vb8/v8rO7wWT5kb19QkxCPz/hYT4wQOKQS/vFxf1
-        /iLA1Y3q6xNiEPjPISGiav5n0UL8v3GYP0lOsYf3Bw6Uof0c2nx1H+8O+IZm0B7+vQHfAMJ7NRw6
-        D7tat/SypZnzBG4N36JoGca9SsRF/HLXz43ZFzj3NviK9qZ/2pc0QOq9NiDWw9bzPWDcbBtuhnGz
-        x3EzjJtV880whrXa93/JL/l/AIa3YZIOGQAA
+        Il+2zd3sB+s6n5bF7v6nDx7u7dz/9GB87/7DBw/vHTy8f3Dw0eijZbbICd8b21GXq7xui7z56NEv
+        /qjNF6uSkHpeLN/i73VdEJB5266aR3el02b2dlqMJ2U1GU+rOh9fFctZddWMl3l717w+r5r27gkP
+        7ye/eP3699/b2f10e4f+tyswZCTjn26qJaEwrZYtDeonadxECOpvd7yD/z76JYReVtNAWvoK6Pz+
+        GWF6nk3b5nk1zUA2fNperzDU121dLC8I3mVWrvHBN4g2UMlmi2L5Mmuaq6omVnD95lOCr72bdl81
+        eS1T4NpJC4ff4pqb8jvrdk4kKGRQb/iF4RdXBgl6c7pu2mrxZfO0aN7e9J6OufvaV5jk4bfQfLZs
+        XmSL/FlVv1xPymJ69vKWb9yE0rJa5mheLJs2W07zk2q9bDe9sI/WZZXNnmQlXqifZNO3+XL2sqpK
+        dLjp3cv6/HLRNJN8RY27cG75cjnpv9i+R+fLrI31fiOd8it5RThkU9OrvGnXPMk3MaCiJE1bS8h6
+        4wTcI9Whb5ze3Pr+zs5D0/x1S+J7ixd2WPIr5s2bqFo1M2pVLLILZiN56SZiks6DmmX5qZovz8/z
+        elPz74rYvM7rS2rI77AUNHP6c8N7VodHALz+vb7a9Cppnr3tV3vbT7M2m5JiMK/dNLITFmtpa/Xp
+        cHMovabl5oQZk+WmV55lZcOkXtXFJb1+tjqezUi9sn4eemmXtDn9dz/23nF5G6Ym7UDakd8H6afv
+        +frsmmQh+v5NDEYyQm8Uq8irN01G/q5oWnxErzbN/CmR+vfKr19m7XzTW3fn1SK/q7bh7phevAvr
+        UNXFD/LZ7/82v2Z5pY8J1k/KO8PAuGlb1SQeJ9l0ji83tH6VZ7Pv1kXL82teI+OcFUuouRsINZ8J
+        ZvLeq3y2Xs5It13fRCZSC9Swnv3+z1+9ZgDrCRllS+WXdX5evNsEQLlr5+4eGwd5/0Z0Rfe95sZ4
+        bb26qLNZ/rKiKb7+oppRo+G3aUaqBXEdc9RlUbfrrHyRt2SU334dxHc/7cO55QB+8sXpm/7LN9Fc
+        zcnl4vXb9aZ2dm6e7v7+l3sf/RJ6Z8Gk+ehsSe4rfNGspPZWddDr9A5xEL27nk5zcvVm9H1bLIj7
+        s8WKPifdRi7VA/rfm92Hj/YPHu08GO/eO3jw8GDvp6jpbF0TYSHOH718c/+L3YPx7sHup/d3X9N3
+        5LnVOSkt+vqMXLCP9ic7e7v3pve2dx+ez7b3H+7sb2c79z4lR/zhp/vns9m9h9w7Ywe3+qNH3/vF
+        ZIkIlxWpVQJgVbRzs6k9zR7/DirKO/4n9Jr4rxg9mhsFhKbLdVl+/5d8/5eMhvo5qRarNdHnFr3o
+        lH7Bgpu/RtjwOu/1aOz9xl5fi1DSq34feL3Xq8rv8XQKV2xTb9+nycpX5DLkyynHDwRMPmi+pOmj
+        v/5fFTKpwJDrGlKBULzhVe8FkUojfAQLVPh/4zCfP/Gw/sBhEiywFjX9uZ9b5eS7HTa9W6x+0fJ8
+        L793sTfd+1Tx/kV1k3mD6lFhAJb3itJhEDjI8v8yQtx/8G46v5gs93+w/HTt4+pG9fUJMQj8/4WE
+        mLTZ2/uL2X41vbcKJs2N6usTYhD4/wsJ8fayvP7p/f35VXZ+L5g0N6qvT4hB4P8vJMQPHlAEenm/
+        uKj3FwGublRfnxCDwH8OCRFV8z+LFuL/jcP8SXKJPbw/cKAM7efQ5qv7eHfANzSD9vDvDfgGEN6r
+        4dB52NW6pZctzZwncGv4FkXLMO5VIi6il7t+Zsy+wJm3wVe0N/3TvqThUe+1AbEetp7vAeNm23Az
+        jJs9jpth3Kyab4YxrNW+/0t+yf8Dd3egLxQZAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['1623']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:44:32 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['1625']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:48:21 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [ae0d258f-43a9-11e6-914b-001dd8b7c0ad]
+      x-ms-client-request-id: [c27d5600-447b-11e6-b427-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scaleset_create_options_rg/providers/Microsoft.Network/loadBalancers/vrfvmsslb?api-version=2016-03-30
   response:
@@ -1296,49 +692,49 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj96LI+v1w0TTn5aMSfFzN8erdZT5ppXazaolo2d+/t7OcHDx9+uv3gwflke//T/GB7
         ks2y7fv3H3y6s3v/4f4k379b5021rqf553W1XjV3m2lW5k3e/v7TOs/a/PevBNbvX1/cXdXVZTHL
-        6+buF8W0rprqvB2/yNurqn57t6yy2ZOszJZTfN/FLm+zC+D33bu/70f5zt696fn9B9u7nz58uL2f
-        z/Lth9lkZzvbO3g4m92/lz2YZb/vR/pie73i4d7QobYuq2kGbPHGVd60a/MFYb7K67bIG/qKCSkf
-        XhYNNS+WF69bGit999Hr9XSaE04zeZOaWfqshcY704f3D2afHmw/vP9wd3t/Zy/fPth9kPNw7u1l
-        988P8k/ty+d1tWzz5ezs5Um1PC8u1jUjCDS+J01Sgw8eO73PvdE9A4zTpcUIz/9b5/vu0IDv3jii
-        r8sj8mA2e1MsD766xUTLQ42LS2py9vK4NOz0Rd7OK6b302uaoGLafWU9KYspvTGbEXF7/VOLn+vZ
-        6mCY84zRh8XqIx/TXxKOq1hOqvVy9iJrX62pVxqC5Vl5OsPEKz/HAx1iy85QzDfLrF1VVTneCcjQ
-        JcT/jwa6+/NloHs/XwZ6rztQ/8/vB6P2BPolvfr/E4HmoZhvlCobaeL+sJ/rL4ZcH02y6VsyYqou
-        uQcigyWWRyZrsRWBSc79KyA8/68lYWSQ5tvIKP5fYp4V6a57Qa/Y2ZEn6APPz9k8nFSL1brN714W
-        dbvOyi+y6bxY5q8B5HXeWpp3vm/u7txdygyekUdVn2dT+kzb/qJ6WUzvFquQCO7bYjXlb7pyENDy
-        /w802v0RjQBkI432fkQjANlIo3vfPI38P29jc5yaJj3Ipp5I+D37NY120vnI2UDbXL4JZqRrodRE
-        ks+rcPD8nE3YTUaqM0bzTXwQ/y+xUQMxML0SAKWW/2+l+sAIBqJ4f1CharCkeFnVLQ31/g49YQs1
-        6Nrg3r2Dh+H3+TKblPkzwrQl2p+9pEbnWdnkYatiVuZvikVerduz5RfFknQAJnE/bEWkaKspOTZE
-        9DfTVWfaFJPOmKnt/1tm7esqt2/akVDNhcf+6ubdo9aQ6tn1Kf9zRs6bhOAG1RMO4keq5xui+sAI
-        vhHVsxu2UIHXBj9SPQRraNa+rur5pv1zq2+8X928e9QaUj17PuV/zsh5kxDcoHrCQfxI9XxDVB8Y
-        wTeievbCFirw2uBHqodgDc3a11U933TYa/WN96ubd49aQ6rnnk/5nzNy3iQEN6iecBA/Uj3fENUH
-        RuCrnq+teu6FLVTgtcGPVA/BGpq1r6t6vulsktU33q/6i00G0UQEgksUi2WKOM2P7+Sb2yguf9Z+
-        zqbiJgHqjNB8ExvC/8uUFgTxVba8yOkNFknIbCdJ0msLLcAtH3akV2UKDalBX7oJxQ0Safr5f69I
-        3sQHAyO4jSJ1f9hf9RdO39Lvv+T/ASZLaiOEJQAA
+        6+buF8W0rprqvB2/yNurqn57t6yy2ZOszJZTfN/FLm+zC+D33bu/70d793fuTfcf7G9PdrP72/vn
+        k/Pt7Pzeve2Hu3uT89mnn96/v7/3+36kL7bXKx7uDR1q67KaZsAWb1zlTbs2XxDmq7xui7yhr5iQ
+        8uFl0VDzYnnxuqWx0ncfvV5Pp3k+y2fyJjWz9FkLjR/k9+9PJ4T63qcPCf8Hn862H852su2HD/en
+        +ztZRv/bty+f19WyzZezs5cn1fK8uFjXjCDQ+J40SQ0+eOz0PvdG9wwwTpcWIzz/b53vu0MDvnvj
+        iL4uj8iD2exNsTz46hYTLQ81Li6pydnL49Kw0xd5O6+Y3k+vaYKKafeV9aQspvTGbEbE7fVPLX6u
+        Z6uDYc4zRh8Wq498TH9JOK5iOanWy9mLrH21pl5pCJZn5ekME6/8HA90iC07QzHfLLN2VVXleCcg
+        Q5cQ/z8a6O7Pl4Hu/XwZ6L3uQP0/vx+M2hPol/Tq/08EmodivlGqbKSJ+8N+rr8Ycn00yaZvyYip
+        uuQeiAyWWB6ZrMVWBCY596+A8Py/loSRQZpvI6P4f4l5VqS77gW9YmdHnqAPPD9n83BSLVbrNr97
+        WdTtOiu/yKbzYpm/BpDXeWtp3vm+ubtzdykzeEYeVX2eTekzbfuL6mUxvVusQiK4b4vVlL/pykFA
+        y/8/0Gj3RzQCkI002vsRjQBkI43uffM08v+8jc1xapr0IJt6IuH37Nc02knnI2cDbXP5JpiRroVS
+        E0k+r8LB83M2YTcZqc4YzTfxQfy/xEYNxMD0SgCUWv6/leoDIxiI4v1BharBkuJlVbc01Ps79IQt
+        1KBrg3v3Dh6G3+fLbFLmzwjTlmh/9pIanWdlk4etilmZvykWebVuz5ZfFEvSAZjE/bAVkaKtpuTY
+        ENHfTFedaVNMOmOmtv9vmbWvq9y+aUdCNRce+6ubd49aQ6pn16f8zxk5bxKCG1RPOIgfqZ5viOoD
+        I/hGVM9u2EIFXhv8SPUQrKFZ+7qq55v2z62+8X518+5Ra0j17PmU/zkj501CcIPqCQfxI9XzDVF9
+        YATfiOrZC1uowGuDH6kegjU0a19X9XzTYa/VN96vbt49ag2pnns+5X/OyHmTENygesJB/Ej1fENU
+        HxiBr3q+tuq5F7ZQgdcGP1I9BGto1r6u6vmms0lW33i/6i82GUQTEQguUSyWKeI0P76Tb26juPxZ
+        +zmbipsEqDNC801sCP8vU1oQxFfZ8iKnN1gkIbOdJEmvLbQAt3zYkV6VKTSkBn3pJhQ3SKTp5/+9
+        InkTHwyM4DaK1P1hf9VfOH1Lv/+S/wfOxC/VhCUAAA==
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:44:33 GMT']
-      etag: [W/"e023cf57-1699-4ede-9ab0-a289dd53a7da"]
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:48:21 GMT']
+      ETag: [W/"2503c474-b1a5-4fbf-af33-912bfd665542"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [ae40b8b0-43a9-11e6-bb8a-001dd8b7c0ad]
+      x-ms-client-request-id: [c2aef0d8-447b-11e6-a7e1-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scaleset_create_options_rg/providers/Microsoft.Compute/virtualMachineScaleSets/vrfvmss?api-version=2016-03-30
   response:
@@ -1360,33 +756,33 @@ interactions:
         H3y6s3v/4f4k379b5021rqf553W1XjV3m2lW5k3e/v7CI79/JbB+//riLnV9WcyIkHft/I1fCFHu
         qtrVP5u7ivpPvjh9c5eQIiTtZ6/5z49+yeijsspmT7IyI36pn2TTt/lydjybEULNy6oqaYBEip/j
         cfko2hGUk7uTPrrm20m+oj8/+iXfDwd4tpxU6+XsRdZy6/83D64IUTXfLLNWR/ZL5H8iLUZqwJpi
-        ykhlkPknVUHS9no9neb5LHeOQEWyaJtSk/OsbIy9+2i9LH7ROj8jupDVy+99SoR4uH1v/16+vZ9N
-        7m0/3N+dbE8mu0SbfLZ/nn/KYiwYMDXTnwNynojjYGRAXY/XAPLa43shgMo2aaTg0/Z6xZ/eGqq+
-        V1ZT1ht494rU2hqW4Zf8P0PwU/G4CQAA
+        ykhlkPknVUHS9no9neb5LHeOQEWyaJtSk/OsbIy9+2i9LH7ROj8juqQf7ezv70/2JzvbB/n5ve39
+        h5/ubR/szh5u37+3v3e+tzfdP9/bZTEWDJia6c8BOU/EcTAyoK7HawB57fG9EEBlmzRS8Gl7veJP
+        bw1V3yurKesNvHtFam0Ny/BL/h+0fFD/uAkAAA==
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:44:33 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:48:21 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [ae6e5861-43a9-11e6-bd79-001dd8b7c0ad]
+      x-ms-client-request-id: [c2e6a4b4-447b-11e6-a27e-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scaleset_create_options_rg/providers/Microsoft.Compute/virtualMachineScaleSets/vrfvmss/virtualmachines/0?api-version=2016-03-30
   response:
@@ -1395,28 +791,28 @@ interactions:
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfFsmmz5TQ/m330KP1o56MRf9q8XdOf3IL+WmaLnP786DW1nGX17Pd/uvv7X+5JU/q6LfLa//oj
-        fP5L+NuPVnW1ymtq0VALA6/M2rxpv6hmeXm8WpVFjr7bep3zO9TgciHo3Nu9t3t/b7Kz/fDTe/vb
-        +/vZ/vbD/Wm2fX9/uj/LDyafHjy8Z9Fo2qrOLvKXdXVelMBXu6OvigV98So/z+uchup/RV+u1pOy
-        aOYyhi+KaV011Xn73WI5q66a13l9Sd9oH3g+qs4JDtoONxHyfbS3s7u3/Wpv+2nWZtN82XZa0VtN
-        US3Rcn+8M6bWn+7s39th8uEREuL5qGqeFs1baukjXjVvrlcYjcEkgG4mrWpm9CpTYLtqtne2H3y6
-        ++le/vD++fTTfP/eJDvYfZA/uL937/5s53x3dm8WQJnWOU3Wl6tWEX1WV4szwApaXc4xXR5u9Nm6
-        Luizj+Ztu2oe3b1brH7R8nwvv3exN9379LI+v1w0zS+qm2w8KavJeFrV+fhKRjFe5u1dgtjcfW/U
-        x/SaJZ9PQMJnmk3nxfICOL3Ks9l366LNbdtfIr+YF4hoMTaaVovVmmbxhZLWDmOHH0eSj7LZolh+
-        1eS1mYXFNX/kNdHRnlTL8+JiXWdKYdsbNSHhuSzAIj/5xfEF8Q997UkJno/yZTYp8+N1Wy0IwvSr
-        1YymC7KGhqadGRa1b3Ka0RYNvvd9+dB8+RGR/aqq33oDNx+dgXXPiYXpve/94o8KmuyP7jbrSTOt
-        C+aM5u69nf384OHDT7cfPDifbO9/mh9sT7IZSer9B5/u7N5/uD/J9+/WeVOt62n+eV2tV83dZpqV
-        eZO3vz+hRFj//pXA+v3ri7s88hnJx10rkOMTof7dy6Ju11n5Bc9n/hpAXtOQ7upsdL5v7u7c7Q3D
-        tP1F9bKYfvRLvm9pwP2C4sQppM6IQ2juXq+n0zyfkZZCK2nLREj/v0QFYT2rFrTd728+b1WVvEdP
-        weeqfD4qqykxIrPyR1ek5dcNUe2X/D82EW0TbAYAAA==
+        fP5L+NuPVnW1ymtq0VALA6/M2rxpv6hmeXm8WpVFjr7bep3zO9TgciHoPNyfze4dTHa3P/304Wx7
+        P3u4sz05z+5vT8/3d2fT6c7uwYPMotG0VZ1d5C/r6rwoga92R18VC/riVX6e1zkN1f+KvlytJ2XR
+        zGUMXxTTumqq8/a7xXJWXTWv8/qSvtE+8HxUnRMctB1uIuT7aG9nd2/71d7206zNpvmy7bSit5qi
+        WqLl/nhnTK0/3dm/t8PkwyMkxPNR1TwtmrfU0ke8at5crzAag0kA3Uxa1czoVabAdtVs7xDxdu/t
+        nZ/fn356MN2f3r+XTc539j6dnJ/PPp3unz9QFpDno2md02R9uWoV0Wd1tTgDrKDV5RzT5eFGn63r
+        gj77aN62q+bR3bvF6hctz/fyexd7071PL+vzy0XT/KK6ycaTspqMp1Wdj69kFONl3t4liM3d90Z9
+        TK9Z8vkEJHym2XReLC+A06s8m323Ltrctv0l8ot5gYgWY6NptVitaRZfKGntMHb4cST5KJstiuVX
+        TV6bWVhc80deEx3tSbU8Ly7WdaYUtr1RExKeywIs8pNfHF8Q/9DXnpTg+ShfZpMyP1631YIgTL9a
+        zWi6IGtoaNqZYVH7JqcZbdHge9+XD82XHxHZr6r6rTdw89EZWPecWJje+94v/qigyf7obrOeNNO6
+        YM5o7t7b2c8PHj78dPvBg/PJ9v6n+cH2JJtl2/fvP/h0Z/f+w/1Jvn+3zptqXU/zz+tqvWruNtOs
+        zJu8/f0JJcL6968E1u9fX9zlkc9IPu5agRyfCPXvXhZ1u87KL3g+89cA8pqGdFdno/N9c3fnbm8Y
+        pu0vqpfF9KNf8n1LA+4XFCdOIXVGHEJz93o9neb5jLQUWklbJkL6/yUqCOtZtaDtfn/zeauq5D16
+        Cj5X5fNRWU2JEZmVP7oiLb9uiGq/5P8BJZqh0WwGAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:44:34 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:48:22 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_scaleset_create_simple.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_scaleset_create_simple.yaml
@@ -4,16 +4,16 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI2MTE1LCJuYmYiOjE0Njc4MjYxMTUsImV4cCI6MTQ2NzgzMDAxNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.BsXPjbpDDitiOiqCh89LqEkRNwGth9IsXslnNhFEHJBysUJjzEBeOZaEwQCAZtLOO2DLZkoTvDZ2ddXEfZ3XNXS4wSAj2Hf0L0-d3gbP7mvzGpcZIsAH4eUlfX8LoGuQt4MyBNPH1pfTfNJYTMOFAsnsy3vPjr6qVj8butsv2XpDhPrDGRTE7WrgCBF-I7OfWqeiej_zc3ZKEXneOgxc6IbWGBqmUfM8SyLh48O2a_hoEs1KciA4AKt77zbsCbqrnbHdNadvVTDvkM-ToYNzgjWXp6kcW13cwS_roFV3Afz3YNB61ICCYog45D3uATmoKVE9BCZkrwCGrljteh9djw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 resourcemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [694ad48f-43a7-11e6-b785-001dd8b7c0ad]
+      x-ms-client-request-id: [e71fe702-447a-11e6-9ed1-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27scaleset_create_simple_rg%27%20and%20name%20eq%20%27vrfvmss%27%20and%20resourceType%20eq%20%27Microsoft.Compute%2FvirtualMachineScaleSets%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?$filter=resourceGroup%20eq%20%27scaleset_create_simple_rg%27%20and%20name%20eq%20%27vrfvmss%27%20and%20resourceType%20eq%20%27Microsoft.Compute%2FvirtualMachineScaleSets%27&api-version=2016-02-01
   response:
     body:
       string: !!binary |
@@ -21,74 +21,83 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
         uc4/evS97/+S/wdC6kBEDAAAAA==
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['133']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:28:19 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['133']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:42:15 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateVMSS_2016-06-01/azuredeploy.json"},
-      "mode": "Incremental", "parameters": {"osSKU": {"value": "2012-R2-Datacenter"},
-      "publicIpAddressAllocation": {"value": "dynamic"}, "instanceCount": {"value":
-      "2"}, "authenticationType": {"value": "password"}, "adminPassword": {"value":
-      "Test1234@!"}, "dnsNameType": {"value": "none"}, "subnetIpAddressPrefix": {"value":
-      "10.0.0.0/24"}, "upgradePolicyMode": {"value": "manual"}, "adminUsername": {"value":
-      "myadmin"}, "vmSku": {"value": "Standard_D1_v2"}, "natBackendPort": {"value":
-      "3389"}, "_artifactsLocation": {"value": "https://azuresdkci.blob.core.windows.net/templatehost/CreateVMSS_2016-06-01"},
-      "osType": {"value": "Win2012R2Datacenter"}, "osVersion": {"value": "latest"},
-      "customOsDiskType": {"value": "windows"}, "natStartPort": {"value": "50000"},
-      "virtualNetworkIpAddressPrefix": {"value": "10.0.0.0/16"}, "storageRedundancyType":
-      {"value": "Standard_LRS"}, "name": {"value": "vrfvmss"}, "storageCaching": {"value":
-      "ReadOnly"}, "osDiskType": {"value": "provided"}, "storageContainerName": {"value":
-      "vhds"}, "loadBalancerType": {"value": "new"}, "osOffer": {"value": "WindowsServer"},
-      "osPublisher": {"value": "MicrosoftWindowsServer"}, "natEndPort": {"value":
-      "50099"}, "privateIpAddressAllocation": {"value": "dynamic"}, "osDiskName":
-      {"value": "osdiskimage"}}}}'
+    body: !!binary |
+      eyJwcm9wZXJ0aWVzIjogeyJwYXJhbWV0ZXJzIjogeyJuYXRTdGFydFBvcnQiOiB7InZhbHVlIjog
+      IjUwMDAwIn0sICJsb2FkQmFsYW5jZXJUeXBlIjogeyJ2YWx1ZSI6ICJuZXcifSwgIm9zRGlza05h
+      bWUiOiB7InZhbHVlIjogIm9zZGlza2ltYWdlIn0sICJkbnNOYW1lVHlwZSI6IHsidmFsdWUiOiAi
+      bm9uZSJ9LCAiYWRtaW5QYXNzd29yZCI6IHsidmFsdWUiOiAiVGVzdDEyMzRAISJ9LCAidXBncmFk
+      ZVBvbGljeU1vZGUiOiB7InZhbHVlIjogIm1hbnVhbCJ9LCAib3NUeXBlIjogeyJ2YWx1ZSI6ICJX
+      aW4yMDEyUjJEYXRhY2VudGVyIn0sICJuYW1lIjogeyJ2YWx1ZSI6ICJ2cmZ2bXNzIn0sICJvc1NL
+      VSI6IHsidmFsdWUiOiAiMjAxMi1SMi1EYXRhY2VudGVyIn0sICJhdXRoZW50aWNhdGlvblR5cGUi
+      OiB7InZhbHVlIjogInBhc3N3b3JkIn0sICJzdG9yYWdlQ2FjaGluZyI6IHsidmFsdWUiOiAiUmVh
+      ZE9ubHkifSwgIm5hdEJhY2tlbmRQb3J0IjogeyJ2YWx1ZSI6ICIzMzg5In0sICJvc09mZmVyIjog
+      eyJ2YWx1ZSI6ICJXaW5kb3dzU2VydmVyIn0sICJ2aXJ0dWFsTmV0d29ya0lwQWRkcmVzc1ByZWZp
+      eCI6IHsidmFsdWUiOiAiMTAuMC4wLjAvMTYifSwgImN1c3RvbU9zRGlza1R5cGUiOiB7InZhbHVl
+      IjogIndpbmRvd3MifSwgInN1Ym5ldElwQWRkcmVzc1ByZWZpeCI6IHsidmFsdWUiOiAiMTAuMC4w
+      LjAvMjQifSwgImFkbWluVXNlcm5hbWUiOiB7InZhbHVlIjogIm15YWRtaW4ifSwgInZtU2t1Ijog
+      eyJ2YWx1ZSI6ICJTdGFuZGFyZF9EMV92MiJ9LCAic3RvcmFnZVJlZHVuZGFuY3lUeXBlIjogeyJ2
+      YWx1ZSI6ICJTdGFuZGFyZF9MUlMifSwgIl9hcnRpZmFjdHNMb2NhdGlvbiI6IHsidmFsdWUiOiAi
+      aHR0cHM6Ly9henVyZXNka2NpLmJsb2IuY29yZS53aW5kb3dzLm5ldC90ZW1wbGF0ZWhvc3QvQ3Jl
+      YXRlVk1TU18yMDE2LTA2LTAxIn0sICJvc1B1Ymxpc2hlciI6IHsidmFsdWUiOiAiTWljcm9zb2Z0
+      V2luZG93c1NlcnZlciJ9LCAiaW5zdGFuY2VDb3VudCI6IHsidmFsdWUiOiAiMiJ9LCAib3NEaXNr
+      VHlwZSI6IHsidmFsdWUiOiAicHJvdmlkZWQifSwgInByaXZhdGVJcEFkZHJlc3NBbGxvY2F0aW9u
+      IjogeyJ2YWx1ZSI6ICJkeW5hbWljIn0sICJwdWJsaWNJcEFkZHJlc3NBbGxvY2F0aW9uIjogeyJ2
+      YWx1ZSI6ICJkeW5hbWljIn0sICJzdG9yYWdlQ29udGFpbmVyTmFtZSI6IHsidmFsdWUiOiAidmhk
+      cyJ9LCAibmF0RW5kUG9ydCI6IHsidmFsdWUiOiAiNTAwOTkifSwgIm9zVmVyc2lvbiI6IHsidmFs
+      dWUiOiAibGF0ZXN0In19LCAidGVtcGxhdGVMaW5rIjogeyJ1cmkiOiAiaHR0cHM6Ly9henVyZXNk
+      a2NpLmJsb2IuY29yZS53aW5kb3dzLm5ldC90ZW1wbGF0ZWhvc3QvQ3JlYXRlVk1TU18yMDE2LTA2
+      LTAxL2F6dXJlZGVwbG95Lmpzb24ifSwgIm1vZGUiOiAiSW5jcmVtZW50YWwifX0=
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI2MTE1LCJuYmYiOjE0Njc4MjYxMTUsImV4cCI6MTQ2NzgzMDAxNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.BsXPjbpDDitiOiqCh89LqEkRNwGth9IsXslnNhFEHJBysUJjzEBeOZaEwQCAZtLOO2DLZkoTvDZ2ddXEfZ3XNXS4wSAj2Hf0L0-d3gbP7mvzGpcZIsAH4eUlfX8LoGuQt4MyBNPH1pfTfNJYTMOFAsnsy3vPjr6qVj8butsv2XpDhPrDGRTE7WrgCBF-I7OfWqeiej_zc3ZKEXneOgxc6IbWGBqmUfM8SyLh48O2a_hoEs1KciA4AKt77zbsCbqrnbHdNadvVTDvkM-ToYNzgjWXp6kcW13cwS_roFV3Afz3YNB61ICCYog45D3uATmoKVE9BCZkrwCGrljteh9djw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Length: ['1415']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
+      x-ms-client-request-id: [e8600df0-447a-11e6-b278-001dd8b7c0ad]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/azurecli1467829698.6496292","name":"azurecli1467829698.6496292","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVMSS_2016-06-01/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVMSS_2016-06-01"},"adminPassword":{"type":"SecureString"},"adminUsername":{"type":"String","value":"myadmin"},"authenticationType":{"type":"String","value":"password"},"customOsDiskType":{"type":"String","value":"windows"},"customOsDiskUri":{"type":"String","value":""},"dnsNameForPublicIP":{"type":"String","value":""},"dnsNameType":{"type":"String","value":"none"},"instanceCount":{"type":"String","value":"2"},"loadBalancerBackendPoolName":{"type":"String","value":"vrfvmssbepool"},"loadBalancerName":{"type":"String","value":"vrfvmsslb"},"loadBalancerNatPoolName":{"type":"String","value":"vrfvmssnatpool"},"loadBalancerType":{"type":"String","value":"new"},"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"vrfvmss"},"natBackendPort":{"type":"String","value":"3389"},"natEndPort":{"type":"String","value":"50099"},"natStartPort":{"type":"String","value":"50000"},"osDiskName":{"type":"String","value":"osdiskimage"},"osDiskType":{"type":"String","value":"provided"},"osOffer":{"type":"String","value":"WindowsServer"},"osPublisher":{"type":"String","value":"MicrosoftWindowsServer"},"osSKU":{"type":"String","value":"2012-R2-Datacenter"},"osType":{"type":"String","value":"Win2012R2Datacenter"},"osVersion":{"type":"String","value":"latest"},"overprovision":{"type":"String","value":"true"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddressName":{"type":"String","value":"vrfvmssPublicIP"},"publicIpAddressType":{"type":"String","value":"new"},"sshDestKeyPath":{"type":"String","value":"/home/myadmin/.ssh/authorized_keys"},"sshKeyValue":{"type":"String","value":""},"storageCaching":{"type":"String","value":"ReadOnly"},"storageContainerName":{"type":"String","value":"vhds"},"storageRedundancyType":{"type":"String","value":"Standard_LRS"},"subnetIpAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetName":{"type":"String","value":"vrfvmssSubnet"},"upgradePolicyMode":{"type":"String","value":"manual"},"virtualNetworkIpAddressPrefix":{"type":"String","value":"10.0.0.0/16"},"virtualNetworkName":{"type":"String","value":"vrfvmssVNET"},"virtualNetworkType":{"type":"String","value":"new"},"vmSku":{"type":"String","value":"Standard_D1_v2"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-06T18:28:19.9149247Z","duration":"PT0.1882486S","correlationId":"1dea76fc-6822-4199-9c93-fa2ab287bfb6","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/vrfvmssIP","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmssIP"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/vrfvmssLB","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmssLB"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_simple_rg/providers/Microsoft.Storage/storageAccounts/7clfz5cy65muovrfvmssz7sa","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"7clfz5cy65muovrfvmssz7sa"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_simple_rg/providers/Microsoft.Storage/storageAccounts/5jc5pyfvqdeegvrfvmssz7sa","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"5jc5pyfvqdeegvrfvmssz7sa"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_simple_rg/providers/Microsoft.Storage/storageAccounts/ew3e54kuikfv6vrfvmssz7sa","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"ew3e54kuikfv6vrfvmssz7sa"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_simple_rg/providers/Microsoft.Storage/storageAccounts/qwup4vedqqfjwvrfvmssz7sa","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"qwup4vedqqfjwvrfvmssz7sa"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_simple_rg/providers/Microsoft.Storage/storageAccounts/rg7p5anh4dcxyvrfvmssz7sa","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"rg7p5anh4dcxyvrfvmssz7sa"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/vrfvmssLB","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmssLB"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/vrfvmssVNet","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmssVNet"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_simple_rg/providers/Microsoft.Compute/virtualMachineScaleSets/vrfvmss","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vrfvmss"}]}}'}
+    body: {string: '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/azurecli1467920535.6606831791","name":"azurecli1467920535.6606831791","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVMSS_2016-06-01/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVMSS_2016-06-01"},"adminPassword":{"type":"SecureString"},"adminUsername":{"type":"String","value":"myadmin"},"authenticationType":{"type":"String","value":"password"},"customOsDiskType":{"type":"String","value":"windows"},"customOsDiskUri":{"type":"String","value":""},"dnsNameForPublicIP":{"type":"String","value":""},"dnsNameType":{"type":"String","value":"none"},"instanceCount":{"type":"String","value":"2"},"loadBalancerBackendPoolName":{"type":"String","value":"vrfvmssbepool"},"loadBalancerName":{"type":"String","value":"vrfvmsslb"},"loadBalancerNatPoolName":{"type":"String","value":"vrfvmssnatpool"},"loadBalancerType":{"type":"String","value":"new"},"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"vrfvmss"},"natBackendPort":{"type":"String","value":"3389"},"natEndPort":{"type":"String","value":"50099"},"natStartPort":{"type":"String","value":"50000"},"osDiskName":{"type":"String","value":"osdiskimage"},"osDiskType":{"type":"String","value":"provided"},"osOffer":{"type":"String","value":"WindowsServer"},"osPublisher":{"type":"String","value":"MicrosoftWindowsServer"},"osSKU":{"type":"String","value":"2012-R2-Datacenter"},"osType":{"type":"String","value":"Win2012R2Datacenter"},"osVersion":{"type":"String","value":"latest"},"overprovision":{"type":"String","value":"true"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddressName":{"type":"String","value":"vrfvmssPublicIP"},"publicIpAddressType":{"type":"String","value":"new"},"sshDestKeyPath":{"type":"String","value":"/home/myadmin/.ssh/authorized_keys"},"sshKeyValue":{"type":"String","value":""},"storageCaching":{"type":"String","value":"ReadOnly"},"storageContainerName":{"type":"String","value":"vhds"},"storageRedundancyType":{"type":"String","value":"Standard_LRS"},"subnetIpAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetName":{"type":"String","value":"vrfvmssSubnet"},"upgradePolicyMode":{"type":"String","value":"manual"},"virtualNetworkIpAddressPrefix":{"type":"String","value":"10.0.0.0/16"},"virtualNetworkName":{"type":"String","value":"vrfvmssVNET"},"virtualNetworkType":{"type":"String","value":"new"},"vmSku":{"type":"String","value":"Standard_D1_v2"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-07T19:42:18.3960117Z","duration":"PT0.1820285S","correlationId":"0fda4eee-7948-4426-a744-5992ae602df6","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/vrfvmssIP","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmssIP"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/vrfvmssLB","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmssLB"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_simple_rg/providers/Microsoft.Storage/storageAccounts/7clfz5cy65muovrfvmssz7sa","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"7clfz5cy65muovrfvmssz7sa"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_simple_rg/providers/Microsoft.Storage/storageAccounts/5jc5pyfvqdeegvrfvmssz7sa","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"5jc5pyfvqdeegvrfvmssz7sa"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_simple_rg/providers/Microsoft.Storage/storageAccounts/ew3e54kuikfv6vrfvmssz7sa","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"ew3e54kuikfv6vrfvmssz7sa"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_simple_rg/providers/Microsoft.Storage/storageAccounts/qwup4vedqqfjwvrfvmssz7sa","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"qwup4vedqqfjwvrfvmssz7sa"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_simple_rg/providers/Microsoft.Storage/storageAccounts/rg7p5anh4dcxyvrfvmssz7sa","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"rg7p5anh4dcxyvrfvmssz7sa"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/vrfvmssLB","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmssLB"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/vrfvmssVNet","resourceType":"Microsoft.Resources/deployments","resourceName":"vrfvmssVNet"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/scaleset_create_simple_rg/providers/Microsoft.Compute/virtualMachineScaleSets/vrfvmss","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vrfvmss"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/azurecli1467829698.6496292/operationStatuses/08587337771857510497?api-version=2015-11-01']
-      cache-control: [no-cache]
-      content-length: ['5876']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:28:20 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/azurecli1467920535.6606831791/operationStatuses/08587336863472637406?api-version=2015-11-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['5882']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:42:18 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
+      x-ms-client-request-id: [e8600df0-447a-11e6-b278-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771857510497?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863472637406?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -96,30 +105,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:28:50 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:42:48 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
+      x-ms-client-request-id: [e8600df0-447a-11e6-b278-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771857510497?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863472637406?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -127,30 +136,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:29:21 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:43:18 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
+      x-ms-client-request-id: [e8600df0-447a-11e6-b278-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771857510497?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863472637406?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -158,30 +167,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:29:51 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:43:48 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
+      x-ms-client-request-id: [e8600df0-447a-11e6-b278-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771857510497?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863472637406?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -189,30 +198,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:30:21 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:44:18 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
+      x-ms-client-request-id: [e8600df0-447a-11e6-b278-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771857510497?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863472637406?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -220,30 +229,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:30:53 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:44:48 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
+      x-ms-client-request-id: [e8600df0-447a-11e6-b278-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771857510497?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863472637406?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -251,30 +260,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:31:23 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:45:19 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
+      x-ms-client-request-id: [e8600df0-447a-11e6-b278-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771857510497?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863472637406?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -282,30 +291,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:31:53 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:45:49 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
+      x-ms-client-request-id: [e8600df0-447a-11e6-b278-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771857510497?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863472637406?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -313,30 +322,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:32:23 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:46:19 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
+      x-ms-client-request-id: [e8600df0-447a-11e6-b278-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771857510497?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863472637406?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -344,30 +353,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:32:54 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:46:49 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
+      x-ms-client-request-id: [e8600df0-447a-11e6-b278-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771857510497?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863472637406?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -375,650 +384,30 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:33:24 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:47:19 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
+      x-ms-client-request-id: [e8600df0-447a-11e6-b278-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771857510497?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:33:54 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771857510497?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:34:25 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771857510497?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:34:55 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771857510497?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:35:25 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771857510497?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:35:56 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771857510497?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:36:25 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771857510497?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:36:56 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771857510497?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:37:26 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771857510497?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:37:56 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771857510497?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:38:26 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771857510497?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:38:57 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771857510497?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:39:27 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771857510497?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:39:57 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771857510497?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:40:27 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771857510497?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:40:57 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771857510497?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:41:28 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771857510497?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:41:58 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771857510497?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:42:28 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771857510497?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:42:59 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771857510497?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:43:28 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587337771857510497?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336863472637406?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -1026,28 +415,28 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['141']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:43:59 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['141']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:47:50 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 vmsscreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [697280cf-43a7-11e6-807e-001dd8b7c0ad]
+      x-ms-client-request-id: [e8600df0-447a-11e6-b278-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/scaleset_create_simple_rg/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
@@ -1057,55 +446,55 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
         o0cf3W3Wk2ZaF6u2qJbN3Xs7+/nBw4efbj94cD7Z3v80P9ieZLNs+/79B5/u7N5/uD/J9+/WeVOt
         62n+eV2tV83dZpqVeZO3v/+0zrM2//2bYrEq89+/vri7qqvLYpbXzd0vimldNdV5O36lLzd3Z/mq
-        rK4X+bJt7mY/WNf5tCx29z99cLD38NOHB+NP9x9+uvdw76PRR8tskROqG9tQV6u8bou8+ejRL/6o
-        zQkFwuV5sXyLv9d1QQDmbbtqHt2VzprZ22kxnpTVZDyt6nx8VSxn1VUzXubtXfP6vGrauyc8qp/8
-        4vXr339vZ/fT7R36367AkBGMf7qploTCtFq2NJifpPESLam/3fEO/vvolxB6WU2DaOkroPP7Z4Tp
-        eTZtm+fVNAPl8Wl7vcIwX7d1sbwgeJdZucYH3yDaQCWbLYrly6xprqqaOMD1m08JvvZu2n3V5LWQ
-        37WTFg6/xTU35XfW7ZxIUMig3vALwy+uDBL05nTdtNXiy+Zp0by96T0dc/e1rzDJw2+h+WzZvMgW
-        +bOqfrmelMX07OUt37gJpWW1zNG8WDZttpzmJ9V62W56YQ+tyyqbPclKvFA/yaZv8+XsZVWV6HDT
-        u5f1+eWiaSb5ihp34dzy5XLSf7F9j86XWRvr/UY65VfyinDIpqZXedOueZJvYkBFSZq2lpD1xgm4
-        d+/gob5xenPr+zs7D03z1y2J7y1e2GHJr5g3b6Jq1cyoVbHILpiN5KWbiEk6D+qV5adqvjw/z+tN
-        zb8rYvM6ry+pIb/DUtDM6c8N71ndHQHw+vf6atOrpHn2tl/tbT/N2mxKisG8dtPIqCe8+mqv+6JV
-        rsPvQgM2LTcnNJlGN73S1vSDXljVxSW9fbY6ns1I1bKuHnon1v64vA1jz66JoYspAwD9p9/Y+zdx
-        mQoKzzp0Xx/CTROj8ts086dE5N8rv36ZtfNNL9ydV4v8rpqIu2N68S6MRFUXP8hnv//b/JrFlj4m
-        WD8p7wwD46ZtVZOUnGTTOb7c0PpVns2+XJbX/ltkorNiCWV3A6XmM0FM3nuVz9bLGWm465sIRMqB
-        Gtaz3//5q9cMYD0h02zp+7LOz4t3mwDskseA/+7u7bv3b0RXJvY1N8Zr69VFnc3ylxVN7vUX1Ywa
-        Db+9yJbrjFX5ZVG39OuLvCW7/PbrYL37aR/OLbH/yRenb/ov30Rw5cjLxeu3603t7MQ83f39L8n6
-        0jsLpstHZ0tyXOGGEg1IIIzCoNfpnRYtXq+n05y8vRl93xYL4vxssaLPSUeRV/WAfKs3uweP9u89
-        2v90fH//3sODT/d+iprO1rUK80cv3+ze/2Lv0/HB7oN7uzu7r+lbct/qnJQVNTgjP+yj3VmePfj0
-        fLr96cHe3vb+7sOH2w+nD+9tn2d72WTv4MHkfPIpvcb4waf+6NH3fjGZI8JmRSqSAFg97Xxsak/z
-        x7+DjvKO/wm9Jk4sxo/mRgGh6XJdlt//Jd//JaOhfk6qxWpNFLpFLzqpX7DY5q8RMrzOez0ao7+x
-        19cik/Sq3wde7/Wq4ns8ncIf29Tb92m68hX5DflyykEEAZMPmi9pAumv/zeFSyoxpMJDIhCGN7zq
-        vSBiaaSPYIEI/y8c5fMnHtIfOEqCBcaipj/nM6tsfLfDo3cfTMvzH9yfXn96f7GuFO0fPGgyb0w9
-        IgzA8l5RMgwCB1X+30WH+z89vb+6Pr/8RbM8v/BRdYP6+nQYBP7/PjrkV/fy+/tv18Xb88tPfVTd
-        oL4+HQaB/7+PDr/oar3av8xnv+gXnf/0lY+qG9TXp8Mg8P/30aG+eLC6ny3n+7Ppu2sfVTeor0+H
-        QeA/d3SIKvifRdvw/8JR/iT5wh7aHzhOhvZzZ+vVabw74BGaMXvo98Z7Awjv1XDkPOpq3dLLlmTO
-        A7g1fIuiZRf3KtEWUctdPylmX+Ck2+ArGoq/1KArt6958frgy4qq/mlf1Ziq99qAQhg2uu8B42Yf
-        42YY+Y126WYYN+v0m2EM68Pv/5Jf8v8AsT4hekMZAAA=
+        rK4X+bJt7mY/WNf5tCx29z998HBv5/69++NPP9359ODe7oOHux+NPlpmi5ywvakZdbjK67bIm48e
+        /eKP2pwQIYyeF8u3+HtdFwRj3rar5tFd6bKZvZ0W40lZTcbTqs7HV8VyVl0142Xe3jWvz6umvXvC
+        Y/vJL16//v33dnY/3d6h/+0KDBnH+KebakkoTKtlS0P6SRo1UZT62x3v4L+Pfgmhl9U0jpa+Ajq/
+        f0aYnmfTtnleTTPQH5+21yuM9HVbF8sLgneZlWt88A2iDVSy2aJYvsya5qqqiQ9cv/mU4Gvvpt1X
+        TV7LDLh20sLht7jmpvzOup0TCQoZ1Bt+YfjFlUGC3pyum7ZafNk8LZq3N72nY+6+9hUmefgtNJ8t
+        mxfZIn9W1S/Xk7KYnr285Rs3obSsljmaF8umzZbT/KRaL9tNL+yhdVllsydZiRfqJ9n0bb6cvayq
+        Eh1ueveyPr9cNM0kX1HjLpxbvlxO+i+279H5Mmtjvd9Ip/xKXhEO2dT0Km/aNU/yTQyoKEnT1hKy
+        3jgB9+4dPNQ3Tm9ufX9n56Fp/rol8b3FCzss+RXz5k1UrZoZtSoW2QWzkbx0EzFJ50HJsvxUzZfn
+        53m9qfl3RWxe5/UlNeR3WAqaOf254T2rwSMAXv9eX216lTTP3varve2nWZtNSTGY124aGfWEV1/t
+        dV+0ynX4XWjApuXmhCbT6KZX2pp+0Aururikt89Wx7MZqVrW1UPvxNofl7dh7Nk1MXQxZQCg//Qb
+        e/8mLlNB4VmH7utDuGliVH6bZv6UiPx75dcvs3a+6YW782qR31UTcXdML96Fkajq4gf57Pd/m1+z
+        2NLHBOsn5Z1hYNy0rWqSkpNsOseXG1q/yrPZl8vy2n+LTHRWLKHsbqDUfCaIyXuv8tl6OSMNd30T
+        gUg5UMN69vs/f/WaAawnZJotfV/W+XnxbhOAXfIY8N/dvX33/o3oysS+5sZ4bb26qLNZ/rKiyb3+
+        oppRo+G3F9lynbEqvyzqln59kbdkl99+Hax3P+3DuSX2P/ni9E3/5ZsIrhx5uXj9dr2pnZ2Yp7u/
+        /yVZX3pnwXT56GxJ7iucUaIBCYRRGPQ6vdOixev1dJqTtzej79tiQZyfLVb0Oeko8qoe0P/e7D58
+        tP/g0d7D8e793d2D3d2foqazda3C/NHLN/e/IBo9vPdg9+GDh6/pS/Le6px0FX1/Rm7YRzvns2w/
+        z/PtBw/3D7b39/c+3c4e7O9v33/4cC/LP93Zm51/Sq8xenCsP3r0vV9M1oiQWZGGJABWTTtHm9rT
+        9PHvIKO8439Cr4kPi+GjudE/aLpcl+X3f8n3f8loqJ+TarFaE4Fu0YvO6RcstflrxA2v816PxuZv
+        7PW1iCS96veB13u9qvQeT6dwxzb19n2arXxFbkO+nHIMQcDkg+ZLmj/66/9NMZMKDGnwkAiE4Q2v
+        ei+IVBrhI1ggwv8LR/n8iYf0B46SYIGxqOnP+cwqG9/t8OjdB9Py/Af3p9ef3l+sK0X7Bw+azBtT
+        jwgDsLxXlAyDwEGV/3fR4f5PT++vrs8vf9Eszy98VN2gvj4dBoH/v48O+dW9/P7+23Xx9vzyUx9V
+        N6ivT4dB4P/vo8Mvulqv9i/z2S/6Rec/feWj6gb19ekwCPz/fXSoLx6s7mfL+f5s+u7aR9UN6uvT
+        YRD4zx0dogr+Z9E2/L9wlD9JrrCH9geOk6H93Nl6dRrvDniEZswe+r3x3gDCezUcOY+6Wrf0siWZ
+        8wBuDd+iaNnFvUq0RdBy18+J2Rc45zb4ikbiLzXmyu1rXrg++LKiqn/aVzWk6r02oBCGje57wLjZ
+        x7gZRn6jXboZxs06/WYYw/rw+7/kl/w/gIrDfUgZAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['1628']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:43:59 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['1628']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:47:50 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3ODI5NDMwLCJuYmYiOjE0Njc4Mjk0MzAsImV4cCI6MTQ2NzgzMzMzMCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.R50AdSrOQ19gmx8qP3_siVRKA48BmS2c3LUveQzrfjoW88dYTbESkL-zSW28H2E05FK4xYy8chLcMs5Vds0-L5zhNtx4PwwJuFkm76647Ob9rQImMTSvX-bS7RZtwgK5m9yXWbEkio7rMhk3YOHWhVWmbGPZQ8DQFcKFOVDNQMsOEuIQtH6RKUMQN_al5oMwzBySUPUQjRI36xVwGulsUAxMeaj98sQ8GHUmscJwij96dpyLQYx0Y_GIUnj-p7TwU8OIkmXg-GHxsBF7UvMW5Yeop-kw-i54VwZK4rU3119Xld7N14IcYwoQ6BSwnWzeEFvA5xe1ANo_FNoo2K6H0w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10240-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [9a84fe80-43a9-11e6-9dca-001dd8b7c0ad]
+      x-ms-client-request-id: [b0298fa4-447b-11e6-9112-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/scaleset_create_simple_rg/providers/Microsoft.Compute/virtualMachineScaleSets/vrfvmss?api-version=2016-03-30
   response:
@@ -1127,18 +516,18 @@ interactions:
         5gfbk2yWbd+//+DTnd37D/cn+f7dOm+qdT3NP6+r9aq520yzMm/y9vcXFvn9m2KxKvPfv764Sz1f
         FjOi4107feMXQpO7qnT1z+auYv6TL07f3CWcCEf72Wv+86NfMvqorLLZk6zMiF3qJ9n0bb6cHc9m
         hE/zsqpKGh9R4ud2WD6GdgDl5O6kj635dpKv6M+Pfsn3w/GdLSfVejl7kbXc+v/FYytCTM03y6zV
-        gf0S+Z+IihEZ8KWYMVIXZPdb4l9yANbTaZ7PcucBVCSItik1YSHQ79bL4het8zOiSvrRzvnDvZ1P
-        7+9tH3z64OH2/sP797dp5Pe3p9nuZPJw79Ns8ukei7AgwLRMf/jEPBGXwfC/Oh2vAeO1x/MyfBVr
-        UkbBp+31ij+9NVR9r6ymrDLw7hVptDVswi/5fwBzgehqrwkAAA==
+        gf0S+Z+IihEZ8KWYMVIXZPdb4l9yANbTaZ7PcucBVCSItik1YSHQ79bL4het8zOiSvrR7uz83v1P
+        702278/yve39+wf3tg8mn8629/b2Hz7M88nD6cMJi7AgwLRMf/jEPBGXwfC/Oh2vAeO1x/MyfBVr
+        UkbBp+31ij+9NVR9r6ymrDLw7hVptDVswi/5fwBjsNYtrwkAAA==
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 06 Jul 2016 18:44:00 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 07 Jul 2016 19:47:51 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_show_list_sizes_list_ip_addresses.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_show_list_sizes_list_ip_addresses.yaml
@@ -4,14 +4,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.32]
+          AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [3676c28f-3f38-11e6-b69f-001dd8b7c0ad]
+      x-ms-client-request-id: [bce9ab8f-447d-11e6-ae4a-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/publicIPAddresses?api-version=2016-03-30
   response:
@@ -19,92 +19,121 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UeXWbnOP3qUfg9/pSl/iOejZbbA5x9dLrZnWZvNiubtdps37cv1pCymZy8/GtmmxQwN7zbrSTOt
-        i1VbVMvm7r2d/fzg4cNPtx88OJ9s73+aH2xPslm2ff/+g093du8/3J/k+3frvKnW9TT/vK7Wq+bu
-        tCzeUBevLn5/0+XdVV1dFrO8bu5+UUzrqqnO2/GLvL2qavpOUTmezQhQkzd3b4Fs3mYXQPe7d3/f
-        jx4eTLPd83y6/enk3sPt/fOH59sP9x8cbO8/fJDdmzzY279/sP/7fuS93F6vmCi3wMV7q6ymGYiC
-        N68Iq7X/JaHT0BeW8PQRob8qs+sXOgNmEAr6I9PylzggRKVVXrcFdRuCoi8ui4b6LpYXr9usZYCv
-        19Npns/ymUODmhJsmYu1zGe2t/fw3l6WbU8+fbC3vZ/t7G5PHkwfbt+7n00eHHz64NP98xBAsTIY
-        0tu798YP74339j4d7x7sBM06lPpJmlvCD++cvbzcjzctDQm/yNt5xeg9vSYOLaZB+2JW5m+KRV6t
-        27PlF8VyTTxAbfeDNquTanleXKxrBkhfe/TC9wz97g+dmZfy82zZ5vV5No0w809+8aKY3u3g39AH
-        U/6g29zyCXGK+VV/MZxjR26lnZDml7cvF3uG7xyJfzaI85NfnNQ5Mebv/9VkvWzXexuJZBlCeIeI
-        RIA2IexL+6e7e59Od7K97fw+sfH+g4f3Sdr3720fTA92psTQ2f17ez9vpf3hp/u70/OH0+3Z7D4p
-        wL17s+2He+f3t3c/nTzYzx6eP/j0fh4A6Ej7wfjh7njv/u5492HQrEOpnwfS/l4M3Zd6AmQZ+gaJ
-        95taPiFOMb/qL4Zz7MittJPKuMiXeZ2VxQ9yw3iOxj8r1Fl8bnvcSBnLDcI4RJmbsPVl/Xwy25s9
-        +DTffnDvU0JyNtnbzh7uPtz+9N6D6Wz//sN7u7v3ft7K+uzedOfTT/dIws/3yLLvk9RnO+fT7f3z
-        T8/3HhBtdrJQiDuyDlG//+l4795e0KpDqJ8Pon5bZu6LecDMN8h50NYyCbGJ+VV/MWxjx+0LegMe
-        2V5UM8N0jsA/O6Rhpvyimm0kjGUE4RkhzCZUfSEn633//sFsd/sg2yPuvf9wZ3syOZhtP5hNdw5m
-        09292TT7eSvkNE275KGT+753sEvTN6HYZmdnsv3pwcPswWS2P83vTQIAHRL8vBBfpulNPBoVXsuj
-        N8uubWqnnibf/Kq/GGawY7aiS5L/nCj2zrCRI+w3RxLqo1hkFzSyTXSwsy4MQq3pvSHcfDl9sLuX
-        7R6QlZnsnz8gY5yT5cl28u3dnU93Hzz89P7B/U9//hrj8wdZlt/PDrbvH8AE379/fzs7yHIyywcH
-        5+cPH0zuP9zkeO/sj/d3xg/3x7sPBmRUGv//VpyJB2/Bu30ZpveYd2+QX9PMsgMxhPlVfzEMYgfo
-        y+5VsYzFpT/k4dsZFmag1vTeAGqB5O7sZAef3tvdnu5NiDnPd0iG83vZ9uzTPNu/d//8Xvbp7Oet
-        5FLm8NOHD2aT7fufPqTpevgg357MDna2P90/yB/u3j948PPVwhJv3YInoyIJnrxZItHKzjLNs/lV
-        fzHzbofnC+R3i6XhF0fBH/bY7fQKJ1Brei+OmS+O0/P7+cHs4YPt3fOHs+39nV3iuIPp/e3pvenu
-        9OFDCnOzn78O7/nebPbwYHawfX4+paj2QZ5tP/x09952du/8YX5+QKnoyW4AIGZIP703vvcgaNUh
-        1I+EFj9DoSXGvVlmqZHlBOIF86v+YnjDDs6K7CJbrrPyctGsipWj3jc3bgu/qS82Dt3OrjACDd2+
-        GqLmS+zk0+ns/B6tn+QknCSxs4eUdLk32d69v/fpvYcP7+X57s7PtsTSoL5xYft058H0/s55TqSl
-        f/YnexRnzvLJdr4z2X+Y7eUZ5YsDAB3sf9hiNFs2r/O2pYHiK48I+K5aZMUS2ut5NslL+t4xnUdH
-        PB+d/6IZI+0ajIXe42lZrWfZajXOfrCu8/G0Wvjs7kH54Ym0Q/IG1i6rbPYkK7PlFN/b18rJ3fO6
-        IlFfzs5eBjg3d597rzxDo9Pl14tvF9c034H8fHPjv64vNqffqWthNeFKyHQPHV+cD/Z3J5N8km8f
-        THbukY2BP3yP3OM9Wjben0x2H95/+PD/K+LMhFJxJrzzLJs83D44382296fniNAf0NLY7gHFp7Qu
-        tL8XymhoOykjfG9MKm28G7YiUvrk/bpCD930NWT+hydnN/JZR8CufyiSdV5Vk4wG5nk93+SYSUFs
-        HLOdUZl8kq0YQr50TWd7+we7s/vbezv37lNAle1vH3y6c749O5juP6QVHWLC+z/b0kXogJEsNemj
-        /3e4t9nDB7vkxk62aX1mnxZoH97bfrh77x4tcM1m9PFs7/znPgFkmtyGNQMdK0O8+3PGlgEyPkve
-        O5hkFMZ/up1lROt9SqlTxDXb257cn96b7X86+3R6/vM44trZnU6nDw62swcHFHEdkEk82J882P4U
-        sWg+fTg5P78XAOiQ4P9VLAnO2dnd2X1riOnAE3C0uPtzw554Zwgxn1UnO/f29rKDKS1/7Tyk2bg3
-        2z7I9+9tU2I427+fZXt7D89/3rLqfaJC/vDhwfaDnb1zisPIy5nc//TTbcqm7B7s7RzsP5x8GgAI
-        HBxKDOzukndD6957O2G7Dql+GCwdtPnh+Tg3cW4/NYB3mHNvyA7YdpYbiB/Mr/qL4Q87vJ7g/sCw
-        liPiD3P4dnaFEbzhxxDzBXfn4eTep7NdktkH5PvsU/S8fXBvjwT304PdTyd7M3KGPv15K7j5vb08
-        z6fT7fu7WB6jJYjtjLTc9jTLaU1iN9vZvfcwABAIrmb19j4dP/yR2NIYI3w7LLY/uKXY/sDyAnGD
-        +VV/Mdxhh2fFdrpu5HXDWI6I3/DwN4dmdnqFE2j8mzDz5TbboVXtT3cn2w8e7u4Qa07I4E6y8+0H
-        k737Ow/IoEw+Pfh5K7e0ajg5eHD+6fb9PXJJ9j8ll+ThHuXl9yY7B3k22Xu4Oz0IAIRySxmFXaxq
-        7+3vBa06hPr/t9xuZty+4FrGvUFwbTvLDMQO5lf9xbCHHV9PcGNrxz/M8dv5FVbwxh/DzBfc/f29
-        809nZGbz+9NdMrg7e5T32t+hVN7D3U+zg4P79x78/A3qdib3zimdT5n96T3K7J/v7dEKGrnL9yk7
-        M6XJOs86AALBJWO7u3sw3qV1NFpwC9p1SPUj0Y2J7k2L37adZQdiCPOr/mIYxI7Pii5Qo5d3f9rw
-        lqPiD3X8dn6FFWj8eGkIM190H0woH31/j2SVEjKUIswpM0OuIKWsJ2RjyN2bPLj381Z0d+9Pzx8c
-        0GxNdmYPaFHunPKnGWVmJtB3B/mEwoudAEAgumJzDx6S8IatOoT6keD6gouXiO92f/oGwbXtLDMQ
-        O5hf9RfDHnZ8geA2ze6nheEsR8VvePzN5mjBTrDwghJgCDVfcncffrqb5QcZpac+Jcm9f5+M7qf7
-        u9uz2XT/4ODT+/vn0591yaWRffNCNyOb+ODBdHv24D45Ew9oEe3hpw/vb+/uZ5PZQZYd3Dvo8HxX
-        6Gjp7FNKLP08dnRvYLru6hneIIb7oSyimd5ihumHSgQ7y8IQnuTFUPMlb+fBzv18dwdGkvy4/fuE
-        28E5obX7IJ/sn5/v5Od7O/9flLx7+cNpPt1/QPJ2Tsmz6eR8++F0trt9bz+/RxFmvn+e5wGAqOQh
-        rfv/S3t3E9cp/2zmurjo/fQPU/R2swh/Cwfc/cZEb7PZ77G9vhbHzZe980/v7ZNbdn87RwZk/yFJ
-        4cEehVR7n+49ePhpvvOQUkj/X5S9nXu7s+n5zv72g11aiN6f7ZHTOaH0zmQ/351REJ0fnIf2LJA9
-        jhJJ8A4owbMbNOsM8v/vZm8z20WFbzf7oQif4eur508cFb+58b949fLV5xsHb6dXOIFkLo6SL22T
-        nfN7D/Zpjf7e/j0KgB7uUnR4sJdtz84pqzMhYZtN/z8pbbTQcU7x232ydNn+9v69Ca1e7nxKQfDs
-        4PzB+fn5/f1ZFgAIpO0+SdqnO+OHlJY5eBA06wzy60obRvM1hG22bF7nbUvkwFceqfBdtciKJeLp
-        59kkL+n7j67KerJcCR7FamdnN9Ac9M75L5ox7v2GY5ml8bSs1rNstRpnP1jX+XhaLXzZ8KARAQPB
-        IrAhfjIvd38YghBqAWL+H4L0L66XzcXlwlPh39yICXJ9sXHEMnXEa8KWJPoRfHy5P9jZmebZ/Z3t
-        /OGnJPdTSnxkezu0Zkir/QdTyoHs7O79f1HuZ+Sg7+xO8+3zffIZ9ncekAbI8p3t3b1Jfm9KKoGC
-        zwBAIPdsZUno790b/+zI/f/rrSwxzQ2sFkvo0FvEapSToORNgKjL5ny9lZNsZkyYI9k3N9i6ut7d
-        u0fkbjeO2E6ozD2NOIqWL16z2Q6wmWzfe3CP1vJ29h5uH9x/mG/v5XuUgH2wc36wt/v/RfH6lMLF
-        vfsUQN7Desf+QzKwtPixS875dOfh/sOH97MH9wIAgXghgKS0DazrQWCKnMxI4x+2eL2nXRW+8Xuh
-        dsaWypf/L7afgiBRYTPXh0Y0m/mWcoM9ffLs1B+h+VV/MSO2Q7OSbgTqsj4vJ46039ywm2lW5k3e
-        /v7TOiee//3zd0WDGf/9KwH6+9cXm2MLy3jCo7lzr7s4+5pgcjD59OHuwf3tT/MJSQyt5JMmoPX9
-        hwe0ZEi29tPZzv8nU0n3793f2/90d3ebRJ5SZNn00+2He9lkeze7NznYm8zy/b0NhpaWnSiO3Rnv
-        74939w6Cdp1R/rBVwQ9NDD+YH0MBZR7cIJde4w/yc6kfBNWG9R19/19EGcsXwkI5U2cAa19W9x+e
-        72YPDu5tH0wnZLUfZoTs7ux8e3p+vv/wwc7kfOf+7P+LsprNdnYf7GcPtymopWA4+xQptU/3tj8l
-        t//e9P7Dg2z6c26OTZPbMCD1WawcVIKJL+5+85znGO79+Y0+DJAMGO3+XjabTXa3z6ezHcpOPHxA
-        ucDzbJtyMdPp3pSm6f7/J6Ov3d3p9OE9ytjuT+5TjnNCiydEclqxzKcPdnZ2Dh5M74fcEzUK9/bg
-        IwbtOqP8YTBk0ObnyijckgF7pgDK7v+v5qApFqsyv4kklg2EY3JLlgiqgWg+gK58MCEbsEssnGXT
-        7YOH9+9vk1zeP9/fmR48uJ/9f1E07+/sUrpnNqNF9wfn27TQd3872yFJpehtlh/QkkQ+vR8AiIsm
-        JUceBpGPkzdp/fNGNG/Hhj/HkvmDCLd/YxS5XBhaTNdNWy1+/2J1EzksBwiz5ARkCE1fKA9gFzMy
-        kPdnn5IDM53sbT+8B8v58P5O/un9nSmZ0J9toSR0wHyW0PTRrGhWZXaN3AB9Y0NYBW1nzcwRvUG0
-        +cYl+8H+/sG9T893tjNaISXiPNzdfrj7cLq9uze7v3v/nFb6p2GEFUg2pSoePhwf3B93wrUOnb6u
-        WGMsX0Oq3zMhQ0yEtT4sXOD/P/D7ozdMaqbb7H2TNIT7D0vbfA3Z6idmabwkWz/5xYtiSnnYAHOX
-        mJVGllmJXc2v+othXzvSUMUYrnc0/9mmwtcK/iJo+hpmQsHeZHqf8jIP9++TXtmfkUd+/3z7/Dz7
-        lOTq/P69vQc/bzXM+cPJvf2dg8n2+e7uw+39nFK/lOwlCu1ks71PP31wQHmsAECgYSTre/Bw/GAn
-        aNSh0/+nNIzfHb0woGD+P6dfNkvWgIK5jX7xx2t+1V/M+O1AffVCEx8E0T8L449klzZSgVASXhS2
-        FSrQhwGevmqZ3t/NPn2Y71MIcX5Aa0GTyXa2e393m7zuvZyWgshO/39yLSjf//TBZGf26fa9e9mM
-        IqUHU/JASGXu7O8/OJh+er63dxAC6GiFA6iF3U/v0f8DeXLSLq2/rmL4f31E8fV58IctiUSlFoHL
-        7irg8m+MElf5BF1sHLOdauEKGjNeiWDly945rbo+yPZJ4kgKt/f3Pp1tZ5N7O9v3H052aMny/GF+
-        /rMue4QOeMxSlT4aMOt2bsxMUFMiyTcuuVn+4OHO/gNatp3tkEb69BwZbyxRne9Pae7OD2a7A2Im
-        Y/9hS+R72mqCIHzhd0RNjZW23/+/2D7fRiLC3AKa86i+yewCfnz/N05+yf8DaQMtsvpsAAA=
+        6UeXWbnOP3qUfg9/pSl/iOejZbbA5x9d5MvnxXL97uV6UhbTs5cfjWyTYoYGd5v1pJnWxaotqmVz
+        997Ofn7w8OGn2w8enE+29z/ND7Yn2Szbvn//wac7u/cf7k/y/bt13lTrepp/XlfrVXOX+igW2UXe
+        3F3V1WUxy+vm7hfFtK6a6rwdv8jbq6p+e3elGBzPZvR+Q63pvSHc8ja7AHbfvfv7fvRgdy/bPXg4
+        3Z7snz/Y3p/ls+2H2U6+vbvz6e6Dh5/eP7j/6b3f9yPv5fZ6xWO/BQ7eW2U1zUADvHmVN+3a/5LQ
+        aegLS1/6aFY0qzK7fqGENoNQ0B+Zlr/EASHqrPK6LajbEBR9cVk01HexvHjdZi0DfL2eTvOcRuvQ
+        oKYEW0i/luk7f5Bl+f3sYPv+wfl0e//+/fvb2UGWb+/vHxycnz98MLn/MA8AFCuDIb29u7M/3t8Z
+        P9wf7z7YD5p1KPWTNKeEH945e3k50LQ0JPwib+cVo/f0mhixmAbti1mZvykWebVuz5ZfEAO0TJD9
+        oM3qpFqeFxfrmgHS1x698D1Dv/vD4t2l/Dxbtnl9nk2pNb3HvPuTX7wopnc76Db0wZQ/MM0sOxBD
+        mF/1F8MgdoC+7F4Vyz3DWY6IP+zh2xkWZqDW9N4AaoHk7uxkB5/e292e7k2IOc93SIbze9n27NM8
+        2793//xe9uns563k7p7nnz58MJts3//0IU3Xwwf59mR2sLP96f5B/nD3/sGD/N4kANAhwY9EEj9D
+        kQRP3iyRaGVnmebZ/Kq/mHm3w/MF8rvF0vCLo+APe+x2eoUTqDW9F8fMF8fp+f38YPbwwfbu+cPZ
+        9v7OLnHcwfT+9vTedHf68OH+bJJlP2/F8XxvNnt4MDvYPj+f7m3vP8iz7Yef7t7bzu6dP8zPD/b2
+        Pp3sBgBihvTTe+N7D4JWHUL9SGjxMxRaYtybZZYaWU4gXjC/6i+GN+zgrMgusuU6Ky8XOzsPPG36
+        zY3bwN84bDuzwgQ0bPNaBy1fWu8/3DvYv3d/d/v+/qcZYbP3YPtg92G+Pb1/sPfw3r3d6Sz79Gdb
+        WmlQ37igTc53H9w/mOxs70xn5Kc+vD/bPtjJ9rbvPXg42c3uz/K9SShCfUG7P97buz/efxg06wzy
+        /7eSZlhnI8f1Bc28Bo57eP8hyVaArxO23Q+UswOPdj/kUdt5FRYIRh2g5cvZw53Z/clD8k9n5w92
+        tvcnhNfkgJhy8unu5N69+9NPp7Pp/xflbP/+wcHD7NNPtyl4prA5z+5tT/Z2drfP93cfTM/v7+/f
+        28kCAKGc3RsfHIwPxrufBm06I/yRkNHPqJCRX7Vzn2QqwPebErJmVawc7b75UTdNfbFx5HZuhQ28
+        kXdQ8wVtQpJ0fu/B3nZOnia5n7OH2w/P7022d+/vfXrv4cN7eb678/9FQft05wFN9nlOpKV/9id7
+        GQVy+WQ735nsP8z28uzBp/cDAB3sf9hCNFs2r/O2pYHiK48I+K5aZMUSrvjzbJKX9L1jOo+OeD46
+        /0UzRto1GAu9x9OyWs+y1Wqc/WBd5+NptfDZ3YPywxfoG1m7rLLZk6zMllN8b18rJ3fP64okfTk7
+        exng3Nx97r3yDI1OlzN/wOZX/cUQwI7Uyfc1zXcgP9/c+K/ri72NA6euhdWEKyHTPXR8cT7Y351M
+        8km+Tb7cPQqYkNwht3R77+H+g/3JZJecjIf/XxRnwjvPssnD7YPzXfK7p+dINz+4R873ASVbp+cP
+        9/dCGe3azYf3xqTSxrthq84Yv67QYzBfQ+Z/eHJ2I591BOz6hyJZ07KAVfYCi29yyKQfNg7ZTqjM
+        PYlWBB9ftj7NH07y+3uz7b2DCcnWNJtsPzw42N3Oz3d2dncms3t7s/xnW7YIHbCRpSV99P+OTM3D
+        6ZQciHyX0sifUhpr7yFlajJaFDq4d57fnz28N9nPwyWPDgm+ruh9XXv7Q5S9mxix77EaRrwhA2Oa
+        2TmmWTa/6i9m1u3gesLnZzp+iIO2cyrT7w3aR8gXv/N7+UF2vvdw+97D3X3C4wHhsbc33Sb9v/vp
+        g0/p2wf3f96K395+do88eFqoIGeelmNnu0ScnYPtbDL59GD33vTg/GAnANAhwY/ELyJ+k1vK38TO
+        Ms2zGYb+YubdDs8J4Lqht+/v7t3LJoZrHB1/mBSwEyy8AApsxs0Xy93Z3kFG7cjP3GGUKIDcPdjf
+        3rkPrsvOs9l08vNWLHd28tnB/kPSWRyFPtwlt3VyP9ve3Z2e39vdpQTXgafuCEDUbT0YP/x5mlW9
+        kXUjwuux7k3y6zW1HEE8YX7VXwyP2EHGRNgwmCPmD5MMdpaFIUIyRFDzBTjP9/Z3d/J8++GDh+fb
+        +9kBJSdntKRxb/bpg/Pdnenefv7z2K5++nAye5DNtvNdrPc8ONjbJi6bbH+6l+092D+gmTsPFyA7
+        JPiRaMZF8/aSaWea5tr8qr+YubdDjAim4RtHyR8mDewUCzcENIhg5ovlg/OdB7tkWInfyK3b//R8
+        Z/vgU1ouyM7vU5g1+fTT/U9nP2/FcvaQFk32Ds63H3y6R8TJHlDC6wEtqMzOd7KH+X5+b38/FMvQ
+        rrrlyt29vaBdh1Q/Et+o+N5aei0/EEeYX/UXwyF2gFZ4z6tqktHovBn8YQ7czquwAA08hpAvqtPZ
+        3v7B7uz+9t7Ovfvk5WX7JKo759uzg+n+w/PJjHKTP38taPbwwW5+fkC5snsI2/ce3qP44N697Qf3
+        ZjP6eLZ3/mBArgTPH4YImia3Yc0g9S5DvPtzxpYBMj5L3juYZPm9CblyGdF6/wGRfnIw29ue3J/e
+        m5Hl+HR6nv28Zcnznd3pdEr5owz+3P4BrZQc7E8ebH86ffhwP58+nJyf3wsAdEjw/yqWNIthlIdw
+        gAksvrv7c8OYcZR89pxkO/vns4wyVRPEHLu7n9IM7B9sk/48p2BkOtk9//Rnmz1pTN84Z5HnkT04
+        z6fb9+59Spy1f/98O/s0O9h++Gl+b2/30/3J+cGPInkaY4SN+v6Gx0Z79x+SdxHg6tyNXas3SE7M
+        r/rLBrkhjHZ29ndi4fEPcdh2VoUBMGx6ZwgxX4byvU/39mfT/e3ZDD7w3gHllh7cn21nuwfZfpbl
+        +af3zn+2ZYjQAU9Z6tJH/+9Q8feybLrz4AEtQk13yCU7p0Xjh/dJ3+zez/Nsunf/QbYfOv79AGFn
+        TOvFezs/klcaY4RxI/JK7zDj3hAe2HaWGYgdzK/6i2EPO7xQbnd3dt8aznJE/GEO386uMIIZ/gBi
+        vtxOdvLJwcPzB9v3D+5TTvh8/+H2Qb6/t53v3c8yUnUHO7s/f12z+7sP9vOHDw+2H+zskWNApCCX
+        9VPyDma0qEALWvsPJ58GADok+JFAdgUSHHkbgUQ7O8s0z+ZX/cXMux1eTyBLwzKOiD/M4dvZFUbw
+        hh9DzBfI3U+pTwTt+/fID92//+nO9mR3f3c7/3T/AaGU38/3f9adUUIHvGWpSx/9v0Mgp3t75/mD
+        Sb59vp/vkrbavb/98ODBw+3d3b37k+neJM/3DgIAHRL8SCAjAlneUiBLO8s0z+ZX/cXMux1eTyAX
+        hmUcEX+Yw7ezK4zgDT+GmC+Q+f17uw8+vU+JohxG4MGn5NnuEmYPH87u7RI77lH2++dGIG8SSBqJ
+        nRgaFJHnGxfI2f370wfETtvT2YwE8v4eEYeWCrZpQYDmbO/TA/JtAwCdefiRQEYEcnFLgVx8kEAu
+        I3z/Qxy+nV1hBG/4McR8gXx4kE32p7S+cr47pbTGw/3Z9sG93Smtuczy6YPZzqd753s/bwVy59N7
+        0wfTndn2ebZH/vy97OH25N7BfUr8zB7eo1XinYOHOwGADgl+JJARgVzeUiCXdpZpns2v+ouZdzu8
+        nkBWhmUcEX+Yw7ezK4zgDT+GmC+Q+zuznfwBMdn5p5TG3r+/e7B9MKUVp8nO7N6nO/sPDnbz/Oet
+        QN7PprsHO1Najpvepwzzp7L2NN3eOc92ds4f3ssPJqFAhrmfe+OHu+OHe+MfZWoH2HZYaqtbSm1l
+        WYGYwfyqvxjmsMPrSe3K8JUj4g9z+HZ2hRG84ccQ86V2sjvbe3A/z7b39u8RYx7s3KfkxgOyquTn
+        3j/fvXdOmduft1I7+3R35/793Z3tXZo0Smfv71CguXd/e+c+6bR8Mj3Y3btZau+PfxSM0hgjXDss
+        tKtbCu3KcgLxgvlVfzG8YYfXE1rDVY6GP8zR28kVPvBGH8ErENnZw53zg8nD7ZyW9SgUnVK0lZOh
+        nd7fnXz6MN+ffPpg8vNWZCcTWu4kImyTuaW52s1IZHcpStg/33t47/7Bzvne/RBAhwQ/EseION5S
+        Gu0c0yybX/UXM+t2cD1h/EWGYRwJf5iDt3MrbOANPoaYL47nD+5/OsuyT2kx796M+OzTbPvgICcL
+        upPNDmYkk/sHP38D0U/Jozh/+GBn++DTezRZ92ez7cn+jNY8J/fy+7vTT3dn0wcBgJ4FvTfe27s/
+        3tsNWnUI9SOhjQjtL7ql1P4iywvEDeZX/cVwhx1eT2xrw1iOiD/M4dvZFUbwhh9DzBfb7OG9ezt7
+        e7vb0wckrPsP8/PtbJeWE7IHO+e7+c7DB3uzhz9vxXZ3cjA9n0x3tvODHXJ8759jsh6eb5/nD3d2
+        HswmB3v7ewGAUGx39sf7O/B8d/fvBc06lPqR3Ebktr6l3NaWGYgdzK/6i2EPO7ye3DaGsxwRf5jD
+        t7MrjOANP4aYL7fTe7TSMHs4QxBGK6PnDybbWUaJlZ2DB5/u53vkAk/u/7yV23xnMn3w4P759kGW
+        U2gwofWqyfnubPvT2e55dn+XMuUPzwMAfbklW3tvl/4/II3S+keCGxHc5paC67iB+MH8qr8Y/rDD
+        6wlua1jLEfGHOXw7u8II3vBjiPmCez+/fz+fHJDB3X94f3ufwlSytdMH2/dne9Pze58+2L238/M3
+        00T+x8HB/U/z7ft7n+5v75OYbk9mD8jg7u3PHmYUYOx/GnrAoeDeO0Cqae/+vfHup0GzDqV+JLcR
+        uW1vKbetZQZiB/Or/mLYww6vJ7drw1mOiD+c4fOw+yJjhx9DzJfbvcm9KbU72CaPkGxKtjfZPoAE
+        53sPHk6n5w8ePni4+/NWbj+d3b93ns/uUV6YF70e7JLpJQrR55Ps/vl05/6nmxzle+ODg/Huw53x
+        7oMwkdyh1I/kNiK361vK7doyA7GD+VV/Mexhh9eT2x8YznJE/GEO386uMII3/Bhivtzu3MsfPniw
+        s789o/TU9v7OTrY9eUCLsjuzyfT+vXw/O5/+/A1w83t7eZ5Pp9v3d8+n5Iyc72xnexnpuCyf7k0o
+        a7x770dLrTTGCEcOC+QPbimQP7CzTPNsftVfzLzb4VmBnK4bed2wjCPiNzz8vY3jt9MrnEDj34SZ
+        L5HZTrZ78OnuZJss5g4x3WS2fTDJzrcfTPbu7zx4SJHrpwc/byUSCeKDB+efkgd8QBL56c7D7Yd7
+        073tvcnOQZ5N9h7uTsN11K4lJQf44f54r5OY6hDq/99yu5lx+4JrGfcGwbXtLDMQO5hf9RfDHnZ8
+        fcH9QTaZGu5ylPyh0sDOsbCDT4MB7AIBnmT757PJZHsymRJS9+/vbWczWu+ZHUxoYXF3Mj04n/68
+        FeCd83x6MHnwcHv3nKzpPoX72xnN0vanlEe+d/Dg3r38wYalHsoX7+4eUAi79/M7abyZfTeIMNj3
+        tmKMtpYtiDHMr/qLYRQ7zpgoGy5z9PyhUsLOtDBFSIkIboEY72f5jBy97dnOfcpEZbwoCVmeTGZ7
+        B/fPd88/nf28FeOH57QsdkAS/HB/Z4+I83CPMlH3P90+n8w+/XRvf3Jw/37oGcfFGGnkH4nxAPNu
+        FOPbC7FlCWIK86v+YpjEjjEiwobBHCl/qESwkyz8EBAhgpovwJRdyQ6mlC39lBQZZUtzyr+Qs7j9
+        YO98Sh89zHbu//y1w5OHn5IzMn2IPDulkj/99N52du8+klNEsfuk8R58ukGAd+89GO/euz/eJzt8
+        cD9o1yHVjwQ4LsC3ll/LEMQS5lf9xbCIHWFPfPcMdzk6/lApYGdYmMGjQAwzX3j39/fIvu7l2/n9
+        6S4ZGLIyB+f7O9uTew93P81oFeTeg5+/60A7k3vnk72M1oGm9yjZfr5HXsm9XZqtKa2S0WSdk+cS
+        AAiEV63v7qf3xnt7P48Xgjaz7rDw7t1SdvcsOxBDmF/1F8MgdnxWdIEavbz704a3HBV/qOO38yus
+        QOPHS0OY+aL7YHL+ILu/R7KaZfe2ac2SlnApY7q9P51QwmZ3Z3/y4N7PW9HdvU+LYQc0W5Od2YPt
+        /cn5Pi0FHZD3DH13kE8ezO6HazyB6EoC6+AhCW/YqkOoHwmuL7h4ifhu96dvEFzbzjIDsYP5VX8x
+        7GHHFwhu0+x+mhvOclT8hsffbE692wkWXlACDKEWSC5Zkk93CaPZ7i55zPd2z7cf3jvY2c6nu5Pd
+        nU/v784OHvxsSy6N7BsXuv0H9z6laHVGrv99onR+kG1neT7Z3n04O88fUhKK1qgDAB2hU2d3Z7xH
+        yU2/XWeUP4dip/T0CEboyejv3obtPpztyiqbPcnKbDnF9/LG7qd5Obl7XlckjMvZ2cuO4D33XnmG
+        RqfL2QfJXhFh8B8qEToM4cleDDVf9kjsdjNw5oMZxWKcNT74dH93ezab7h8cfHp//3z6s241aWTf
+        uOztzsgfffCA0mgP7pMj/2BCKzafPry/vbufTWYHWXZw72Cj7I0f3iNrt0uuatCqM8YfSZ6KkXmD
+        GO6HKnkxp/CHSgQ7y8IQnuTFUPMlb+fBzv18dwcOKsVQ+/cJt4NzQmv3QT7Zp1WK/Hxv5/+Lkncv
+        fzjNp/sPSN7OH9LgJmTNp7Pd7Xv7+T1aKs33z/M8ABCVPMrwPPx57GvewHVx0fvpH6bo7cYWMr5p
+        Imx2ue00C0c42Yvi5sve+af39ikkur+dYyl//yFJ4cEepTP2Pt178PDTfOdhtnvw/0XZ27m3O5ue
+        7+xvP9h9SNZ8tkcB32SKMC/fnVECKz84D+1ZIHvkae7ukuAd7I/3fl47nJvZLip8u9kPRfgMX189
+        f+Ko+M2N/8Wrl68+3zh4O73CCSRzcZR8aZvsnN97sL+7TybgHiUfHu5SZuZgL9uenVNGdULCNpv+
+        f1La9ia755Q7uU+WLqPFjHuTjNIrn1ICanZw/uD8/Pz+/iwLAATSdp8k7dOd8UNKiR48CJp1Bvl1
+        pQ2j+RrCNls2r/O2JXLgK49U+K5aZMUSuazn2SQv6fuPrsp6slwJHsVqZ2c30Bz0zvkvmjHu/YZj
+        maXxtKzWs2y1Gmc/WNf5eFotfNnwoBEBA8EisCF+Mi93fxiCEGoBYv4fgvQvrpfNxeXCU+Hf3IgJ
+        cn2xccQydcRrwpYk+hF8fLk/2NmZ5tl9SuQ8/JTkfkpJx2xvZ7p9/wEt4k8p/7izu/f/RbmfkYO+
+        szvNt8/3yWfY33lAGiDLd7Z39yb5vSmpBAo+AwCB3LOVJaG/d2/8syP3/6+3ssQ0N7BaLJlKbxGr
+        UU6CEqcBoi6Tuvu1pCqbGRPmSPbNDbaurnf37hG5240jthMqc08jjqLli9dstgNsJtv3HtyjtOnO
+        3sPtg/sP8+29fI8WPx7snB/s7f5/Ubw+pXBx7z4FkPew1rj/kAwsLTzuknM+3Xm4//Dh/ezBvQBA
+        IF4IICltA+t6EJgiJzPS+IctXu9pV4Vv/F6onbGl8uX/i+2nIEhU2Mz1oRHNZr6l3GBPnzw79Udo
+        ftVfzIjt0KykG4G6rM/LiSPtNzfsZpqVeZO3v/+0zonnf//8XdFgxn//SoD+/vXFvY0EsYwnPJo7
+        97qLs68JHh6cH9ybzsgC7ZyTxMzI0D4836N1B0rDTGf3phTUPvz/oiZ4cH9n5yCjhVzK1pKDfX+X
+        wvR855wUw4Qm5t6E/v/z04J+MJ+Fgse8tUHevMYf5L9SPwiWDUs7+v6/iDKWL4SFcqbOANa+DE4m
+        +/c/3TnfoaVLWr/cv3c/2z7YOTjYfrDzkPzCfWLjnfv/X5TBvb3ZwcMHD89p6fIepanz8/PtycF0
+        uv3gfPrw/j6leu8/DKyUEyzB/ochg6bJjQxI7VvM5e6qWDnIBBdf3v1w7rvKJ+jiPRkMr0Sw8rnr
+        nDy7B9n+ZDubYjlr79PZdja5t7N9/yFlHKY75w/z8591X4/QAbUtVemjWdGsyuwajgt9Y+2rVQ5m
+        JqgpkeQb582MVtB39h+QazjbOaApOr+3TXHl/e1Pz/enNHfnB7PdAYaTsf8weNNv854uIEEQvvA7
+        oqbGC7Tf/7/YEbxBIpgjQ2NkR/VNmiT8+P5vnPyS/wd6YXY9cKAAAA==
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 03:02:15 GMT']
+      date: ['Thu, 07 Jul 2016 20:02:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -116,14 +145,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.32]
+          AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [3710b8a1-3f38-11e6-b369-001dd8b7c0ad]
+      x-ms-client-request-id: [bdf0461e-447d-11e6-abf7-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/networkInterfaces?api-version=2016-03-30
   response:
@@ -131,224 +160,244 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UeXWbnOP3qUfg9/pSl/iOejZbbA5x9dLrZnWZvNiubtdps37U9+8aKYfjSy7YoZWt1t1pNmWher
-        tqiWzd17O/v5wcOHn24/eHA+2d7/ND/YnmSzbPv+/Qef7uzef7g/yffv1nlTretp/nldrVfN3WlZ
-        vCH4ry5+f9Pf3VVdXRazvG7uflFM66qpztvxi7y9quq3d5fy82zZ5vV5Ns2buzdhmrfZBXD97t3f
-        96NP7z3M7h3c29v+dHf34fb+5N7D7cn57NPtab6fP5x8en93b7r7+37kvVxW0wxjA4ArAr5uvC8J
-        cENfWOLRR4TFqsyuXygVFWuL7Uem6S9xUGi0q7xui7wLi764LBrqvFhevG6zliG+Xk+neT7LZw4P
-        amppupZ5yWbT2c7s4OH2vf2D3e396aefbj/c38+373+6c2+yu7tzb7r/IABQrE6q5Xlxsa55uEBF
-        WUMeDy88lk2K1ZTf606CDxzP/9v55W6XAPTBLUf2IfwlD2Y6ygLy4OtbMoI89EJxSc3OXh7PZkQ+
-        QP1od2eM//Y3Ni8Nv3+Rt/OKp+zpNc21L1Dm+Wi1npTFlN6ynfRQp1Y/VxPfwS4y8S+1hRVK8zjh
-        NM9HhD5xEo3k/01DvCzqdp2V+md/gD/54vTNXcKKMO9/+Zo/v83YiT0WWX1NY2zrdR79XtlHSP2T
-        hC2RgNp/dPbycr/TxS/x//T++L4H+KPZsnmdty3xe4+t5Lv6kjqhr77nv0ZfZqtVWeSzp5vaFNAF
-        y6x8Wi2yYglV/Xp9fl68o6YftTuXu816Ppv9dLa+LK9WxeK6+sHip7MsH8/ejc2b42lZrWfU1zgk
-        oU+8jxbZVAkCwDs72ztPt+8db9/b2d7d397b8wXqo3yZTUqi4LOqvsrqGY2b3jnPysYn90fUGSb6
-        dT5d10V7zUxD7ULy/FwxYwy5Pte9eP35EL2IjeJs9pHy+RfZdF4sofx+bkd8Ui1W6zY34qdo9cfq
-        D9T86kb8UXu9wlg+coA7pHQ2SyGZl+3wrRkmzLnL7cvFHtszx10/G+T5yS9O6pxE/vf/arJetuu9
-        KJkGRwNAg9j61vThzuT8/v798+2dh5MpeTH3MrKm2adE5ek023+wc76zd9+3pv9f9db2Hj649+l0
-        7+H27r0H97b38/Pd7Ww62d+ePbx3/3x3J589uLcTAOg6KwTkvbw1fwJ8wHj+v8Av5JyFBKAPbjGy
-        D+EteTDL0emXB1/fkgnkoRdC24n2/z/y1N5r4jtYdib+/83e2nsN81LMhv7JYOwgA4/N/+JH3lrM
-        W7uo969/cL+ZFL8oy+vsB+X9enK+aNvm3fQb89b2timAvnffF6r/l3tr78WMMSQZmOW8/494bLca
-        9ZDnRmDseP3Bml/dqL9Rr40cxot8SZxbFj/I2bA5NvtZodHic9tdlD6DQ4FvO4yqb1eznXvZ3sHu
-        wfb9nb0H2/sPHh5sH9zP72+f7z7cf3gwmUx2s3u+Xf3/qs/26fl098Hevd3tyXSyRzPxYGc7y/OH
-        2wc72UH26ezhwc69EEDXZSEg7+WzBTPgQ8bz/3puIQctHD59cJtxfQhryYNJjs6+PPj6ljwgD70Q
-        GlC0//+Ty3bbae9g2J32/1f7a7cd46UYCv2zM8LAWQu++ZG3FvPW9i+yX3RxUWS/aLJcryb3f3r2
-        gx9cznfe7S++udza7vYz+t8TX57+3+6t3ZYVYwh22O7/K67aTUMectOCwfojNb+6IX/TfloDy7C9
-        qGZszRx//ezQh+3QF9UsSp3BcYA+g3j6hvTBg/z+wf1PJ9vZfka5j3sPd7Yf7s4ebO/du/9gdnDv
-        09lklvmG9P+rPlq2/+m9vfP9B9vnn36aUY4n39mePKTB7u4c3H94fz97uHcQAug6KQTkfX00OwE+
-        YDz/b+EUon+EU8gdC4dOH9xiTB/CVfJgfqMTLw++vuX0y0MvhBYT7f9/5Z4xFW5SDh38OlP+/27f
-        7FYDVNugf4bD6zpm9oufT36Za+IP7//13tCtJj+GXjjTHVfI/OpI8Y06CKxCn+aL6v7uvZ/8wqmL
-        b45ECvw2VHF43x3Ey9fbsx1SzWQht/d2dmcUVt/f387ufbq7nT+Y7p5PswfTg/zA19v/X/UGyPyc
-        H+xNZtuf7mWUPtg/uLd98CCbbD+gBaB7k53pp/tZsGREVj00iQTkvbyBCOHl+X8XW5ClD8dJH9w0
-        gA/hH3kwk9Eplgdf33Ki5aEXQo2M9t+83acpI3pSmx7G9OUPdVq7BhBGT9+jOSUcCM/mrlg8+7mV
-        NfM4mTMPKPP/cdMXtjGJhVhKYnl/Z7a8mp/PynvE/dfT3flFvVwUl0323imJYcNqGrnm/980PtlG
-        fuwh3lEzHmK+9th5+HD/XpbPtid7lNndf/DgPmnlh7Tq9mBvdzo5f3g+uRckdf+/an3u7UzOD+7v
-        PtiezB6y9XmwnZ1/er59cO9gdv/g4Pzepwf3AgBdrUxA/l9qfT6ML8jahAOlD24awYcwkDyYyugc
-        y4OvbznT8tALoVZE+/+Pm5/N8/oj+0Nfkk34IPszXZzvNW+z2dVVtf7BxbKeZbP83U+XVTb/kf3p
-        8+NkupEje6h3NI2Hmq9AHk6gg+892N79dP/e9v7B7OH2w1l2f3v33u7+bO/+w71PJzu+Avn/qgXa
-        y3b3dvLp7vbubIf89D1aQ82QDb23S2uns2yfkndZAKCrmAnI/1st0AdyBpmccKj0wU1j+BAWkgeT
-        GZ1lefD1LedaHnoh1Ixo//91G3TDzP7ICtGXZBk+yApV75r1/uqyrX/RZP3TxflFlWU/uDdZZNns
-        /6tWiNjGE5CfDa68VYLS4d9ROADg4efrkk9nO/dnD7N72w+xcrV/8PB8++HO+afbB+fn092d6XQn
-        m+z6uuT/q+bo/mx/916OJNynk/vb+7sH8Nsf7GzvPdx5MMv2SIlmuwGAro4mIF/PHIXEl+f/nSxC
-        ZigcM31wm8F8CD/Jg5mNTrk8+PqWEy8PvRDqS7T//75t2jzFG40Tv024EL49A4XvrByax8mjeUCl
-        nzdGKrtarOf59eJtdW/9g8UvIhlo5/Pldbb3/kZqkU2VIAC8s7O983T73vH2vb3tZ7vbDw58vtpg
-        0PxWROj4RHykPPBFNp0XS0hJSLJvnieJq2I8eVItVus2v3sZ4GN5ucdzdv4d5b5Re32RL58Xy/U7
-        VnqO4t8cQagDmpMLGmKMHIOI470oYoFOPbi3u/NwmhHL3KNQihJ525OHu5Pt+w8eUCbv3oO9yb1A
-        p/5/1UYfUFA4O6C02s509un2/s7+wfbB3sP72/n+vXv3DvbOd893Pg0AdO0VAXkvG22I7wPF8/8y
-        tiAzHI6TPrhhAB/CPvJgIqMzLA++vuU8y0MvhNYB7b95k7xaT8piSm/ZTnqoU6sf8vx2kKLW9B5P
-        3Ev9xoqYeZyomecjwpYYhRD/f8GI1M7on/wWjwc+x11CghB1H4q7cZsh0qTHDZs8+F6ZQij5/2kP
-        Y7Jen++U0/u/6P76B2/Xb9usLJq9+/feTb5BD2Nvn37xxeSWHgZ1hol9nU/XddFeM29Qu5A8P2Se
-        i+HE7zKTvXj9+RB5iGviXPVDc5cISUJhaIBDzhK9xUPzx2V+dQP8pv2kq2K5x2bHsc0PixCDeOO9
-        GF6+mZt+em82OZjMth88PNhDwjmjrOi96fZs8uD+7N7ObOcgy3wz9/9VLyk/yO4d3Dsnc7774OH2
-        fr67s32Qn5OXtJftZfez/P69qUciAtD1HgjI+3pJoL0PE8//u5iCXKJwlPTBZvQ/hHfkwSxGp1ce
-        fH3LSZaHXgjNG9r/fHaRMG//P/KQMJyug4TPfj75R66JP7z/P3olmNkNTonyhxp7QvnnZBQbXA/g
-        7yNvfnWj+KY9j+8WS9blTmf9sMgwiDbei6Dl24575/vTBw/z8+3p5NMdwmZ3H9h8ur17f/Lg04fT
-        /fPd6b5vO/4/63fs70x2H1J2Zm+2zysoB9sPP80ps59NaDoodXO+9zAA0LXIBOR9/Q4ivQ8Sz/+r
-        WIKcjHCM9MFG5D+EceTBFEbnVh58fcsZlodeCG0G2v98djpo2v5/5HPQaLouB33088njCNuYvEos
-        IzN7d7VavVu+u3y3WLfzi/vr3Xuzqvnp5SL/JjMyO9vHYRb7/4e+D7HYBteHeCbOU//vd4poYP6o
-        zK9ueN+oT7TIltT/5aJZ+jr1myODhd/UF+9BidfTrMxJRD0AnRbN3d3+cF3rcDi+TdzN70139u49
-        2D54OKHkxs49WgLaP9/fzu49mD0kB+PBZHfi20Tipbg1xBe3tIMfWaqop/Pw0517O/mnk+29T+/t
-        b+/P7mfk5DzY235wfp9M9mx/7/75/QBA1wsgILfydCxBjNfgQ8Xz/4upJp8oJI/7dnDcH8IT8oAB
-        opwhD76+JX/IQy+Elg7t1U8KuEEer/l7+Uk000RNatPDmL784XGD0Vk61/qn9+IlYXmXEKEf3qfy
-        geo1fvgfo+HcA/LEbYA8+F7JJ9Tu+hX9N8oqmz3Jymw5zesn2fRtvpzpuy+rqsR0BTIpT4TKBOqH
-        T2cfee+1cnJ30h+K+36Sr+iDHr2J4t2PQjcIT0Cws+WkWi9nL7L21bpkifn/JLGKcBjuu2XWglLj
-        3VvRKvwg+N77wyepOKbfnNPqmviyc0tXUYVWFTS1CNH54U3YB9gUb54syfUXQxE7qr49JavjNMT/
-        Jwa8d4MR9YYT2MZs/8G983uUj8kfHGzvZxhFfvDpNv1yLzu4T+N78NC3jaRX41YRX9zSHn5kqaL+
-        0oOdnen5zsPd7U8fzHa39+9NH24ffLr/YHt2/jDbm+1m9ya75wGArkNAQAJ14+GFpz+/g36DIHT3
-        /9NT/cH+0nvyhDxggChnyIOvb8kf8tALoQVHe/WXgvhXHq/5j/wlo+HcA/L8yF9ydPaR914jF+BH
-        /tJ7EOtGf8lfATJPn1bhB8H33h8+ScUn+pG/RPh7E/YBNsWbJ0ty/cVQxI7K2tNysk32ZpfMg9MP
-        3+Bwr+uLveg4DWOS7sNPzw5GMfKN2+R+9iDLZg+3H87uka+xdzDbPtj79P72zt6DaXZ/srszuRck
-        A0hqxZgAQG+1jZCL2jx8cUtr95EdtXpDe/v37p3vnd/f3psAw3v3P6XR7O9v700/3bl/P999eP9h
-        FgDomnsCEigTDy88dvaMM7DrQ8Pz/5Yp7Dsywyh/yBzLgzmLTqY8+PqWUyoPvRCaVLRXByZmT13z
-        /zc6MDdOpGoU/RNvBC6LrBj5YZk8Rrm4B4T4+eCq3EhRH2u0J3sbdU6us1WPrETY7kehHcQT0OX/
-        FR7J16FJ1wdpmnmfzWL0CD8Ivvf+8MkmnsU353WEbcwCYWxpcTLb2zlvdi6v9rL18ny6nF1V1/PF
-        5LKYfINLiyf3tvee+uJzS/+HBDIusD88z2iQceIuEd64XPgUMr86Un2jK3Fi1PbIqDn6/jCGP4ix
-        mtkORr4V3Z083P00n2Tbk/OMEMnPH25nnx5Mth/kD6fnu+ef7j6YBFaUtIlYLQD4oXhKsyzPd/cf
-        5Ns7+wc72/u796eE6/18ezd7sH/+6YQW4X4+eEqYQnKMwpHRB0Mof8gcy4M5i06mPPj6llMqD70Q
-        WnS0V0/p/3tLYzdOpKoi/RNv/MhT+jCK+lijPXkFP/KUPIzRnmgS8ZT8uN88fXqEHwTfe3/4ZBNv
-        6P+/ntLJ9t4zX3z+f+4p+WxiZ9zRaoOrROQFOzqrpZDMy3aY1tiiv53dnd23P/nFi2LqiPxN0gAp
-        sBgNjPD0sOZ3olj55nRvNr13//6UcjXnezNK3ewdbGf3s+n2eZ7RqtbeLNudfuqbU1IrYr4AoOcy
-        EWAwnqUQfTQrmlWZXYPj6ZuPFF2LptLWUZdeoWFGbTW+uKWV/sjSTx2vnd2D6c7DB59u38vvYZzk
-        QDy8P3uwfW+y83D6YCefzQ4eBgC67gkBCXSmhxceywvGi7HU96Hi+X8TU5DPFY6SPrgJ/Q/hHnkw
-        j9EJlgdf33Ka5aEXQqcB7dUZi3kMrvl7OWOr9aQspvSW7aSHOrX6Ic5uByF/dl/qV1a8zOPEzDwf
-        EarEJ4T1z/FwLkWL65/yBg/mJ1+cvrlLGBCW3qfidN5mgDTfcRMmD75XfhBCdn3O8AVrTPB4f/gG
-        X/yFnwtf4mp3unw3Xa731zvrdrK/v1i05WVWrOezb8yXIGnf294/9iXklr4EdYapfZ1P13XRXjNn
-        ULuQPD9EjovhI+8xh714/fkQbYhl4iz1Q/SKhka3ySvicfmDMr+60f2seEY/YHPjWOaHQYdBrPmd
-        KFa+bfs0y3c+3d3Z2z4/oNWY/d17n25nM8Iop3zN/sHBvfPpbOrbtv+veka79yZ5/nB3sr2zk93b
-        3t/PP90+uPdgb3v28HyWTfay2XT6s+MZ/cCHiuf/TUxBjlA4SvrgJvQ/hHvkwTxGJ1gefH3LaZaH
-        XghNG9r/vPaMfvD/J8/oB1HP6Ac/8oxintFFfv+nf/CLLnf3l6v15cXb+fRyMZm191bn59+YZ3Rv
-        +/TT7adfJ8tCnWFqA0+E2oXk+SFyXAwfeY857P+nntEP/EGZX93ovlHPaLpupFM2N45lvmE6xBNn
-        g2jfHUTLN260WLWXffrgYHu2M9nd3n+w9+n2wwf3Hm7Pdu+df/rpHi3HHNz3jdv/V12j+9nO+UH2
-        6b3tBzSu7f2H+w/JNdr5dPs8o1nY3znPsom3FEkAuk4DAXkv18hS34eK5/9VXEGuUDhM+uAm/D+E
-        feTBREZnWB58fct5lodeCI0b2u/CM/r/vG+0eXo7GPnT+/9S52jzeFSb65/eaALvyH76I+8o5h0t
-        r+5V+7vZT+/OLvPzxbye7uxX17vVrPkm16AoHHoaxpL/r/WONrNcDCGPxf7f7x7FhzfkH9mB+aMy
-        v7rh/az4R3tschzT/FAIMYi2JUUPLd/AHezMJrO9h/vkN1A2Zf9etr/98Dzb3T4/f/jpp/d27u0+
-        mN3zDdz/V/2jnfP7u/t7tKhGjSl1dEAink0ekCHPdh+c39vfn2Q79wIAXceBgHwt/2jPh4rn/1Vc
-        Qe5QOEz64Cb8P4R95MFERmdYHnx9y3mWh14IzRva//z2j/Zu5R8RvvR8RLgSoxDaP9fjUW2uf3qj
-        ifpHez/yj2L+0U/vX17f21ucv/3Bcr27eLe7mL57t1s1uz/IvzH/6N728dPtvVBh/v/SP9r7/6t/
-        tOePyvzqhveN+keLbEkoLIupZ0t+KEQYRPluFCXfsE2zBzv7u/mD7dm92XR7P7ufbz98OCPEpntZ
-        /mB3Pz//9KFv2Db7RYRc1N7hi1tauo/ssNWjmTzIpxklI7Z3Z7sPt/fvk1tzsHN/un3/3kH2YLaz
-        t/fgYRjAdE09AXkvj6afKRFE7v6czyE5LeHQ6IMhnD9kkuXBpEVnUx58fcs5lYdeCI0P2n/z3gvN
-        EtGQ2vQwpi+/sZm8XPz+0zon9H5/0jRttfj9i9XvX19snFlVUfongajPLxeBwedPfmTsY8b+B4tf
-        NJu/rYusebcup5c/vXtvnv10Xv30u4tv0NjvPNk+PvFZ6pbGnggdn4j/N1tIvEIGcnfq08n86gj2
-        s2MhPZfqh0KEQZSddvVR8pXnp9O9+w939ne2d/N8h1Lj+/n2QbY/2X6wu5dP9ycHs3wapMZ/+BZy
-        dn7v3my2f2/7PN+n4HR6cL6dEcrb04P9ye70/P4k2/1m10T61kYQuftzPodkEMOh0QdDOH/IJMuD
-        SYvOpjz4+pZzKg+9EGpstFcL+enG5j+ykE7tuAcEiitmefC9ElDo/SMLiYfU9KCFPNl+9tRnqfe2
-        kL2vdNLVLlGLkGbfGD9u0Cz/rzKR2mfBeUtH6h8KIQbR5peiaPlalAKy/eze3ozMz062vX9OK/QP
-        d3doUTn7dPZw/+DTgwd7O74W3WwqCTD4z5KIPvp/S5L93sPdbG9CUdQO2dr9+7s72wf3zyndPrt3
-        //69h5P9Hco7+AC6VomAvJfBtdT3oeL5fxVXkK0Nh0kf3IT/h7CPPJjI6AzLg69vOc/y0AuhUUB7
-        NcL/nwtTQfgbZlWVnv4pr/BcBYbXfvoj4xszvr9ob97cu9/+onp9b305+UX39te79bLe37345tbq
-        d7bv7W4/fOCz0i2NL3WGqQ1Sv9QuJM8Pk+ViCMmLzGL/f8tF4xUemD8q86sb3s+KG/HTrJkd0/xQ
-        CDGINr8URcu3A58eTLPZ7GG+vXMvo3g2n0y2Jw+mk+3dyacPZpQNnk3Pd3078P9VN2I2OX+Y7WcH
-        RPUHe+Q87JF8P8wp8vz04N5k9+D+vcnEIxEB6NpXAvK13Iif9qHi+X8VV5DXEA6TPrgJ/w9hH3kw
-        kdEZlgdf33Ke5aEXQvOG9t+8G9FZGafGPdSp1Q9zejsY+dM7uFbvBM08HxGuxCiE9jcxng8Zj2pz
-        /VNe4dFE/aOf/pF/FPOPltVe8XbvF02ynXfrd/nV/fnl5XlRvd2Zf3Nr9Xvbn+5vP3ziy8j/P/2j
-        n/7/q3/00/6ozK9ueN+4f9Q0u58WlDV2LPMNk6Fp3oMOr6dZmZN0mncJt06L5u5uf6SudTgS3yLm
-        9+7v70/v39+e7j+YkUXce7B9MPs0396jwPpgN7+/8zCb+RaR2ChuC/HFLa3gR5Yg6u1k9x7khMan
-        2zOK87f398/3t7OD8/vbk8nug2z33r37B5/uBAC6bgABuZW3Ywli3AYfKp7/r88y+UMhZdy3g0P+
-        EHaQB3MfZQp58PUtWUMeeiG0b2ivDtL9jc3fy0GiSSZqUpsexvTlD4URjJLSadY/zTs0aT1Hgj/9
-        4TkS/TfKKps9ycpsOc3rJ9n0bb6c6bsvq6rETAWSKE+EwATqh0piH2/zBpGynNyd9Efhvp/kK/qg
-        R2oidvej0OXBE9DqbDmp1svZi6x9tS5ZTv6/RqciHIH7bpm1INJ491ZkCj8Ivvf+8Kkp/ufPiW/6
-        05Ort7/op9eX7dt896fL3dUP7k3fluvLcvqN+aa7WDt7EEjaLX1Tkt24bP9wHboBfvoAG+eT0Pyq
-        vxiS2gH1TTtZQUfM/7ePde8Ge+6NxDfTs4cP7n96cH93+2C683B7/+GnZKZ3d2lh5NN8und+//7O
-        9NOpb6aJV+IGGl/c0jR/ZAmiXtveg8l+dr4z285ns11ak5nMtg/O72Xb051P9/Y/3ad/skkAoOub
-        EJBAB3p44elP7aALIwjd/f/qLH+o1/a+7CAP5j7KFPLg61uyhjz0QuhMoL16bZ9ubP4jry14QJm4
-        ZpcH3yvlhNA/8tp4FO77H3lt9AbRgeh0o9e2dysyhR8E33t/+NQUz+z/t17b/v3tp/d8Sft57rX5
-        bGQ5Qn8xJLUD6pn2nyYr6Ij5/66x/nSnRXN3Z4M974zEN9P7n07uH0weIsO1e297fzLbo/W8yf3t
-        T/fu37+PrMvuvXPfTBOvxA00vrilaf7IEkS9tk93pvey/d3p9n0sKu7PCJOHDx5Mth9O9ijR+hBr
-        iwcBgK5vQkACHejhhac/tYMujCB09/+rszzstQ0P+UPYQR7MfZQp5MHXt2QNeeiF0JlAe/XaYp6E
-        a/7/M6+tv2jHn/7Ia3t/Evt4mzeIlOSNbPLafvpHXhu9QXQgOg15bT9tvLadW5Ep/CD43vvDp6Z4
-        Zj8XXtv1utr9RTvvrncv3uV1flWW72gh+KKq3l58g14bmbwnJ76kffTzyWuL2DifhOZX/cWQ1A6o
-        b9rJCjpi/r99rJvWzjoj8c30+ac7k3uz2YPt+3sPdii5snewffBgP9+ePLx3P3uwe+/B/r0d30wT
-        r8QNNL64pWn+yBJEvbad2e75ZJfyOnsPH1BeZye7t32Q0YLp7sP9BweT+/c+ne7sBQC6vgkBCXSg
-        hxee/tQOujCC0N3/r87yh3pt78sO8mDuo0whD76+JWvIQy+EzgTaq9f282qF9Ede2zdGYh9v8waR
-        kryRH3ltt6PTjV6bv7Rlnj6Zwg+C770/fGqKZ/b/W6/t3t72zqkvaT+vcm0RG+eT0PyqvxiS2gF1
-        TftuRlbQEfMbH+vehwx2N+u0oMEOG/TuUHw7ff/ezsH0wTTbfjilZNf+9IDWxB7unG8fzPZ27k2z
-        6c7s4FPfThOzxC00vrilbf7IUkTdtsn5wezB3vTT7XsPzve29+89eLh9cO/Bve3zg/tZlj/IJuRE
-        BAC6zgkBCZSghxee/twO+jCC0N3/z07zoN+2Ycwfwg/yYPKjXCEPvr4lb8hDL4TuBNr/f9xvi3OC
-        sZY6z/qneYlmLea47WY/cty+Bo19xM0rREvySDZ4brvZ/x89t69LqAHXjVTP/29dt3Z9frW6WL0r
-        d+7nP12U6/lPV4uL2Q+umuwbc912th+cbp+E60n/H3Pd4gz1AXbOp6H5VX8xNLUj6tt3soSOmv+v
-        H+zeDUbdG4pvqz+9P9unFMvB9u7+HtnqB7u7lF45v7c9nTw42H24u3/+4NPAVhO3xK00vrilff7I
-        UkR9t91Pd/PdWX5/e2+yc0DL/fcJieze/van9/azB7Pz6b1P97/RlNsGP0YQuvv/2Wn+UN/tfflB
-        Hkx+lCvkwde35A156IXQo0B79d0+3dj8R74b/fAekCau3eXB90o6ofSPfDcZhvv+R74bXiFCEKFu
-        9N32bkWn8IPge+8Pn5zin/3/1nd7Qpm3e76s/Xz33Xw+siyhvxia2hF59n3ZXFwu9g4OPCvxzY2V
-        gNcX0YEayaHJx8/AONNbPZR8k/twL9+/N53MtnfPz+/TMtfB/e3J7AF5P7sPzqcPJlk+Ozj3TS7p
-        FDFxAHCVN+268b4k7KKW+KNVTWhDtRMrbbbBH9lhq3+W7xx8So0oofPp5B6cgnuEIQh2QOjt3Msn
-        053AvA74Z/SNPh5eeOz8GRdl14eG5/81c9j3r4Zx/pBJlmdwNuXB17ecU3nohdDaoz35VbvkV8VM
-        vWv+Xn7Vaj0piym9ZTvpoU6tfohT2kHIm1JPzchjlIt7PiIMiScI2Z/jUVyKjtQ/zRvUM2HX3J3l
-        59m69G2PPJEB0bTGrYY8+F6nXejV9QnDF1Qry+P94dtYMdE/F+b7py93d9/Omsm8fZdf/vT15Wxn
-        kme7P7gs8m/MfO9uP3mwff/rmG/qDFP5Op+u66K9Zk6gdiF5fogcFsMnKisBXYhd4uz0Q3NCCL+B
-        kcU9kPiYzK9ucB+11yug/ZED2CGVsxIKybxsR2qNWzZ74WvLb270dXW9u3evJU8gSoJBjO92MfIN
-        Vn6P+rs3ybcfTD89J0QyWk/beTjZ/vTT7GDv3u7k4b3JxDdYP3yvZHZ+Pnl4sE+kyu/ntMx0f7Kd
-        TQ7Otyf3708ms4P7+c55FgDomm4CEgRgHl547MQNW3hB5O7P9RSSDxKOjD4YQvlD5lgezFl0MuXB
-        17ecUnnohdDcoD05JfjvvZ0SdOjztHk+ojki6lGTHsL05Q97Hi9FG+mfmMUgzZPNfpTf+Vp09VEH
-        GZ97f0eTPM+fPDntUZno3P0odDjwBGT6f0Nm55sgUTe9k81ePX15K/qEHwTfe3/4ZBS37+fCJZwu
-        Vm935vPJbL6T17NlXVbt7u5stjObfGMu4R68wmdPfem6pUtI8hqX5x+aM3UDIw15VKTDvvDJZH51
-        9PpGvanL+hy5o/U7WvRwZP7mqNAgSdXk7e8/rXPSn79//q5owKu/fyVAf//64uvlvBTxzvfN3Z0+
-        EUzb7iB9G34wO9h5cEAjyh58mm3v37v/cDubHextn+efZvl0f7J7cG/m23BisLj1xhe3tNsfWVqp
-        K3Zv5yG5DPnONqUxHm7v71Ce4+HOwT75Y+fnB7OHe/d373n4E4Cuw0JAAo3p4YWnP+vGwfGh4vn/
-        MQOQUxcSzX07SI0P4RR5wBZRfpEHX9+Sa+ShF0KHBO2/rrc3nIKi+SdqUpsexvTlzz2PGL2nPKB/
-        yowS3ncJNfrBf8uvqg/dYzSje0CquOmQB98rKYXy/990BT+Y5v6gmMK0rhXzDfmbSY5lrR71if7d
-        j0IHBE9Avv83uIg/K6Tr+oz8qVkO3LkV5cIPgu+9P3wCi4P4c+E8/nSR7fyiOtu7mvwgL6tZViyW
-        s3X107Pr+TfoPD7d2b7//03n8Wuz2Ne2mj51za/6i6G2HWvfjyC76uj8/2Ey7N3gPHiD9H2C873p
-        bGf/YLr94N7uLq3sTR9sH0xm021apDp/sJOdZ5O9+75PQBwW9wbwxS39gI8srdR7fHB/Z2/v3v3z
-        7en5PUpD5Q/IRbk3293+lByVB7TyuJvffxgA6DpCBCRQph5eePqzPugvCUJ3/3/IAB/qPb4vp8gD
-        tojyizz4+pZcIw+9EPowaK/eo7e+bh6v+Y+8R/8xmtE9IFXcdsiD75WUQvn39x47Dhb1FEitPBGK
-        U+f/76F5zAX6kfcIoF+LdBu9R391zjx9yoUfBN97f/gEFg/x/7/e473tvdBg/sh7JM1Itq7zPVlN
-        n7rmV/3FUNuOtetH/KKa7Kqj888eGdzov9HBb0g4dYfmewL72b2H53v70+3dnT3KI+1NPt0++HSW
-        b+99enDv4f37n2af7gWrhsRXcR8AX9zS+n9kKaQ+48G9vZ2Dh9P97b0HD3a2KXm1uz15OKEV4P29
-        BwcH+f3980+/mcVfS5BBL0kQuvv/m2kf9BQ30OBD+EMeMEOUS+TB17fkFXnohdBfQXv1FGOpLtf8
-        /wOe4g2cYQyuzrz+aecxWGvWz3604PyNUNwfiqUtuTkDHiK+/f+1j/iBZIt4h/jG+Id+7sc8faqF
-        HwTfe3/4xBUf8OfCPyx3i3c/vTz/RXsX9fqyvK4n76p7Oz/4Rddvv1H/cIem1JfD/8/6hzew19e2
-        kD5Nza/6i6GxHWHfUyAb6qj7/7nB797gHnhD863+/YMZ2fXp3vaD/WxGI3pwvv3wfP/B9vls/35+
-        vv/pbnYe5IeIm+L2Hl/c0tJ/ZCmkXuG9T3fyB9P7RMcJrT7v72b3aIlz9+H27Hzn0wfZwe7uvft7
-        AYCuq0NAAqXp4YWnP9eDHpEgdPf/N9P+oV7h+/KHPGCGKJfIg69vySvy0Auhd4L26hXe39j8R16h
-        e4wOdA8IFbcN8uB7JaTQ/UdeIbk3P/IKvxbZbvAKd29FtfCD4HvvD5+44vn9/9crpAW3HV8Of+QV
-        +t+ThfRpan7VXwyN7Qj7ngLZUEfd/88NfsPyYndovtXfm96f3ZueT7cf5vcebu+fZ3uUoZucb+f3
-        znfOdx/MzvfuPfCtPnFT3N7ji1ta+o8shdQr3Jvt55O93en2vcmEvML9yZSQuDfbPt+7vzOb7ezu
-        nU8CA/Qjr1C/v3naP9QrfF/+kAfMEOUSefD1LXlFHnoh9E7QXr3C/8+vKt/AGcbY6szrn3Yef+QV
-        /qxR3B+KpS25N1/bK6RB2Sf0LvAEpPs58Qp/dsl2g1for/SZR423e37kFQJw4BXube8EKvBHXqH/
-        PVlIn6bmV/3F0NiOsO8pkA111P3/3ODv3eAeeEPzrf50d/Lw4ezewfbuw73d7f0HOa0Q7n26v30v
-        y88ne+cPKU039a0+cVPc3uOLW1r6jyyF1Ct8cG92f5qTLzilJeTt/YMH2XZGCartg9n0fPfeZHaP
-        HJEAQNfVISCBrfHwwtOf60GPSBC6+/+baf9Qr/B9+UMeMEOUS+TB17fkFXnohdA7QXv1CoPlE3m8
-        5j/yCt1jdKB7QKi4bZAH3yshhe4/8grJvZn0h2W+/VGucJhsN3iF925FtfCD4HvvD5+44vn9/9cr
-        3N8+/lGusLXs1PmeUPNpan7VXwyN7Qi7nsIPHpANddT92Rt8UyxWZf5Nj33DSmJ3ZL7RP5/cu7f7
-        8P6URnD+6fZ+tr+zfUB5O2K33fOHD/P9nZ2d3Df6xExxc48vbmnoP7IEUqfw/MH5g2n26WQ7fzC7
-        v72/t59tT/Z3drcnB5PJ7uz83v75Xh4A6Ho6BCTQmR5eePpTPegQCUJ3//8y64M+4QYSfAh7yANe
-        iDKJPPj6lqwiD70Q+iZorz7h/+fXjzczhrG0OvH6p53GH7mEP1sE90diSVv+/PUIP4xqNziE/iKf
-        efpECz8Ivvf+8GkrTt/PhUN4dbG7d3lv7979Nl+/m76bXt6n3+/99Hxn9k06hJQmfOpL4f9nHcLN
-        3PW1raNPUvOr/mJIbAfYdxLIfjri/n9t7BvWELsj8w3+g91PH5zPHhxs75xPdsgVe7i3ffDpvd3t
-        2f2dew+mD3d37z+45xt84qW4qccXtzTyH1kCqT+YTyYP7++dP9ie0Qry9v7DT7Ptg3uf3tuePNzb
-        yXez+wfZ7r0AQNfLISCBxvTwwtOf6kFnSBC6+/+XWf9Qf/B92UMe8EKUSeTB17dkFXnohdAxQXv1
-        B4NlE3m85j/yB+1jFKB7QKe4XZAH3ysdhew/8gd/5A9+Pard4A/6y3vm6RMt/CD43vvDp634fP//
-        9Qefbe+e+lIIf/BH/qB+T9bRJ6n5VX8xJLYDtE4Cmc1dR9Rvbsxt3rS//250gEZ8iAvw0zPmHWR8
-        27xz/94su5/Ba/qUvKbd+7S0ej+7t33wML//MM+nn+7uBraZVIzYQgC4ImTWjfclAQZ/WXLQR7Oi
-        WZXZNRibvvlocf3i7MRS1NCP2tGIotYeX9zSzn9kaaUu4YODven9g52D7dn0IRH4fPqQHA/yQ+4d
-        3Nuj9eOdB3uf7gUAuo4OAQmUpocXHjvbxg3yqCzP/wsmvu+9DWP7IZwhD6YrOo/y4OtbzqY89ELo
-        PqC9em0x38E1/3+h18ZzuLdxDlX76J+kjQitvbvUNf1s7opX5keo8jg5Mg8IEVfP8uB7JZTQteuW
-        hS+ovpPH+8M3ZmILfy7sZHuvKKq9H1zli1+0Xub5/dmkvmqrZdlO3ttODudCTCPX/KP2esX8259G
-        6gE/nShqf+ZlSxyrQtj8/OAnv3jh8+c3x3qXC2Mlp+umrRa/f7EaMpSDYxAT2cPRVxqf3nuYHTy4
-        N9nem3yK1P/uw+2MFgBI4+5Op/sUn9+bPvSVxoeaE8XV4qhkdoSmV2iMUY2EL26piz6y1FTLMvl0
-        9iC//+DB9oN87+E2LTvlpBc/3d8+2Lv3cIdi2+n9T7+ZxSejq4X0Pkg8/+/lDzIy4YDpg40j+RAu
-        kgfzGZ1oefD1LadbHnohVJFor6bnvReQ0KEvNeb5aLWelMWUXrJ99DCnVj+X89zB0M7zS/3cypx5
-        nOyZ5yNCnNiFxvD/tsH17C0PrZ8R+YGY3tuMlfjg543l3XtXX0/Kq19U1vfyefF256L9RW8nV1fT
-        +fS9Le9whPrwmObfF50NVtpvRZ1hUl/n03VdtNfMJNQuJM/PJfPFECRAzG8vXn8+RClioDiD/dAi
-        7/cYazzsJhA8Sn+I5lc31m/ewWLb5FjpZ5sim3393hiEKF0cfcv4cHe2O3k42d8+//ThAfkdO7TI
-        8XAy3X64k9+/tzPNs+n9ICj7/6p/dX6QT6YPyfgf3J/NtvfvTc+3Dyb5w+0H5+f39x7eO985f7AT
-        AOi6GwTk/f0rHyKe//eyB3lT4Xjpg00D+RAekgezGZ1mefD1LSdbHnohNINo//9P72rzNHdQNNP8
-        /xXvavPgVOvrnwQDQ+t7Vz9yrmLO1dv95Xr2g/P793/RD9arVT3/6bc/XefX673y/dMaQ87Vzjbp
-        2HsnvuT8f8i52sx7MQwJEvjt/4POVXysG70rf4jmVzfW/086V/m7ooEk/v6VgCPCROkyOBKhTBdT
-        3zzu7uU7s4Pzh9vTnfuU2qGFgu1sku9tzybTgweTg739B7Opbx7/v+piTbJPyct6+ICUwP7O9v6D
-        g4Pt7ODTfDufPPz0fOfThw8P8sAOk6sUuhwE5P+dLtY3ySTkV4Wjpg82DedDOEkezGl0suXB17ec
-        cnnohdAkor06Wt/gCkrHjaHGPdSp1f8LZruDqMw2fVisrOSZx0mgeT4izIldaBCbR/dzNjo1BPon
-        QSIuJYTvCt78t/y6ebA0VBossULcFsqD75VVhJb/X3a29svFvct87+reL5qsf3De5uvV3mLn/Ope
-        ffGNOVt7FGdtPwuV6v+7na335b4YngSvPl82F0PUIiaKM9nPgcN12/H+kN0u/Pj+b5z8kv8HJUBu
-        1ZaDAQA=
+        6UeXWbnOP3qUfg9/pSl/iOejZbbA5x/95BcviunTfFHd3733k198NLINihm+vtusJ820LlZtUS2b
+        u/d29vODhw8/3X7w4Hyyvf9pfrA9yWbZ9v37Dz7d2b3/cH+S79+t86Za19P887par5q7Cvzuqq4u
+        i1leN3e/KKZ11VTn7fhF3l5V9du7S/l5tmzz+jyb5s3dQbzyNrsAZt+9+/t+NNv5dDY5//TT7b2d
+        3dn2/oP7+9vZvU93t/MH093zafZgepAf/L4feS+X1TTDSADgKm/adeN9SYAb+sLSiD6aFc2qzK5f
+        KLEUXYvmR6bpL3FQaJirvG6LvAuLvrgsGuq8WF68brOWIb5eT6d5PstnDg9qaim4llmYzLLzg73J
+        bPvTvezB9v7+wb3tgwfZZPvBw8n03mRn+ul+thcAKFYn1fK8uFjXPFygohwgj4cXHssNxWrK70UI
+        L8//u9jibnec9MFNA/gQ/pEHMxmdYnnw9S0nWh56obikZmcvj2czohKgfrS7M8Z/+xubl4afv8jb
+        ecUz8/Sa5rKYRl6jKSN6UpsexvTlD3VaL4u6XWel/kmT+uL0jb5Hc0o4EJ7N3df8035uZc08TubM
+        A8ossvqahtLW6zz6vVJOCP2ThB+NlNp/dPbycr/TxS/x//T++L4H+KPZsnmdty1NNaYtIK18V19S
+        J/TV9/zX6MtstSqLfPZ0U5sCjL/MyqfVIiuW0EKv1+fnxTtq+tHy/s5seTU/n5X3iPuvp7vzi3q5
+        KC6bbDx7NzZvjqdltZ5RX2OipTc+n3gf5ctsUhJVnlX1VVbPaCzUwXlWNrlp5Jp/1F6vmKH700o9
+        4KeTVu3PvGyJY9VNKM2OZ79xdsw28mMP8Y6a8RDztcfOw4f797J8tj3Z2z0g7fHgPmnlh3v0z97u
+        dHL+8Hxy756vPf6/an3u7UzOD+7vPtiezB6y9XmwnZ1/er59cO9gdv/g4Pzepwf3AgBdrUxA/l9q
+        fT6ML8jahAOlD24awYcwkDyYyugcy4OvbznT8tALoVZE+/+Pm5/N8/oj+0Nfkk34IPszXZzvNW+z
+        2dVVtf7BxbKeZbP83U+XVTb/kf3p8+NkupEje6h3NI2Hmq9AHk6gg+892N79dP/e9v7B7OH2w1l2
+        f3v33u7+bO/+w71PJzu+Avn/qgXay3b3dvLp7vbubIf89L09skAPH+5s39s9mFBstH//4H4WAOgq
+        ZgLy/1YL9IGcQSYnHCp9cNMYPoSF5MFkRmdZHnx9y7mWh14INSPa/3/dBt0wsz+yQvQlWYYPskLV
+        u2a9v7ps6180Wf90cX5RZdkP7k0WWTb7/6oVIrbxBORngytnG9myh39H4QCAh5+vSz6d7dyfPczu
+        bT8836dA4eDh+fbDnfNPtw/Oz6e7O9PpTjbZ9XXJ/1fN0f3Z/u69HEm4Tyf3t/d3D+C3P9jZ3nu4
+        82CW7ZESzXYDAF0dTUC+njkKiS/P/ztZhMxQOGb64DaD+RB+kgczG51yefD1LSdeHnoh1Jdo//99
+        27R5ijcaJ36bcCF8ewYK31k5NI+TR/OASj9vjFR2tVjP8+vF2+re+geLX0Qy0M7ny+ts7/2N1CKb
+        KkEAeGdne+fp9r3j7Xt72892tx8c+Hy1waD5rYjQ8Yn4SHngi2w6L5aQkpBkPzSePKkWq3WbG55U
+        fOx7PZ6z8+8o943a64t8+bxYrt+x0nMU/+YIQh3QnFzQEGPkGEQc70URC3Tqwb3dnYfTjFjmHoVS
+        lMjbnjzcnWzff/CAMnn3HuxN7gU69f+rNvqAgsLZAaXVdqazT7f3d/YPtg/2Ht7fzvfv3bt3sHe+
+        e77zaQCga68IyHvZaEN8Hyie/5exBZnhcJz0wQ0D+BD2kQcTGZ1hefD1LedZHnohtA5o/82b5NV6
+        UhZTest20kOdWv2Q57eDFLWm93jiXuo3ImKEmnmcqJnnI8KWGIUQ/3/BiFSv65/8Fo8HPsddQoIQ
+        dR+Ku3GbIdKkxw2bPPhemUIo+f9pD2OyXp/vlNP7v+j++gdv12/brCyavfv33k2+QQ9jb59+8cXk
+        lh4GdYaJfZ1P13XRXjNvULuQPD9knovhxO8yk714/fkQeYhr4lz1Q3OXCElCYWiAQ84SvcVD88dl
+        fnUD/Kb9pKtiucdmx7HND4sQg3jjvRhevpmbfnpvNjmYzLYfPDzYQ8I5o6zoven2bPLg/uzezmzn
+        IMt8M/f/VS8pP8juHdw7J3O+++Dh9n6+u7N9kJ+Tl7SX7WX3s/z+valHIgLQ9R4IyPt6SaC9DxPP
+        /7uYglyicJT0wWb0P4R35MEsRqdXHnx9y0mWh14IzRva/3x2kTBv/z/ykDCcroOEz34++UeuiT+8
+        /z96JZjZDU6J8ocae0L552QUG1wP4O8jb351o/imPY/vFkvW5U5n/bDIMIg23oug5duOe+f70wcP
+        8/Pt6eTTHcJmdx/YfLq9e3/y4NOH0/3z3em+bzv+P+t37O9Mdh9SdmZvts8rKAfbDz/NKbOfTWg6
+        KHVzvvcwANC1yATkff0OIr0PEs//q1iCnIxwjPTBRuQ/hHHkwRRG51YefH3LGZaHXghtBtr/fHY6
+        aNr+f+Rz0Gi6Lgd99PPJ4wjbmLxKLCMze3e1Wr1bvrt8t1i384v76917s6r56eUi/yYzMjvbx2EW
+        +/+Hvg+x2AbXh3gmzlP/73eKaGD+qMyvbnjfqE+0yJbU/+ViZ+fB5OF9z7p+c5QwXUQJMYi5fa2P
+        WWDhprPz/NMpmbRPd7Lt/Xt7D7Yn0wf72/uz/cn92cPZZDeb+hZus2tEGEYNH764pcn7yI5enZqD
+        7MH9yfnO/vYuRfmE1x6R7ODTbDuf7JFP8/DgIWVbAgBdg09A3sup2fWh4fl/21SSBxOOkD4YQv1D
+        5loezF10UuXB17ecWnnohdAeoT15M3v/n/ZmzBRtnNkOTp2ZVV3jHqN13PMRIUrsQTj/3A9GVa/+
+        6b1E/ROOzd1Zfp6tS9/+yhMZFs1x3NzIg++VB4Ry/592Ya7zX1RXV/Oi+Ol1vdjLy8n9t3Wevcu/
+        ORdmf/tkb/vT//cvKlmW2cRnMZTcqx3BCchDXBPnqh+aE2OwjA5wyIcxL3WHZn51Y/xZ8mQOpvd3
+        7jvm+SGRYxBz+1ofM9+6Hezdm+7nGeU9HmZk0yYPJtuT8wf59sN7s1m2cz/ff/jpzLducU/GfEkY
+        Ro0evrilufvIjl49mfsP7uXkrOTbO59+em97f/fT/e2Dvd3z7f0HB9N9Qi+fTO4FALp2noD8/8aT
+        4akkxyUcIX0whPqHzLU8mLvopMqDr285tfLQC6FZQnv1ZDwuNY/X/P/XnszBVHWNe4zWcc9HhCix
+        B+H8cz8YVcD6p/cS9U84/siTIX/k58iTubf9YG/72akvFf//9WQCwQnIQ1wT56r/r3gy4dDMr26M
+        PyueTLP09ek3T4umqS/egx6vp1mZk6R6ADotmru7/eG61uFwfHu4m9+b7uzde7B98HDycHt/597B
+        9sH++f52du/B7CEt+jyY7E58e0gMFbeE+OKWNvAjSxV1bx5+unNvJ/90sr33KUUg+7P7GS08kfg+
+        OL9Pyyiz/b3754FVJDclNP4E5FbujSWIcRZ8qHj+fzHV5AqF5HHfDo77Q3hCHjBAlDPkwde35A95
+        6IXQ4KE9+Uj4L+AGebzm7+Uj0UwTNalND2P68ofHDUZn6Vzrn96Ll4TlXUKEfnifygeq19xjNJx7
+        QJ64IZAH3yv5hNpd96L/RlllsydZmS2nef0km77NlzN992VVlZiuQCbliVCZQP3w6ewj771WTu5O
+        +kNx30/yFX3QozdRvPtR6A3hCQh2tpxU6+XsRda+WpcsMf+fJFYRDsN9t8xaUGq8eytahR8E33t/
+        +CQV//Sb811dE192bukxqtCqgqYWITo/vAn7AJvizZMluf5iKGJH1benZHWchvj/xID3bjCi3nAC
+        25jtP7h3fo/yB/mDg+39DKPIDz7dpl/uZQf3aXwPHvq2kfRq3Crii1vaw48sVdRferCzMz3febi7
+        /emD2S4tx0wfbh98uv9ge3b+MNub7Wb3JrvnAYCuQ0BAAnXj4YWnP7+DfoMgdPf/01P9wf7Se/KE
+        PGCAKGfIg69vyR/y0AuhBUd79Zc+3dj8R/6S0XDuAXl+5C85OvvIe6+RC/Ajf+k9iHWjv7R3K1qF
+        HwTfe3/4JBWf6Ef+EuHvTdgH2BRvnizJ9RdDETsqa0/LyTbZm10yD04/fIPDva4v9qLjNIxJug8/
+        PTsYxcg3bpP72YMsmz3cfji7R77G3sGMlp4+vb+9s/dgmt2f7O5M7gXJAJJaMSYAcJU37brxviTk
+        ojYPX9zS2n1kR63e0N7+vXvne+f3t/cmwPDe/U9pNPv723vTT3fu3893H95/mAUAuuaegATKxMML
+        j5094wz0V5gEkbs/11PYd2SGUf6QOZYHcxadTHnw9S2nVB56ITSpaK8OTMyeuub/b3RgbpxI1Sj6
+        J94IXJbX/NMPy+QxysU9IMTPB1flRor6WKM92duoc3KdrXpkJcJ2PwrtIJ6ALu/rkdD7+vwc06Tr
+        gzTNvM9mMXqEHwTfe3/4ZBPP4pvzOsI2Zp0wtsI4me3tnDc7l1d72Xp5Pl3Orqrr+WJyWUy+sRXG
+        ve2Te9t7T33xuaX/QwIZF9gfnmc0yDhxlwhvXC58CplfHam+0ZU4MWp7ZNQcfX8Ywx/EWM1sByPf
+        iu5OHu5+mk+y7cl5Rojk5w+3s08PJtsP8ofT893zT3cfTAIrStpErBYA/FA8pVmW57v7D/Ltnf2D
+        ne393ftTwvV+vr2bPdg//3RCi3A/HzwlTCE5RuHI6IMhlD9kjuXBnEUnUx58fcsplYdeCC062qun
+        9P+9pbEbJ1JVkf6JN37kKX0YRX2s0Z68gh95Sh7GaE80iXhKftxvnj49wg+C770/fLKJN/T/X0/p
+        ZHvvmS8+/z/3lHw2sTPuaPWNukrTsrhc7Ow8mPzkFy98Pf5N0gApsBgNBrG+O4iVb07398/3Z59m
+        n27fn+zPaOVkcr49uX9Orsn9nemDh59m+9OdXd+ckloR8wUAPZeJAIPxLIXoo1nRrMrsGhxP33yk
+        6Fo0lbaOuvQKDTNqq/HFLa30R5Z+6nhNDz69P90lP2H/030a3ae7k+2Hk73d7Xv7s90Hu5ODnXzi
+        eZUEoOueEJBAZ3p44bG8YLwYS30fKp7/NzEF+VzhKOmDm9D/EO6RB/MYnWB58PUtp1keeiF0GtBe
+        nbEHG5u/lzO2Wk/KYkpv2U56qFOrH+LsdhDyZ9eKlXmceJnnI0KR+IOw/TkexqVob/1T3tjZ3dl9
+        +5MvTt/cJQwIS+9TcTZvM0Ca57jpkgffKx8IAbu+ZviCNSJ4vD98Qy9+wjfnQ7gm/vBuabmJSiDo
+        63y6rov2mueD2oVI/RDnOYZPnGWDwSp7qHEnbH/oAxhyM6Kom1/dGH5WXA1W305J/TDIMIi0JUQX
+        Kd9UkIl9MN19uEOm4l62TZmP3e2H5/cPtrNs79PZ3oyyH58+8E3F/1cdjYPpg4OD808z9iy29x/O
+        Pt0+ePDpbPt8Z39/srN/P7/36c+Oo+EDxfP/IpYgryIcI31wA/IfwjryYBKjsysPvr7lHMtDL4Tm
+        Au3Vy/h0Y/P/v3oZVqTM40TLPB8RhsQchOzP8ShUd+uf8ga7Ez9yMlwTf3j/v3QyPGoHY1XuUMtO
+        yP7Q8b/Jx/AxN7+6IXyzLsa6oS7v7+7dyyRKdFrqh0GJQcTvbkLMtxcPs4f3d+/T+spufp/sxexe
+        vn0wPZ9tP8zz/EG2/3B/d/eeby/+v+pq3Mvvz+7tPPh0e/f8Hrka2e7e9kOkOM7z/U8/3SWH43z/
+        PADQNcME5P1cDW8CfMB4fgis8T6sQR5GONa7xeoWg/gQNpIHExqdaXnw9S3nWx56ITQgaK9uR2w5
+        xDX//53b4U3cS/3Wipp5nMiZ5yPClhiGEP85HpGqdv0zHE/ghfhf/HxyRMI2Zt0jtmJSvr386XLy
+        0/vr++/W9fzd8l1dL8/n652rb27FZHf76f72/p4vKv//cok8Jnvx+vMh8hDXxLnq/80+kzc0f1zm
+        VzfAny2/iU2QY50fBjEG8fbJ0cXLN3f5/enDg4fZbDu7/ymhc37+YHuyd35/ezfbP989mJ3v3M8+
+        9c3d/1e9psnk3gF5R/n2+b3Z3vZ+fm+6fTCbnm9PDx7snH+6v5fPdncCAF1PgoB8Xa/Jh4vn/12M
+        cSufqTeED+EheTCb0WmWB1/fcrLloRdCU4f2P99dpv+feUxDDtOP/KWYv3Q+W11PLsq9rNhfT84n
+        9bt8f3n50/em98/f21/6/6kP1HGBzK9u6D9LrgIrXqdcfg5o4tD26NFFy1fy97LJfVrgn21/SjHx
+        9v6DB/n25N4DSsfff5DvU7y8tz/Z95X8/1cdhYPdnYPpQT7d/jR/cH97f38/o9D/0/3tnYPs4cHe
+        +b3pvU+DBAIZ/NB8EpCv6Sj4YPH8v4otyCsIx0kf3DiAD2EgeTCV0TmWB1/fcqbloRdCBY/2P8+9
+        hP9/OQkDPsKPXISYi3DdrN7eb3d/cPGL8vX9bO/yPC+r/b3zXzTP39tFGEqp7G3Tou39YK33/6fu
+        RMeb8IdCPBPnqf9PJFT8UZlf3fC+UR9pkS0JB+p358He/YeOaX4YhBjE+u4gVr6BO793//xghzyH
+        fPrwISURswfbB+e7u9sP9naz2f3sAS0j7PgGbrOHRAhG7R6+uKXF+8iOXH2bbHZvb/fezsPte/fO
+        KQlyTmhmuxStP9zLdg7O9z59QCtKAYCuzScg7+XbBNDw/L9pGsmBCUdHHwyh/SHzLA/mLTqh8uDr
+        W06rPPRCaIbQXh2Z+xub///NkfFmVdWLe4yicc9HhCRxBuH7czwQVbf6p7yxs7uz+zZwYOynP5/8
+        F9fEH97/r7yGONMGw1UGUXtM+P7QhzDkGQwgb351o/hmXQPCc2dnf0fS1k5X3UCJb4QSg1jzO1Gs
+        fJNBawz7FOfubJ9PyPru379/vv3w3nR3O7+XH5C5eEg/HvomY7NrQIAhJ5ZC9NH/S5In5w93svP9
+        2c72vQOMkzhx+2CHTOOn0+zhfnZv79PpNFxb7ZpgAvJeDoalvg8Vz/+bmIL8inCU9MFN6H8I98iD
+        eYxOsDz4+pbTLA+9ENoNtFeH42Bj8//fORz0Ds/a/78SJ9kk8Dz8L34+OR9hG5MCiSVPyreXP11O
+        fnp/ff/dup6/W76r6+X5fL1zNfnGkie72wfH2/dPfTn5/5cbRO+xKP3/LHeCN3hc/qDMr25037x/
+        hFCBjY5jmR8GHQax5neiWPkWbnL+cPrw3oP97XsP97E2cD7bzh5MdrY/fXCwO30wpcB6P/Mt3P9X
+        /aOd3YPpzsMHn27fy+/NtvfvTWhx6f7swfY9MuzTBzv5bHbgZZcIQNdzICDv7x+B+j5UPP9vYgpy
+        h8JR0gc3of8h3CMP5jE6wfLg61tOszz0Qmja0F79o59fK0t4h2ft/w/+Ed7gwQTOkf3055Nn5Jr4
+        w/v/nz+Ced3gjyiHqK0nhH/oY9jodQB7H3XzqxvDz4rXUbIqdwrrh0GHQaz5nShWvt3YP59Os/z+
+        7vbDB/dyssb3Z9sHWXa+Pds72Huwnz3Y2T8P7Mb/V72OLNt5cG9ycH/74NMJjRMOx0GeHWzvTPNP
+        9/do7eLe7k4AoGuPCcjX8jpKHyqe/zcxBTkZ4Sjpg5vQ/xDukQfzGJ1gefD1LadZHnohNBto//Pa
+        6yj//+R1lFGvo/yR1/H/S6+j/P+011H6qJtf3Rh+VryOBatyp7B+GHQYxJrfiWLl2437D/L9/Xv3
+        9rb3d+7TP/Ti9sP9/en2zuze+b1Ps53Z/u7Mtxv/X/U6pp8+PPgUQ5xMc1q1mM0ol7m/t7t9vvvg
+        fpZ9OtmjbwMAXXtMQL6W17HwoeL5fxNTkJMRjpI+uAn9D+EeeTCP0QmWB1/fcprloRdCs4H2P6+9
+        jsX/n7yORdTrWPzseB2E9c+q10Ek/ZHXwT8DfOQ9ntf/T3sdCx9186sbw8+K17FkVe4U1g+DDoNY
+        8ztRrHy7cW//4MGnn84m2w9nU0Imnz7cntwnZD7NDh5M8gf5+f3svm83/r/qdeT3znemu59+SlaR
+        RrefU2j+cDZ7uL13nh+c7z082N2b3gsAdO0xAflaXsfSh4rn/01MQU5GOEr64Cb0P4R75ME8RidY
+        Hnx9y2mWh14wboTYX7T/ee11LP//5HUso17H8kdex/8vvY7l/6e9jqWPuvnVjeFnxeuoWJU7hfXD
+        oMMg1vxOFCvfblDof+98urOznZ3vUA7g3jmtPGT7k+1Pd/bvZbv3d++d39/x7cb/V72OvXz3YHr/
+        /FMidf4pReX7e9sPp7PZ9t79yfTg/qcH9yYPHwYAuvaYgHwtr6PyoeL5fxNTkJMRjpI+uAn9D+Ee
+        eTCP0QmWB1/fcprloRdCs4H2P6+9jur/T15HFfU6qp9PXkfYpoA4L7PyabXIiiU06+v1+Xnxjpp+
+        NN2ZzJeLy9VsXeXvqv3pavqLLn5RcVE2F+PZu7F5czwtq/WM+hqHJPSJ99EimypBAJiEfOfp9r3j
+        7Xu7209Ptu+d+BLy/0v/p9rg/xDLxFnq/wOeUeUPyvzqRvez4hmt2Nw4lvlh0GEQa34nilVg287v
+        7892Zvn2TrY7295/cD/fPtjbmW7fmx3s3f90f+fTh7Mgov7/qmf06f2DnfMsI/N9QAtA+9mn0+2H
+        e/f2t89nn07y3cnupwd5YETJwwl9BgLytTyjlQ8Vz/+bmIIcoXCU9MFN6H8I98iDeYxOsDz4+pbT
+        LA+9EJo2tFfP6P7G5v9/9YxW/3/wjKbrhkZzf3fvXjYJnCP/ix/5RzH/qHx7+dPl5Kf31/ffrev5
+        u+W7ul6ez9c7V5NvzD/a235KweWxLyf/v/SPVv8/9Y9W/qDMr250Pyv+0S9io+NY5odBh0Gs+Z0o
+        Vr6F+zT/dHK+c48i/vN8f3v//NN72+RAzLbPpw+zew939+9P9/d9C/f/Vf9of7b76f4BZY6y3Zz8
+        ox0a7MHO/qfb9+/tnOcPsJiVfxoA6HoOBORr+Ue/yIeK5/9NTEHuUDhK+uAm9Ie45zbcIw/mMTrB
+        8uDrW06zPPRCaNrQXv2jYFLl8Zr//9U/+kU/8o+6n2DW48ZMHnyvXCHk/JF/hGfQPyJx399+GIjX
+        /y/9o1/0/1P/6Bf5gzK/utH9rPhHNRsdxzI/DDoMYs3vRLEKLNzu9OHOw3s725+e3zsnZHZm25Pp
+        g/vb9x4e5J9mD+5l96cPfAv3/1X/6OG9Sba/8+Dh9u5kQitrD/YPtrOde/e39/b2d3fuTfbOp/d2
+        AwBdz4GAfC3/qPah4vl/E1OQOxSOkj64Cf0P4R55MI/RCZYHX99ymuWhF0LThvbqHz3Y2Pz/r/5R
+        /SP/qPsJZj1uzOTB98oVQs4f+Ud4Bv2je9uf3t8+3fPl5P+X/lH9/1P/qPYHZX51o/tZ8Y8aNjqO
+        ZX4YdBjEmt+JYuVbuOlscvBgb3+2/XA2vbe9Pzl4uH3wgBaX9+7v38t393fP92af+hbu/6v+0d5+
+        fn83z3Oy35/uUP7oYG87O6D80fmnnz64R2OfTe7vBAC6ngMB+Vr+kUceef7fxBTkDoWjpA9uQv9D
+        uEcezGN0guXB17ecZnnohdC0ob36Rw83Nv//q3/U/Mg/6n6CWY8bM3nwvXKFkPNH/hGeDf7R/Sfb
+        x2FM+f9H/6j5/6l/ZLwaPJZ/3eh+Vvyjlo2OY5kfBh0GseZ3olj5Fm52f3//3t7+ZHvvIfIq08nO
+        9sN8/972vYOH2acPz+9lO3sPfQv3/13/6OHswe7kYDvffZAR0SeT7ezefrb9cO/h7uTe+f7uvb2D
+        AEDXcyAgX8s/an2oeP7fxBTkDoWjpA9uQv9DuEcezGN0guXB17ecZnnohdC0ob36R7uB1yuP1/7/
+        rw5S+yMHqfsJZj1uzeTB98oVQs4fOUh4Bh2kvW1KFN+/78vJRgfJtaLOMMGBQ0KwQ/J843w3zHcx
+        fIRfWZT+f+ogBRNufnWj+1lxkNZsdRzL/DDoMIg1vxPFyjdxOwezT8nqzLbz7N7B9v7swb3th+cP
+        72/PJjuUBcjuHxyc7/om7v+rDtKDnU+zyeRgup092KNxZp9m25MZRUH3pg92pgf3du5/uh+sxZCj
+        E7oOBORrOUhrHyqe/zcxBflD4Sjpg5vQ/xDukQfzGJ1gefD1LadZHnohNG1obxykIMSVx2v//1cH
+        af0jB6n7CWY9bs3kwffKFULOHzlIeAYdpP3tk1Oaf19O/n/pIK3/f+ogrf1BmV/d6H5WHCQ2Oo5j
+        fhhkGESa34kh5Ru46cHk4b2dPQoG7tGSEy1C7W9ns+l0O9/fubdz7+Hep/lOsELy/1X3aDYj431w
+        73x7//4+GfLd+3vbB5Tc2L4/3dvL9x/mew8PwlCo6zgQkK/lHvlA8fy/iCXIFwrHSB/cgPyHsI48
+        mMTo7MqDr285x/LQC6FVQ3v1jfY3Nv//q2v0/wfPCG9gLIFXZD78+eQRuSb+8P5/6YdscEOUPdTE
+        E74/9CHc5Gz4mJtf3RB+VnyNH7ASd7rqh0GGQaz5nShWvsm4v5PRf/v59sGMDPD+ebazne1ntFQ7
+        Pdj/dOfh3t7+bmAy/r/qbezem+Q5LUxt7+zQ6Pb380+3D+492NuePTyfZZM9mMmHAYCuJSYgX8vb
+        +IEPFc//m5iC3ItwlPTBTeh/CPfIg3mMTrA8+PqW0ywPvRAaDbT/ee1w/OD/Tx7HD6Iuxw9+5HP8
+        /9Ln+MH/p52OH/iom1/dGL5Rr0NSktQpq3KnsL5hOuxFCTGItmZKI2j5hiN7sL+XffrgYHu2M9nd
+        3n+w9+n2wwf3Hm7Pdu+df/rp3qcHk4P7vuH4/6rbcT/bOT/IPr1HEfn5p9v7D/cfktux8+n2eUaz
+        sL9znmWTPADQNcgE5L3cDkt9Hyqe/1dxBbkZ4TDpg5vw/xD2kQcTGZ1hefD1LedZHnohNBxo//8P
+        v2Pz9CpGBiN/ev9f6nhsHo9qc/3TG03gedhPfz55HmEbs4oTW/9ZXt2r9nezn96dXebni3k93dmv
+        rnerWfPNrf/sbe/sbT8N47T/1/pAm1kuhpDHYhucIOKZOE/9cN2j+PCG/CM7MH9U5lc3vJ8d/+gH
+        2WTKZscxzg+FGIOoO3LEUPMN3d7eQf7wwYPd7XufHpD/kM0o1N47f7A93d/7lNCZ3T/Yfegbuv+v
+        +kkP9mefZtNPz7cffnr/4TYNLt+e7O5m2+ef3pven+zt7j64H1hU8ndCB4KAfD0/CTPgQ8bz/zru
+        IPcoHC59cJtxfAgryYNJjc62PPj6lnMuD70Qmjy0/3nuM2Hq/v/lN2FEcd8J3/zIf4r5T/Odss6r
+        2eTd6qfzeb53//ynq/P1fvHuevqN+U/3th/Svw98efn/qf8ENvv/rQ+FwfkjM7+6If5s+VFsjBz7
+        /FDIMYi4T5AuYr7hmz3MKA1zMNvev5+Rb3GfDN/D/YxyB+cP8z36Ks8+nfqG7/+rPtSn2fm9/OF9
+        yjXNdnNa4tqfbk9yypHsnD/cezjN9x9OdvcCAF2ngoB8XR/Kh4vn/2WcQe5SOFT64OYxfAgTyYPp
+        jM6zPPj6lrMtD70QGjy0/3nvPf3/zXca8px+5DfF/Kb7bfaLdovre9m0XL/Ly3tl8W4xyy7m9+ff
+        mN+0u/1kb/vTY19S/n/rN/3/2Gvyx2V+dQP8WfKZ2P44zvmh0GIQb48aXbx8Y7eTn9MyyqcH2w8+
+        fZiRJ5FTNubTB7R0tf/w/v2DfLY7m+z6xu7/qx7Tg93z/Xz24P72Xo6UCK0abT88OMi3z3fz2b3Z
+        LvlTOz9Lq3M/8MHi+X8XX5B7FA6UPrhxBB/CQfJgLqOTLA++vuVUy0MvhHYO7X++u0v/P/OWBpyl
+        H/lKMV+pmq7e/eD+6vxy9tNk/i+r8vwH+9l+vswvvjFfaX/75Hj74OdFjuln21X62Rrfza6SP+nm
+        Vzf7xlP6Rj2lPTY8jm1+LmbaoW1p0UPLt3IHO7PJbO/h/vaDezn5D/ey/e2H59nu9vn5w08/vbdz
+        b/fB7J5v5f6/6iftnN/f3d978Ok2Nb5HfhItxGcTsuazbPfB+b39/Um2cy8A0HUfCMjX8pOCfBWe
+        /1dxBTlF4TDpg5vw/xD2kQcTGZ1hefD1LedZHnohNHBo//PbSdr7/5WPtBd1kfZ+5CHFPKSf3r+8
+        vre3OH/7g+V6d/FudzF99263anZ/kH9jHtK97eOn23uhwvz/pYe09/9XB2nPH5X51Q3vG/WPFtmS
+        UFgWU8+W/FCIMIjy3ShKvmGbZg929nfzB9uURZlu72f3abHk4YwQm+5l+YPd/fz804e+YdvsFxFy
+        UXuHL25p6T6yw1aPZvIgn2YPH9zb3p3tYjmH3JqDnfvT7fv3DrIHs529vQcPHwYAuqaegLyXR7Pr
+        Q8Pz/5o5JKclHBp9MITzh0yyPJi06GzKg69vOafy0Auh8UH7b957oVkiGlKbHsb05Tc2k5eL339a
+        54Te70+apq0Wv3+x+v3ri40zqypK/yQQ9fnlIjD4/MmPjH3M2P9g8Ytm87d1kTXv1uX08qd3782z
+        n86rn373zaVD7m3vPNk+PvFZ6pbGnggdn4j/N1tIvEIGcnfq08n86gj2s2MhPZfqh0KEQZSddvVR
+        8pXnp9O9+w939ne2d/N8Z3v/wX6+fZDtT7Yf7O7l0/3JwSyf3veV5w/fQs7O792bzfbvbZ/n+xSc
+        Tg/OtzNCeXt6sD/ZnZ7fn2S73+zaSN/aCCJ3f87nkAxiODT6YAjnD5lkeTBp0dmUB1/fck7loRdC
+        jY32aiE/3dj8RxbSqR33gEBxxSwPvlcCCr1/ZCHxkJoetJAn28+e+iz13hay95VOutolahHS7Bvj
+        xw2a5f9VJlL7LDhv6Uj9QyHEINr8UhQtX4tSQLaf3dubkfnZoaVkWlfefri7c0DJ509nD/cPPj14
+        sLfja9HNppIAg/8sieij/7ck2e893M32JhRF7ZCt3b+/u7N9cP+c0u2ze/fv33s42d+hvIMPoGuV
+        CMh7GVxLfR8qnv9XcQXZ2nCY9MFN+H8I+8iDiYzOsDz4+pbzLA+9EBoFtFcj/P+5MBWEv2FWVenp
+        n/IKz1VgeO2nPzK+MeP7i/bmzb377S+q1/fWl5NfdG9/vVsv6/3di8k3Znx3tu/tbj/8//FqPV5k
+        Fvv/Wy4ar/DA/FGZX93wflbciJ9mzfyRtqMGPwxCDKLNL0XR8u3ApwfTbDZ7mG/v3Msons0nk+3J
+        g+lke3fy6YMZZYNn0/Nd3w78f9WNmE3OH2b72QFR/cEeOQ97JN8Pc4o8Pz24N9k9uH9vMvFIRAC6
+        9pWAfC034qd9qHj+X8UV5DWEw6QPbsL/Q9hHHkxkdIblwde3nGd56IXQvKH9N+9GdFbGqXEPdWr1
+        w5zeDkb+9P7/Yq0er/Boov7RT//IP4r5R8tqr3i794sm2c679bv86v788vK8qN7uzL+5tfq97U/3
+        tx8+8WXk/5/+0U///9U/+ml/VOZXN7xv3D9qmt1Pc8oaO5b5hsnQNO9Bh9fTrMxJOs27hFunRXN3
+        pz9S1zociW8Rp+cPP80+zc637z+cPdgmdO9tZzv397an9x9mDyb37+/uPgzWf4mN4rYQX9zSCn5k
+        CaLezqf7Dw4OJju729nkgLyd871PKWkyI7N8vv9w/+HugweT8yBHT15L6AYQkFt5O5Ygxm3woeL5
+        //oskz8UUsZ9OzjkD2EHeTD3UaaQB1/fkjXkoRdC+4b237yDRJNM1KQ2PYzpyx8KIxglpdOsf5p3
+        aNJ6jgR/+sNzJPpvlFU2e5KV2XKa10+y6dt8OdN3X1ZViZkKJFGeCIEJ1A+VxD7e5g0iZTm5O+mP
+        wn0/yVf0QY/UROzuR6HLgyeg1dlyUq2XsxdZ+2pdspz8f41ORTgC990ya0Gk8c6tyBR+EHzv/eFT
+        U/zPnwvfdDZdv7tur6u9q2vig1U+3T1fXlOPk+wb8033t0+Ot0++jm9KshuX7R+uQzfATx9g43wS
+        ml/1F0NSO6C+aScr6Ij5//ax7t5gz72R+Gb6YC8/ePDwU1pg+nRCyyH3P93Znkw/3d0+ONg5OJje
+        P39wfhDkMYhXiHsjBhpf3NI0f2QJol7b9H52sHN/Z4+WunYJifP797cnk4MJ5ah2Z+fTe9Pdh7uB
+        Afn567XdNMsf6rW9LzvIg7mPMoU8+PqWrCEPvRA6E2ivXtv9jc1/5LUFDygT1+zy4HulnBD6R14b
+        j8J9/yOvjd4gOhCdbvTadm9FpvCD4HvvD5+a4pn9/9drO9h+eupL2s9zr81nI8sR+oshqR1Qz7QX
+        ZAUdMf/fNdai04LGusGed0bim+n83v39/Sm5SdP9BzNafdp7sH0w+zTf3ss+nR3s5vd3HmYz30wT
+        rxD3Rgw0vrilaf7IEkS9tuzeg5zQ+HR7dpBRhmf/fH87OziH67b7INu9d+/+wac7AYCub0JAAh3o
+        4YWnP7WDLowgdPf/q7OsXpujjPt2cMgfwg7yYO6jTCEPvr4la8jzESmkwJlA+5+PXlsR9dqKH3lt
+        709iH2/zBpGSvJFNXlvxI6+N3iA6EJ2GvLbi/79e2/KnJ1dvf9FPry/bt/nuT5e7qx/cm74t15fl
+        9Bvz2na3793bfhBI2s8rry1i43wSml/1F0NSO6C+aScr6Ij5//ax7t1gz72R+GZ69vDB/U8P7lM2
+        ZbrzcHv/4adkpneR8Po0n+5R0mtn+unUN9PEK3EDjS9uaZo/sgRRr23vwWQ/O9+Zbeez2S7l2iaz
+        7YPze9n2dOfTvf1P9+mfbBIA+Hnrtd00yx/qtb0vO8iDuY8yhTz4+pasIQ+9EDoTaK9e26cbm//I
+        awseUCau2eXB90o5IfSPvDYehfv+R14bvUF0IDrd6LXt3YpM4QfB994fPjXFM/v/rde2f3/76T1f
+        0n6ee20+G1mO0F8MSe2Aeqb9p8kKOmL+v2usP91pQavBG+x5ZyS+maaVsPsHk4fIcO3e296fzPZo
+        XXJyf/vTvfv37yPrsnvv3DfTxCtxA40vbmmaP7IEUa/t053pvWx/d7p9f7ZHXDwjTB4+eDDZfjjZ
+        29ndebh7cP/eQQCg65sQkEAHenjh6U/toAsjCN39/+osD3ttw0P+EHaQB3MfZQp58PUtWUMeeiF0
+        JtBevbaYJ+Ga///Ma/vpqNf20z/y2t6fxD7e5g0iJXkjm7y2n/6R10ZvEB2ITkNe208br23nVmQK
+        Pwi+9/7wqSme2c+F13a9rnZ/0c67692Ld3mdX5Xlu8vL84uqenvxDXptZPKenPiS9vPKa4vYOJ+E
+        5lf9xZDUDqhv2skKOmL+v32sm9bOOiPxzfT5pzuTe7PZg+37ew92KLmyd7B98GA/3548vHc/e7B7
+        78H+vR3fTBOvxA00vrilaf7IEkS9tp3Z7vlkl/I6ew8fUF5nJ7u3fZDRgunuw/0HB5P79z6d7uwF
+        ALq+CQEJdKCHF57+1A66MILQ3f+vzvKHem3vyw7yYO6jTCEPvr4la8hDL4TOBNqr1/bzaoX0R17b
+        N0ZiH2/zBpGSvJEfutcGn4dG/v81Ot3otflLW+ZRa+ueH3ltAOx7bff2tndOfUn7ee61+WxkOUJ/
+        MSS1A+qa9t2MrKAj5jc+1r0PGexu1mlBgx026N2h+Hb6/r2dg+mDabb9cErJrv3pAa2JPdw53z6Y
+        7e3cm2bTndnBp76dJmaJW2h8cUvb/JGliLptk/OD2YO96afb9x6c723v33vwcPvg3oN72+cH97Ms
+        f5BNyIkIAHSdEwISKEEPLzz9uR30YQShu/+fneZBv23DmD+EH+TB5Ee5Qh58fUvekIdeCN0JtP//
+        uN8W5wRjLXWe9U/zEs1azHHbzX7kuH0NGvuIm1eIluSRbPDcdrP/P+bbvi6hBlw3Uj3/v3Xd2vX5
+        1epi9a7cuZ//dFGu5z9dLS5mP7hqsm/MddvZfnC6fRKuJ/1/zHWLM9QH2DmfhuZX/cXQ1I6ob9/J
+        Ejpq/r9+sHs3GHVvKL6t/vT+bJ9SLAfbu/t7ZKsf7O5SeuX83vZ08uBg9+Hu/vmDTwNbTdwSt9L4
+        4pb2+SNLEfXddj/dzXdn+f3tvcnOAS333ycksnv725/e288ezM6n9z7d/0ZTbhv8GEHo7v9np/lD
+        fbf35Qd5MPlRrpAHX9+SN+ShF0KPAu3Vd/t0Y/Mf+W70w3tAmrh2lwffK+mE0j/y3WQY7vsf+W54
+        hQhBhLrRd9u7FZ3CD4LvvT98cop/9v9b3+0JZd7u+bL289138/nIsoT+YmhqR+TZ92VzcbnYOzjw
+        rMQ3N1YCXl9EB2okhyYfPwPjTG/1UPJN7sO9fP/edDLb3j0/v0/LXAf3tyezB+T97D44nz6YZPns
+        4Nw3uaRTxMQBwFXetOvG+5Kwi1pifHFLG/yRHbb6Z/nOwafUiBI6n07uwSm4RxiCYAeE3s69fDLd
+        Cczr1/bPjIuy60PD8/+aOez7V8M4f8gky4NJi86mPPj6lnMqD70QWnu0J79ql/yqmKl3zd/Lr1qt
+        J2UxpbdsJz3UqdUPcUo7CHlT6qkZeYxycc9HhCHxBCH7czyKS9GR+qd5g3om7Jq7s/w8W5e+7ZEn
+        MiCa1rjVkAff67QLvbo+YfiCamV5vD98Gysm+ufCfP/05e7u21kzmbfv8sufvr6c7UzybPcHl0X+
+        jZnv3e0nD7bvfx3zTZ1hKl/n03VdtNfMCdQuJM8PkcNi+ERlJaALsUucnX5oTgjhNzCyuAcSH5P5
+        1Q3uo/Z6BbQ/cgA7pHJWQiGZl+1IrXHLZi98bfnNjb6urnf37rXkCURJMIjxXWDkY+QbrPwe9Xdv
+        km8/mH56TohktJ6283Cy/emn2cHevd3Jw3uTiW+wfvheyez8fPLwYJ9Ild/PaZnp/mQ7mxycb0/u
+        359MZgf3853zLADQNd0E5P8tXsmHTSH5IOHI6IMhlD9kjuXBnEUnUx58fcsplYdeCM0N2pNTgv/e
+        2ylBh76UmecjmiOiHjXpIUxf/rDn8VK0kf6JWQzSPNnsR/mdr0VXH3WQ8bn3dzTJ8/zJk9MelYnO
+        3Y9ChwNPQKb/N2R2vgkSddM72ezV05e3ok/4QfC994dPRnH7fi5cwuli9XZnPp/M5jt5PVvWZdXu
+        7s5mO7PJN+YS7sErfPbUl65buoQkr3F5/qE5Uzcw0pBHRTrsC59M5ldHr4/a62/Om6K1Ds+4fXOj
+        x7h//93oyAeRvdtBxrexO/fvzbL72YPtWf7p3vb+7v1sm/68t33wML//MM+nn+7u3vNtLOkVsWkA
+        0POjCDA4zZKDPpoVzarMrsHi9A2lwF6cnSj1HP2oHY0oarXxxS3t9UeWVuqCPTjYm94/oDW72ZTc
+        hv3zKTkQn9Li0b2De3t7lBV6sPfpN7NwN+zPCCJ3fw4nnpytcFD0wRC2H8IZ8mC6ovMoD76+5WzK
+        Qy+EDgLaf13vazglRPND1KM2PYzpy292DuOpaDOHqrb0z+buJaG1d5e6pp/NXfG7dq38mMfJkXlA
+        iLiilgffK6GErl3HK3zBqks83h++WROr+HNhMdt7RVHt/eAqX/yi9TLP788m9VVbLcv2/S3msBU0
+        jVzzr2Mw8IO8kV/y/wCSUYC22M4BAA==
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 03:02:15 GMT']
+      date: ['Thu, 07 Jul 2016 20:02:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -360,14 +409,78 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [be3d7bc0-447d-11e6-9663-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/virtualnetworks?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS97/+S/wdC6kBEDAAAAA==
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['133']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 07 Jul 2016 20:02:33 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 storagemanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [be5c274f-447d-11e6-83a2-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Storage/storageAccounts?api-version=2016-01-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS97/+S5P8BxWZBqg0AAAA=
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-type: [application/json]
+      date: ['Thu, 07 Jul 2016 20:02:33 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 resourcemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.32]
+          AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [376170ae-3f38-11e6-9df7-001dd8b7c0ad]
+      x-ms-client-request-id: [be7f8dcf-447d-11e6-8330-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27cliTestRg_VmListIpAddresses%27%20and%20name%20eq%20%27vm-with-public-ip%27%20and%20resourceType%20eq%20%27Microsoft.Compute%2FvirtualMachines%27
   response:
@@ -381,7 +494,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['133']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 03:02:16 GMT']
+      date: ['Thu, 07 Jul 2016 20:02:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -395,54 +508,54 @@ interactions:
       {"value": "none"}, "subnetIpAddressPrefix": {"value": "10.0.0.0/24"}, "adminUsername":
       {"value": "ubuntu"}, "networkInterfaceType": {"value": "new"}, "_artifactsLocation":
       {"value": "https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30"},
-      "osType": {"value": "Custom"}, "sshKeyValue": {"value": "C:\\Users\\burtbiel\\.ssh\\id_rsa.pub"},
-      "osVersion": {"value": "latest"}, "customOsDiskType": {"value": "windows"},
-      "virtualNetworkIpAddressPrefix": {"value": "10.0.0.0/16"}, "name": {"value":
-      "vm-with-public-ip"}, "storageCaching": {"value": "ReadWrite"}, "adminPassword":
-      {"value": "testPassword0"}, "networkSecurityGroupRule": {"value": "RDP"}, "storageContainerName":
-      {"value": "vhds"}, "osOffer": {"value": "UbuntuServer"}, "osPublisher": {"value":
-      "Canonical"}, "privateIpAddressAllocation": {"value": "dynamic"}, "size": {"value":
-      "Standard_DS1"}, "location": {"value": "westus"}}}}'
+      "osType": {"value": "Custom"}, "osVersion": {"value": "latest"}, "customOsDiskType":
+      {"value": "windows"}, "virtualNetworkIpAddressPrefix": {"value": "10.0.0.0/16"},
+      "name": {"value": "vm-with-public-ip"}, "storageCaching": {"value": "ReadWrite"},
+      "adminPassword": {"value": "testPassword0"}, "networkSecurityGroupRule": {"value":
+      "SSH"}, "storageContainerName": {"value": "vhds"}, "osOffer": {"value": "UbuntuServer"},
+      "osPublisher": {"value": "Canonical"}, "privateIpAddressAllocation": {"value":
+      "dynamic"}, "size": {"value": "Standard_DS1"}, "osDiskName": {"value": "osdisk1467921754"},
+      "location": {"value": "westus"}}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
-      Content-Length: ['1304']
+      Content-Length: ['1282']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [37acd191-3f38-11e6-a9ca-001dd8b7c0ad]
+      x-ms-client-request-id: [beaf0240-447d-11e6-b2a4-001dd8b7c0ad]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/azurecli-test-deployment-vm-list-ips","name":"azurecli-test-deployment-vm-list-ips","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30"},"adminPassword":{"type":"SecureString"},"adminUsername":{"type":"String","value":"ubuntu"},"authenticationType":{"type":"String","value":"password"},"availabilitySet":{"type":"String","value":""},"availabilitySetType":{"type":"String","value":"none"},"customOsDiskType":{"type":"String","value":"windows"},"customOsDiskUri":{"type":"String","value":""},"dnsNameForPublicIP":{"type":"String","value":""},"dnsNameType":{"type":"String","value":"none"},"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"vm-with-public-ip"},"networkSecurityGroup":{"type":"String","value":"vm-with-public-ipNSG"},"networkSecurityGroupRule":{"type":"String","value":"RDP"},"networkSecurityGroupType":{"type":"String","value":"new"},"networkInterfaceIds":{"type":"Array","value":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/networkInterfaces/vm-with-public-ipVMNic"}]},"networkInterfaceType":{"type":"String","value":"new"},"osDiskName":{"type":"String","value":"osdiskimage7ndmdde7ce7ca"},"osDiskType":{"type":"String","value":"provided"},"osDiskUri":{"type":"String","value":"https://vhdstorage6oayrczyf2jh6.blob.core.windows.net/vhds/osdiskimage7ndmdde7ce7ca.vhd"},"osOffer":{"type":"String","value":"UbuntuServer"},"osPublisher":{"type":"String","value":"Canonical"},"osSKU":{"type":"String","value":"14.04.4-LTS"},"osType":{"type":"String","value":"Custom"},"osVersion":{"type":"String","value":"latest"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddress":{"type":"String","value":"vm-with-public-ipPublicIP"},"publicIpAddressType":{"type":"String","value":"new"},"size":{"type":"String","value":"Standard_DS1"},"sshDestKeyPath":{"type":"String","value":"/home/ubuntu/.ssh/authorized_keys"},"sshKeyValue":{"type":"String","value":"C:\\Users\\burtbiel\\.ssh\\id_rsa.pub"},"storageAccount":{"type":"String","value":"vhdstorage6oayrczyf2jh6"},"storageAccountType":{"type":"String","value":"new"},"storageCaching":{"type":"String","value":"ReadWrite"},"storageContainerName":{"type":"String","value":"vhds"},"storageType":{"type":"String","value":"Premium_LRS"},"subnetIpAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetName":{"type":"String","value":"vm-with-public-ipSubnet"},"virtualNetworkIpAddressPrefix":{"type":"String","value":"10.0.0.0/16"},"virtualNetwork":{"type":"String","value":"vm-with-public-ipVNET"},"virtualNetworkType":{"type":"String","value":"new"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-01T03:02:17.8373908Z","duration":"PT0.0774438S","correlationId":"da893af5-f64a-4ce5-b3a5-9a5d8b325385","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipVNet","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipVNet"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipNSG","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipNSG"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipNicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipNicIp"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ip2ehks2ugdnrb2","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ip2ehks2ugdnrb2"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipNicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipNicIp"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipVM"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-iph2hph5unfy62ynew","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-iph2hph5unfy62ynew"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-iph2hph5unfy62ynewfqdn","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-iph2hph5unfy62ynewfqdn"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipvm-with-public-ipVMNicmac","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipvm-with-public-ipVMNicmac"}]}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/azurecli-test-deployment-vm-list-ips","name":"azurecli-test-deployment-vm-list-ips","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-06-30"},"adminPassword":{"type":"SecureString"},"adminUsername":{"type":"String","value":"ubuntu"},"authenticationType":{"type":"String","value":"password"},"availabilitySet":{"type":"String","value":""},"availabilitySetType":{"type":"String","value":"none"},"customOsDiskType":{"type":"String","value":"windows"},"customOsDiskUri":{"type":"String","value":""},"dnsNameForPublicIP":{"type":"String","value":""},"dnsNameType":{"type":"String","value":"none"},"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"vm-with-public-ip"},"networkSecurityGroup":{"type":"String","value":"vm-with-public-ipNSG"},"networkSecurityGroupRule":{"type":"String","value":"SSH"},"networkSecurityGroupType":{"type":"String","value":"new"},"networkInterfaceIds":{"type":"Array","value":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/networkInterfaces/vm-with-public-ipVMNic"}]},"networkInterfaceType":{"type":"String","value":"new"},"osDiskName":{"type":"String","value":"osdisk1467921754"},"osDiskType":{"type":"String","value":"provided"},"osDiskUri":{"type":"String","value":"https://vhdstorage6oayrczyf2jh6.blob.core.windows.net/vhds/osdisk1467921754.vhd"},"osOffer":{"type":"String","value":"UbuntuServer"},"osPublisher":{"type":"String","value":"Canonical"},"osSKU":{"type":"String","value":"14.04.4-LTS"},"osType":{"type":"String","value":"Custom"},"osVersion":{"type":"String","value":"latest"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddress":{"type":"String","value":"vm-with-public-ipPublicIP"},"publicIpAddressType":{"type":"String","value":"new"},"size":{"type":"String","value":"Standard_DS1"},"sshDestKeyPath":{"type":"String","value":"/home/ubuntu/.ssh/authorized_keys"},"sshKeyValue":{"type":"String","value":""},"storageAccount":{"type":"String","value":"vhdstorage6oayrczyf2jh6"},"storageAccountType":{"type":"String","value":"new"},"storageCaching":{"type":"String","value":"ReadWrite"},"storageContainerName":{"type":"String","value":"vhds"},"storageType":{"type":"String","value":"Premium_LRS"},"subnetIpAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetName":{"type":"String","value":"vm-with-public-ipSubnet"},"virtualNetworkIpAddressPrefix":{"type":"String","value":"10.0.0.0/16"},"virtualNetwork":{"type":"String","value":"vm-with-public-ipVNET"},"virtualNetworkType":{"type":"String","value":"new"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-07T20:02:34.9320079Z","duration":"PT0.0945047S","correlationId":"d59a41a6-9323-4ec6-9306-7fd298ec6c27","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipVNet","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipVNet"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipNSG","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipNSG"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipNicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipNicIp"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ip2ehks2ugdnrb2","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ip2ehks2ugdnrb2"},{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipNicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipNicIp"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipVM"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-iph2hph5unfy62ynew","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-iph2hph5unfy62ynew"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-iph2hph5unfy62ynewfqdn","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-iph2hph5unfy62ynewfqdn"},{"dependsOn":[{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipVM"}],"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipvm-with-public-ipVMNicmac","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipvm-with-public-ipVMNicmac"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/azurecli-test-deployment-vm-list-ips/operationStatuses/08587342647477177473?api-version=2015-11-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/azurecli-test-deployment-vm-list-ips/operationStatuses/08587336851306401934?api-version=2015-11-01']
       cache-control: [no-cache]
-      content-length: ['6699']
+      content-length: ['6646']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 03:02:17 GMT']
+      date: ['Thu, 07 Jul 2016 20:02:34 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [37acd191-3f38-11e6-a9ca-001dd8b7c0ad]
+      x-ms-client-request-id: [beaf0240-447d-11e6-b2a4-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342647477177473?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336851306401934?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -454,7 +567,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['140']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 03:02:47 GMT']
+      date: ['Thu, 07 Jul 2016 20:03:05 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -465,15 +578,15 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [37acd191-3f38-11e6-a9ca-001dd8b7c0ad]
+      x-ms-client-request-id: [beaf0240-447d-11e6-b2a4-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342647477177473?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336851306401934?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -485,7 +598,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['140']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 03:03:19 GMT']
+      date: ['Thu, 07 Jul 2016 20:03:34 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -496,15 +609,15 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [37acd191-3f38-11e6-a9ca-001dd8b7c0ad]
+      x-ms-client-request-id: [beaf0240-447d-11e6-b2a4-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342647477177473?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336851306401934?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -516,7 +629,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['140']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 03:03:49 GMT']
+      date: ['Thu, 07 Jul 2016 20:04:04 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -527,15 +640,15 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [37acd191-3f38-11e6-a9ca-001dd8b7c0ad]
+      x-ms-client-request-id: [beaf0240-447d-11e6-b2a4-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342647477177473?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336851306401934?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -547,7 +660,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['140']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 03:04:19 GMT']
+      date: ['Thu, 07 Jul 2016 20:04:34 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -558,15 +671,15 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [37acd191-3f38-11e6-a9ca-001dd8b7c0ad]
+      x-ms-client-request-id: [beaf0240-447d-11e6-b2a4-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342647477177473?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336851306401934?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -578,7 +691,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['140']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 03:04:50 GMT']
+      date: ['Thu, 07 Jul 2016 20:05:05 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -589,15 +702,15 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [37acd191-3f38-11e6-a9ca-001dd8b7c0ad]
+      x-ms-client-request-id: [beaf0240-447d-11e6-b2a4-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342647477177473?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336851306401934?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -609,7 +722,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['140']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 03:05:19 GMT']
+      date: ['Thu, 07 Jul 2016 20:05:36 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -620,263 +733,15 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [37acd191-3f38-11e6-a9ca-001dd8b7c0ad]
+      x-ms-client-request-id: [beaf0240-447d-11e6-b2a4-001dd8b7c0ad]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342647477177473?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 03:05:50 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [37acd191-3f38-11e6-a9ca-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342647477177473?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 03:06:20 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [37acd191-3f38-11e6-a9ca-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342647477177473?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 03:06:50 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [37acd191-3f38-11e6-a9ca-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342647477177473?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 03:07:20 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [37acd191-3f38-11e6-a9ca-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342647477177473?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 03:07:51 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [37acd191-3f38-11e6-a9ca-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342647477177473?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 03:08:21 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [37acd191-3f38-11e6-a9ca-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342647477177473?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 03:08:51 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [37acd191-3f38-11e6-a9ca-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342647477177473?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 03:09:22 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [37acd191-3f38-11e6-a9ca-001dd8b7c0ad]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587342647477177473?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587336851306401934?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -888,7 +753,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['141']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 03:09:52 GMT']
+      date: ['Thu, 07 Jul 2016 20:06:06 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -899,13 +764,13 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.32]
+          msrest_azure/0.4.1 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [37acd191-3f38-11e6-a9ca-001dd8b7c0ad]
+      x-ms-client-request-id: [beaf0240-447d-11e6-b2a4-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
@@ -921,32 +786,31 @@ interactions:
         07Z5Xk0zzAY+ba9XGO7rti6WFwTvMivX+OAbQxqIZLNFsXyZNc1VVRNPuF7zKUHXvk27r5q8lklw
         7aSFw249WS/bNb+ybuc0/kJG9IbbD7+3MjjgzcusKLNJURbt9eu83fRapPlNPS2rZY7XpuumrRZf
         Nk+L5u1N7yhZu699BS4afgvNZ8vmRbbIn1X1y/WkLKZnL2/5xk0omWGUt2CZK5KUNWN/0/SRDF0V
-        7Xx7xciSKPFLeUtT85Z5gmjMsv9eQF68/nwIzqt1Sa8Mw3r19OXQqzdSKL/yXj0jaaxJyPKzGQud
-        vnVc19m1e+l7P3e68YXgebeLb3O3R8+f/OJFMf3ol3w/MrpbEqVi/gWfbWpcNTNqVSyyi/zBcraY
-        zfIHU/pf5iDc1J0OlMVa3rhBZox2u5zPSM5q6vnTKruupz+4Pt/76fmnA6oOre8OYTumb6X/L8/P
-        83pT71+x9nqd15fUjl9hqW3m9OeG104ykkZSdKW88/r3+mpT69398c7+eH/7+ZvX0v4mIp6wypG2
-        1pwMN4fOb1o0X9XFJf1hOW/TW7H2x+VttMvsmrQK+JEAgFrTb+z9TW/1hIJnCvq1D+cmAqtQNMUP
-        6K/hZq/bbDnL6tnv//T1Lrdv5k+J0r9Xfv0ya+eb3rw7rxb5XbGNd8f03l1Yx6qmDme//9v8mnUz
-        fUygflJeGYZ18uj3/X1hiZvf9/edrOt2UuTl7/v7Aubv+/sWs9+/brIxjZ7hifwcT6cV9bsJJAmI
-        Ng6ErQ/ktoSUl06y6Rzfb3jhVZ7NvksanU2ZeY0cp6xY5vVN6gloe+/dhNzLOl8U68Xv//wVyx1p
-        eFIdlkfo2/Pi3ab3d8l5w3939/bd+zfi2GXT1/waAFwWdbvOStX7XweRXZ6iEM6mF3vI/OSL0zd9
-        EDcRkmeZ3lpUM/x5tpwSZcnVI/1HogeNDxVF75DA0MwShPV0mpN7PKPv22JBMpMtyIP4SHzRB9s7
-        u2927j3aefhob3988PDg050HD36Kms7WtSqPj16+efDFg/HuvYNP6cvX9B2ZgDonTUdfn8Fgz7KD
-        h/ey8/vb55/uZ9v70/z+9uRedn/7YXZ/djC5t3f/3sF9eo2xg+FlU096J29W2RQ4OkNsgxRqTxPC
-        v4Mk8o7/Cb0mPj9Gj+ZG3aHpcl2W3ycb/X0aSL7Kl7N8OeVohIDIB82XNDT66+fK47ADDaKxCJMQ
-        v4akIHxvAOO9ICISYz6C+0tG/68fP7xXN5pvbPgAC+b4f/voYUe94Xxz42fAmH967/870rCXz982
-        e+uL2bKe7HnD/MboEnYA+vy/nCIykW5g3xglBPD/B2TkJ7/wRvONDZ+gYvbppf/vSAfh7Ab2jVLi
-        //1cMN+br+b318vz60/3ruEjuYF9Y5To9fEjDjFQ/z/IIee/aIZMMQHmt78xakT7+RGnGKj/H+CU
-        3gec8ltkU2+E3xhJeh/YzkCpat2u1gSHAkIQbTgsvPvDp+ZJtSDc8rsav37BCQdq2xsRcX83KbRp
-        KPs7493dg/He/v549z7eZQna8ALadLNnm9prCM+JBCL0Ld7Y2dneebp973j73u72KUXNBxyCy+TY
-        iXdi/fVo1HuZQjRkBN4jKX0jjCCHH4HDcdEwFGl39lJJFsPEywQOglFq6J8RIJoa6QF4Lcmmu5p0
-        0sQYAaBklHzUyaF9/5f8kv8HTuOVmnEdAAA=
+        7Xx7xciSKPFLeUtT85Z5gmjMsv9eQF68/nwIzqt1Sa8Mw3r9+ttDr95IofzKe/WMpLEmIcvPZix0
+        +tZxXWfX7qXv/dzpxheC590uvs3dHj1/8osXxfSjX/L9yOhuSZSK+Rd8tqlx1cyo1e7+pw8e7u0+
+        uL/v3rypGx0gi7O8cYOsGK12OZ+RfNXZRf5plV3X0x9cn+/99PzTARWH1ne7WI7pU+n3y/PzvN7U
+        61esrV7n9SW141dYSps5/bnhtZOMpI8UWynvvP69vtrUend/vLM/3t9+/ua1tL+JeCesYqStNR/D
+        zaHjmxbNV3VxSX9YTtv0Vqz9cXkbbTK7Ji0C/iMAoNb0G3t/01s9IeCZgj7tw7mJwCoETfED+mu4
+        2es2W86yevb7P329y+2b+VOi9O+VX7/M2vmmN+/Oq0V+V2zh3TG9dxfWsKqpw9nv/za/Zl1MHxOo
+        n5RXhmFxUxGJ4+m0IpCbWhPva+NAfvpAbksjeekkm87x/YYXXuXZ7LuknNkqmdfIB8qKZV7fpGmA
+        tvfeTci9rPNFsV78/s9fsUiRsiZtYKefvj0v3m16f5f8MPx3d491mrx/I45dDnzNrwHAZVG366xU
+        Ff51ENnlKQrhbHqxh8xPvjh90wdxEyF5lumtRTXDn2fLKVGWvDZSbSRVUOLQPvQOyQLNLEFYT6c5
+        eboz+r4tFiQO2YKcgY/ErXxA/3uzt/No5/6jewfjvXv3H+zd3/spajpb16oXPnr55t4X98b3Hh7s
+        7e29pq9Iqdc56TD69gymd3b/Yba/m326/fDe3r3t/XyK38hhfXA+23t4QH9O9x7Qa4wcTCgbbdIo
+        ebMi+0cAnEm14Qa1p/ng30ERecf/hF4T7x2DR3OjyNB0uS7L75O1/T6NI1/ly1m+nHJcQUDkg+ZL
+        Ghn99XPlO9iBBnFVhEeIXUNSEL43gPFeEAmJ8R7B/SWj/9ePH36oG803NnyABXP8v330sJDecL65
+        8TNgzD+99/8dadjL52+bvfXFbFlP9rxhfmN0CTsAff5fThGZSDewb4wSAvj/AzLyk194o/nGhk9Q
+        Mfv00v93pINwdgP7Rinx/34umO/NV/P76+X59ad713CR3MC+MUr0+vgRhxio/x/kkPNfNEPOlwDz
+        298YNaL9/IhTDNT/D3BK7wNO3i2yqTfCb4wkvQ9sZ6BUtW5Xa4JD8SCINhwV3v3hU/OkWhBu+V0N
+        X7/gfAO17Y2IuL+b7tk0lP2d8cG98e7B7nhvl5M4LEEbXkCbbl5sU3uN4DmPQIS+xRs7O9s7T7fv
+        HW/fu4d/Tx5wBC6TYyfeifXXo1HvZQrRkBB4j/TyjTCCbHwEDsdFw1Ck3dlLJVkMEy/HNwhGqaF/
+        RoBoZqQH4LXkmu5qzknzYgSAclHyUSeF9v1f8kv+H6HpNzk7HQAA
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
-      content-length: ['1679']
+      content-length: ['1635']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 03:09:52 GMT']
+      date: ['Thu, 07 Jul 2016 20:06:07 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -957,14 +821,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.32]
+          AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [4845ab70-3f39-11e6-8719-001dd8b7c0ad]
+      x-ms-client-request-id: [3db97070-447e-11e6-a226-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Compute/virtualMachines/vm-with-public-ip?api-version=2016-03-30&$expand=instanceView
   response:
@@ -972,30 +836,30 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UerulrldVvkzUePUv6IPrxcnM3oz492dh6eZzsP97azh3m2vT+9N9ue5PmD7emD8/3d+7v7u5PZ
-        px+N9KV5Vs+usjp/WVfnRZnT+wqOvrtcvC5+gI8+et1myxm1/P2fvt79SL7/JQZC01Z1dhEFUCzo
-        i1f5eV7ny2nwFX25Wk/KopnnNX3+0Um2rJbFNCsNYng+qs7pVXz91WS9bNev8/qS/vZbNG/X+H53
-        f7yzP97ffv7mdfA1NW+KaokmZdbmTavIO/SpUdU8LZq31MbHrmreXK+A8kfPi+X6XQB1mS34m6qZ
-        0Ys8yAfL2WI2yx9M6X9Z0Hha59Tzl6tW8XhWV4szvBK0upxj6jwE6LN1XdBnH83bdtU8unuXmiip
-        P62y63r6g+vzvZ+efzqelNVkPK3qfHxVLGfVVTNe5i23vjuE4Ji+tZTwaUG9TrPpvFheoOdXeTb7
-        bl20uW3rWn40y9oMdAMHfu/78rH5migTY4dptVit27x+ofS7XGxfFe18mzlhul2sHEk+ymaLYvlV
-        k9eG2GtmAa9FiXk5qZbnxcW6zpS8tjNqQGPPJmX+Mmuaq6qeHa/beb5sicm07XlWNrlpb1Cn95qc
-        5qyNjosoS6DeeoMzH50taWDn2RQS+b1f/FFB0/nR3WY9aaZ1wXPf3L23s58fPHz46faDB+eT7f1P
-        84PtSTbLtu/ff/Dpzu79h/uTfP9unTfVup7mn9fVetXcnZbFG2LbVxe//08unhdNe7Y6ns2oTZM3
-        d0kJXBYz4vC7XxTTumqq83b8QrC528Pqbo/YP/nFi2L60S/5vh0cw4O40PSTwNO0E9lfr6fTPJ/l
-        M0P5j4plQ9pgmv9kkV9RC0txms7jCyKw/5n79CcJTwJNX3703WMWKf54e2+8M9616ggPKZSsXdMA
-        qe333MepDxUPsdOMUaTZCPG+23SRNs9HZX6Zl3jpbHle9b4ljlmV2TWArNH9R5CA616zBdGfRAoN
-        Pl/T7PBI0qJJ6/USSKSkLNOMUKCJp7+W+VU69fm0GfdAtoVw+d7O7qfbOw+2d3bf7Nx7tPPw0b37
-        n+zsPNrZsSKI55e4P77vQfoof9fmS1Di24RBSRQnkIaH6S3bFAMVwTWfdKj7XiqOmg9NWQcsnq8z
-        bfTWxomj7wnNcOp88OkmyAOkf/Bo99Pxg3v393YefhqZAiKn/6clsve5m5oB+gS0eX+6bKLJ16PH
-        EC0OHu3tjQ/29z/dffCwRwvHVoMjqq7yGpjkd1VCOt2+10B+8gsjZz4S5ledCP5bMGNdnP5cKOMT
-        sXd3L4u6XWflF2xZqW1PFcuQrdANfd+qR3JjD9q+rKyt++iKECf6yRdtdgFS6mwZEhuz/JMBMCYy
-        kfOX/D8SyBepegoAAA==
+        6UerulrldVvkzUePUv6IPrxcnM3oz492Dz7dv5d9Otne/fRgd3s/n8y2Dx7en25/+un5w529B/ne
+        +YODj0b60jyrZ1dZnb+sq/OizOl9BUffXS5eFz/ARx+9brPljFr+/k9f734k3/8SA6Fpqzq7iAIo
+        FvTFq/w8r/PlNPiKvlytJ2XRzPOaPv/oJFtWy2KalQYxPB9V5/Qqvv5qsl6269d5fUl/+y2at2t8
+        v7s/3tkf728/f/M6+JqaN0W1RJMya/OmVeQd+tSoap4WzVtq42NXNW+uV0D5o+fFcv0ugLrMFvxN
+        1czoxd39Tx883Nt9cH8/aDStc+rxy1Wr/T+rq8UZ6BG0upxjyryO6bN1XdBnH83bdtU8unuXmiiJ
+        P62y63r6g+vzvZ+efzqelNVkPK3qfHxVLGfVVTNe5i23vttFbEyf2pH7Y6feptl0Xiwv0OOrPJt9
+        ty7a3LZ1LT+aZW0GOoHjvvd9+dh8TZSITf+0WqzWbV6/UHpdLravina+zTM/3S5WjhQfZbNFsfyq
+        yWtD3DVPudeixDycVMvz4mJdZ0pW2xk1oDFnkzJ/mTXNVVXPjtftPF+2xFTa9jwrm9y0N6jTe01O
+        c9VGx0UUJVBvvcGZj86WNLDzbAoJ/N4v/qigafzobrOeNNO64Dlv7t7b2c8PHj78dPvBg/PJ9v6n
+        +cH2JJtl2/fvP/h0Z/f+w/1Jvn+3zptqXU/zz+tqvWruTsviDbHpq4vf/ycXz4umPVsdz2bUpsmb
+        uyT0l8WMOPruF8W0rprqvB2/EGzu9rC62yP2T37xoph+9Eu+bwfH8CAeNP0k4DTtRPbX6+k0z2f5
+        zFD+o2LZkPRP858s8itqYSlO03l8QQT2P3Of/iThSaDpy4++e8wixB9v7413xrufGuB4SIFk7ZoG
+        SG2/5z5Ofah4iJ1mjCLNRoj33aaLtHk+KvPLvMRLZ8vzqvctccyqzK4BZI3uP4IEXPeaLYj+JH5o
+        8PmaZodHkhZNWq+XQCIl5ZhmhAJNPP21zK/Sqc+nzbgHsi2Ey/d2dj/d3nlA/3uzt/No5/6j+/c/
+        2aFfdqwI4vkl7o/ve5A+yt+1+RKU+DZhUBLFCaThYXrLNsVARXDNJx3q3kqlUbOhqeqAw/N1pove
+        2jhh9D2hF06ZDz7dBHmA5Pce7d8bH9x/cO9BjPJERf9PS1vvczcjA+QJSPP+ZNlEkq9HjiFS3H+0
+        e2/88NNPD+7fe9CjheOmwRFVV3kNTPK7Khidbt9rID/5hREvHwnzq04E/y2YsQpOfy508ImYubuX
+        Rd2us/ILNqjUtqeBZchW1oa+b9XxuLEHbV9W1sR9dEWIE/3kiza7ACl1tgyJjTX+yQAYE5nI+Uv+
+        H1pOtb9hCgAA
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 03:09:53 GMT']
+      date: ['Thu, 07 Jul 2016 20:06:07 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1007,14 +871,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 computemanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.32]
+          AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [4888a7e1-3f39-11e6-b781-001dd8b7c0ad]
+      x-ms-client-request-id: [3de73730-447e-11e6-8c37-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Compute/virtualMachines/vm-with-public-ip/vmSizes?api-version=2016-03-30
   response:
@@ -1032,7 +896,7 @@ interactions:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 03:09:54 GMT']
+      date: ['Thu, 07 Jul 2016 20:06:07 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1044,14 +908,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.32]
+          AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [48e96580-3f39-11e6-9ec3-001dd8b7c0ad]
+      x-ms-client-request-id: [3e0b880f-447e-11e6-8d78-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/publicIPAddresses?api-version=2016-03-30
   response:
@@ -1062,92 +926,126 @@ interactions:
         6UeXWbnOP3qUfg9/pSl/iOejZbbA5x9dLrZnWZvNiubtdps37cv1pCymZy8/GtmmxQwN7zbrSTOt
         i1VbVMvm7r2d/fzg4cNPtx88OJ9s73+aH2xPslm2ff/+g093du8/3J/k+3frvKnW9TT/vK7Wq+bu
         tCzeUBevLn5/0+XdVV1dFrO8bu5+UUzrqqnO2/GLvL2qavpOUTmezQhQkzd3b4Fs3mYXQPe7d3/f
-        jx4eTLPd83y6/enk3sPt/fOH59sP9x8cbO8/fJDdmzzY279/sP/7fuS93F6vmCi3wMV7q6ymGYiC
+        jw4+/XR35+BBtj27vzPd3j/f/XQ7e7A/25483Msf3Nvduzd5sPP7fuS93F6vmCi3wMV7q6ymGYiC
         N68Iq7X/JaHT0BeW8PQRob8qs+sXOgNmEAr6I9PylzggRKVVXrcFdRuCoi8ui4b6LpYXr9usZYCv
-        19Npns/ymUODmhJsmYu1zGe2t/fw3l6WbU8+fbC3vZ/t7G5PHkwfbt+7n00eHHz64NP98xBAsTIY
-        0tu798YP74339j4d7x7sBM06lPpJmlvCD++cvbzcjzctDQm/yNt5xeg9vSYOLaZB+2JW5m+KRV6t
-        27PlF8VyTTxAbfeDNquTanleXKxrBkhfe/TC9wz97g+dmZfy82zZ5vV5No0w809+8aKY3u3g39AH
-        U/6g29zyCXGK+VV/MZxjR26lnZDml7cvF3uG7xyJfzaI85NfnNQ5Mebv/9VkvWzXexuJZBlCeIeI
-        RIA2IexL+6e7e59Od7K97fw+sfH+g4f3Sdr3720fTA92psTQ2f17ez9vpf3hp/u70/OH0+3Z7D4p
-        wL17s+2He+f3t3c/nTzYzx6eP/j0fh4A6Ej7wfjh7njv/u5492HQrEOpnwfS/l4M3Zd6AmQZ+gaJ
-        95taPiFOMb/qL4Zz7MittJPKuMiXeZ2VxQ9yw3iOxj8r1Fl8bnvcSBnLDcI4RJmbsPVl/Xwy25s9
-        +DTffnDvU0JyNtnbzh7uPtz+9N6D6Wz//sN7u7v3ft7K+uzedOfTT/dIws/3yLLvk9RnO+fT7f3z
-        T8/3HhBtdrJQiDuyDlG//+l4795e0KpDqJ8Pon5bZu6LecDMN8h50NYyCbGJ+VV/MWxjx+0L+lXR
-        zreF7tvFynCeo/LPDn2eF017ZriHhr2JSIIcMYVtfRu0fam//+mD+5ODbHd7bwJs79872H746fTe
-        9mQ6yQ6I7pO9g52ft1Kf5efTg3vnD7cfHGT3t/fvPdgl4lDYs/vp/b39/b1P89mDDVK/vzPe3T0Y
-        U8vx7v2gWYdSPy/E/n3YOir7IVvfLP9he8syxDTmV/3FMJElgq8DGnDM9qKaGRZ01P7ZoROz6BfV
-        bCOBZFjEFZacN6Dqizx58PfvH8x2tw+yPbJg9x/ubE8mB7PtB7PpzsFsurs3m2Y/b0WepmmXonQK
-        4fcOdmn6JpTf2NmZbH968DB7MJntT/N7kwBAhwQ/L2SZaXoTj0aF2PLozfJrm9qpp8k3v+ovhhns
-        mK3okvV/ThR7Z9jIEfabIwn1USyyCxrZJjrYWRcGodb03hBuvpw+2N3Ldg/I05zsnz8ghzwn7zPb
-        ybd3dz7dffDw0/sH9z/9+euQnz/Isvx+drB9/wBu+P3797ezgywn1/zg4Pz84YPJ/Yebgu+d/TGZ
-        54dkmR8MyKg0/v+tOBMP3oJ3+zJM7zHv3iC/ppllB2II86v+YhjEDtCX3atiGctN/ZCHb2dYmIFa
-        03sDqAWSu7OTHXx6b3d7ujch5jzfIRnO72Xbs0/zbP/e/fN72aezn7eSS6sHnz58MJts3//0IU3X
-        wwf59mR2sLP96f5B/nD3/sGDn68WlnjrFjwZFUnw5M0SiVZ2lmmeza/6i5l3OzxfIL9bLA2/OAr+
-        sMdup1c4gVrTe3HMfHGcnt/PD2YPH2zvnj+cbe/v7BLHHUzvb0/vTXenDx9Sqiv7+evwnu/NZg8P
-        Zgfb5+dTymw9yDOKcXfvbWcU9+bnB7QcNdkNAMQM6af3xvceBK06hPqR0OJnKLTEuDfLLDWynEC8
-        YH7VXwxv2MFZkV1ky3VWXi6aFcW+2oq+/sbGbeE39cXGodvZFUagodtXQ9R8iZ18Op2d36M11JyE
-        kyR29pASr/cm27v39yj/8vBenu/+rGelaFBdYaOP5YuvK2yf7jyY3t85z4m09M/+ZI/izFk+2c53
-        JvsPs708ozWjAEAH+x+2GM2Wzeu8bWmg+MpyGZ6PZtUiK5bQXs+zSV7S947pPDri+ej8F80Yaddg
-        LPQeT8tqPctWq3H2g3Wdj6fVwmd3D8oPT6QdkjewdlllsydZmS2n+N6+Vk7untcVifpydvYywLm5
-        +9x75RkanS6/Xny7uKb5DuTnmxv/dX2xeQmOuhZWE66ETPfQ8cX5YH93Mskn+fbBZOce2Rj4w/fI
-        Pd57uP9gfzLZfXj/4cP/L4oz4Z1n2eTh9sH5bra9Pz1HhP6Alsd3Dyg+pbXh/b1QRkPbSatC9yg1
-        vDfeDVt1xvh1hR6D+Roy/8OTsxv5rCNg1z8UyTqvqklGA/O8nm9yzKQgNo7ZzqhMPslWDCFfuqaz
-        vf2D3dn97b2de7RK8TDb3z74dOd8e3Yw3X9Iq7rEhPd/tqWL0AEjWWrSR//vcG+zhw92yY2dbNMa
-        7f72/t7De9sPd+/do0Xu2Yw+nu2d/9wngEyT27BmoGNliHd/ztgyQMZnyXsHk4zC+E+3s4xovU8p
-        dYq4Znvbk/vTe7P9T2efTs9/HkdcO7vT6fTBwXb24IAirgMyiQf7kwfbnyIWzacPJ+fn9wIAHRL8
-        v4olwTk7uzu7bw0xHXgCjhZ3f27YE+8MIeaz6mTn3t5edjCl5a+dhzQb92bbB/n+vW1KDGf797Ns
-        b+/h+c9bVr1PVMgfPjzYfrCzd05xGHk5k/uffrpN2ZTdg72dg/2Hk08DAIGDQ4mB3V3ybh7ujvd2
-        wnYdUv0wWDpo88PzcW7i3H5qAO8w596QHbDtLDcQP5hf9RfDH3Z4PcH9gWEtR8Qf5vDt7AojeMOP
-        IeYL7s7Dyb1PZ7sksw/I99mn6Hn74N4eCe6nB7ufTvZm5Ax9+vNWcPN7e3meT6fb93exPEZLENsZ
-        abntaZbTmsRutrN772EAIBBczertfTp++COxpTFG+HZYbH9wS7H9geUF4gbzq/5iuMMOz4rtdN3I
-        64axHBG/4eFvDs3s9Aon0Pg3YebLbbZDq9qf7k62Hzzc3SHWnJDBnWTn2w8me/d3HpBBmXx68PNW
-        bmnVcHLw4PzT7ft75JLsf0ouycM9ysvvTXYO8myy93B3ehAACOWWMgq7WNXe298LWnUI9f9vud3M
-        uH3BtYx7g+DadpYZiB3Mr/qLYQ87vp7gxtaOf5jjt/MrrOCNP4aZL7j7+3vnn87IzOb3p7tkcHf2
-        KO+1v0OpvIe7n2YHB/fvPfj5G9TtTO6dUzqfMvvTe5TZP9/boxU0cpfvU3ZmSpN1nnUABIJLxnZ3
-        92C8S+totOAWtOuQ6keiGxPdmxa/bTvLDsQQ5lf9xTCIHZ8VXaBGL+/+tOEtR8Uf6vjt/Aor0Pjx
-        0hBmvug+mFA++v4eySolZChFmFNmhlxBSllPyMaQuzd5cO/nreju3p+ePzig2ZrszB7Qotw55U8z
-        ysxMoO8O8gmFFzsBgEB0xeYePCThDVt1CPUjwfUFFy8R3+3+9A2Ca9tZZiB2ML/qL4Y97PgCwW2a
-        3U8Lw1mOit/w+JvN0YKdYOEFJcAQar7k7j78dDfLDzJKT31Kknv/PhndT/d3t2ez6f7Bwaf398+n
-        P+uSSyP75oVuRjbxwYPp9uzBfXImHtAi2sNPH97f3t3PJrODLDu4d9Dh+a7Q0dLZp5RY+iYd3ZuE
-        7v9lQncD03VXz/AGMdwPZRHN9BYzTD9UIvSYXt+Ko+ZL3s6Dnfv57g6MJPlx+/cJt4NzQmv3QT7Z
-        Pz/fyc/3dv6/KHn38ofTfLr/gOTtnJJn08n59sPpbHf73n5+jyLMfP88zwMAUclDWvfnsb27gevi
-        ovfTP0zR280i/P1NE2Gz2bfTLBzhZC+Kmy9755/e2ye37P52jgzI/kOSwoM9Cqn2Pt178PDTfOch
-        pZD+vyh7O/d2Z9Pznf3tB7u0EL0/2yOnc0Lpncl+vjujIDo/OA/tWSB7HCWS4B1Qgmc3aNYZ5P/f
-        ZW8z20WFbzf7oQif4eur508cFb+58b949fLV5xsHb6dXOIFkLo6SL22TnfN7D/Zpjf7e/j0KgB7u
-        UnR4sJdtz84pqzMhYZtN/z8pbbTQcU7x232ydNn+9v69Ca1e7nxKQfDs4PzB+fn5/f1ZFgAIpO0+
-        SdqnO+OHlJY5eBA06wzy60obRvM1hG22bF7nbUvkwFceqfBdtciKJeLp59kkL+n7j67KerJcCR7F
-        amdnN9Ac9M75L5ox7v2GY5ml8bSs1rNstRpnP1jX+XhaLXzZ8KARAQPBIrAhfjIvd38YghBqAWL+
-        H4L0L66XzcXlwlPh39yICXJ9sXHEMnXEa8KWJPoRfHy5P9jZmebZ/Z3t/OGnJPdTSnxkezu0Zkir
-        /QdTyoHs7O79f1HuZ+Sg7+xO8+3zffIZ9ncekAbI8p3t3b1Jfm9KKoGCzwBAIPdsZUno790b/+zI
-        /f/rrSwxzQ2sFkvo0FvEapSToORNgKjL5ny9lZNsZkyYI9k3N9i6ut7du0fkbjeO2E6ozD2NOIqW
-        L16z2Q6wmWzfe3CP1vJ29h5uH9x/mG/v5XuUgH2wc36wt/v/RfH6lMLFvfsUQN7Desf+QzKwtPix
-        S875dOfh/sOH97MH9wIAgXghgKS0DazrQWCKnMxI4x+2eL2nXRW+8XuhdsaWypf/L7afgiBRYTPX
-        h0Y0m/mWcoM9ffLs1B+h+VV/MSO2Q7OSbgTqsj4vJ46039ywm2lW5k3e/v7TOiee//3zd0WDGf/9
-        KwH6+9cXm2MLy3jCo7lzr7s4+5pgcjD59OHuwf3tT/MJSQyt5JMmoPX9hwe0ZEi29tPZzv8nU0n3
-        793f2/90d3ebRJ5SZNn00+2He9lkeze7NznYm8zy/b0NhpaWnSiO3Rnv74939w6Cdp1R/rBVwQ9N
-        DD+YH0MBZR7cIJde4w/yc6kfBNWG9R19/19EGcsXwkI5U2cAa19W9x+e72YPDu5tH0wnZLUfZoTs
-        7ux8e3p+vv/wwc7kfOf+7P+LsprNdnYf7GcPtymopWA4+xQptU/3tj8lt//e9P7Dg2z6c26OTZPb
-        MCD1WawcVIKJL+5+85znGO79+Y0+DJAMGO3+XjabTXa3z6ezHcpOPHxAucDzbJtyMdPp3pSm6f7/
-        J6Ov3d3p9OE9ytjuT+5TjnNCiydEclqxzKcPdnZ2Dh5M74fcEzUK9/bgIwbtOqP8YTBk0Obnyijc
-        kgF7pgDK7v+v5qApFqsyv4kklg2EY3JLlgiqgWg+gK58MCEbsEssnGXT7YOH9+9vk1zeP9/fmR48
-        uJ/9f1E07+/sUrpnNqNF9wfn27TQd3872yFJpehtlh/QkkQ+vR8AiIsmJUceBpGPkzdp/f9X0fya
-        bPhzLJk/iHC78MPdDxfMy4WhxXTdtNXi9y9WN5Gjwyw5ARlC0xfKA9jFjAzk/dmn5MBMJ3vbD+/B
-        cj68v5N/en9nSib0Z1soCR2IgiU0fTQrmlWZXSM3QN/YEFZB21kzc0RvEG2+ccl+sL9/cO/T853t
-        jFZIiTgPd7cf7j6cbu/uze7v3j+nlf5pGGEFkk2piocPxwf3x51wrUOnryvWGMvXMLjvmZAhJsJa
-        HxYu8P8f+P3RGyY10232/+IkzdeQrX5ilsZLsvWTX7woppSHDTB3iVlp5A/Y/Kq/GALYkYYqxnC9
-        o/nPNhW+VvAXQdPXMBMK9ibT+5SXebh/n/TK/ow88vvn2+fn2ackV+f37+09+HmrYc4fTu7t7xxM
-        ts93dx9u7+eU+qVkL1FoJ5vtffrpgwPKYwUAAg0jWd+Dh+MHO0GjDp3+P6Vh/O7ohQEF8/85/bJZ
-        sgYUzG30iz9e86v+YsZvB+qrF5r4IIj+WRh/JLu0kQqEkvCisK1QgT4M8PRVy/T+bvbpw3yfQojz
-        A1oLmky2s937u9vkde/ltBREdvr/k2tB+f6nDyY7s0+3793LZhQpPZiSB0Iqc2d//8HB9NPzvb2D
-        EEBHKxxALex+eo/+H8iTk3Zp/XUVw//rg/2vz4M/bEkkKrUIXHZXAZd/Y5S4yifoYuOY7VQLV9CY
-        8UoEK1/2zmnV9UG2TxJHUri9v/fpbDub3NvZvv9wskNLlucP8/OfddkjdMBjlqr00YBZt3NjZoKa
-        Ekm+ccnN8gcPd/Yf0LLtbIc00qfnyHhjiep8f0pzd34w2x0QMxn7D1si39NWEwThC78jamqstP3+
-        /8X2+TYSEeYW0JxH9U1mF/Dj+79x8kv+H5VmTB3+cAAA
+        19Npns/ymUODmhJsmYu1zOenew/uz3aILpPs3mx7f/Jwun2Q79/f/nT2YJYd7EwfPrj3aQCgWBkM
+        6e39nfHBvfHuwc54b3cnaNah1E/S3BJ+eOfs5eV+vGlpSPhF3s4rRu/pNXFoMQ3aF7Myf1Ms8mrd
+        ni2/KJZr4gFqux+0WZ1Uy/PiYl0zQPraoxe+Z+h3f+jMvJSfZ8s2r8+zaYSZf/KLF8X0bgf/hj6Y
+        8gfd5pZPiFPMr/qL4Rw7cl/aL/JlXmdl8YPcMJ6j8c8GdX5y8bntcSOFLDcI4wiFNmLry3r28Pze
+        5OHs/vZs78HD7f187+H2waeT+9v3Pp1M9naybJZPHvy8lfWdyb17DzCDnx7cy7b3pxkpwnMi0869
+        /OHs3sH5p3v38gBATNYfPBzv3g9adQj180DUb83MUXF3zHyzrLu2lkmITcyv+othGztuX9Cvina+
+        LXTfLlaG8xyVf3bo87xo2jPDPTTsTUQS5IgpbOvboO1L/f7e9HxnsjPZvpfdJ2wPpgfbDyfA+172
+        6fR8MqWv9n7eSv3kHkn6dO/+9v2HD8nC3/t0b/vh/fzh9sOD7HwftLm/EwKISf3BLln43aBZh1I/
+        L8T+fdg6KvshW98s/2F7yzLENOZX/cUwkSWC1QGkQp4TCd8Z9nOU/uZoRH0Ui+yCxriJIjIOYgNL
+        P3pvCDdfvh/s7mW7B+SaTvbPH2zvE8dvP8x28u3dnU/JHn16/+D+p/d+3sr3+YMsy+9nB9v3D84p
+        vLl///52dpDl2/v7Bwfn5w8fTO4/3GDVd3f2xyTjD/fJsg8IrTT+/618Ew/egnf70kzvMe/eIMSm
+        mWUHYgjzq/5iGMQO0Jfdq2K5ZzjLEfGHPXw7w8IM1JreG0AtkNydnezg03u729O9CTHnOQLNnJzP
+        2ad5tn/v/jkZ6NnPW8ndPc8/ffhgNtm+/+lDmq6HD/LtyexgZ/vT/YP84e79gwf5vUkAoEOCH4kk
+        foYiCZ68WSLRys4yzbP5VX8x826H5wvkd4ul4RdHwR/22O30CidQa3ovjpkvjtPz+/nB7OGD7d1z
+        +II7u8RxB9P729N7093pw4f7s0mW/bwVx/O92ezhwexg+/x8ure9/yDPth9+untvO7t3/jA/P9jb
+        +3QSesAxQ/rpvfG9B0GrDqF+JLT4GQotMe7NMkuNLCcQL5hf9RfDG3ZwVmQX2XKdlZeLnZ0Hnjb9
+        5sZt4G8ctp1ZYQIatnmtg5Yvrfcf7h3s37u/u31//1PK11Cqdvtg92G+Pb1/sPfw3r3d6Sz79Gdb
+        WmlQ37igTc53H9w/mOxs70xn5Kc+vD/bPtjJ9rYpOTXZze7P8r1JKEJ9Qbs/3tu7P95/GDTrDPL/
+        t5JmWGcjx/UFzbwGjnt4/yHJVoCvE7bdD5SzA492P+RR23kVFghGHaDly9nDndn9yUPyT2fnD3aw
+        BvIpWUViysmnu5QxvT/9dDqb/n9RzvbvHxw8zD6lLO/uAYXNeXZvm5Lgu9vn+7sPpuf39/fv7WQB
+        gFDO7o0PDsYH491w/aczwh8JGf2MChn5VTv3SaYCfL8pIWtWlA3SVvT1Nz7qpqkvNo7czq2wgTfy
+        Dmq+oE1Iks7vPdjbzsnTJPdzRlnI83uT7d37e5/ee/jwXp7v/qyvxNKgvnFB+3TnAU32eU6kpX/2
+        J3sZBXL5ZDvfmew/zPby7MGnP1dLJlEhmi2b13nb0kDxlUcEfFctsmIJV/x5NslL+t4xnUdHPB+d
+        /6IZE9k1GAu9x9OyWs+y1Wqc/WBd5+NptfDZ3YPywxfoG1m7rLLZk6zMllN8b18rJ3fP64okfTk7
+        exng3Nx97r3yDI1OlzN/wOZX/cUQwI7Uyfc1MXYgP9/c+K/ri72NA6euQ5mid+izAB1fnA/2dyeT
+        fJJvky93jwImJHfILd3ee7j/YH8y2SUn4+H/F8WZ8M6zbEJLx+e75HdPz5FufnCPnO8DSrZOzx/u
+        74WGrms3H9KKyf298W7YqjPGr2s5MZj/VxvOG/msI2DXPxTJomUcWGUvsPgmh0z6YeOQ7YTK3JNo
+        RfDxZevT/OEkv7832947mJBsTbMJLdgd7G7n5zs7uzuT2b29Wf6zLVuEDtjI0pI++n9HpubhdEoO
+        RL5LaeRPKY2195AyNRktCh3cO8/vzx7em+zn4ZJHhwRfV/T+3++03siIfY/VMOINGRjTzM4xzbL5
+        VX8xs24H1xM+P9PxQxy0nVOZfm/QPkK++J3fy2l5fO/h9r2Hu/uExwPCY29vuk36f/fTB5/Stw/u
+        /7wVv7397B558LRQQc48LcfOdok4Owfb2WTy6cHuvenB+cFOAKBDgh+JX0T8JreUv4mdZZpn86v+
+        YubdDs8J4Lqht+/v7t3LJoZrHB1/mBSwEyy8AApsxs0Xy93Z3kFG7cjP3GGUKIDcPdjf3rkPrsvO
+        s9l08vNWLHd28tnB/kPSWRyFPtwlt3VyP9ve3Z2e39vdpQTXgafuCEDUbT0YP/x5mlW9kXUjwuux
+        7k3y6zW1HEE8YX7VXwyP2EHGRNgwmCPmD5MMdpaFIUIyRFDzBTjP9/Z3d/J8++GDh+fb+9kBJSdn
+        tKRxb/bpg/Pdnenefv7z2K5++nAye5DNtvNdrPc8ONjbJi6bbH+6l+092D+gmTsPFyA7JPiRaMZF
+        8/aSaWea5tr8qr+YubdDjAim4RtHyR8mDewUCzcENIhg5ovlg/OdB7tkWInfyK3b//R8Z/vgU1ou
+        yM7vU5g1+fTT/U9nP2/FcvaQFk32Ds63H3y6R8TJHlDC6wEtqMzOd7KH+X5+b38/FMvQrrrlyt29
+        vaBdh1Q/Et+o+N5aei0/EEeYX/UXwyF2gFZ4z6tqktHovBn8YQ7czquwAA08hpAvqtPZ3v7B7uz+
+        9t7Ovfvk5WX7JKo759uzg+n+w/PJjHKTP38taPbwwW5+fkC5snsI2/ce3qP44N697Qf3ZjP6eLZ3
+        /mBArgTPH4YImia3Yc0g9S5DvPtzxpYBMj5L3juYZPm9CblyGdF6/wGRfnIw29ue3J/em5Hl+HR6
+        nv28Zcnznd3pdEr5owz+3P4BrZQc7E8ebH86ffhwP58+nJyf3wsAdEjw/yqWNIthlIdwgAksvrv7
+        c8OYcZR89pxkO/vns4wyVRPEHLu7n9IM7B9sk/48p2BkOtk9//Rnmz1pTN84Z5HnkT04z6fb9+59
+        Spy1f/98O/s0O9h++Gl+b2/30/3J+cGPInkaY4SN+v6Gx0Z79x+SdxHg6tyNXas3SE7Mr/rLBrkh
+        jHZ29ndi4fGHDfumYQfDtrMqDIBhb0DMl6F879O9/dl0f3s2gw+8d0C5pQf3Z9vZ7kG2n2V5/um9
+        859tGSJ0wFOWuvTR/ztU/L0sm+48eECLUNMdcsnOadH44X3SN7v38zyb7t1/kO2Hjn8/QNgZ03rx
+        3s6P5JXGeDt5pXeYcW8ID2w7ywzEDuZX/cWwhx1eKLe7O7tvDWc5Iv4wh29nVxjBDH8AMV9uJzv5
+        5ODh+YPt+wf3KSd8vv9w+yDf39vO9+5nGam6g53dn7+u2f3dB/v5w4cH2w929sgxIFKQy/opeQcz
+        WlSgBa39h5NPAwAdEvxIILsCCY68jUCinZ1lmmfzq/5i5t0OryeQpWEZR8Qf5vDt7AojeMOPIeYL
+        5O6n1CeC9v175Ifu3/90Z3uyu7+7nX+6/4BQyu/n+z/rziihA96y1KWP/t8hkNO9vfP8wSTfPt/P
+        d0lb7d7ffnjw4OH27u7e/cl0b5LnewcBgA4JfiSQEYEsbymQpZ1lmmfzq/5i5t0OryeQC8Myjog/
+        zOHb2RVG8IYfQ8wXyPz+vd0Hn96nRFEOI/DgU/Jsdwmzhw9n93aJHfco+/3zViBn9+9PHxA7bU9n
+        MxLI+3tEHFoq2KYFAZqzvU8PyLcNAHRI8COBjAjk4pYCubCzTPNsftVfzLzb4fUEcmlYxhHxhzl8
+        O7vCCN7wY4j5AvnwIJvsT2l95Xx3SmmNh/uz7YN7u1Nac5nl0weznU/3zvd+3grkzqf3pg+mO7Pt
+        82yP/Pl72cPtyb2D+5T4mT28R6vEOwcPdwIAHRL8SCAjArm8pUAu7SzTPJtf9Rcz73Z4PYGsDMs4
+        Iv4wh29nVxjBG34MMV8g93dmO/kDYrLzTymNvX9/92D7YEorTpOd2b1Pd/YfHOzm+c9bgbyfTXcP
+        dqa0HDe9TxnmT2Xtabq9c57t7Jw/vJcfTEKBDHM/98YPd8cP98Y/ytQOsO2w1Fa3lNrKsgIxg/lV
+        fzHMYYfXk9qV4StHxB/m8O3sCiN4w48h5kvtZHe29+B+nm3v7d8jxjzYuU/JjQdkVcnPvX++e++c
+        Mrc/b6V29unuzv37uzvbuzRplM7e36FAc+/+9s590mn5ZHqwu3ez1N4f/ygYpTFGuHZYaFe3FNqV
+        5QTiBfOr/mJ4ww6vJ7SGqxwNf5ijt5MrfOCNPoJXILKzhzvnB5OH2zkt61EoOqVoKydDO72/O/n0
+        Yb4/+fTB5OetyE4mtNxJRNgmc0tztZuRyO5SlLB/vvfw3v2DnfO9+yGADgl+JI4RcbylNNo5plk2
+        v+ovZtbt4HrC+IsMwzgS/jAHb+dW2MAbfAwxXxzPH9z/dJZln9Ji3r0Z8dmn2fbBQU4WdCebHcxI
+        JvcPfv4Gop+SR3H+8MHO9sGn92iy7s9m25P9Ga15Tu7l93enn+7Opg8CAD0Lem+8t3d/vLcbtOoQ
+        6kdCGxHaX3RLqf1F4AXCGo9Kq/3FcIcdXk9sa8NYjog/zOHb2RVG8IYfQ8wX2+zhvXs7e3u729MH
+        JKz7D/Pz7WyXlhOyBzvnu/nOwwd7s4c/b8V2d3IwPZ9Md7bzgx1yfO+fY7Ienm+f5w93dh7MJgd7
+        +3sBgFBsd/bH+zvwfHf37wXNOpT6kdxG5La+pdzWlhmIHcyv+othDzu8ntw2hrMcEX+Yw7ezK4zg
+        DT+GmC+303u00jB7OEMQRiuj5w8m21lGiZWdgwef7ud75AJP7v+8ldt8ZzJ98OD++fZBllNoMKH1
+        qsn57mz709nueXZ/lzLlD88DAH25JVt7b5f+PyCN0vpHghsR3OaWguu4gfjB/Kq/GP6ww+sJbmtY
+        yxHxhzl8O7vCCN7wY4j5gns/v38/nxyQwd1/eH97n8JUsrXTB9v3Z3vT83ufPti9t/PzN9NE/sfB
+        wf1P8+37e5/ub++TmG5PZg/I4O7tzx5mFGDsfxp6wKHg3jtAqmnv/r3x7qdBsw6lfiS3Ebltbym3
+        rWUGYgfzq/5i2MMOrye3a8NZjog/zOHb2RVG8IYfQ8yX273JvSm1O9gmj5BsSrY32T6ABOd7Dx5O
+        p+cPHj54uPvzVm4/nd2/d57P7lFemBe9HuyS6SUK0eeT7P75dOf+p5sc5Xvjg4Px7sOd8e6DMJHc
+        odSP5DYit+tbyu3aMgOxg/lVfzHsYYfXk9sfGM5yRPxhDt/OrjCCN/wYYr7c7tzLHz54sLO/PaP0
+        1Pb+zk62PXlAi7I7s8n0/r18Pzuf/vwNcPN7e3meT6fb93fPp+SMnO9sZ3sZ6bgsn+5NKGu8e+9H
+        S600xghHDgvkD24pkD+ws0zzbH7VX8y82+FZgZyuG3ndsIwj4jc8/L2N47fTK5xA49+EmS+R2U62
+        e/Dp7mSbLOYOMd1ktn0wyc63H0z27u88eEiR66cHP28lEgnigwfnn5IHfEAS+enOw+2He9O97b3J
+        zkGeTfYe7k7DddSuJSUH+OH+eK+TmOoQ6v/fcruZcfuCaxn3BsG17SwzEDuYX/UXwx52fH3B/UE2
+        mRrucpT8odLAzrGwg0+DAewCAZ5k++ezyWR7MpkSUvfv721nM1rvmR1MaGFxdzI9OJ/+vBXgnfN8
+        ejB58HB795ys6T6F+9sZzdL2p5RHvnfw4N69/MGGpR7KF+/uHlAIu/fzO2m8mX03iDDY97ZijLaW
+        LYgxzK/6i2EUO86YKBsuc/T8oVLCzrQwRUiJCG6BGO9n+Ywcve3Zzn3KRGW8KAlZnkxmewf3z3fP
+        P539vBXjh+e0LHZAEvxwf2ePiPNwjzJR9z/dPp/MPv10b39ycP9+6BnHxRhp5B+J8QDzbhTj2wux
+        ZQliCvOr/mKYxI4xIsKGwRwpf6hEsJMs/BAQIYKaL8CUXckOppQt/ZQUGWVLc8q/kLO4/WDvfEof
+        Pcx27v88s8OgvArw5OGn5IxMHyLPTqnkTz+9t53du4/kFFHsPmm8B5/2BZinAG/v3nsw3r13f7xP
+        dvjgvqM/zUBnwn4kwHEBvrX8fpD47kVE5IdJATvDwgweBWKY+cK7v79H9nUv387vT3fJwJCVOTjf
+        39me3Hu4+2lGqyD3Hvz8XQfamdw7n+xltA40vUfJ9vM98kru7dJsTWmVjCbrnDyXAEDM+u5+em+8
+        t/fzeCFoM+sOC+/eLWV3z7IDMYT5VX8xDGLHZ0UXqNHLuz9teMtR8Yc6fju/wgo0frw0hJkvug8m
+        5w+y+3skq1l2b5vWLGkJlzKm2/vTCSVsdnf2Jw/u/bwV3d37tBh2QLM12Zk92N6fnO/TUtABec/Q
+        dwf55MHsfrjGE4iuJLAOHpLwhq06hPqR4PqCi5eI73Z/+gbBte0sMxA7mF/1F8MednyB4DbN7qe5
+        4SxHxW94/M3m1LudYOEFJcAQaoHkkiX5dJcwmu3uksd8b/d8++G9g53tfLo72d359P7u7ODBz7bk
+        0si+caHbf3DvU4pWZ+T63ydK5wfZdpbnk+3dh7Pz/CEloWiNOgDQETp1dnfGe5Tc9Nt1Rvn/b7G7
+        ge3KKps9ycpsOcX38sbup3k5uXteVySMy9nZywDd5u5z75VnaHS6nH2Q7BURBv+hEsHOsjCEJ3sx
+        1HzZI7HbzcCZD2YUi3HW+ODT/d3t2Wy6f3Dw6f398+nPutWkkX3jsrc7I3/0wQNKoz24T478gwmt
+        2Hz68P727n42mR1k2cG9gw7jh7I3fniPrN0uuapBq84YfyR5KkbmDWK4H6rkxZzCHyoR7CwLQ3iS
+        F0PNl7ydBzv3890dOKgUQ+3fJ9wOzgmt3Qf5ZJ9WKfLzvZ3/L0revfzhNJ/uPyB5O39Ig5uQNZ/O
+        drfv7ef3aKk03z/P8wBAVPIow/Pw57GveQPXxUXvp3+YorcbW8j4pomw2eW20ywc4WQvipsve+ef
+        3tunkOj+do6l/P2HJIUHe5TO2Pt078HDT/Odh9nuwf8XZW/n3u5ser6zv/1g9yFZ89keBXyTKcK8
+        fHdGCaz84Dy0Z4Hskae5u0uCd7A/3vt57XBuZruo8O1mPxThM3x99fyJo+I3N/4Xr16++nzj4O30
+        CieQzMVR8qVtsnN+78H+7j6ZgHuUfHi4S5mZg71se3ZOGdUJCdts+v9Jadub7J5T7uQ+WbqMFjPu
+        TTJKr3xKCajZwfmD8/Pz+/uzLAAQSNt9krRPd8YPKSV68CBo1hnk15U2jOZrCNts2bzO25bIga88
+        UuG7apEVS+SynmeTvKTvP7oq68lyJXgUq52d3UBz0Dvnv2jGuPcbjmWWxtOyWs+y1Wqc/WBd5+Np
+        tfBlw4NGBAwEi8CG+Mm83P1hCEKoBYj5fwjSv7heNheXC0+Ff3MjJsj1xcYRy9QRrwlbkuhH8PHl
+        /mBnZ5pn9ymR8/BTkvspJR2zvZ3p9v0HtIg/pfzjzu7e/xflfkYO+s7uNN8+3yefYX/nAWmALN/Z
+        3t2b5PempBIo+AwABHLPVpaE/t698c+O3P+/3soS09zAarFkKr1FrEY5CUqcBoi6TOru15KqbGZM
+        mCPZNzfYurre3btH5G43jthOqMw9jTiKli9es9kOsJls33twj9KmO3sPtw/uP8y39/I9Wvx4sHN+
+        sLf7/0Xx+pTCxb37FEDew1rj/sPJfVp+Pd8l53y683D/4cP72YN7AYBAvBBAUtoG1vUgMEVOZqTx
+        D1u83tOuCt/4vVA7Y0vly/8X209BkKiwmetDI5rNfEu5wZ4+eXbqj9D8qr+YEduhWUk3AnVZn5cT
+        R9pvbtjNNCvzJm9//2mdE8///vm7osGM//6VAP3964t7GwliGU94NHfudRdnXxM8PDg/uDedkQXa
+        OSeJmZGhfXi+R+sOlIaZzu5NKah9+P9FTfDg/s7OQUYLuZStJQf7/i6F6fnOOSmGCU3MvQn9/+en
+        Bf1gPgsFj3lrg7x5jT/If6V+ECwblnb0/X8RZSxfCAvlTJ0BrH0ZnEz273+6c75DS5e0frl/7362
+        fbBzcLD9YOch+YX7xMY79/+/KIN7e7ODhw8entPS5T1KU+fn59uTg+l0+8H59OH9fUr13n8YWCkn
+        WIL9D0MGTZMbGZDat5jL3VWxcpAJLr68++Hcd5VP0MV7MhheiWDlc9c5eXYPsv3JdjbFctbep7Pt
+        bHJvZ/v+Q8o4THfOH+bnP+u+HqEDaluq0kezolmV2TUcF/rG2lerHMxMUFMiyTfOmxmtoO/sPyDX
+        cLZzQFN0fm+b4sr725+e709p7s4PZrsDDCdj/2Hwpt/mPV1AgiB84XdETY0XaL//f7EjeBuJCI0R
+        mvOovkmThB/f/42TX/L/APwOyVZLrAAA
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 03:09:54 GMT']
+      date: ['Thu, 07 Jul 2016 20:06:07 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1159,14 +1057,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3MzQwODgwLCJuYmYiOjE0NjczNDA4ODAsImV4cCI6MTQ2NzM0NDc4MCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.EmdCH5YoR0g76Tik5_2vWwhZoVDMw_GYgreJEnJefzwyK1TS34MwIxTFhUwSg0e6MT0Oz3OrzihOcccefF1W76rISKiO7ukTTjFGbDMr4KwEUQ4MUqrpV8oUM7X3Lo6t_DO_WB1kQmcd0mIJ0GigFGwnIzols1lak79qMkv--pj9TVZtvykzT49mC_7w-Lhn7BRLFdTAmVa5IWtXOECOWq9yzpymhrW54uFElVmWVOTq9kYpqL6wpsHbeNPG2j2fkvX0X06xMbzKTuhQ_QUnUe_q9eDykgLH2O6_lBNYaq6WeHmicL4g8lAeNiv0v4uqvL-2px2Kf8vnAWkb28r78g]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDY3OTIwMTE5LCJuYmYiOjE0Njc5MjAxMTksImV4cCI6MTQ2NzkyNDAxOSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImZhbWlseV9uYW1lIjoiQmllbGlja2kiLCJnaXZlbl9uYW1lIjoiQnVydCIsImluX2NvcnAiOiJ0cnVlIiwiaXBhZGRyIjoiMTY3LjIyMC4xLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.bO4puEC6GsOtmc-SxuheSqLBUM_5uTtaTFBt-DW3SIph9tGEmt0rF_PS4EMgDmSHI9b7bVv4lXiUrnY5WWlwqb5PLPru0Pm0yvt0XYd_fH3F0M3dQnu5s_ctxN9_xVlrwS0W4nBsh8UR5sdXu_d-GXUY0ix8l7Mx6XaHiBZ2DWqFO0dtBomDdx8H4ElfssHZl9nWMmFBXLYVBm467RB6U4Pbf74ZheUa0LmGq5foL1JkWy4tmgqCLPGvy9v8cMxc6_9xK4VqX184XyhommWQq9UyrU2xX1W-ASqHF5YBZjoAnr-JBWAPSx-vQx7pF78MosjkoEKAGgMvLBz5455dHA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.32]
+          AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [492e5dc0-3f39-11e6-b7aa-001dd8b7c0ad]
+      x-ms-client-request-id: [3e3f6951-447e-11e6-8f19-001dd8b7c0ad]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/networkInterfaces?api-version=2016-03-30
   response:
@@ -1177,224 +1075,256 @@ interactions:
         6UeXWbnOP3qUfg9/pSl/iOejZbbA5x9dLrZnWZvNiubtdps37U9+8aKYfjSy7YoZWt1t1pNmWher
         tqiWzd17O/v5wcOHn24/eHA+2d7/ND/YnmSzbPv+/Qef7uzef7g/yffv1nlTretp/nldrVfN3WlZ
         vCH4ry5+f9Pf3VVdXRazvG7uflFM66qpztvxi7y9quq3d5fy82zZ5vV5Ns2buzdhmrfZBXD97t3f
-        96NP7z3M7h3c29v+dHf34fb+5N7D7cn57NPtab6fP5x8en93b7r7+37kvVxW0wxjA4ArAr5uvC8J
-        cENfWOLRR4TFqsyuXygVFWuL7Uem6S9xUGi0q7xui7wLi764LBrqvFhevG6zliG+Xk+neT7LZw4P
-        amppupZ5yWbT2c7s4OH2vf2D3e396aefbj/c38+373+6c2+yu7tzb7r/IABQrE6q5Xlxsa55uEBF
-        WUMeDy88lk2K1ZTf606CDxzP/9v55W6XAPTBLUf2IfwlD2Y6ygLy4OtbMoI89EJxSc3OXh7PZkQ+
-        QP1od2eM//Y3Ni8Nv3+Rt/OKp+zpNc21L1Dm+Wi1npTFlN6ynfRQp1Y/VxPfwS4y8S+1hRVK8zjh
-        NM9HhD5xEo3k/01DvCzqdp2V+md/gD/54vTNXcKKMO9/+Zo/v83YiT0WWX1NY2zrdR79XtlHSP2T
-        hC2RgNp/dPbycr/TxS/x//T++L4H+KPZsnmdty3xe4+t5Lv6kjqhr77nv0ZfZqtVWeSzp5vaFNAF
-        y6x8Wi2yYglV/Xp9fl68o6YftTuXu816Ppv9dLa+LK9WxeK6+sHip7MsH8/ejc2b42lZrWfU1zgk
-        oU+8jxbZVAkCwDs72ztPt+8db9/b2d7d397b8wXqo3yZTUqi4LOqvsrqGY2b3jnPysYn90fUGSb6
-        dT5d10V7zUxD7ULy/FwxYwy5Pte9eP35EL2IjeJs9pHy+RfZdF4sofx+bkd8Ui1W6zY34qdo9cfq
-        D9T86kb8UXu9wlg+coA7pHQ2SyGZl+3wrRkmzLnL7cvFHtszx10/G+T5yS9O6pxE/vf/arJetuu9
-        KJkGRwNAg9j61vThzuT8/v798+2dh5MpeTH3MrKm2adE5ek023+wc76zd9+3pv9f9db2Hj649+l0
-        7+H27r0H97b38/Pd7Ww62d+ePbx3/3x3J589uLcTAOg6KwTkvbw1fwJ8wHj+v8Av5JyFBKAPbjGy
-        D+EteTDL0emXB1/fkgnkoRdC24n2/z/y1N5r4jtYdib+/83e2nsN81LMhv7JYOwgA4/N/+JH3lrM
-        W7uo969/cL+ZFL8oy+vsB+X9enK+aNvm3fQb89b2timAvnffF6r/l3tr78WMMSQZmOW8/494bLca
-        9ZDnRmDseP3Bml/dqL9Rr40cxot8SZxbFj/I2bA5NvtZodHic9tdlD6DQ4FvO4yqb1eznXvZ3sHu
-        wfb9nb0H2/sPHh5sH9zP72+f7z7cf3gwmUx2s3u+Xf3/qs/26fl098Hevd3tyXSyRzPxYGc7y/OH
-        2wc72UH26ezhwc69EEDXZSEg7+WzBTPgQ8bz/3puIQctHD59cJtxfQhryYNJjs6+PPj6ljwgD70Q
-        GlC0//+Ty3bbae9g2J32/1f7a7cd46UYCv2zM8LAWQu++ZG3FvPW9i+yX3RxUWS/aLJcryb3f3r2
-        gx9cznfe7S++udza7vYz+t8TX57+3+6t3ZYVYwh22O7/K67aTUMectOCwfojNb+6IX/TftpV0c63
-        ReNtFys2aY7JfnaI9Lxo2rOVsjmNPkapwTGBVptx9i3r5MG93fPdvYPt3U/372/v788m2weT2cPt
-        T/fyven9fH+XrKtvWf+/6rTdu7dzf3a+e05z8CmN85wS8dlDiu8+3TvY+/TT+58+zM6/2URbbxZ8
-        6Hh++KzzdVmHHLaQFvTBbQf5IbwmD2Y9yg7y4OtbMoU89EJoWNH+/1de3Puojw6a1Lo3p//vdufe
-        Z7BqVfTPyFC7fl347Y98u5hvd2/+i65X7b239yfler7ae1us7t2b7t+vLi6+Qd/u9NPtnQNfyv5f
-        79u9D1/GsIzw3/9nnLzbjH2DpxeO2h+y+dWN/Zv29hpYkO1FNWPL5zjuZ4dQbK++qGZRCg2OAzQa
-        xNM3uA8e5PcP7n862c72M1rpuvdwZ/vh7uzB9t69+w9mB/c+nU1mmW9w/7/q3GX7n97bO99/sH3+
-        6acZrejlO9uThzTY3Z2D+w/v72cP9w5CAF2HhoC8r3NnJ8AHjOf/3ZxCrls4dPrgFmP6EK6SB/Mb
-        nXh58PUtp18eeiG0oWj//ys3jqlw05R38OtM+f+7XbdbDVDtg/4ZDq/rrtkvfj55aq6JP7z/1/tH
-        t5r8GHrhTHd8IvOrI8U36iCwCn2aL6r7u/d+8gunLr45Einw21DF4X13EC9fb892SDWThdze29md
-        0SLKfUqB3Pt0dzt/MN09n2YPpgf5ga+3/7/qDZD5OT/Ym8wor5DRYtH+wb3tgwfZZPvBw8n03mRn
-        +ul+thcA6JpEAvJe3kCE8PL8v4styNKH46QPbhrAh/CPPJjJ6BTLg69vOdHy0AuhRkb7b97u05QR
-        PalND2P68oc6rV0DCKOn79GcEg6EZ3NXLJ793MqaeZzMmQeU+f+46QvbmFRDLEmxvL8zW17Nz2fl
-        PeL+6+nu/KJeLorLJnvvJMWwYTWNXPP/bxqfbCM/9hDvqBkPMV977Dx8uH8vy2fbkz1ax99/8OA+
-        aeWHe/TP3u50cv7wfHIvWML//6r1ubczOT+4v/tgmzLbbH0ebGfnn55vH9w7mN0/ODi/9+nBvQBA
-        VysTkP+XWp8P4wuyNuFA6YObRvAhDCQPpjI6x/Lg61vOtDz0QqgV0f7/4+Zn87z+yP7Ql2QTPsj+
-        TBfne83bbHZ1Va1/cLGsZ9ksf/fTZZXNf2R/+vw4mW7kyB7qHU3joeYrkIcT6OB7D7D8eG97/4BW
-        Hh/Osvvbu/d292d79x/ufTrZ8RXI/1ct0F62u7eTT3e3d2c75Kfv7ZEFQjb0HtZXZ9k+Je+yAEBX
-        MROQ/7daoA/kDDI54VDpg5vG8CEsJA8mMzrL8uDrW861PPRCqBnRfndnfJMN+n+1DbphZn9khehL
-        sgwfZIWqd816f3XZ1r9osv7p4vyiyrIf3Jsssmz2/1UrRGzjCcjPBlfeKkHp8O8oHADw8PN1yaez
-        nfuzh9m97YdYudo/eHi+/XDn/NPtg/Pz6e7OdLqTTXZ9XfL/VXN0f7a/ey9HEu7Tyf3t/d0D+O0P
-        drb3Hu48mGV7pESz3QBAV0cTkK9njkLiy/P/ThYhMxSOmT64zWA+hJ/kwcxGp1wefH3LiZeHXgj1
-        Jdr/fz0+ItJvnOKNxonfJlwI356BwndWDs3j5NE8oNLPGyOVXS3W8/x68ba6t/7B4heRDLTz+fI6
-        23t/I7XIpkoQAN7Z2d55un3vePve3vaz3e0HBz5fbTBofisidHwiPlIe+CKbzoslpCQk2Q+NJ0+q
-        xWrd5oYnFR/7Xo/n7Pw7yn2j9voiXz4vlut3rPQcxb85glAHNCcXNMQYOQYRx3tRxAKdenBvd+fh
-        NCOWuUehFCXyticPdyfb9x88oEzevQd7k3uBTv3/qo0+oKBwdkBptZ3p7NPt/Z39g+2DvYf3t/P9
-        e/fuHeyd757vfBoA6NorAvJeNtoQ3weK5/9lbEFmOBwnfXDDAD6EfeTBREZnWB58fct5lodeCK0D
-        2n/zJnm1npTFlN6ynfRQp1Y/5PntIEWt6T2euJf6jRUx8zhRM89HhC0xCiH+/4IRqV7XP/ktHg98
-        jruEBCHqPhR34zZDpEmPGzZ58L0yhVDy/9MexmS9Pt8pp/d/0f31D96u37ZZWTR79++9m3yDHsbe
-        Pv3ii8ktPQzqDBP7Op+u66K9Zt6gdiF5fsg8F8OJ32Ume/H68yHyENfEueqH5i4RkoTC0ACHnCV6
-        i4fmj8v86gb4TftJV8Vyj82OY5sfFiEG8cZ7Mbx8Mzf99N5scjCZbT94eLCHhHNGWdF70+3Z5MH9
-        2b2d2c5Blvlm7v+rXlJ+kN07uHdO5nz3wcPt/Xx3Z/sgPycvaS/by+5n+f17U49EBKDrPRCQ9/WS
-        QHsfJp7/dzEFuUThKOmDzeh/CO/Ig1mMTq88+PqWkywPvRCaN7T/+ewiYd7+f+QhYThdBwmf/Xzy
-        j1wTf3j/f/RKMLMbnBLlDzX2hPLPySg2uB7A30fe/OpG8U17Ht8tlqzLnc76YZFhEG28F0HLtx33
-        zvenDx7m59vTyac7hM3uPrD5dHv3/uTBpw+n++e7033fdvx/1u/Y35nsPqTszN5sn1dQDrYffppT
-        Zj+b0HRQ6uZ872EAoGuRCcj7+h1Eeh8knv9XsQQ5GeEY6YONyH8I48iDKYzOrTz4+pYzLA+9ENoM
-        tP/ZdDpMJz3UCZcf8txGnQ6atv8f+Rw0mq7LQR/9fPI4wjYmrxLLyMzeXa1W75bvLt8t1u384v56
-        996san56uci/yYzMzvZxmMX+/6HvQyy2wfUhnonz1P/7nSIamD8q86sb3jfqEy2yJfV/uWiWgffx
-        jZHBwm/qi/egxOtpVuYkoh6ATovm7m5/uK51OBzfJu7m96Y7e/cebB88nFByY+ceLQHtn+9vZ/ce
-        zB6Sg/FgsjvxbSLxUtwa4otb2sGPLFXU03n46c69nfzTyfbep/f2t/dn9zNych7sbT84v08me7a/
-        d//8fgCg6wUQkFt5OpYgxmvwoeL5/8VUk08Uksd9OzjuD+EJecAAUc6QB1/fkj/koRdCS4f26icF
-        3CCP1/y9kjM000RNatPDmL784XGD0Vk61/qn9+IlYXmXEKEf3qfygeo19xgN5x6QJ24D5MH3Sj6h
-        dtev6L9RVtnsSVZmy2leP8mmb/PlTN99WVUlpiuQSXkiVCZQP3w6+8h7r5WTu5P+UNz3k3xFH/To
-        TRTvfhS6QXgCgp0tJ9V6OXuRta/WJUvM/yeJVYTDcN8tsxaUGu/eilbhB8H33h8+ScUx/eacVtfE
-        l51buooqtKqgqUWIzg9vwj7ApnjzZEmuvxiK2FH17SlZHach/j8x4L0bjKg3nMA2ZvsP7p3fo3xM
-        /uBgez/DKPKDT7fpl3vZwX0a34OHvm0kvRq3ivjilvbwI0sV9Zce7OxMz3ce7m5/+mC2u71/b/pw
-        ++DT/Qfbs/OH2d5sN7s32T0PAHQdAgISqBsPLzz9+R30GwShu/+fnuoP9pfekyfkAQNEOUMefH1L
-        /pCHXggtONqrvxTEv/J4zX/kLxkN5x6Q50f+kqOzj7z3GrkAP/KX3oNYN/pL/gqQefq0Cj8Ivvf+
-        8EkqPtGP/CXC35uwD7Ap3jxZkusvhiJ2VNaelpNtsje7ZB6cfvgGh3tdX+xFx2kYk3Qffnp2MIqR
-        b9wm97MHWTZ7uP1wdo98jb2D2fbB3qf3t3f2Hkyz+5Pdncm9IBlAUivGBAB6q22EXNTm4YtbWruP
-        7KjVG9rbv3fvfO/8/vbeBBjeu/8pjWZ/f3tv+unO/fv57sP7D7MAQNfcE5BAmXh44bGzZ5yBXR8a
-        nv+3TGHfkRlG+UPmWB7MWXQy5cHXt5xSeeiF0KSivTowMXvqmv+/0YG5cSJVo+ifeCNwWWTFyA/L
-        5DHKxT0gxM8HV+VGivpYoz3Z26hzcp2temQlwnY/Cu0gnoAu/6/wSL4OTbo+SNPM+2wWo0f4QfC9
-        94dPNvEsvjmvI2xjFghjS4uT2d7OebNzebWXrZfn0+XsqrqeLyaXxeQbXFo8ube999QXn1v6PySQ
-        cYGNekb0uT5fj3Hej3HiLhHeuFz4FDK/OlJ9oytxYtT2yKg5+v4whj+IsZrZDka+Fd2dPNz9NJ9k
-        25PzjBDJzx9uZ58eTLYf5A+n57vnn+4+mARWlLSJWC0A+KF4SrMsz3f3H+TbO/sHO9v7u/enhOv9
-        fHs3e7B//umEFuF+PnhKmEJyjMKR0QdDKH/IHMuDOYtOpjz4+pZTKg+9EFp0tFdP6f97S2M3TqSq
-        Iv0Tb/zIU/owivpYoz15BT/ylDyM0Z5oEvGU/LjfPH16hB8E33t/+GQTb+j/v57SyfbeM198/n/u
-        KflsYmfc0eobdZXQ387uzu7bn/ziha/Hv0kaIAUWo8Eg1vxOFCvfnO7Npvfu359SruZ8b0apm72D
-        7ex+Nt0+zzNa1dqbZbvTT31zSmpFzBcA9FwmAgzGsxSij2ZFsyqza3A8ffORomvRVNo66tIrNMyo
-        rcYXt7TSH1n6qeO1s3sw3Xn44NPte/k9jJMciIf3Zw+27012Hk4f7OSz2cHDAEDXPSEggc708MJj
-        ecF4MZb6PlQ8/29iCvK5wlHSBzeh/yHcIw/mMTrB8uDrW06zPPRC6DSgvTpjMY/BNX8vZ2y1npTF
-        lN6ynfRQp1Y/xNntIOTP7kv9yoqXeZyYmecjQpX4hLD+OR7OpWhx/VPe4MH85IvTN3cJA8LS+1Sc
-        ztsMkOY7bsLkwffKD0LIrs8ZvmCNCR7vD9/gi7/wc+FLXO1Ol++my/X+emfdTvb3F4u2vMyK9Xz2
-        jfkSJO172/vHvoTc0pegzjC1r/Ppui7aa+YMaheS54fIcTF85D3msBevPx+iDbFMnKV+iF7R0Og2
-        eUU8Ln9Q5lc3up8Vz+gHbG4cy/ww6DCINb8Txcq3bZ9m+c6nuzt72+cHtBqzv3vv0+1sRhjllK/Z
-        Pzi4dz6dTX3b9v9Vz2j33iTPH+5Otnd2snvb+/v5p9sH9x7sbc8ens+yyV42m05/djyjH/hQ8fy/
-        iSnIEQpHSR/chP6HcI88mMfoBMuDr285zfLQC6FpQ/uf157RD/7/5Bn9IOoZ/eBHnlHMM7rI7//0
-        D37R5e7+crW+vHg7n14uJrP23ur8/BvzjO5tn366/fTrZFmoM0xt4IlQu5A8P0SOi+Ej7zGH/f/U
-        M/qBPyjzqxvdN+oZTdeNdMrmxrHMN0yHeOJsEO27g2j5xo0Wq/ayTx8cbM92Jrvb+w/2Pt1++ODe
-        w+3Z7r3zTz/do+WYg/u+cfv/qmt0P9s5P8g+vbf9gMa1vf9w/yG5Rjufbp9nNAv7O+dZNvGWIglA
-        12kgIO/lGlnq+1Dx/L+KK8gVCodJH9yE/4ewjzyYyOgMy4OvbznP8tALoXFD+114Rt+4bwR/w3XS
-        Q51w+WFOb985stP2/1LnaPN4VJvrn95oAu/Ifvoj7yjmHS2v7lX7u9lP784u8/PFvJ7u7FfXu9Ws
-        +SbXoCgcehrGkv+v9Y42s1wMIY/F/t/vHsWHN+Qf2YH5ozK/uuH9rPhHe2xyHNP8UAgxiLYlRQ8t
-        38Ad7Mwms72H++Q3UDZl/162v/3wPNvdPj9/+Omn93bu7T6Y3fMN3P9X/aOd8/u7+3u0qEaNKXV0
-        QCKeTR6QIc92H5zf29+fZDv3AgBdx4GAfC3/aM+Hiuf/VVxB7lA4TPrgJvw/hH3kwURGZ1gefH3L
-        eZaHXgjNG9r//PaP9v5/5R/tRf2jvR/5RzH/6Kf3L6/v7S3O3/5gud5dvNtdTN+9262a3R/k35h/
-        dG/7+On2Xqgw/3/pH+39/9U/2vNHZX51w/tG/aNFtiQUlsXUsyU/FCIMonw3ipJv2KbZg5393fzB
-        9uzebLq9n93Ptx8+nBFi070sf7C7n59/+tA3bJv9IkIuau/wxS0t3Ud22OrRTB7k04ySEdu7s92H
-        2/v3ya052Lk/3b5/7yB7MNvZ23vwMAxguqaegLyXR9PPlAgid3/O55CclnBo9MEQzh8yyfJg0qKz
-        KQ++vuWcykMvhMYH7b9574VmiWhIbXoY05ff2ExeLn7/aZ0Ter8/aZq2Wvz+xer3ry82zqyqKP2T
-        QNTnl4vA4PMnPzL2MWP/g8Uvms3f1kXWvFuX08uf3r03z346r3763cU3aOx3nmwfn/gsdUtjT4SO
-        T8T/my0kXiEDuTv16WR+dQT72bGQnkv1QyHCIMpOu/oo+crz0+ne/Yc7+zvbu3m+Q6nx/Xz7INuf
-        bD/Y3cun+5ODWT4NUuM/fAs5O793bzbbv7d9nu9TcDo9ON/OCOXt6cH+ZHd6fn+S7X6zayJ9ayOI
-        3P05n0MyiOHQ6IMhnD9kkuXBpEVnUx58fcs5lYdeCDU22quF/HRj8x9ZSKd23AMCxRWzPPheCSj0
-        /pGFxENqetBCnmw/e+qz1HtbyN5XOulql6hFSLNvjB83aJb/V5lI7bPgvKUj9Q+FEINo80tRtHwt
-        SgHZfnZvb0bmZyfb3j+nFfqHuzu0qJx9Onu4f/DpwYO9HV+LbjaVBBj8Z0lEH/2/Jcl+7+Futjeh
-        KGqHbO3+/d2d7YP755Run927f//ew8n+DuUdfABdq0RA3svgWur7UPH8v4oryNaGw6QPbsJ/iH1u
-        wz7yYCKjMywPvo7M8zoyz/LQC6FRIKjGCP9/LkwF4W+YVVV6+qe8wnMVGF776Y+Mb8z4/qK9eXPv
-        fvuL6vW99eXkF93bX+/Wy3p/9+KbW6vf2b63u/3wgc9KtzS+1BmmNkj9UruQPD9MloshJC8yi/3/
-        LReNV3hg/qjMr254PytuxE+zZnZM80MhxCDa/FIULd8OfHowzWazh/n2zr2M4tl8MtmePJhOtncn
-        nz6YUTZ4Nj3f9e3A/1fdiNnk/GG2nx0Q1R/skfOwR/L9MKfI89ODe5Pdg/v3JhOPRASga18JyNdy
-        I37ah4rn/1VcQV5DOEz64Cb8P4R95MFERmdYHnx9y3mWh14IzRvaf/NuRGdlnBr3UKdWP8zp7WDk
-        T+//L9bq8QqPJuof/fSP/KOYf7Ss9oq3e79oku28W7/Lr+7PLy/Pi+rtzvybW6vf2/50f/vhE19G
-        /v/pH/30/1/9o5/2R2V+dcP7xv2jptn9tKCssWOZb5gMTfMedHg9zcqcpNO8S7h1WjR3d/sjda3D
-        kfgWMb93f39/ev/+9nT/wYws4t6D7YPZp/n2HgXWB7v5/Z2H2cy3iMRGcVuIL25pBT+yBFFvJ7v3
-        ICc0Pt2eUZpoe3//fH87Ozi/vz2Z7D7Idu/du3/w6U4AoOsGEJBbeTuWIMZt8KHi+f/6LJM/FFLG
-        fTs45A9hB3kw91GmkAdf35I15KEXQvuG9uog3d/Y/L0cJJpkoia16WFMX/5QGMEoKZ1m/dO8Q5PW
-        cyT40x+eI9F/o6yy2ZOszJbTvH6STd/my5m++7KqSsxUIInyRAhMoH6oJPbxNm8QKcvJ3Ul/FO77
-        Sb6iD3qkJmJ3PwpdHjwBrc6Wk2q9nL3I2lfrkuXk/2t0KsIRuO+WWQsijXdvRabwg+B77w+fmuJ/
-        /pz4pj89uXr7i356fdm+zXd/utxd/eDe9G25viyn35hvuou1sweBpN3SNyXZjcv2D9ehG+CnD7Bx
-        PgnNr/qLIakdUN+0kxV0xPx/+1j3brDn3kh8Mz17+OD+pwf3d7cPpjsPt/cffkpmeneXFkY+zad7
-        5/fv70w/nfpmmnglbqDxxS1N80eWIOq17T2Y7GfnO7PtfDbbpTWZyWz74Pxetj3d+XRv/9N9+ieb
-        BAC6vgkBCXSghxee/tQOujCC0N3/r87yh3pt78sO8mDuo0whD76+JWvIQy+EzgTaq9f26cbmP/La
-        ggeUiWt2efC9Uk4I/SOvjUfhvv+R10ZvEB2ITjd6bXu3IlP4QfC994dPTfHM/j/otfljGPba9u9v
-        P73nS9rPc6/NZyPLEfqLUXF2QD3T/tNkBR0x/9811p/utGju7myw552R+GZ6/9PJ/YPJQ2S4du9t
-        709me7SeN7m//ene/fv3kXXZvXfum2nilbiBxhe3NM0fWYKo1/bpzvRetr873b6PRcX9GWHy8MGD
-        yfbDyR4lWh9ibfEgAND1TQhIoAM9vPD0p3bQhRGE7v5/dZaHvbbhIX8IO8iDuY8yhTz4+pasIQ+9
-        EDoTaK9eW8yTcM3/f+a19Rft+NMfeW3vT2Ifb/MGkZK8kU1e20//yGujN4gORKchr+2njde2cysy
-        hR8E33t/+NT8ufPartfV7i/aeXe9e/Eur/OrsnxHC8EXVfX24hvMtZHJe3LiS9rPK68tYuN8Eppf
-        9RdDUjugvmknK+iI+f/2sW5aO+uMxDfT55/uTO7NZg+27+892KHkyt7B9sGD/Xx78vDe/ezB7r0H
-        +/d2fDNNvBI30Pjilqb5I0sQ9dp2Zrvnk13K6+w9fEB5nZ3s3vZBRgumuw/3HxxM7t/7dLqzFwDo
-        +iYEJNCBHl54+lM76MIIQnf/vzrLH+q1vS87yIO5jzKFPPj6lqwhD70QOhNor17bz6sV0h95bd8Y
-        iX28zRtESvJGfuS13Y5ON3pt/tKWefpkCj8Ivvf+8Kkpntn/b722e3vbO6e+pP0899p8NrIcob8Y
-        ktoBdU37bkZW0BHzGx/r3ocMdjfrtKDBDhv07lB8O33/3s7B9ME02344pWTX/vSA1sQe7pxvH8z2
-        du5Ns+nO7OBT304Ts8QtNL64pW3+yFJE3bbJ+cHswd700+17D873tvfvPXi4fXDvwb3t84P7WZY/
-        yCbkRAQAus4JAQmUoIcXnv7cDvowgtDd/89O86DftmHMH8IP8mDyo1whD76+JW/IQy+E7gTa/3/c
-        b4tzgrGWOs/6p3mJZi3muO1mP3LcvgaNfcTNK0RL8kg2eG672f8fPbevS6gB141Uz/9vXbd2fX61
-        uli9K3fu5z9dlOv5T1eLi9kPrprsG3PddrYfnG6fhOtJ/x9z3eIM9QF2zqeh+VV/MTS1I+rbd7KE
-        jpr/rx/s3g1G3RuKs9W/70ef3p/tU4rlYHt3f49s9YPdXUqvnN/bnk4eHOw+3N0/f/BpYKuJW+JW
-        Gl/c0j5/ZCmivtvup7v57iy/v7032Tmg5f77hER2b3/703v72YPZ+fTep/vfaMptgx8jCN39/+w0
-        f6jv9r78IA8mP8oV8uDrW/KGPPRC6FGgvfpun25s/iPfjX54D0gT1+7y4HslnVD6R76bDMN9/yPf
-        Da8QIYhQN/pue7eiU/hB8L33h09O8c/+f+u7PaHM2z1f1n6++24+H1mW0F8MTe2IPPu+bC4uF3sH
-        B56V+ObGSsDri+hAjeTQ5ONnYJzprR5Kvsl9uJfv35tOZtu75+f3aZnr4P72ZPaAvJ/dB+fTB5Ms
-        nx2c+yaXdIqYOAC4ypt23XhfEnZRS4wvbmmDP7LDVv8s3zn4lBpRQufTyT04BfcIQxDsgNDbuZdP
-        pjuBef3a/plxUXZ9aHj+XzOHff9qGOcPmWR5MGnR2ZQHX99yTuWhF0Jrj/bkV+2SXxUz9a75e/lV
-        q/WkLKb0lu2khzq1+iFOaQchb0o9NSOPUS7u+YgwJJ4gZH+OR3EpOlL/NG9Qz4Rdc3eWn2fr0rc9
-        8kQGRNMatxry4HuddqFX1ycMX1CtLI/3h29jxUT/XJjvn77c3X07aybz9l1++dPXl7OdSZ7t/uCy
-        yL8x8727/eTB9v2vY76pM0zl63y6rov2mjmB2oXk+SFyWAyfqKwEdCF2ibPTD80JIfwGRhb3QOJj
-        Mr+6wX3UXq+A9kcOYIdUzkooJPOyHak1btnsha8tv7nR19X17t69ljyBKAkGMb7bxcg3WPk96u/e
-        JN9+MP30nBDJaD1t5+Fk+9NPs4O9e7uTh/cmE99g/fC9ktn5+eThwT6RKr+f0zLT/cl2Njk4357c
-        vz+ZzA7u5zvnWQCga7oJyP9bvJIPm0LyQcKR0QdDKH/IHMuDOYtOpjz4+pZTKg+9EJobtCenBP+9
-        t1OCDn2eNs9HNEdEPWrSQ5i+/GHP46VoI/0TsxikebLZj/I7X4uuPuog43Pv72iS5/mTJ6c9KhOd
-        ux+FDgeegEz/b8jsfBMk6qZ3stmrpy9vRZ/wg+B77w+fjOL2/Vy4hNPF6u3OfD6ZzXfyerasy6rd
-        3Z3NdmaTb8wl3INX+OypL123dAlJXuPy/ENzpm5gpCGPinTYFz6ZzK+OXt+oN3VZnyN3tH5Hix6O
-        zN8cFRokqZq8/f2ndU768/fP3xUNePX3rwTo719ffL2clyLe+b65u9MngmnbHaRvww9mBzsPDmhE
-        2YNPs+39e/cfbmezg73t8/zTLJ/uT3YP7s18G04MFrfe+OKWdvsjSyt1xe7tPCSXId/ZpjTGw+39
-        HcpzPNw52Cd/7Pz8YPZw7/7uPQ9/AtB1WAhIoDE9vPD0Z904OD5UPP8/ZgBy6kKiuW8HqfEhnCIP
-        2CLKL/Lg61tyjTz0QuiQoP3X9faGU1A0/0RNatPDmL78uecRo/eUB/RPmVHC+y6hRj/4b/lV9aF7
-        jGZ0D0gVNx3y4HslpVD+594V/DmheegBEYVpXSvmG/I3kxzLWj3qE/27H4UOCJ7/17mIPyuk6/qM
-        /KlZDty5FeXCD4LvvT98AouD+HPhPP50ke38ojrbu5r8IC+rWVYslrN19dOz6/k36Dw+3dm+//9N
-        5/Frs9jXtpo+dc2v+ouhth1r348gu+ro/P9hMuzd4Dx4g/R9gvO96Wxn/2C6/eDe7i6t7E0fbB9M
-        ZtNtWqQ6f7CTnWeTvfu+T0AcFvcG8MUt/YCPLK3Ue3xwf2dv79798+3p+T1KQ+UPyEW5N9vd/pQc
-        lQe08rib338YAOg6QgQkUKYeXnj6sz7oLwlCd/9/yAAf6j2+L6fIA7aI8os8+PqWXCMPvRD6MGiv
-        3qO3vm4er/mPvEf/MZrRPSBV3HbIg++VlEL5H3mP9D1RmFygH3mPAPq1SLfRe/RX58zTp1z4QfC9
-        94dPYPEQ///rPd7b3gsN5o+8R9KMZOs635PV9KlrftVfDLXtWLt+xC+qya46Ov/skcGN/hsd/IaE
-        U3doviewn917eL63P93e3dmjPNLe5NPtg09n+fbepwf3Ht6//2n26V6wakh8FfcB8MUtrf9HlkLq
-        Mx7c29s5eDjd39578GBnm5JXu9uThxNaAd7fe3BwkN/fP//0m1n8tQQZ9JIEobv/v5n2QU9xAw0+
-        hD/kATNEuUQefH1LXpGHXgj9FbRXTzHmrLjm/x/wFG/gDGNwdeb1TzuPwVqzfvajBedvhOL+UCxt
-        yc0Z8BDx7f+vfcQPJFvEO8Q3xj/0cz/m6VMt/CD43vvDJ674gD8X/mG5W7z76eX5L9q7qNeX5XU9
-        eVfd2/nBL7p++436hzs0pb4c/n/WP7yBvb62hfRpan7VXwyN7Qj7ngLZUEfd/88NfvcG98Abmm/1
-        7x/MyK5P97Yf7GczGtGD8+2H5/sPts9n+/fz8/1Pd7PzID9E3BS39/jilpb+I0sh9QrvfbqTP5je
-        JzpOaPV5fze7R0ucuw+3Z+c7nz7IDnZ3793fCwB0XR0CEihNDy88/bke9IgEobv/v5n2D/UK35c/
-        5AEzRLlEHnx9S16Rh14IvRO0V6/w/sbmP/IK3WN0oHtAqLhtkAffKyGF7j/yCsm9+Vn3Cqm//1d7
-        hV+PbDd4hbs9fiWO7X70I68QgAOvkBbcdnw5/JFX6H9PFtKnqflVfzE0tiPsewpkQx11/z83+A3L
-        i92h+VZ/b3p/dm96Pt1+mN97uL1/nu1Rhm5yvp3fO985330wO9+798C3+sRNcXuPL25p6T+yFFKv
-        cG+2n0/2dqfb9yYT8gr3J1NC4t5s+3zv/s5strO7dz4JDNCPvEL9/uZp/1Cv8H35Qx4wQ5RL5MHX
-        t+QVeeiF0DtBe/UK/z+/qnwDZxhjqzOvf9p5/JFX+LNGcX8olrbk3vzIK/xaZLvBK/RX+szTp1r4
-        QfC994dPXPH8/v/rFe5t7wQq8Edeof89WUifpuZX/cXQ2I6w7ymQDXXU/f/c4O/d4B54Q/Ot/nR3
-        8vDh7N7B9u7Dvd3t/Qc5rRDufbq/fS/Lzyd75w8pTTf1rT5xU9ze44tbWvqPLIXUK3xwb3Z/mpMv
-        OKUl5O39gwfZdkYJqu2D2fR8995kdo8ckQBA19UhIIHS9PDC05/rQY9IELr7/5tp/1Cv8H35Qx4w
-        Q5RL5MHXt+QVeeiF0DtBe/UKg+UTebzmP/IK3WN0oHtAqLhtkAffKyGF7j/yCsm9mfSHZb79kVc4
-        TLYbvMJ7t6Ja+EHwvfeHT1zx/P7/6xXubx//KFfYWnbqfE+o+TQ1v+ovhsZ2hF1P4QcPyIY66v7s
-        Db4pFqsy/6bHvmElsTsy3+ifT+7d2314f0ojOP90ez/b39k+oLwdsdvu+cOH+f7Ozk7uG31ipri5
-        xxe3NPQfWQKpU3j+4PzBNPt0sp0/mN3f3t/bz7Yn+zu725ODyWR3dn5v/3wvDwB0PR0CEuhMDy88
-        /akedIgEobv/f5n1QZ9wAwk+hD3kAS9EmUQefH1LVpGHXgh9E7RXn/D/8+vHmxnDWFqdeP3TTuOP
-        XMKfLYL7I7GkLX/+eoQfRrUbHEJ/kc88faKFHwTfe3/4tBWn7+fCIby62N27vLd3736br99N300v
-        79Pv9356vjP7Jh1CShM+9aXwdg4h5Dou9z9nDuFm7vra1tEnqflVfzEktgPsOwlkPx1x/7829g1r
-        iN2R+Qb/we6nD85nDw62d84nO+SKPdzbPvj03u727P7OvQfTh7u79x/c8w0+8VLc1OOLWxr5jyyB
-        1B/MJ5OH9/fOH2zPaAV5e//hp9n2wb1P721PHu7t5LvZ/YNs914AoOvlEJBAY3p44elP9aAzJAjd
-        /f/LrH+oP/i+7CEPeCHKJPLg61uyijz0QuiYoL36g8GyiTxe8x/5g/YxCtA9oFPcLsiD75WOQvYf
-        +YM/8ge/HtVu8Af95T3z9IkWfhB87/3h01Z8vv//+oPPtndPfSn8kT/ofU/W0Sep+VV/MSS2A7RO
-        ApnNXUfUb27Mbd60v/9udIBGfIgL8NMz5h1kfNu8c//eLLufwWv6lLym3fu0tHo/u7d98DC//zDP
-        p5/u7ga2mVSM2EIAuCJk1o33JQEGf1ly0EezolmV2TUYm775aHH94uzEUtTQj9rRiKLWHl/c0s5/
-        ZGmlLuGDg73p/YOdg+3Z9CER+Hz6kBwP8kPuHdzbo/XjnQd7n+4FALqODgEJlKaHFx4728YN8qgs
-        z/8LJr7vvQ1j+yGcIQ+mKzqP8uDrW86mPPRC6D6gvXptMd/BNf9/odfGc7i3cQ5V++ifpI0Irb27
-        1DX9bO6KV+ZHqPI4OTIPCBFXz/LgeyWU0LXrloUvqL6Tx/vDN2ZiC38u7GR7ryiqvR9c5YtftF7m
-        +f3ZpL5qq2XZTt7bTg7bPtPINf+ovV4x//ankXrATyeK2p952RLHqhA2Pz/4yS9e+Pz5zbHe5cJY
-        yem6aavF71+shgzl4BjERPZw9JXGp/ceZgcP7k229yafIvW/+3A7owUA0ri70+k+xef3pg99pfGh
-        5kRxtTgqmR2h6RUaY1Qj4Ytb6qKPLDXVskw+nT3I7z94sP0g33u4TctOOenFT/e3D/buPdyh2HZ6
-        /9NvZvHJ6GohvQ8Sz/97+YOMTDhg+mDjSD6Ei+TBfEYnWh58fcvplodeCFUk2qvpee8FJHToS415
-        PlqtJ2UxpZdsHz3MqdXP5Tx3MLTz/FI/tzJnHid75vmIECd2oTH8v21wPXvLQ+tnRH4gpvc2YyU+
-        +Hljeffe1deT8uoXlfW9fF683blof9HbydXVdD59b8s7HKE+PKb590Vng5X2W1FnmNTX+XRdF+01
-        Mwm1C8nzc8l8MQQJEPPbi9efD1GKGCjOYD+0yPs9xhoPuwkEj9IfovnVjfWbd7DYNjlW+tmmyGZf
-        vzcGIUoXR98yPtyd7U4eTva3zz99eEB+xw4tcjycTLcf7uT37+1M82x6PwjK/r/qX50f5JPpQzL+
-        B/dns+39e9Pz7YNJ/nD7wfn5/b2H9853zh/sBAC67gYBeX//yoeI5/+97EHeVDhe+mDTQD6Eh+TB
-        bEanWR58fcvJlodeCM0g2v//07viaR6c5g6KZpr/3+ZdEVpfY3Cq9fVPgoGh9b2rHzlXMefq7f5y
-        PfvB+f37v+gH69Wqnv/025+u8+v1Xvn+aY0h52pnm3TsvRNfcv4/5Fxt5r0YhgQJ/Pb/QecqPtaN
-        3pU/RPOrG+v/J52r/F3RQBJ//0rAEWGidBkciVCmi6lvHnf38p3ZwfnD7enOfUrt0ELBdjbJ97Zn
-        k+nBg8nB3v6D2dQ3j/9fdbEm2afkZT18QEpgf2d7/8HBwXZ28Gm+nU8efnq+8+nDhwd5YIfJVQpd
-        DgLy/04X65tkEvKrwlHTB5uG8yGcJA/mNDrZ8uDrW065PPRCaBLRXh2tb3AFpePGUOMe6tTq/wWz
-        3UFUZps+LFZW8szjJNA8HxHmxC40iP+Xjk4Ngf5JkIhLCeG7hBP94L/l19sMllghbgvlwffKKkLL
-        /y87W/vl4t5lvnd17xdN1j84b/P1am+xc351r774xpytPYqztp+FSvX/3c7W+3JfDE+CV58vm4sh
-        ahETxZns58Dhuu14f8huF358/zdOfsn/AwpOU/OEjQEA
+        96PpbHI+uf/pw+3ze3vT7f29g/1t+uBgO9vPzx8c3Jvdf7D/8Pf9yHu5rKYZxgYAVwR83XhfEuCG
+        vrDEo48Ii1WZXb9QKirWFtuPTNNf4qDQaFd53RZ5FxZ9cVk01HmxvHjdZi1DfL2eTvN8ls8cHtTU
+        0nQt87Kf5fce7O5l2+eT6d72/gH9lu2f729/eu/Bzs7BbLIzm+4FAIrVSbU8Ly7WNQ8XqChryOPh
+        hceySbGa8nvdSfCB4/l/O7/c7RKAPrjlyD6Ev+TBTEdZQB58fUtGkIdeKC6p2dnL49mMyAeoH+3u
+        jPHf/sbmpeH3L/J2XvGUPb2mufYFyjwfrdaTspjSW7aTHurU6udq4jvYRSb+pbawQmkeJ5zm+YjQ
+        J06ikfy/aYiXRd2us1L/7A/wJ1+cvrlLWBHm/S9f8+e3GTuxxyKrr2mMbb3Oo98r+wipf5KwJRJQ
+        +4/OXl7ud7r4Jf6f3h/f9wB/NFs2r/O2JX7vsZV8V19SJ/TV9/zX6MtstSqLfPZ0U5sCumCZlU+r
+        RVYsoapfr8/Pi3fU9KPr+v7s/ur84hf99C9a3//pd9f78+Vit72f/WAynr0bmzfH07Jaz6ivcUhC
+        n3gfLbKpEgSAd3a2d55u3zvevkda+Mn2wTNfoD7Kl9mkJAo+q+qrrJ7RuOmd86xsfHJ/RJ1hol/n
+        03VdtNfMNNQuJM/PFTPGkOtz3YvXnw/Ri9gozmYfKZ9/kU3nxRLK7+d2xCfVYrVucyN+ilZ/rP5A
+        za9uxB+11yuM5SMHuENKZ7MUknnZDt+aYer6Il/mdVYWP8jZoDn2+tmgz08uPrfdRWk0OBRQaRhV
+        35bO9rOD3dmDg+1Pd/fJlt7bv7/98N69bHs/m0w/Pbi/++lkf8+3pf9f9dVm9z69v7+/P9nOzqc0
+        uun0fJsm5v72p/mn9x/MJg8OZvuTAEDXVSEg7+uruRnwIeP5fz23kGMWDp8+uM24PoS15MEkR2df
+        Hnx9Sx6Qh14IDSfa///ITbv1tHcw7E77/5v9tFuPUY2F/tkZYddRc9/8yEuLeWk762Lxi1bny1WW
+        rev5/N1qNrmez7L7l9k35qXd2957sH3w1Jen/5d7abdmxRiCHbb7/4ibduOQN7hqbrD+SM2vbsjf
+        tJ92VbTzbdF428WKTZpjsp8dIj0vmvZspWxOo49RanBMoNVmnH3L+uD83s6Dvfv3t+8dTO9R4une
+        hFDdnW6fn9//dOfelJyb+7u+Zf3/qtO28yDfv3fv4cPth/l98iAOsr3tbHcn384m2d75g/v5gwef
+        fuMJtnAWfOh4/r/DOuSwhbSgD247yA/hNXkw61F2kAdf35Ip5KEXQsOK9v+/8uLehwc6aFLr3pz+
+        v9ude5/BqlXRPyND7fp14bc/8u1ivt3kp/euaBT7y+oy/0H2i+6fV+9Wy3eX1eXsG/Tt6N+TB76U
+        /b/et3sfvoxhGeG//884ebcZ+wZPLxy1P2Tzqxv7N+rtsbV7mi+q+7v3fvILx27fHJUUeJQig3jf
+        HcTLt66znU9pMevTT7f3dnZn2/sP7u9vZ/c+3d3OH0x3KVH1YHqQH/jW9f+rntxklp0f7E1m25/u
+        ZQ+298mN2D54kE22HzycTO9Ndqaf7mffrCcXIbw8Pxy2UDrfyBbklIXjpA9uGsCH8I88mMnoFMuD
+        r2850fLQC6FpRPtv3jsjSSZ6UpsexvSl8NldavNDkHbVf/onTSq5IPoezSnhQHg2d8X1sJ9bWTOP
+        kznzgDJxkyAPvlfKCaH/v+yDLO/vzJZX8/NZeY+4/3q6O7+ol4visnn//NKwX2Eaueb/3zQ+2UZ+
+        7CHeUTMeYr722Hn4cP9els+2J3u7B6Q9Htwnrfxwj/7Z251Ozh+eT+7d87XH/1etz72dyTktODzY
+        nswesvV5QMtAn9IK0L2D2f2Dg/N7nx7cCwB0tTIB+X+p9fkwviBrEw6UPrhpBB/CQPJgKqNzLA++
+        vuVMy0MvhFoR7f8/bn42z+uP7A99STbhg+zPdHG+17zNZldX1foHF8t6ls3ydz9dVtn8R/anz4+T
+        6UaO7KHe0TQear4CeTiBDr73YHv3031kF2eU66Ulpu3de7v7s737D/c+nez4CuT/qxZoL9vd28mn
+        u9u7sx3y0/do2St7+HBn+97uwYRio/37B/ezAEBXMROQ/7daoA/kDDI54VDpg5vG8CEsJA8mMzrL
+        8uDrW861PPRCqBnR/v/rNuiGmf2RFaIvyTJ8kBWq3jXr/dVlW/+iyfqni/OLKst+cG+yyLL3z8T+
+        v8QKEdt4AvKzwZWzjWzZw7+jcADAw8/XJZ/Odu7PHmb3th+e71OgcPDwfPvhzvmn2wfn59Pdnel0
+        J5sEi13/XzVH92f7u/dyJOE+ndzf3t89gN/+YGd77+HOg1m2R0o02w0AdHU0Afl65igkvjz/72QR
+        MkPhmOmD2wzmQ/hJHsxsdMrlwde3nHh56IVQX6L9//dt0+Yp3mic+G3ChfDtGSh8Z+XQPE4ezQMq
+        /bwxUtnVYj3Prxdvq3vrHyx+EclAO58vr7O99zdSQ8uFe9vPdrcfHPh8tcGg+a2I0PGJ+KEtoynv
+        gHOiPDm0bKbv9XjOzr+j3Ddqry/y5fNiuX7HSs9R/JsjCHVAc3JBQ4yRYxBxvBdFLNCpB/d2dx5O
+        M2KZexRKUSJve/Jwd7J9/8EDyuTde7A3uRfo1P+v2ugDCgpnB5RW25nOPt3e39k/2D7Ye3h/O9+/
+        d+/ewd757vnOpwGArr0iIO9low3xfaB4/l/GFmSGw3HSBzcM4EPYRx5MZHSG5cHXt5xneeiF0Dqg
+        /TdvkmU9nt6ynfRQp1Y/5PntIEWt6T2euJf6jRUx8zhRM89HhC0xCiH+/4IRqV7XP/ktHg98jruE
+        BCHqPhR34zZDpEmPGzZ58L0yhVDy/9MexmS9Pt8pp/d/0f31D96u37ZZWTR79++9m3yDHsbePv3i
+        i8ktPQzqDBP7Op+u66K9/ryu1itqF5In4LmffZ6L4cTvMpO9eP35EHmIa+Jc9UNzlwhJQmFogEPO
+        Er3FQ/PHZX51A/ym/aSrYrnHZsexzQ+LEIN4470YXr6Zm356bzY5mMy2Hzw82EPCOaOs6L3p9mzy
+        4P7s3s5s5yDLfDP3/1UvKT/I7h3cOydzvvvg4fZ+vruzfZCfk5e0l+1l97P8/r2pRyIC0PUeCMj7
+        ekmgvQ8Tz/+7mIJconCU9MFm9D+Ed+TBLEanVx58fctJlodeCM0b2v98dpEwb/8/8pAwnK6DhM9+
+        PvlHrok/vP8/eiWY2Q1OifKHGntC+edkFBtcD+DvI29+daP4pj2P7xZL1uVOZ/2wyDCINt6LoOXb
+        jnvn+9MHD/Pz7enk0x3CZncf2Hy6vXt/8uDTh9P9893pvm87/j/rd+zvTHYfUnZmb7bPKygH2w8/
+        zSmzn01oOih1c773MADQtcgE5H39DiK9DxLP/6tYgpyMcIz0wUbkP4Rx5MEURudWHnx9yxmWh14I
+        bQba/3x2Omja/n/kc9Boui4HffTzyeMI25i8SiwjM3t3tVq9W767fLdYt/OL++vde7Oq+enlIv8m
+        MzI728dhFvv/h74PsdgG14d4Js5T/+93imhg/qjMr25436hPtMiW1P/lYmfnweThfc+6fnOUMF1E
+        CTGIuX2tj1lg4aaz8/zTKZm0T3ey7f17ew+2J9MH+9v7s/3J/dnD2WQ3m/oWbrNrRBhGDR++uKXJ
+        +8iOXp2ag+zB/cn5zv72LkX5hNcekezg02w7n+yRT/Pw4CFlWwIAXYNPQN7Lqdn1oeH5f9tUkgcT
+        jpA+GEL9Q+ZaHsxddFLlwde3nFp56IXQHqE9eTN7/5/2ZswUbZzZDk6dmVVd4x6jddzzESFK7EE4
+        /9wPRlWv/um9RP0Tjs3dWX6erUvf/soTGRbNcdzcyIPvlQeEcv+fdmGu819UV1fzovjpdb3Yy8vJ
+        /bd1nr3LvzkXZn/7ZG/70//3LypZltnEZzGU3KsdwQnIQ1wT56ofmhNjsIwOcMiHMS91h2Z+dWP8
+        WfJkDqb3d+475vkhkWMQc/taHzPfuh3s3Zvu5xnlPR5mZNMmDybbk/MH+fbDe7NZtnM/33/46cy3
+        bj98T+b+g3s5OSv59s6nn97b3t/9dH/7YG/3fHv/wcF0n9DLJ5N7AYCunScg/7/xZHgqyXEJR0gf
+        DKH+IXMtD+YuOqny4OtbTq089EJoltBePRmPS83jNf+58WS+wZnd5MkcTFXXuMdoHfd8RCxI7EEU
+        680DffnDZVNVwPqn9xL1Tzj+yJMhf+TnyJO5t/1gb/vZqS9M///1ZALBCchDXBPnqv+veDLh0Myv
+        bow/K55Ms/Qjw2+eFk1TX7wHPV5PszInSfUAdFo0d3f7w3Wtw+H49nA3vzfd2bv3YPvg4eTh9v7O
+        vYPtg/3z/e3s3oPZQ1r0eTDZnfj2kBgqbgnxxS1t4EeWKurePPx0595O/ulke+9TikD2Z/czWngi
+        8X1wfp+WUWb7e/fPA6tIbkpo/AnIrdwbSxDjLPhQ8fz/YqrJFQrJ474dHPeH8IQ8YIAoZ8iDr2/J
+        H/LQC6HBQ3vykfBfwA3yeM3fy0eimSZqUpsexvTlD48bjM7SudY/vRcvCcu7hAj98D6VD1Svucdo
+        OPeAPHFDIA++V/IJtbvuRf+NsspmT7IyW07z+kk2fZsvZ/ruy6oqMV2BTMoToTKB+uHT2Ufee62c
+        3J30h+K+n+Qr+qBHb6J496PQG8ITEOxsOanWy9mLrH21Llli/j9JrCIchvtumbWg1Hj3VrQKPwi+
+        9/7wSSr+6Tfnu7omvuzc0mNUoVUFTS1CdH54E/YBNsWbJ0ty/cVQxI6qb0/J6jgN8f+JAe/dYES9
+        4QS2Mdt/cO/8HuUP8gcH2/sZRpEffLpNv9zLDu7T+B489G0j6dW4VcQXt7SHH1mqqL/0YGdner7z
+        cHf70wezXVqOmT7cPvh0/8H27Pxhtjfbze5Nds8DAF2HgIAE6sbDC09/fgf9BkHo7v+np/qD/aX3
+        5Al5wABRzpAHX9+SP+ShF0ILjvbqL326sfmP/CWj4dwD8vzIX3J09pH3XiMX4Ef+0nsQ60Z/ae9W
+        tAo/CL73/vBJKj7Rj/wlwt+bsA+wKd48WZLrL4YidlTWnpaTbbI3u2QenH74Bod7XV/sRcdpGJN0
+        H356djCKkW/cJvezB1k2e7j9cHaPfI29gxktPX16f3tn78E0uz/Z3ZncC5IBJLViTADgh7I4trd/
+        79753vn97b0JMLx3/1Mazf7+9t7005379/Pdh/cfZgGArrknIIEy8fDCY2fPOAP9FSZB5O7P9RT2
+        HZlhlD9kjuXBnEUnUx58fcsplYdeCE0q2qsDE7Onrvn/Gx2YGydSNYr+iTcCl+U1//TDMnmMcnEP
+        CPHzwVW5kaI+1mhP9jbqnFxnqx5ZibDdj0I7iCegy/8rPJKvQ5OuD9I08z6bxegRfhB87/3hk008
+        i2/O6wjbmHXC2ArjZLa3c97sXF7tZevl+XQ5u6qu54vJZTH5xlYY97ZP7m3vPfXF55b+DwlkXGB/
+        tjyj92CcqEtEXELqaeFTyPzqSPWNrsSJUdsjo+bo+8OUmx7GamY7GPlWdHfycPfTfJJtT84zQiQ/
+        f7idfXow2X6QP5ye755/uvtgElhR0iZitQDgh+IpzbI8391/kG/v7B/sbO/v3p8Srvfz7d3swf75
+        pxNahPv54ClhCskxCkdGHwyh/CFzLA/mLDqZ8uDrW06pPPRCaNHRXj2l/+8tjd04kT/ylL5pivpY
+        oz15BT/ylDyM0Z5oEvGU/LjfPH16hB8E33t/+GQTb+j/v57SyfbeM198/n/uKflsYmfc0eobdZWm
+        ZXG52Nl5MPnJL174evybpAFSYDEaDGJ9dxAr35zu75/vzz7NPt2+P9mf0crJ5Hx7cv+cXJP7O9MH
+        Dz/N9qc7u745JbUi5gsAei4TAQbjWQrRR7OiWZXZNTievvlI0bVoKm0ddekVGmbUVuOLW1rpjyz9
+        1PGaHnx6f7pLfsL+p/s0uk93J9sPJ3u72/f2Z7sPdicHO/nE8yoJQNc9ISCBzvTwwmN5wXgxlvo+
+        VDz/b2IK8rnCUdIHN6H/IdwjD+YxOsHy4OtbTrM89ELoNKC9OmMPNjZ/L2dstZ6UxZTesp30UKdW
+        P8TZ7SDkz64VK/M48TLPR4Qi8Qdh+3M8jEvR3vqnvLGzu7P79idfnL65SxgQlt6n4mzeZoA0z3HT
+        JQ++Vz4QAnZ9zfAFa0TweH/4hl78hG/Oh3BN/OHd0nITlUDQ1/l0XRftNc8HtQuR+iHOcwyfOMsG
+        g1X2UONO2P7QBzDkZkRRN7+6MfysuBqsvp2S+mGQYRBpS4guUr6pIBP7YLr7cIdMxb1smzIfu9sP
+        z+8fbGfZ3qezvRllPz594JuK/686GgfTBwcH559m7Fls7z+cfbp98ODT2fb5zv7+ZGf/fn7v058d
+        R8MHiuf/RSxBXkU4RvrgBuQ/hHXkwSRGZ1cefH3LOZaHXgjNBdqrl/Hpxub/f/UyrEiZx4mWeT4i
+        DIk5CNmf41Go7tY/5Q12J37kZLgm/vD+f+lkeNQOxqrcoZadkP2h43+Tj+Fjbn51Q/hmXYx1Q13e
+        3927l0mU6LTUD4MSg4jf3YSYby8eZg/v796n9ZXd/D7Zi9m9fPtgej7bfpjn+YNs/+H+7u493178
+        f9XVuJffn93befDp9u75PXI1st297YdIcZzn+59+uksOx/n+eQCga4YJyPu5Gt4E+IDx/L+MNcjD
+        CMdKH9xiEB/CRvJgQqMzLQ++vuV8y0MvhAYE7dXtiC2HuOb/v3M7vIl7qd9aUTOPEznzfETYEsMQ
+        4j/HI1LVrn+G4wm8EP8L44h0MI8Mkyb+/+OOSNjGrHvEVkzKt5c/XU5+en99/926nr9bvqvr5fl8
+        vXP1za2Y7G4/3d/e3/NF5f9fLpHHZC9efz5EHuKaOFf9v9ln8obmj8v86gb4s+U3sQlyrPPDIMYg
+        3j45unj55i6/P3148DCbbWf3PyV0zs8fbE/2zu9v72b757sHs/Od+9mnvrn7/6rXNJncOyDvKN8+
+        vzfb297P7023D2bT8+3pwYOd80/39/LZ7k4AoOtJEJCv6zX5cPH8v4sxyEUKR0of3DyED+EheTCb
+        0WmWB1/fcrLloRdCU4f2P99dpv+feUxDDtOP/KWYv3Q+W11PLsq9rNhfT84n9bt8f3n50/em98/f
+        21/6/6kP1HGBzK9u6D9LrgIrXqdcfg5o4tD26NFFy1fy97LJfVrgn21/SjHx9v6DB/n25N4DSsff
+        f5DvU7y8tz/Z95X8/1cdhYPdnYPpQT7d/jR/cH97f38/o9D/0/3tnYPs4cHe+b3pvU+DBAIZ/NB8
+        EpCv6Sj4YPH8v4otyCsIx0kf3DiAD2EgeTCV0TmWB1/fcqbloRdCBY/2P8+9hP9/OQkDPsKPXISY
+        i3DdrN7eb3d/cPGL8vX9bO/yPC+r/b3zXzTP39tFGEqp7G3Tou39YK33/6fuRMeb8IdCPBPnqf9P
+        JFT8UZlf3fC+UR9pkS0JB+p358He/YeOaX4YhBjE+u4gVr6BO793//xghzyHfPrwISURswfbB+e7
+        u9sP9naz2f3sAS0j7PgGbrOHRAhG7R6+uKXF+8iOXH2bbHZvb/fezsPte/fOKQlyTmhmuxStP9zL
+        dg7O9z59QCtKAYCuzScg7+XbBNDw/L9pGsmBCUdHHwyh/SHzLA/mLTqh8uDrW06rPPRCaIbQXh2Z
+        +xub///NkfFmVdWLe4yicc9HhCRxBuH7czwQVbf6p7yxs7uz+zZwYOynP5/8F9fEH97/r7yGONMG
+        w1UGUXtM+P7QhzDkGQwgb351o/hmXQPCc2dnf0fS1k5X/TAoMYg1vxPFyjcZtMawT3Huzvb5hKzv
+        /v3759sP7013t/N7+QGZi4f046FvMja7BgQYcmIpRB/9vyR5cv5wJzvfn+1s3zvAOIn+2wc7ZBo/
+        nWYP97N7e59Op+HaatcEE5D3cjAs9X2oeH44TMFUvpEpyK8IR0kf3IS+cM/X4x55MI/RCZYHX99y
+        muWhF0K7gfbqcBxsbP7/O4eD3uFZ+/9X4iSbBJ6H/8XPJ+cjbGNSILHkSfn28qfLyU/vr++/W9fz
+        d8t3db08n693ribfWPJkd/vgePv+qS8n//9yg+g9FqX/n+VO8AaPyx+U+dWN7pv3jxAqsNFxLPPD
+        oMMg1vxOFCvfwk3OH04f3nuwv33v4T7WBs5n29mDyc72pw8OdqcPphRY72e+hfv/qn+0s3sw3Xn4
+        4NPte/m92fb+vQktLt2fPdi+R4Z9+mAnn80OvOwSAeh6DgTk/f0jUN+Hiuf/TUxB7lA4SvrgJvQ/
+        hHvkwTxGJ1gefH3LaZaHXghNG9qrf/Tza2UJ7/Cs/f/BP8IbPJjAObKf/nzyjFwTf3j///NHMK8b
+        /BHlELX1hPAPfQwbvQ5g76NufnVj+FnxOkpW5U5h/TDoMIg1vxPFyrcb++fTaZbf391++OBeTtb4
+        /mz7IMvOt2d7B3sP9rMHO/vngd34/6rXkWU7D+5NDu5vH3w6oXHC4TjIs4PtnWn+6f4erV3c290J
+        AHTtMQH5Wl5H6UPF8/8mpiAnIxwlfXAT+h/CPfJgHqMTLA++vuU0y0MvhGYD7X9eex3l/5+8jjLq
+        dZQ/8jr+f+l1lP+f9jpKH3XzqxvDz4rXsWBV7hTWD4MOg1jzO1GsfLtx/0G+v3/v3t72/s59+ode
+        3H64vz/d3pndO7/3abYz29+d+Xbj/6tex/TThwefYoiTaU6rFrMZ5TL393a3z3cf3M+yTyd79G0A
+        oGuPCcjX8joWPlQ8/29iCnIywlHSBzeh/yHcIw/mMTrB8uDrW06zPPRCaDbQ/ue117H4/5PXsYh6
+        HYsfeR3/v/Q6Fv+f9joWPurmVzeGnxWvY8mq3CmsnzU6eHQYxNpSooeVbzfu7R88+PTT2WT74WxK
+        k5JPH25P7tOkfJodPJjkD/Lz+9l93278f9XryO+d70x3P/2UrCKNbj+n0PzhbPZwe+88Pzjfe3iw
+        uze9FwDo2mMC8rW8jqUPFc//m5iCnIxwlPTBTeh/CPfIg3mMTrA8+PqW0ywPvRCaDbT/ee11LP//
+        5HUso17H8kdex/8vvY7l/6e9jqWPuvnVjeFnxeuoWJU7hfXDoMMg1vxOFCvfblDof+98urOznZ3v
+        UA7g3jmtPGT7k+1Pd/bvZbv3d++d39/x7cb/V72OvXz3YHr//FMidf4pReX7e9sPp7PZ9t79yfTg
+        /qcH9yYPHwYAuvaYgHwtr6PyoeL5fxNTkJMRjpI+uAn9D+EeeTCP0QmWB1/fcprloRdCs4H2P6+9
+        jur/T15HFfU6qp9PXkfYpoA4L7PyabXIiiU06+v1+Xnxjpp+NN2ZzJeLy9VsXeXvqv3pavqLLn5R
+        cVE2F+PZu7F5czwtq/WM+hqHJPSJ99EimypBAJiEfOfp9r3j7Xu7209Ptu+d+BLy/0v/p9rg/xDL
+        xFnq/wOeUeUPyvzqRvez4hmt2Nw4lvlh0GEQa34nilVg287v7892Zvn2TrY7295/cD/fPtjbmW7f
+        mx3s3f90f+fTh7Mgov7/qmf06f2DnfMsI/N9QAtA+9mn0+2He/f2t89nn07y3cnupwd5YETJwwl9
+        BgLytTyjlQ8Vz/+bmIIcoXCU9MFN6H8I98iDeYxOsDz4+pbTLA+9EJo2tFfP6P7G5v9/9YxW/3/w
+        jKbrhkZzf3fvXjYJnCP/ix/5RzH/qHx7+dPl5Kf31/ffrev5u+W7ul6ez9c7V5NvzD/a235KweWx
+        Lyf/v/SPVv8/9Y9W/qDMr250Pyv+0S9io+NY5odBh0Gs+Z0oVr6F+zT/dHK+c48i/vN8f3v//NN7
+        2+RAzLbPpw+zew939+9P9/d9C/f/Vf9of7b76f4BZY6y3Zz8ox0a7MHO/qfb9+/tnOcPsJiVfxoA
+        6HoOBORr+Ue/yIeK5/9NTEHuUDhK+uAm9D+Ee+TBPEYnWB58fctplodeCE0b2qt/FEyqPF7z/7/6
+        R7/o/2P+EQ9HNbmOLnSDfpb9I0yc4woh54/8IzyD/hGJ+/72w0C8/n/pH/2i/5/6R7/IH5T51Y3u
+        Z8U/qtnoOJb5YdBhEGt+J4pVYOF2pw93Ht7b2f70/N45IbMz255MH9zfvvfwIP80e3Avuz994Fu4
+        /6/6Rw/vTbL9nQcPt3cnE1pZe7B/sJ3t3Lu/vbe3v7tzb7J3Pr23GwDoeg4E5Gv5R7UPFc//m5iC
+        3KFwlPTBTeh/CPfIg3mMTrA8+PqW0ywPvRCaNrRX/+jBxub/f/WP6h/5R91PMOtxYyYPvleuEHL+
+        yD/CM+gf3dv+9P726Z4vJ/+/9I/q/5/6R7U/KPOrG93Pin/UsNFxLPPDoMMg1vxOFCvfwk1nk4MH
+        e/uz7Yez6b3t/cnBw+2DB7S4vHd//16+u797vjf71Ldw/1/1j/b28/u7eZ6T/f50h/JHB3vb2QHl
+        j84//fTBPRr7bHJ/JwDQ9RwIyNfyjzzyyPP/JqYgdygcJX1wE/ofwj3yYB6jEywPvr7lNMtDL4Sm
+        De3VP3q4sfn/X/2j5kf+UfcTzHrcmMmD75UrhJw/8o/wbPCP7j/ZPg5jyv8/+kfN/0/9I+PV4LH8
+        60b3s+IftWx0HMv8MOgwiDW/E8XKt3Cz+/v79/b2J9t7D5FXmU52th/m+/e27x08zD59eH4v29l7
+        6Fu4/+/6Rw9nD3YnB9v57oOMiD6ZbGf39rPth3sPdyf3zvd37+0dBAC6ngMB+Vr+UetDxfP/JqYg
+        dygcJX1wE/ofwj3yYB6jEywPvr7lNMtDL4SmDe3VP9oNvF55vPb/f3WQ2h85SN1PMOtxayYPvleu
+        EHL+yEHCM+gg7W1Tovj+fV9O/n/pILX/P3WQggk3v7rR/aw4SGu2Oo5lfhh0GMSa34li5Zu4nYPZ
+        p2R1Ztt5du9ge3/24N72w/OH97dnkx3KAmT3Dw7Od30T97PiIBFcS13qgoYZtZ/44paW8yNLP3WQ
+        Hux8mk0mB9Pt7MEejTP7NNuezCgKujd9sDM9uLdz/9P9YC2GHJ3QdSAgX8tBWvtQ8fy/iSnIHwpH
+        SR/chP6HcI88mMfoBMuDr285zfLQC6FpQ3vjIAUhrjxe+/+/OkjrHzlI3U8w63FrJg++V64Qcv7I
+        QcIz6CDtb5+c0vz7cvL/Swdp/f9TB2ntD8r86kb3s+IgsdFxHPPDIMMg0vxODCnfwE0PJg/v7exR
+        MHCPlpxoEWp/O5tNp9v5/s69nXsP9z7Nd4IVkv+vukezGRnvg3vn2/v398mQ797f2z6g5Mb2/ene
+        Xr7/MN97eBCGQl3HgYB8LffIB4rn/0UsQb5QOEb64AbkP4R15MEkRmdXHnx9yzmWh14IrRraq2+0
+        v7H5/19do/8/eEZ4A2MJvCLz4c8nj8g18Yf3/0s/ZIMbouyhJp7w/aEP4SZnw8fc/OqG8LPia/yA
+        lbjTVT8MMgxize9EsfJNxv2djP7bz7cPZmSA98+zne1sP6Ol2unB/qc7D/f29ncDk/H/VW9j994k
+        z2lhantnh0a3v59/un1w78He9uzh+Syb7MFMPgwAdC0xAfla3sYPfKh4/t/EFORehKOkD25C/0O4
+        Rx7MY3SC5cHXt5xmeeiF0Gig/c9rh+MH/3/yOH4QdTl+8COf4/+XPscP/j/tdPzAR9386sbwjXod
+        kpKkTlmVO4X1DdNhL0qIQbQ1UxpByzcc2YP9vezTBwfbs53J7vb+g71Ptx8+uPdwe7Z77/zTT/c+
+        PZgc3PcNx/9X3Y772c75QfbpPYrIzz/d3n+4/5Dcjp1Pt88zmoX9nfMsm+QBgK5BJiDv5XZY6vtQ
+        8fy/iivIzQiHSR/chP+HsI88mMjoDMuDr285z/LQC6HhQPv/f/gdm6e3g5E/vf8vdTw2j0e1uf7p
+        jSbwPOynP588j7CNWcWJrf8sr+5V+7vZT+/OLvPzxbye7uxX17vVrPnm1n/2tnf2tp+GcdrX9IGI
+        NQh2SJ4fJsvR6PGz4wRZFtvgBBHPxHnqh+sexYc35B/ZgfmjMr+64f3s+Ec/yCZTNjuOcX4oxBhE
+        3ZEjhppv6Pb2DvKHDx7sbt/79ID8h2xGofbe+YPt6f7ep4TO7P7B7kPf0P1/1U96sD/7NJt+er79
+        8NP7D7dpcPn2ZHc32z7/9N70/mRvd/fB/cCikr8TOhAE5Ov5SZgBHzKe/9dxB7lH4XDpg9uM40NY
+        SR5ManS25cHXt5xzeeiF0OSh/c9znwlT9/8vvwkjivtO+OZH/lPMf5rvlHVezSbvVj+dz/O9++c/
+        XZ2v94t319NvzH+6t/2Q/n3gy8v/T/0nsNn/b30oDM4fmfnVDfFny49iY+TY54dCjkHEfYJ0EfMN
+        3+xhRmmYg9n2/v2MfIv7ZPge7meUOzh/mO/RV3n26dQ3fP9f9aE+zc7v5Q/vU65ptpvTEtf+dHuS
+        U45k5/zh3sNpvv9wsrsXAOg6FQTk6/pQPlw8/y/jDHKXwqHSBzeP4UOYSB5MZ3Se5cHXt5xteeiF
+        0OCh/c977+n/b77TkOf0I78p5jfdb7NftFtc38um5fpdXt4ri3eLWXYxvz//xvym3e0ne9ufHvuS
+        8v9bv+n/x16TPy7zqxvgz5LPxPbHcc4PhRaDeHvU6OLlG7ud/JyWUT492H7w6cOMPImcsjGfPqCl
+        q/2H9+8f5LPd2WTXN3b/X/WYHuye7+ezB/e393KkRGjVaPvhwUG+fb6bz+7Ndsmf2vlZWp37gQ8W
+        z/+7+ILco3Cg9MGNI/gQDpIHcxmdZHnw9S2nWh56IbRzaP/z3V36/5m3NOAs/chXivlK1XT17gf3
+        V+eXs58m839Zlec/2M/282V+8Y35SvvbJ8fbBz8vckz//3WV/GGZX934flY8pT02PI5tfiiUGETb
+        0qKHlm/lDnZmk9new/3tB/dy8h/uZfvbD8+z3e3z84effnpv597ug9k938r9f9VP2jm/v7u/9+DT
+        bWp8j/wkWojPJmTNZ9nug/N7+/uTbOdeAKDrPhCQr+UnBfkqPN8YV3wTXEFOUThM+uAm/D+EfeTB
+        REZnWB58fct5lodeCA0c2v/8dpL2/n/lI+1FXaS9H3lIMQ/pp/cvr+/tLc7f/mC53l28211M373b
+        rZrdH+TfmId0b/v46fZeqDD/f+kh7f3/1UHa80dlfnXD+0b9o0W2JBSWxdSzJT8UIgyifDeKkm/Y
+        ptmDnf3d/ME2ZVGm2/vZfVoseTgjxKZ7Wf5gdz8///Shb9g2+0WEXNTe4YtbWrqP7LDVo5k8yKfZ
+        wwf3tndnu1jOIbfmYOf+dPv+vYPswWxnb+/Bw4cBgK6pJyDv5dHs+tDw/L9mDslpCYdGHwzh/CGT
+        LA8mLTqb8uDrW86pPPRCaHzQ/pv3XmiWiIbUpocxffmNzeTl4vef1jmh9/uTpmmrxe9frH7/+mLj
+        zKqK0j8JRH1+uQgMPn/yI2MfM/Y/WPyi2fxtXWTNu3U5vfzp3Xvz7Kfz6qfffXPpkHvbO0+2j098
+        lrqlsSdCxyfi/80WEq+Qgdyd+nQyvzqC/exYSM+l+qEQYRBlp119lHzl+el07/7Dnf2d7d0839ne
+        f7Cfbx9k+5PtB7t7+XR/cjDLp/d95fnDt5Cz83v3ZrP9e9vn+T4Fp9OD8+2MUN6eHuxPdqfn9yfZ
+        7je7NtK3NoLI3Z/zOSSDGA6NPhjC+UMmWR5MWnQ25cHXt5xTeeiFUGOjvVrITzc2/5GFdGrHPSBQ
+        XDHLg++VgELvH1lIPKSmBy3kyfazpz5LvbeF7H2lk652iVqENPvG+HGDZvl/lYnUPgvOWzpS/1AI
+        MYg2vxRFy9eiFJDtZ/f2ZmR+dmgpmdaVtx/u7hxQ8vnT2cP9g08PHuzt+Fp0s6kkwOA/SyL66P8t
+        SfZ7D3ezvQlFUTtka/fv7+5sH9w/p3T77N79+/ceTvZ3KO/gA+haJQLyXgbXUt+Hiuf/VVxBtjYc
+        Jn1wE/4fwj7yYCKjMywPvr7lPMtDL4RGAe3VCP9/LkwF4W+YVVV6+qe8wnMVGF776Y+Mb8z4/qK9
+        eXPvfvuL6vW99eXkF93bX+/Wy3p/92LyjRnfne17u9sP/3+8Wo8XmcX+/5aLxis8MH9U5lc3vJ8V
+        N+KnWTM7pvmhEGIQbX4pipZvBz49mGaz2cN8e+deRvFsPplsTx5MJ9u7k08fzCgbPJue7/p24P+r
+        bsRscv4w288OiOoP9sh52CP5fphT5Pnpwb3J7sH9e5OJRyIC0LWvBOQWbgTeC83wT/tQ8fy/iivI
+        awiG2Xcj+vh/CPvIg4mMzrA8+PqW8ywPvRCaN7T/5t2Izso4Ne6hTq1+mNPbwcif3v9frNXjFR5N
+        1D/66R/5RzH/aFntFW/3ftEk23m3fpdf3Z9fXp4X1dud+Te3Vr+3/en+9sMnvoz8/9M/+un/v/pH
+        P+2PyvzqhveN+0dNs/tpTlljxzLfMBma5j3o8HqalTlJp3mXcOu0aO7u9EfqWocj8S3i9Pzhp9mn
+        2fn2/YezB9uE7r3tbOf+3vb0/sPsweT+/d3dh8H6L7FR3Bbii1tawY8sQdTb+XT/wcHBZGd3O5sc
+        kLdzvvcpJU1mZJbP9x/uP9x98GByHuToyWsJ3QACcitvxxLEuA0+VDz/X59l8odCyrhvB4f8Iewg
+        D+Y+yhTy4OtbsoY89EJo39D+m3eQaJKJmtSmhzF9+UNhBKOkdJr1T/MOTVrPkeBPf3iORP+Nsspm
+        T7IyW07z+kk2fZsvZ/ruy6oqMVOBJMoTITCB+qGS2MfbvEGkLCd3J/1RuO8n+Yo+6JGaiN39KHR5
+        8AS0OltOqvVy9iJrX61LlpP/r9GpCEfgvltmLYg03rkVmcIPgu+9P3xqiv/5c+Gbzqbrd9ftdbV3
+        dU18sMqnu+fLa+pxkn1jvun+9snx9snX8U1JduOy/cN16Ab46QNsnE9C86v+YkhqB9Q37WQFHTH/
+        3z7W3RvsuTcS30wf7OUHDx5+SgtMn05oOeT+pzvbk+mnu9sHBzsHB9P75w/OD4I8BvEKcW/EQOOL
+        W5rmjyxB1Gub3s8Odu7v7NFS1y4hcX7//vZkcjChHNXu7Hx6b7r7cDcwID9/vbabZvlDvbb3ZQd5
+        MPdRppAHX9+SNeShF0JnAu3Va7u/sfmPvLbgAWXiml0efK+UE0L/yGvjUbjvf+S10RtEB6LTjV7b
+        7q3IFH4QfO/94VNTPLP//3ptB9tPT31J+3nutflsZDlCfzEktQPqmfaCrKAj5v+7xlp0WtBYN9jz
+        zkh8M53fu7+/PyU3abr/YEarT3sPtg9mn+bbe9mns4Pd/P7Ow2zmm2niFeLeiIHGF7c0zR9ZgqjX
+        lt17kBMan27PDjLK8Oyf729nB+dw3XYfZLv37t0/+HQnAND1TQhIoAM9vPD0p3bQhRGE7v5/dZaH
+        vbbhIX8IO8iDuY8yhTz4+pasIQ+9EDoTaP/z0Wsrol5b8SOv7f1J7ONt3iBSkjeyyWsr3t9ro5Hp
+        E9Dq/9teG+g05LUV///12pY/Pbl6+4t+en3Zvs13f7rcXf3g3vRtub4sp9+Y17a7fe/e9oNA0n5e
+        eW0RG+eT0PyqvxiS2gH1TTtZQUfM/7ePde8Ge+6NxDfTs4cP7n96cJ+yKdOdh9v7Dz8lM72LhNen
+        +XSPkl4700+nvpkmXokbaHxxS9P8kSWIem17Dyb72fnObDufzXYp1zaZbR+c38u2pzuf7u1/uk//
+        ZJMAQNc3ISCBDvTwwtOf2kEXRhC6+//VWf5Qr+192UEezH2UKeTB17dkDXnohdCZQHv12j7d2PxH
+        XlvwgDJxzS4PvlfKCaF/5LXxKNz3P/La6A2iA9HpRq9t71ZkCj8Ivvf+8Kkpntn/b722/fvbT+/5
+        kvbz3Gvz2chyhP5iSGoH1DPtP01W0BHz/11j/elOC1oN3mDPOyPxzTSthN0/mDxEhmv33vb+ZLZH
+        65KT+9uf7t2/fx9Zl917576ZJl6JG2h8cUvT/JEliHptn+5M72X7u9Pt+7M94uIZYfLwwYPJ9sPJ
+        3s7uzsPdg/v3DgIAXd+EgAQ60MMLT39qB10YQeju/1dnedhrGx7yh7CDPJj7KFPIg69vyRry0Auh
+        M4H26rXFPAnX/P9nXttPR722n/6R1/b+JPbxNm8QKckb2eS1/fSPvDZ6g+hAdBry2n7aeG07tyJT
+        +EHwvfeHT03xzH4uvLbrdbX7i3beXe9evMvr/Kos311enl9U1duLb9BrI5P35MSXtJ9XXlvExvkk
+        NL/qL4akdkB9005W0BHz/+1j3bR21hmJb6bPP92Z3JvNHmzf33uwQ8mVvYPtgwf7+fbk4b372YPd
+        ew/27+34Zpp4JW6g8cUtTfNHliDqte3Mds8nu5TX2Xv4gPI6O9m97YOMFkx3H+4/OJjcv/fpdGcv
+        AND1TQhIoAM9vPD0p3bQhRGE7v5/dZY/1Gt7X3aQB3MfZQp58PUtWUMeeiF0JtBevbafVyukP/La
+        vjES+3ibN4iU5I38yGu7HZ1u9Nr8pS3z9MkUfhB87/3hU1M8s/9veG2+VPryuMFru7e3vXPqS9r/
+        m722W/PTB9g4n4TmV/3FkNQKSte072ZkBR0xv3HZ2fuQwe5mnRY02GGD3h2Kb6fv39s5mD6YZtsP
+        p5Ts2p8e0JrYw53z7YPZ3s69aTbdmR186ttpUvRxC40vbmmbP7IUUbdtcn4we7A3/XT73oPzve39
+        ew8ebh/ce3Bv+/zgfpblD7IJOREBgK5zQkACJejhhac/t4M+jCB09/+z0zzot20Y84fwgzyY/ChX
+        yIOvb8kb8tALoTuB9v8f99vinGCspc6z/mleolmLOW672Y8ct69BYx9x8wrRkjySDZ7bbvb/R8/t
+        6xJqwHUj1fP/W9etXZ9frS5W78qd+/lPF+V6/tPV4mL2g6sm+8YSbjvbD063T8L1pP+PJdziDPUB
+        ds6noflVfzE0tSPq23eyhI6a/68f7N4NRt0bim+rP70/26cUy8H27v4e2eoHu7uUXjm/tz2dPDjY
+        fbi7f/7g08BWE7fErTS+uKV9/shSRH233U93891Zfn97b7JzQMv99wmJ7N7+9qf39rMHs/PpvU/3
+        v9GU2wY/RhC6+//Zaf5Q3+19+UEeTH6UK+TB17fkDXnohdCjQHv13T7d2PxHvhv98B6QJq7d5cH3
+        Sjqh9I98NxmG+/5HvhteIUIQoW703fZuRafwg+B77w+fnOKf/f/Wd3tCmbd7vqz9fPfdfD6yLKG/
+        GJraEXn2fdlcXC72Dg48K/HNjZWA1xfRgRrJocnHz8A401s9lHyT+3Av3783ncy2d8/P79My18H9
+        7cnsAXk/uw/Opw8mWT47OPdNLukUMXEAcJU37brxviTsopYYX9zSBn9kh63+Wb5z8Ck1ooTOp5N7
+        cAruEYYg2AGht3Mvn0x3AvP6tf0z46Ls+tDw/L9mDvv+1TDOHzLJ8mDSorMpD76+5ZzKQy+E1h7t
+        ya/aJb8qZupd8/fyq1brSVlM6S3bSQ91avVDnNIOQt6UempGHqNc3PMRYUg8Qcj+HI/iUnSk/mne
+        oJ4Ju+buLD/P1qVve+SJDIimNW415MH3Ou1Cr65PGL6gWlke7w/fxoqJ/rkw3z99ubv7dtZM5u27
+        /PKnry9nO5M82/3BZZF/Y+Z7d/vJg+37X8d8U2eYytf5dF0X7TVzArULyfND5LAYPlFZCehC7BJn
+        px+aE0L4DYws7oHEx2R+dYP7qL1eAe2PHMAOqZyVUEjmZTtSa9yy2QtfW35zo6+r6929ey15AlES
+        DGJ8t4uRb7Dye9TfvUm+/WD66TkhktF62s7Dyfann2YHe/d2Jw/vTSa+wfrheyWz8/PJw4N9IlV+
+        P6dlpvuT7WxycL49uX9/Mpkd3M93zrMAQNd0E5D/t3glHzaF5IOEI6MPhlD+kDmWB3MWnUx58PUt
+        p1QeeiE0N2hPTgn+2+yURJwSdOjztHk+ojki6lGTHsL05Q97Hi9FG+mfmMUgzZPNfpTf+Vp09VEH
+        GZ97f0eTPM+fPDntUZno3P0odDjwBGT6f0Nm55sgUTe9k81ePX15K/qEHwTfe3/4ZBS37+fCJZwu
+        Vm935vPJbL6T17NlXVbt7u5stjObfGMu4R68wmdPfem6pUtI8hqX5x+aM3UDIw15VKTDvvDJZH51
+        9PpGvSla6/CM2zc3eoz799+NjnwQ2bsdZHwbu3P/3iy7nz3YnuWf7m3v797PtunPe9sHD/P7D/N8
+        +unu7j3fxpJeEZsGAD0/igCD0yw56KNZ0azK7BosTt9QCuzF2YlSz9GP2tGIolYbX9zSXn9kaaUu
+        2IODven9A1qzm03Jbdg/n5ID8SktHt07uLe3R1mhB3uffjMLd8P+jCBy9+dw4snZCgdFHwxh+yGc
+        IQ+mKzqP8uDrW86mPPRC6CCg/df1voZTQjQ/RD1q08OYvvxm5zCeijZzqGpL/2zuXhJae3epa/rZ
+        3BW/a9fKj3mcHJkHhIgrannwvRJK6Np1vMIXrLrE4/3hmzWxij8XFrO9VxTV3g+u8sUvWi/z/P5s
+        Ul+11bJs399iDltB08g1/zoGAz/IG/kl/w+vVJ79HOwBAA==
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 01 Jul 2016 03:09:55 GMT']
+      date: ['Thu, 07 Jul 2016 20:06:08 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]


### PR DESCRIPTION
For VM Create, if no storage account is specified, choose the first account in the current resource group that matches the disk type (same as portal).  For VNet, if no vnet is specified, choose the first vnet and its first subnet (not the same a portal).  Future potential work: follow portal's vnet choosing algorithm (loop over all vnets and subnets in the current resource group until one with available address space is found)
