### PR TITLE
add sphinx extension to support markups: cligroup and clicommand

### DIFF
--- a/doc/sphinx/cligroup/__init__.py
+++ b/doc/sphinx/cligroup/__init__.py
@@ -1,0 +1,2 @@
+import pkg_resources
+pkg_resources.declare_namespace(__name__)

--- a/doc/sphinx/cligroup/cligroup.py
+++ b/doc/sphinx/cligroup/cligroup.py
@@ -1,0 +1,51 @@
+from docutils import nodes
+from sphinx import addnodes
+from sphinx.directives import ObjectDescription
+from sphinx.util.compat import Directive
+from sphinx.util.docfields import Field
+
+cli_field_types = [
+        Field('summary', label='Summary', has_arg=False,
+                   names=('summary', 'shortdesc')),
+        Field('description', label='Description', has_arg=False,
+                   names=('description', 'desc', 'longdesc'))
+    ]
+
+class CliBaseDirective(ObjectDescription):
+    def handle_signature(self, sig, signode):
+        signode += addnodes.desc_addname(sig, sig)
+        return sig
+
+    def needs_arglist(self):
+        return False
+
+    def add_target_and_index(self, name, sig, signode):
+        signode['ids'].append(name)
+
+    def get_index_text(self, modname, name):
+        return name
+
+class CliGroupDirective(CliBaseDirective):
+    doc_field_types = cli_field_types
+
+class CliCommandDirective(CliBaseDirective):
+    doc_field_types = cli_field_types
+
+class CliArgumentDirective(CliBaseDirective):
+    doc_field_types = [
+        Field('summary', label='Summary', has_arg=False,
+                   names=('summary', 'shortdesc')),
+        Field('description', label='Description', has_arg=False,
+                   names=('description', 'desc', 'longdesc')),
+        Field('values', label='Values from:',  has_arg=False,
+                   names=('values', 'source',))
+    ]
+
+class CliExampleDirective(CliBaseDirective):
+    pass
+
+def setup(app):
+    app.add_directive('cligroup', CliGroupDirective)
+    app.add_directive('clicommand', CliCommandDirective)
+    app.add_directive('cliarg', CliArgumentDirective)
+    app.add_directive('cliexample', CliExampleDirective)

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -23,7 +23,8 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.getcwd(), os.path.sep, 'azhelpgen')))
+#sys.path.insert(0, os.path.abspath(os.path.join(os.getcwd(), os.path.sep, 'azhelpgen')))
+sys.path.insert(0, os.getcwd())
 
 # -- General configuration ------------------------------------------------
 
@@ -40,6 +41,7 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
     'sphinx.ext.autodoc',
+    'cligroup.cligroup',
     'azhelpgen.azhelpgen'
 ]
 


### PR DESCRIPTION
The cligroup and clicommand will be used as follow:

.. cligroup:: az account
   
   :summary: summary
   :description: description

.. clicommand:: az account create

   :summary: summary
   :description: description

   .. cliarg:: --name -n
      
     :summary: summary
     :description: description
     :values: values from

   .. cliexample:: the example to create account
      
      az account create -n erich
 
   