### PR TITLE
Fix CI warnings for package_verify step

### DIFF
--- a/scripts/command_modules/package_verify.py
+++ b/scripts/command_modules/package_verify.py
@@ -13,9 +13,6 @@ import imp
 import subprocess
 from _common import get_all_command_modules, exec_command, print_summary, COMMAND_MODULE_PREFIX
 
-LIBS_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..', '..', '..', 'libs'))
-INCLUDE_LOCAL_LIBS = os.environ.get('AZURE_CLI_INCLUDE_LOCAL_LIBS')
-
 def print_heading(heading, file=None):
     print('=' * len(heading), file=file)
     print(heading + '\n', file=file)
@@ -60,7 +57,6 @@ print_heading('Built command package(s).')
 print_heading('Installing CLI package...')
 cli_package_dir = os.path.join(PATH_TO_CLI_PACKAGE, 'dist')
 cmd = 'python -m pip install azure-cli --find-links file://{}'.format(cli_package_dir)
-cmd += ' --find-links file://{}'.format(LIBS_DIR) if INCLUDE_LOCAL_LIBS else ''
 success = exec_command(cmd)
 if not success:
     print_heading('Error installing CLI!', file=sys.stderr)
@@ -72,7 +68,6 @@ failed_module_names = []
 for name, fullpath in all_command_modules:
     package_dir = os.path.join(fullpath, 'dist')
     cmd = 'python -m pip install {} --find-links file://{}'.format(name, package_dir)
-    cmd += ' --find-links file://{}'.format(LIBS_DIR) if INCLUDE_LOCAL_LIBS else ''
     success = exec_command(cmd)
     if not success:
         failed_module_names.append(name)

--- a/scripts/package_verify.sh
+++ b/scripts/package_verify.sh
@@ -3,7 +3,6 @@ set -e
 export PYTHONPATH=
 virtualenv package-verify-env
 export AZURE_CLI_DISABLE_POST_INSTALL=1
-export AZURE_CLI_INCLUDE_LOCAL_LIBS=1
 . package-verify-env/bin/activate
 python scripts/command_modules/package_verify.py
 deactivate


### PR DESCRIPTION
The libs folder no longer exists (it used to have local adal package)
So we no longer need to include this as a location to find packages as it doesn't exist!

This fixes the following warning that would appear in CI.
"Url 'file:///home/travis/build/Azure/azure-cli/libs' is ignored: it is neither a file nor a directory."
