### PR TITLE
RBAC: role assignment creation

### DIFF
--- a/azure-cli.pyproj
+++ b/azure-cli.pyproj
@@ -15,8 +15,7 @@
     <InterpreterId>{54f4b6dc-0859-46dc-99bb-b275c9d0aca3}</InterpreterId>
     <InterpreterVersion>3.5</InterpreterVersion>
     <EnableNativeCodeDebugging>False</EnableNativeCodeDebugging>
-    <CommandLineArguments>
-    </CommandLineArguments>
+    <CommandLineArguments></CommandLineArguments>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'" />
   <PropertyGroup Condition="'$(Configuration)' == 'Release'" />
@@ -147,6 +146,7 @@
     <Compile Include="command_modules\azure-cli-resource\azure\cli\command_modules\resource\_factory.py">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="command_modules\azure-cli-role\azure\cli\command_modules\role\custom.py" />
     <Compile Include="command_modules\azure-cli-storage\azure\cli\command_modules\storage\_command_type.py" />
     <Compile Include="command_modules\azure-cli-storage\azure\cli\command_modules\storage\_factory.py" />
     <Compile Include="command_modules\azure-cli-vm\azure\cli\command_modules\vm\mgmt_acs\lib\acs_creation_client.py" />

--- a/src/azure/cli/commands/client_factory.py
+++ b/src/azure/cli/commands/client_factory.py
@@ -18,15 +18,7 @@ def get_mgmt_service_client(client_type):
 def get_subscription_service_client(client_type):
     return _get_mgmt_service_client(client_type, False)
 
-def _get_mgmt_service_client(client_type, subscription_bound=True):
-    logger.info('Getting management service client client_type=%s', client_type.__name__)
-    profile = Profile()
-    cred, subscription_id, _ = profile.get_login_credentials()
-    if subscription_bound:
-        client = client_type(cred, subscription_id)
-    else:
-        client = client_type(cred)
-
+def configure_common_settings(client):
     _debug.allow_debug_connection(client)
 
     client.config.add_user_agent("AZURECLI/{}".format(cli.__version__))
@@ -43,8 +35,18 @@ def _get_mgmt_service_client(client_type, subscription_bound=True):
     client.config.generate_client_request_id = \
         'x-ms-client-request-id' not in APPLICATION.session['headers']
 
-    return (client, subscription_id)
+def _get_mgmt_service_client(client_type, subscription_bound=True):
+    logger.info('Getting management service client client_type=%s', client_type.__name__)
+    profile = Profile()
+    cred, subscription_id, _ = profile.get_login_credentials()
+    if subscription_bound:
+        client = client_type(cred, subscription_id)
+    else:
+        client = client_type(cred)
 
+    configure_common_settings(client)
+
+    return (client, subscription_id)
 
 def get_data_service_client(service_type, account_name, account_key, connection_string=None,
                             sas_token=None):

--- a/src/azure/cli/utils/vcr_test_base.py
+++ b/src/azure/cli/utils/vcr_test_base.py
@@ -30,6 +30,7 @@ from azure.cli._util import CLIError
 TRACK_COMMANDS = os.environ.get('AZURE_CLI_TEST_TRACK_COMMANDS')
 COMMAND_COVERAGE_FILENAME = 'command_coverage.txt'
 MOCKED_SUBSCRIPTION_ID = '00000000-0000-0000-0000-000000000000'
+MOCKED_TENANT_ID = '00000000-0000-0000-0000-000000000000'
 # MOCK METHODS
 
 def _mock_get_mgmt_service_client(client_type, subscription_bound=True):
@@ -62,7 +63,7 @@ def _mock_subscriptions(self): #pylint: disable=unused-argument
             },
         "state": "Enabled",
         "name": "Example",
-        "tenantId": "123",
+        "tenantId": MOCKED_TENANT_ID,
         "isDefault": True}]
 
 def _mock_user_access_token(_, _1, _2, _3): #pylint: disable=unused-argument
@@ -198,6 +199,8 @@ class VCRTestBase(unittest.TestCase):#pylint: disable=too-many-instance-attribut
         # scrub subscription from the uri
         request.uri = re.sub('/subscriptions/([^/]+)/',
                              '/subscriptions/{}/'.format(MOCKED_SUBSCRIPTION_ID), request.uri)
+        request.uri = re.sub('/graph.windows.net/([^/]+)/',
+                             '/graph.windows.net/{}/'.format(MOCKED_TENANT_ID), request.uri)
         request.uri = re.sub('/sig=([^/]+)&', '/sig=0000&', request.uri)
         request.uri = _scrub_deployment_name(request.uri)
         # prevents URI mismatch between Python 2 and 3 if request URI has extra / chars

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
@@ -156,7 +156,7 @@ def _build_output_content(sp_name, sp_object_id, secret, tenant):
     logger.warning("Service principal has been configured with name: '%s', secret: '%s'",
                    sp_name, secret)
     logger.warning('Useful commands to manage azure:')
-    logger.warning('  Assign a role: "az role assignment create --object-id %s --role Contributor"',
+    logger.warning('  Assign a role: "az role assignment create --assignee %s --role Contributor"',
                    sp_object_id)
     logger.warning('  Log in: "az login --service-principal -u %s -p %s --tenant %s"',
                    sp_name, secret, tenant)

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
@@ -1,15 +1,23 @@
-#---------------------------------------------------------------------------------------------
+﻿#---------------------------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 #---------------------------------------------------------------------------------------------
 
-from azure.mgmt.authorization import AuthorizationManagementClient
-
 import azure.cli.commands.parameters #pylint: disable=unused-import
 
-from azure.cli.commands.client_factory import get_mgmt_service_client
+from azure.cli.commands import register_cli_argument
 
-# FACTORIES
-
-def _auth_client_factory(**_):
-    return get_mgmt_service_client(AuthorizationManagementClient)
+register_cli_argument('ad app', 'application_object_id', options_list=('--object-id',))
+register_cli_argument('ad app', 'app_id', help='application id')
+register_cli_argument('ad', 'display_name', help='object\'s display name or its prefix')
+register_cli_argument('ad', 'identifier_uri',
+                      help='graph application identifier, must be in uri format')
+register_cli_argument('ad', 'spn', help='service principal name')
+register_cli_argument('ad', 'upn', help='user principal name, e.g. john.doe@contoso.com')
+register_cli_argument('ad', 'query_filter', options_list=('--filter',), help='OData filter')
+register_cli_argument('role assignment', 'role_assignment_name',
+                      options_list=('--role-assignment-name', '-n'))
+register_cli_argument('role assignment', 'role', help='role name or id')
+register_cli_argument('ad user', 'mail_nickname',
+                      help='mail alias. Defaults to user principal name')
+register_cli_argument('ad user', 'force_change_password_next_login', action='store_true')

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
@@ -1,30 +1,144 @@
-#---------------------------------------------------------------------------------------------
+﻿#---------------------------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 #---------------------------------------------------------------------------------------------
 
 import uuid
-import re
 
 from azure.cli._util import CLIError
+from azure.cli.commands.client_factory import get_mgmt_service_client, configure_common_settings
+from azure.mgmt.authorization import AuthorizationManagementClient
+from azure.graphrbac import GraphRbacManagementClient
 from azure.mgmt.authorization.models import RoleAssignmentProperties
-from ._params import _auth_client_factory
+from azure.graphrbac.models import UserCreateParameters, PasswordProfile
 
-#TODO: expand the support to be in parity with node cli
-def create_role_assignment(role, object_id, scope=None):
+def _auth_client_factory(**_):
+    return get_mgmt_service_client(AuthorizationManagementClient)
+
+def _graph_client_factory(**_):
+    from azure.cli._profile import Profile
+    profile = Profile()
+    cred, _, tenant_id = profile.get_login_credentials(True)
+    client = GraphRbacManagementClient(cred, tenant_id)
+    configure_common_settings(client)
+    return client
+
+def create_role_assignment(role, assignee, resource_group_name=None, resource_id=None):
+    '''
+    :param assignee: represent a user, group, or service principal.
+    supported format: object id, user sign-in name, or service principal name
+    :param resource_id: resource id
+    '''
     assignments_client = _auth_client_factory().role_assignments
     definitions_client = _auth_client_factory().role_definitions
-    role_id = role
-    scope = scope or '/subscriptions/' + definitions_client.config.subscription_id
-    if not re.match(r'[0-9a-f]{32}\Z', role, re.I): #retrieve role id
+
+    if resource_id:
+        if resource_group_name:
+            err = 'Resource group "{}" is redundant because resource id is supplied'
+            raise CLIError(err.format(resource_group_name))
+        scope = resource_id
+    else:
+        scope = '/subscriptions/' + definitions_client.config.subscription_id
+        if resource_group_name:
+            scope = scope + '/resourceGroups/' + resource_group_name
+
+    role_id = None
+    try:
+        uuid.UUID(role)
+        role_id = role
+    except ValueError:
+        pass
+
+    if not role_id: #retrieve role id
         role_defs = list(definitions_client.list(scope, "roleName eq '{}'".format(role)))
         if not role_defs:
-            raise CLIError('Role {} doesn\'t exist.'.format(role))
+            raise CLIError("Role '{}' doesn't exist.".format(role))
         elif len(role_defs) > 1:
-            raise CLIError('More than one roles match the given name {}'.format(role))
+            ids = [r.id for r in role_defs]
+            err = ("More than one role matches the given name '{}'. "
+                   "Set 'role' to one of the unique ids from {}'")
+            raise CLIError(err.format(role, ids))
         role_id = role_defs[0].id
 
+    object_id = _get_object_id(assignee)
     properties = RoleAssignmentProperties(role_id, object_id)
     assignment_name = uuid.uuid4()
     return assignments_client.create(scope, assignment_name, properties)
 
+def list_apps(client, app_id=None, display_name=None, identifier_uri=None, query_filter=None):
+    sub_filters = []
+    if query_filter:
+        sub_filters.append(query_filter)
+    if app_id:
+        sub_filters.append("appId eq '{}'".format(app_id))
+    if display_name:
+        sub_filters.append("startswith(displayName,'{}')".format(display_name))
+    if identifier_uri:
+        sub_filters.append("identifierUris/any(s:s eq '{}')".format(identifier_uri))
+
+    return client.list(filter=(' and '.join(sub_filters)))
+
+def list_sps(client, spn=None, display_name=None, query_filter=None):
+    sub_filters = []
+    if query_filter:
+        sub_filters.append(query_filter)
+    if spn:
+        sub_filters.append("servicePrincipalNames/any(c:c eq '{}')".format(spn))
+    if display_name:
+        sub_filters.append("startswith(displayName,'{}')".format(display_name))
+
+    return client.list(filter=(' and '.join(sub_filters)))
+
+def list_users(client, upn=None, display_name=None, query_filter=None):
+    sub_filters = []
+    if query_filter:
+        sub_filters.append(query_filter)
+    if upn:
+        sub_filters.append("userPrincipalName eq '{}'".format(upn))
+    if display_name:
+        sub_filters.append("startswith(displayName,'{}')".format(display_name))
+
+    return client.list(filter=(' and ').join(sub_filters))
+
+def create_user(client, user_principal_name, display_name, password, mail_nickname=None, #pylint: disable=too-many-arguments
+                immutable_id=None, force_change_password_next_login=False):
+    '''
+    :param mail_nickname: mail alias. default to user principal name
+    '''
+    mail_nickname = mail_nickname or user_principal_name.split('@')[0]
+    param = UserCreateParameters(user_principal_name=user_principal_name, account_enabled=True,
+                                 display_name=display_name, mail_nickname=mail_nickname,
+                                 immutable_id=immutable_id,
+                                 password_profile=PasswordProfile(
+                                     password, force_change_password_next_login))
+    return client.create(param)
+
+create_user.__doc__ = UserCreateParameters.__doc__
+
+def list_groups(client, display_name=None, query_filter=None):
+    sub_filters = []
+    if query_filter:
+        sub_filters.append(query_filter)
+    if display_name:
+        sub_filters.append("startswith(displayName,'{}')".format(display_name))
+
+    return client.list(filter=(' and ').join(sub_filters))
+
+def _get_object_id(assignee):
+    client = _graph_client_factory()
+    result = None
+    if assignee.find('@') >= 0: #looks like a user principal name
+        result = list(client.users.list(filter="userPrincipalName eq '{}'".format(assignee)))
+    if not result:
+        result = list(client.service_principals.list(
+            filter="servicePrincipalNames/any(c:c eq '{}')".format(assignee)))
+    if not result: #assume an object id, let us verify it
+        from azure.graphrbac.models import GetObjectsParameters
+        result = list(client.objects.get_objects_by_object_ids(
+            GetObjectsParameters(include_directory_object_references=True, object_ids=[assignee])))
+
+    #2+ matches should never happen, so we only check 'no match' here
+    if not result:
+        raise CLIError("No matches in graph database for '{}'".format(assignee))
+
+    return result[0].object_id

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/generated.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/generated.py
@@ -7,11 +7,12 @@
 from __future__ import print_function
 
 from azure.mgmt.authorization.operations import RoleAssignmentsOperations, RoleDefinitionsOperations
-
+from azure.graphrbac.operations import (ApplicationsOperations, ServicePrincipalsOperations,
+                                        UsersOperations, GroupsOperations)
 from azure.cli.commands import cli_command
 
-from ._params import _auth_client_factory
-from .custom import create_role_assignment
+from .custom import (create_role_assignment, list_sps, list_users, create_user, list_groups, list_apps,
+                     _auth_client_factory, _graph_client_factory)
 
 factory = lambda _: _auth_client_factory().role_definitions
 cli_command('role list', RoleDefinitionsOperations.list, factory)
@@ -29,3 +30,27 @@ cli_command('role assignment list-for-resource', RoleAssignmentsOperations.list_
 cli_command('role assignment list-for-resource-group', RoleAssignmentsOperations.list_for_resource_group, factory)
 cli_command('role assignment list-for-scope', RoleAssignmentsOperations.list_for_scope, factory)
 cli_command('role assignment create', create_role_assignment)
+
+factory = lambda _: _graph_client_factory().applications
+cli_command('ad app delete', ApplicationsOperations.delete, factory)
+cli_command('ad app show', ApplicationsOperations.get, factory)
+cli_command('ad app list', list_apps, factory)
+
+factory = lambda _: _graph_client_factory().service_principals
+cli_command('ad sp delete', ServicePrincipalsOperations.delete, factory)
+cli_command('ad sp show', ServicePrincipalsOperations.get, factory)
+#paging is broken at SDK https://github.com/Azure/azure-cli/issues/540
+cli_command('ad sp list', list_sps, factory)
+
+factory = lambda _: _graph_client_factory().users
+cli_command('ad user delete', UsersOperations.delete, factory)
+cli_command('ad user show', UsersOperations.get, factory)
+#paging is broken at SDK https://github.com/Azure/azure-cli/issues/540
+cli_command('ad user list', list_users, factory)
+cli_command('ad user create', create_user, factory)
+
+factory = lambda _: _graph_client_factory().groups
+cli_command('ad group delete', GroupsOperations.delete, factory)
+cli_command('ad group show', GroupsOperations.get, factory)
+#paging is broken at SDK https://github.com/Azure/azure-cli/issues/540
+cli_command('ad group list', list_groups, factory)

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/recordings/test_role_assignment_scenario.yaml
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/recordings/test_role_assignment_scenario.yaml
@@ -1,63 +1,200 @@
 interactions:
 - request:
+    body: !!binary |
+      eyJwcm9wZXJ0aWVzIjogeyJ0ZW1wbGF0ZUxpbmsiOiB7InVyaSI6ICJodHRwczovL2F6dXJlc2Rr
+      Y2kuYmxvYi5jb3JlLndpbmRvd3MubmV0L3RlbXBsYXRlaG9zdC9DcmVhdGVOc2dfMjAxNi0wNy0x
+      OC9henVyZWRlcGxveS5qc29uIn0sICJwYXJhbWV0ZXJzIjogeyJuYW1lIjogeyJ2YWx1ZSI6ICJu
+      c2cxIn19LCAibW9kZSI6ICJJbmNyZW1lbnRhbCJ9fQ==
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY5NTU0MDQ1LCJuYmYiOjE0Njk1NTQwNDUsImV4cCI6MTQ2OTU1Nzk0NSwiYWNyIjoiMSIsImFsdHNlY2lkIjoiNTo6MTAwMzAwMDA4MDFDNDREMyIsImFtciI6WyJwd2QiLCJtZmEiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlbWFpbCI6Inl1Z2FuZ3dAbWljcm9zb2Z0LmNvbSIsImZhbWlseV9uYW1lIjoiV2FuZyIsImdpdmVuX25hbWUiOiJZdWdhbmciLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2Il0sImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0Ny8iLCJpbl9jb3JwIjoidHJ1ZSIsImlwYWRkciI6IjE2Ny4yMjAuMS4xMzAiLCJuYW1lIjoiWXVnYW5nIFdhbmciLCJvaWQiOiI4OWVkNWJlOC1mZjk3LTQxYjUtYWIxMS0wNTVlMWUzY2MzNGIiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODk1NSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IjJEWG5PTmM1RUFyNmFfM1Vya1JSYlFBdkdueHpxQWEtSExWczFyV3dndEkiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6Inl1Z2FuZ3dAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.fy4o2raFkNg7_jFMh7YDRNQuHLdZG2AKcxLdS0PbRgeWd52NIzQEYH-sCbNHsh5kecyVwxBJnqLLYs-FYjGic29jFK0jEeuZl55VKIB3kYaF2U2XXNcag2dfBTIHe9uyGRK5drmrpFT1g5bBA9qZQA_Gq0SoUp0yilVOIPNAg7wfi9fPIoEUzC2qoIxv0yxmZQTqHOi0WNTygVU2GrZqwLKdEegjc-t9eH3tECSBS2-HzBBfxWmYlzEP9CPxlcO-hrtbn9B-Wa97AStVWVSQS-TnMoRLETVVpWXkxiPBqdisyTzQ9rY2nHpr6e54trtul1wFIq26-1HQmp5NBi4Hag]
+      Connection: [keep-alive]
+      Content-Length: ['202']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.0 msrest_azure/0.4.1
+          nsgcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [570769e4-535a-11e6-9b0d-64510658e3b3]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli-role-assignment-test/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+  response:
+    body: {string: '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-role-assignment-test/providers/Microsoft.Resources/deployments/azurecli1469555815.358453338007","name":"azurecli1469555815.358453338007","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateNsg_2016-07-18/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"nsg1"},"tags":{"type":"Object","value":{}}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-07-26T17:56:56.8809533Z","duration":"PT0.5530993S","correlationId":"642292d5-4215-4f6b-b890-6331ec070465","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[]}}'}
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli-role-assignment-test/providers/Microsoft.Resources/deployments/azurecli1469555815.358453338007/operationStatuses/08587320510691497682?api-version=2015-11-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['835']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 26 Jul 2016 17:56:56 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY1NTcxNDYzLCJuYmYiOjE0NjU1NzE0NjMsImV4cCI6MTQ2NTU3NTM2MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2Il0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.fZ7oSJMxpVQE8-0USIDYNmgQHzQO-vl2r9-M2h0mU67VapcCJ2xNTBQ8FU4wkj2zdd2coKEZJpL6dKBNvyELWIKYdxxPjVl7I5DRl6mJNWMKgsxfRghxsCZnudDFxh6ZrpaY7G3vCyc8hU7FY_xh0SSnVFroay4EUv7cmMh6THQDfM6WZ6JukkTZqdBydU-s0Nf0fHQdvplUCpjHKmYCAvHld1RIl3EoRtZrv_4EIDO42don3WBHUMGFnJu_jOYUQfFK3nlUgpNqapMNAUgJMzSTBo6LOrwYEuADT11nl7fjqS-aYFggTk_rszPyGcMmgG4proBxQdH7MMAZeb1PEw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY5NTU0MDQ1LCJuYmYiOjE0Njk1NTQwNDUsImV4cCI6MTQ2OTU1Nzk0NSwiYWNyIjoiMSIsImFsdHNlY2lkIjoiNTo6MTAwMzAwMDA4MDFDNDREMyIsImFtciI6WyJwd2QiLCJtZmEiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlbWFpbCI6Inl1Z2FuZ3dAbWljcm9zb2Z0LmNvbSIsImZhbWlseV9uYW1lIjoiV2FuZyIsImdpdmVuX25hbWUiOiJZdWdhbmciLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2Il0sImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0Ny8iLCJpbl9jb3JwIjoidHJ1ZSIsImlwYWRkciI6IjE2Ny4yMjAuMS4xMzAiLCJuYW1lIjoiWXVnYW5nIFdhbmciLCJvaWQiOiI4OWVkNWJlOC1mZjk3LTQxYjUtYWIxMS0wNTVlMWUzY2MzNGIiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODk1NSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IjJEWG5PTmM1RUFyNmFfM1Vya1JSYlFBdkdueHpxQWEtSExWczFyV3dndEkiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6Inl1Z2FuZ3dAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.fy4o2raFkNg7_jFMh7YDRNQuHLdZG2AKcxLdS0PbRgeWd52NIzQEYH-sCbNHsh5kecyVwxBJnqLLYs-FYjGic29jFK0jEeuZl55VKIB3kYaF2U2XXNcag2dfBTIHe9uyGRK5drmrpFT1g5bBA9qZQA_Gq0SoUp0yilVOIPNAg7wfi9fPIoEUzC2qoIxv0yxmZQTqHOi0WNTygVU2GrZqwLKdEegjc-t9eH3tECSBS2-HzBBfxWmYlzEP9CPxlcO-hrtbn9B-Wa97AStVWVSQS-TnMoRLETVVpWXkxiPBqdisyTzQ9rY2nHpr6e54trtul1wFIq26-1HQmp5NBi4Hag]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 requests/2.9.1 msrest/0.3.0 msrest_azure/0.3.0 authorizationmanagementclient/2015-07-01
-          Azure-SDK-For-Python AZURECLI_0.0.32]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.0 msrest_azure/0.4.1
+          nsgcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [3319a6ec-2f22-11e6-af31-a0b3ccf7272a]
+      x-ms-client-request-id: [570769e4-535a-11e6-9b0d-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments?api-version=2015-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli-role-assignment-test/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587320510691497682?api-version=2015-11-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
+        tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['141']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 26 Jul 2016 17:57:26 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY5NTU0MDQ1LCJuYmYiOjE0Njk1NTQwNDUsImV4cCI6MTQ2OTU1Nzk0NSwiYWNyIjoiMSIsImFsdHNlY2lkIjoiNTo6MTAwMzAwMDA4MDFDNDREMyIsImFtciI6WyJwd2QiLCJtZmEiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlbWFpbCI6Inl1Z2FuZ3dAbWljcm9zb2Z0LmNvbSIsImZhbWlseV9uYW1lIjoiV2FuZyIsImdpdmVuX25hbWUiOiJZdWdhbmciLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2Il0sImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0Ny8iLCJpbl9jb3JwIjoidHJ1ZSIsImlwYWRkciI6IjE2Ny4yMjAuMS4xMzAiLCJuYW1lIjoiWXVnYW5nIFdhbmciLCJvaWQiOiI4OWVkNWJlOC1mZjk3LTQxYjUtYWIxMS0wNTVlMWUzY2MzNGIiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODk1NSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IjJEWG5PTmM1RUFyNmFfM1Vya1JSYlFBdkdueHpxQWEtSExWczFyV3dndEkiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6Inl1Z2FuZ3dAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.fy4o2raFkNg7_jFMh7YDRNQuHLdZG2AKcxLdS0PbRgeWd52NIzQEYH-sCbNHsh5kecyVwxBJnqLLYs-FYjGic29jFK0jEeuZl55VKIB3kYaF2U2XXNcag2dfBTIHe9uyGRK5drmrpFT1g5bBA9qZQA_Gq0SoUp0yilVOIPNAg7wfi9fPIoEUzC2qoIxv0yxmZQTqHOi0WNTygVU2GrZqwLKdEegjc-t9eH3tECSBS2-HzBBfxWmYlzEP9CPxlcO-hrtbn9B-Wa97AStVWVSQS-TnMoRLETVVpWXkxiPBqdisyTzQ9rY2nHpr6e54trtul1wFIq26-1HQmp5NBi4Hag]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.0 msrest_azure/0.4.1
+          nsgcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [570769e4-535a-11e6-9b0d-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli-role-assignment-test/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
+        p/nndbVeNXenZbFdV2W+nTVNcbFc5Mt2u82b9u6qri6LWV43d78opnXVVOft+JW+29yd5auyukbr
+        5m72g3WdE5zd/U8f3r9//2D3/vje/YP9+/fu3TvY2Xnw0eijZbbICd2bG1Knq7xui7z56NEv/qjN
+        F6sya/PnxfIt/l7XBUGZt+2qeXRXum1mb6fFeFJWk/G0qvPxVbGcVVfNeJm3d83r84qGc1Ln9OuL
+        5uL339vZ/XR758H27oGAkKGMf7qploTBtFq2NKqfpIETTam73fEO/vvolxB2WU0DaekrYFNW0wx0
+        x+/t9QoDfN3WxfKCoFxm5RofXBEl1w3eFRIMt1w2F7to12YXDF3bfTn56Xzauna/+Jf8Emq0qGb0
+        +0dny2mdYw6ykloQ7S4LIE2AX7c0WGrxej2d5jTCGX3fFgvCJlus6HNDg71P3+w+eHT/waPdnfHu
+        /fv7O7sPfoqazta1Du2jl292740P9h7c33/w4DV9RVSuc6IqfXsGFvx0f2/v4d7s/vb+3i79c/7p
+        ZHty8HBn+9N793bz6c6Dnf1P79NrjBy46aNH3/vFTIxmlU2BouOuF3l7VdVvqTXNK/PZGyKCvOF/
+        Qi/R9KLp63xKPNFeCy/Ti2ZO8JIh/vd/Cf1HY8pX+XKWL6fMXN+jT6p1u1q39AchlF+9eP05fhui
+        u4xgA3kNhp+vWTRnk8mnuwd797fv5Q8/JboQhbL9nYy47uDhw92H2af39/bprUZH8GpdGrRm+Xm2
+        LlszNvMNIZmBhT46Lsvq6ieJAmfLJ9V6ib65x7s/ZGWg03WXMMFPg6+CAj+TlugP5W4E/5y4nkbw
+        3bu/70cHs0/z6f17e0So811C++D+9sH0wcPtvZ0HD+5/+uAejenh7/sRvUMoeaqC/to4O7Pckoa+
+        YRTSYjlB/2lbZ+fnxTQ9r6tFmpVl+pNfNPRl+pMvTt/QqwS6raZVSe99i/4Ugr2s6vZVtrxAP/iU
+        4LfFknmv+5W8cDybEbGbl3V+Xryjb36yqNt1VioRqZkH4ca2GQ2soXHLQOiDVV1UoPBHjz69v7Oz
+        Q9AK0rSARY3OZJwfkeYImegY6u95lc2eZGW2nOa1m5H/73HUhsH8v4m9gGVaEprpRPGk1wn8zwKL
+        9ShCLT0g3eYAdANj7RKAGxjrab68ppcd8f8/xUk97H/YrAMEWAcVQlvDPdSQAP0sMAm+8V6KfW2Z
+        AsjR3z5PEFPQ+zfwBFFUNP6X69YQ9v9TbBEbwA+bMxiHlHwWpq/hC9UqxDAwWm1lf/3/kf0iovOY
+        +zx1Rr56HU7L//f4KjKI/5fylsGU3if4PwtMhW+8l7pfe/3fwEEdQ0Wk5ZEFHARtRm/Td4bs/5/i
+        nT76P2yuAQbMHl3GoZYE6YfPH/jaMgawo799viDGoPfjfPF9DqxpJBQS2jQHh13MFe8zXx8B2P8D
+        yBrtXKIRAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['1262']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 26 Jul 2016 17:57:26 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY5NTU0MDQ1LCJuYmYiOjE0Njk1NTQwNDUsImV4cCI6MTQ2OTU1Nzk0NSwiYWNyIjoiMSIsImFsdHNlY2lkIjoiNTo6MTAwMzAwMDA4MDFDNDREMyIsImFtciI6WyJwd2QiLCJtZmEiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlbWFpbCI6Inl1Z2FuZ3dAbWljcm9zb2Z0LmNvbSIsImZhbWlseV9uYW1lIjoiV2FuZyIsImdpdmVuX25hbWUiOiJZdWdhbmciLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2Il0sImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0Ny8iLCJpbl9jb3JwIjoidHJ1ZSIsImlwYWRkciI6IjE2Ny4yMjAuMS4xMzAiLCJuYW1lIjoiWXVnYW5nIFdhbmciLCJvaWQiOiI4OWVkNWJlOC1mZjk3LTQxYjUtYWIxMS0wNTVlMWUzY2MzNGIiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODk1NSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IjJEWG5PTmM1RUFyNmFfM1Vya1JSYlFBdkdueHpxQWEtSExWczFyV3dndEkiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6Inl1Z2FuZ3dAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.fy4o2raFkNg7_jFMh7YDRNQuHLdZG2AKcxLdS0PbRgeWd52NIzQEYH-sCbNHsh5kecyVwxBJnqLLYs-FYjGic29jFK0jEeuZl55VKIB3kYaF2U2XXNcag2dfBTIHe9uyGRK5drmrpFT1g5bBA9qZQA_Gq0SoUp0yilVOIPNAg7wfi9fPIoEUzC2qoIxv0yxmZQTqHOi0WNTygVU2GrZqwLKdEegjc-t9eH3tECSBS2-HzBBfxWmYlzEP9CPxlcO-hrtbn9B-Wa97AStVWVSQS-TnMoRLETVVpWXkxiPBqdisyTzQ9rY2nHpr6e54trtul1wFIq26-1HQmp5NBi4Hag]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.0 msrest_azure/0.4.1
+          networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [6ac824d4-535a-11e6-9261-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-role-assignment-test/providers/Microsoft.Network/networkSecurityGroups/nsg1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Ih+Nhe7H434o2KGD+4260kzrYtVW1TL5u7OZPf80/0Hu9u7k/Od7f3ZLNvO8um97enk
+        4d6DvfOdh/cf7tyt86Za19P887par5q707LYrqsy386aprhYLvJlu93mTXt3VVeXxSyvm7tfFNO6
+        aqrzdvwib6+q+u3dpfx8nU/XddFeKygPvbzNLoDgd+/+vh8dzD7Np/fv7W3vHpzvElYH97cPpg8e
+        bu/tPHhw/9MH9wjlh7/vR/pie73iod6yT32rrKYZSIA3rwj5tfmC0Gjow1/8S+RPGtMqr9si5w/x
+        kXx4WTT0drG8eN1mLff/ej2d5vksnwkgambpthbazyaTT3cP9u5v38sffrq9fz67v53t72Q0yoOH
+        D3cfZp/e39u3LzeK9at1yX1/7/vmm1l+nq3L1gzLNpCvU4MlHssHx2VZXf0kEeRs+aRaLy2OeP5f
+        yxl3YyO9u3EoX5eL5MHE9mZbHnx1izmXh6bIUhLNGOW0WE6Ab9rW2fl5MU3P62qRZmWZ/uQXDX2Z
+        /uSL0zcdONRpW02rEkC+1flOKP+yqttX2fKC0ek2ITTaYsl8vrGdgDqezWg+m5d1fl68Q7OfLOp2
+        nZU6UZ13PNjv92JGJGtAXyFL59tVXVSYa/r+0/s7Ozvht7Oizqfokr7+6Ezo+ZFr8UvMryK8eLxJ
+        DIXh+AfrOn9eZbMnWZktp3kdY6f/D0rGrcb1/z0xwajSkoaVTnRcHVjU8c+hqPSo3nnNA997t9vF
+        ewnIbvjtNyMgT/PlNfUd45z/b0nEhoH8v1MEgDDbhELmzkhB5y3q4ueQ2bvNPHA3tnXMjaF2vgx4
+        m5g7/Pab4W1iB3Efvly3fa74/xZ7bx7L/zs5nHFOq3XL82f4W7U8MT6cobayv/7IL+KHRuyJxma/
+        iJiBafs1ZeNs2eb1EE/9f1A+No7n/9MyYkbWAUY9/xwKR7eZB67XdmAA7yUJmxwgmnKm4PtLAowT
+        dU4A+jzz/y0Z2DSS/3dyPzBmNu8KQOc16uP/I3zebesYHGPtfBnwNzF4+O3t+Vt++T5+0O+/5P8B
+        dhaUWhgUAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 26 Jul 2016 17:57:28 GMT']
+      ETag: [W/"8d6ec532-18f1-4d85-8c79-20775673f649"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY5NTU0MDQ1LCJuYmYiOjE0Njk1NTQwNDUsImV4cCI6MTQ2OTU1Nzk0NSwiYWNyIjoiMSIsImFsdHNlY2lkIjoiNTo6MTAwMzAwMDA4MDFDNDREMyIsImFtciI6WyJwd2QiLCJtZmEiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlbWFpbCI6Inl1Z2FuZ3dAbWljcm9zb2Z0LmNvbSIsImZhbWlseV9uYW1lIjoiV2FuZyIsImdpdmVuX25hbWUiOiJZdWdhbmciLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2Il0sImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0Ny8iLCJpbl9jb3JwIjoidHJ1ZSIsImlwYWRkciI6IjE2Ny4yMjAuMS4xMzAiLCJuYW1lIjoiWXVnYW5nIFdhbmciLCJvaWQiOiI4OWVkNWJlOC1mZjk3LTQxYjUtYWIxMS0wNTVlMWUzY2MzNGIiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODk1NSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IjJEWG5PTmM1RUFyNmFfM1Vya1JSYlFBdkdueHpxQWEtSExWczFyV3dndEkiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6Inl1Z2FuZ3dAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.fy4o2raFkNg7_jFMh7YDRNQuHLdZG2AKcxLdS0PbRgeWd52NIzQEYH-sCbNHsh5kecyVwxBJnqLLYs-FYjGic29jFK0jEeuZl55VKIB3kYaF2U2XXNcag2dfBTIHe9uyGRK5drmrpFT1g5bBA9qZQA_Gq0SoUp0yilVOIPNAg7wfi9fPIoEUzC2qoIxv0yxmZQTqHOi0WNTygVU2GrZqwLKdEegjc-t9eH3tECSBS2-HzBBfxWmYlzEP9CPxlcO-hrtbn9B-Wa97AStVWVSQS-TnMoRLETVVpWXkxiPBqdisyTzQ9rY2nHpr6e54trtul1wFIq26-1HQmp5NBi4Hag]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.0 msrest_azure/0.4.1
+          authorizationmanagementclient/0.30.0rc5 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [6afc5a1a-535a-11e6-aab8-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-role-assignment-test/providers/Microsoft.Authorization/roleDefinitions?api-version=2015-07-01&$filter=roleName%20eq%20%27contributor%27
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS9X/zRqq5Wed0WefPRo1/8UV2V+dP8vFgWbVEtz2YfPfrobrOeNNO6WOGT5u7OZPf80/0H
-        u9u7k/Od7f3ZLNvO8um97enk4d6DvfOdh/cf7twloJfFLK+bu18U07pqqvN2fLxu51Vd/CADnLth
-        R83dg/xedv7p/Qfb2cH5+fb+/r3pdvbg/nR77zw/mO5PppNP793/aETYFstpscpKRu1g9+Bgtpsf
-        bN/beUi45Hgpe/Dp9r2D6fne5P70weReRi81UxoiNf8aI6G3p3WetfnsyyVB2NvZ/XR7h97Ye7O3
-        92j/00c7O+N7u7sP9u7v/xQ1Xa9mt22qUJ9cU9PzgwdZvp/PtqfTvb3t/Z2dve1sd2dne3J+/9NP
-        Z/cIzSynVxT67V/5JaOPCpDpa4z7ljN43DTFxXKRL9vm7u7D/N7kfP9g+/50f397f/fBbPsg293b
-        nub3P334cHKQT/cmNIr2mufillDphWW2wAu3Av9LRv/fZujZ3sHOdG/33va9e+f59v5ksrs9uf9w
-        sk2fTWYP9g9m09mUXvrmGXpv583ezqOdTx/t7o93dnb37x88AJcqy92mqUJl7rw32cnPD84n2znJ
-        4Pb+vcmn29n9h/v09r0HBwfTyezh/T16RaHf/pUfLkPvPzggoOf3tj/NJ/e29+mP7YezBzvb+f70
-        wb2HewcPzycfwtC3Av//IobOprPZg73sAfHmwX3CNz/fnsz297bPP9359HySHexm+QMaXcjQ+3s7
-        Dx/MJiS1O/dJag/28u1sb+/e9s6DLPt0/+DT2f7uzwZD36f/vdnZfbT7kDTv+MED0hB7e+BSZbnb
-        NFWot+dOC/32r/xwGfr+zr1s99PsfPvg4YSMxh5po4fnM3RAuvP+p7sPsvuYjK/L0LcC//91hn74
-        YHrvQX5OhjcDLtN7s+2H+U62/YDs0IPdyR7J8Tm99M0z9N499iMePrr/6fjhHjsS4FJluds0VajM
-        nfcffnrv/P7OdPvBdJ+Uzw7NVXb+IN++f2/v4f4sf/BpNpnRKwr99q/8cBn60wez/fzgfHd7Z/Zg
-        QuYym21PPr2f0W/3P93L9z7Ns717NIqvy9C3Av//Ioa+t7uX3f/0PvHmwS65HOezAxJF4Jvv7ebk
-        PBCDQr5Dhn6QPbx3kN0jNPb2PqV/dvLthw8/pddn+weTafbp7P49SMEHMPTdOm+qdT3NP6+r9aq5
-        Oy3XbdM++PRgd5cAK1d6DEz0fvBmZ+fR/oNHu5+OD/Z2H+zs3wMDKzfepqlCvT3jWui3f+VDeH2Y
-        JLecd49h7+7lpIzyPbIt+9Pp9v7DPN+eEHdu3yf/eHo+vZfvHRzQAL+uGNwK/I/E4MaRROf8gGK3
-        QTH4FHp85/6jewfje/c+pZiH9bgy6m2aKtTb87SFfvtXvnExYJLcct49hr07I4f54f2D3e38wX2y
-        5w9pCifnpLinFEYRw95/mB9ggF9XDG4F/kdicONIonO+/2Dn3j4BVobt8fa9R/d34Z8f3Nvf+XSX
-        eVsZ9TZNFertedpCv/0r37gYMEluOe8ew94lziSOnObb5w/OD8it/XSy/XB3mm3v7h8cPLi/s7t3
-        /xyJh68rBrcC//8iMfhaeZh9isT3ZrvZ9uzTe5SH2SEvP8tJgO7Psk8PMorM83PIzjcoBlm9mJZF
-        01Z1diGf3ds9gKgp73psfn979wFre/Lxd8YP9u7dp0gabK48e5umCvX27G2h3/6Vb1Ai4tS5JTd4
-        bHx398HD808/fUDxGoVulEWcEeKEznY2I59+tkcZ5AmI/nWF41bg/18kHP+fshH3H+7uwI9V3vXY
-        nBU/Ejj3Hu3sj+8fPCQ1xGyuPHubpgr19uxtod/+lW9QIjyS3HLePYa9+3DycPpglh1QPwc0hfkO
-        /ZYhN3d/RjmR851P9ybIQ3xdMbgV+B+JwY0jic75vYe7u0g2KsOGvE3R8ENo+/v3aLHp3n2yyeBt
-        ZdTbNFWot+dpC/32r3zjYsAkueW8ewx7d7KztzeZ7N/ffnA+pew0+S7bkwfk4T/Ym+w/nN47mGS7
-        UDhfVwxuBf7/RWLwtVylW834NyoGxz9Y1/nrp7/Xq88JrvKrx9r0vwfQ8MTa5PMc7N27t/dgB6yt
-        fHqbpgqVWfqWcq7Qb//KNygFjiK3m3WfXe/mDw928vs5seV9yoXv36deD+7f292ezibk99JzkCEy
-        +7pCcCvw/y8Sgv9P2QJaSrspe/Tg0d6D8YN7n96/v8vLWsqnt2mqUJmlbynmCv32r3yDUuCR5Jbz
-        7jHs3enOzmw2zWn9de/8ISnrB9PtySRH0nPv4WRCnsvubk4D/LpicCvwv+T71D5/1z4vlm8/erRc
-        l+Uv+X8A+e54K6sjAAA=
+        uc4/evS9X/zRqq5Wed0WefPRo1/8UV2V+YtsQV99dFIt27qYrNuq/mj0UXu9wodP1kXZni1fUTP6
+        cJY307pYtUW1pO+e522TXlfrdJEts4s8zS/z+rqdF8uLNH83zVdtmk2nedOkbZXWeVOta/prTGCy
+        pikultmkzF9PCRlC5Hsf3f3o+6OPCLFFQV9WS3z2iz/KpugKv3/0LXy/rNpj99EXxbSumuq8HR+v
+        23lVFz/I8N3db919mpd5C4SHm3y3LqjF938JQZ3Wedbmsy8xpp2dnd1t/t+bnYNHOzv0vzF9huen
+        CN56NbNN93Z2P93eub99b/fN3r1Hu/ce3T8Yf/pgf/feHjdVqE+uP3q0XJelfdd88EtGHxUzAnO3
+        WU8sVZu7O5Pd80/3H+xu707Od7b3Z7NsO8un97ank4d7D/bOdx7ef7hzl+bwspjldXN3aICY16f5
+        ebEs8Gdzd7K3//DgIJtuf7p7QGD3sp3tbHJwsL23c/7g3sHebLa3PyWkddZvCZVeWArv3Ao8aL3M
+        37XPi+VbpcH/A+KDerWZAgAA
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 10 Jun 2016 15:44:22 GMT']
+      Date: ['Tue, 26 Jul 2016 17:57:29 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
+      Set-Cookie: [x-ms-gateway-slice=productionb; path=/]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
       X-Content-Type-Options: [nosniff]
@@ -68,15 +205,88 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY1NTcxNDYzLCJuYmYiOjE0NjU1NzE0NjMsImV4cCI6MTQ2NTU3NTM2MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2Il0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.fZ7oSJMxpVQE8-0USIDYNmgQHzQO-vl2r9-M2h0mU67VapcCJ2xNTBQ8FU4wkj2zdd2coKEZJpL6dKBNvyELWIKYdxxPjVl7I5DRl6mJNWMKgsxfRghxsCZnudDFxh6ZrpaY7G3vCyc8hU7FY_xh0SSnVFroay4EUv7cmMh6THQDfM6WZ6JukkTZqdBydU-s0Nf0fHQdvplUCpjHKmYCAvHld1RIl3EoRtZrv_4EIDO42don3WBHUMGFnJu_jOYUQfFK3nlUgpNqapMNAUgJMzSTBo6LOrwYEuADT11nl7fjqS-aYFggTk_rszPyGcMmgG4proBxQdH7MMAZeb1PEw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL2dyYXBoLndpbmRvd3MubmV0LyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Njk1NTQ4NzMsIm5iZiI6MTQ2OTU1NDg3MywiZXhwIjoxNDY5NTU4NzczLCJhY3IiOiIxIiwiYWx0c2VjaWQiOiI1OjoxMDAzMDAwMDgwMUM0NEQzIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVtYWlsIjoieXVnYW5nd0BtaWNyb3NvZnQuY29tIiwiZmFtaWx5X25hbWUiOiJXYW5nIiwiZ2l2ZW5fbmFtZSI6Ill1Z2FuZyIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0Ny8iLCJpbl9jb3JwIjoidHJ1ZSIsImlwYWRkciI6IjE2Ny4yMjAuMS4xMzAiLCJuYW1lIjoiWXVnYW5nIFdhbmciLCJvaWQiOiI4OWVkNWJlOC1mZjk3LTQxYjUtYWIxMS0wNTVlMWUzY2MzNGIiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODk1NSIsInNjcCI6IjYyZTkwMzk0LTY5ZjUtNDIzNy05MTkwLTAxMjE3NzE0NWUxMCIsInN1YiI6ImhkcUE5WDBBZ2k5TDdfcjNXUDh2RXhFODJCZDlTVzlzY0ZtRGpPbTFPTUUiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6Inl1Z2FuZ3dAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCJ9.mOt4-DkLilfW_uya-TcnHtN1vUBzGUs-gJw2gtehDetYELnixPhbSRoKxBWWt-dVn_Cg538z4hBTIA45y5bzE-ONyTT7umCbU6f0fBNGbBY9e9n41-X6G85b-ZJ1l5IR0lRp6R6atRZT3ygTg4OWQN8ZytHcF_SmuR-8aCjWIHJO4-yQj0W7AaXHuKqBcPOGaoxVVm2Z01cHukNNeQl6qoblnsa1rMJEkF_sZYYzMZycobxcmsK3qtIrU5b4ooO4fGNGStEi1-ZRJcCfMxigZsexTjGFlALnK7uuUQuAfwfTfK1r4dOHeYuaZzoHEkfRvJHZiQQpNjL0B51LzrRB9A]
+      CommandName: [role assignment create]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 requests/2.9.1 msrest/0.3.0 msrest_azure/0.3.0 authorizationmanagementclient/2015-07-01
-          Azure-SDK-For-Python AZURECLI_0.0.32]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.0 msrest_azure/0.4.1
+          graphrbacmanagementclient/0.30.0rc5 Azure-SDK-For-Python AZURECLI/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [3396187a-2f22-11e6-b200-a0b3ccf7272a]
+      x-ms-client-request-id: [4c322128-535a-11e6-a0cc-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments?api-version=2015-07-01&$filter=principalId%20eq%20%277a938a30-4226-420e-996f-4d48bca6d537%27
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/users?api-version=1.6&$filter=userPrincipalName%20eq%20%27testuser1%40azuresdkteam.onmicrosoft.com%27
+  response:
+    body: {string: '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.User","value":[{"odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"8078ead5-4654-4b65-847b-3bf7ca6a26f8","deletionTimestamp":null,"accountEnabled":true,"signInNames":[],"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"tester123","facsimileTelephoneNumber":null,"givenName":null,"immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"testuser1","mobile":null,"onPremisesSecurityIdentifier":null,"otherMails":[],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2016-07-26T17:56:38Z","sipProxyAddress":null,"state":null,"streetAddress":null,"surname":null,"telephoneNumber":null,"usageLocation":null,"userPrincipalName":"testuser1@azuresdkteam.onmicrosoft.com","userType":"Member"}]}'}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Cache-Control: [no-cache]
+      Content-Length: ['1186']
+      Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
+      DataServiceVersion: [3.0;]
+      Date: ['Tue, 26 Jul 2016 17:57:26 GMT']
+      Duration: ['1114949']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET, ASP.NET]
+      ocp-aad-diagnostics-server-name: [VbwAPpHBrDNXWFpR18OzHh/NfNdUKGwRD1NUkhGV+bc=]
+      ocp-aad-session-key: [mRC1tY2yrx4h70OxqKjnxKG-31FBxAfAGZBHZXDHucSnvAswN9T0pdXxZhvmXw5UI6oX66wiS_Rwf7bWMpMrNYDQA41Q4WjKlgP9h6eYDhVi6mOKi-i0FrsldHki02-cIuBKCFcSHaE9XQxUHTtLLA.XP4dMngj9aAkzmVS5fFnNwIu3QQcMnh1Eng_5n-Srss]
+      request-id: [bedf99e4-d93a-4714-a6b9-1721a86a2df8]
+      x-ms-dirapi-data-contract-version: ['1.6']
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJwcm9wZXJ0aWVzIjogeyJyb2xlRGVmaW5pdGlvbklkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2
+      NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9wcm92aWRlcnMvTWljcm9zb2Z0LkF1dGhv
+      cml6YXRpb24vcm9sZURlZmluaXRpb25zL2IyNDk4OGFjLTYxODAtNDJhMC1hYjg4LTIwZjczODJk
+      ZDI0YyIsICJwcmluY2lwYWxJZCI6ICI4MDc4ZWFkNS00NjU0LTRiNjUtODQ3Yi0zYmY3Y2E2YTI2
+      ZjgifX0=
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY5NTU0MDQ1LCJuYmYiOjE0Njk1NTQwNDUsImV4cCI6MTQ2OTU1Nzk0NSwiYWNyIjoiMSIsImFsdHNlY2lkIjoiNTo6MTAwMzAwMDA4MDFDNDREMyIsImFtciI6WyJwd2QiLCJtZmEiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlbWFpbCI6Inl1Z2FuZ3dAbWljcm9zb2Z0LmNvbSIsImZhbWlseV9uYW1lIjoiV2FuZyIsImdpdmVuX25hbWUiOiJZdWdhbmciLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2Il0sImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0Ny8iLCJpbl9jb3JwIjoidHJ1ZSIsImlwYWRkciI6IjE2Ny4yMjAuMS4xMzAiLCJuYW1lIjoiWXVnYW5nIFdhbmciLCJvaWQiOiI4OWVkNWJlOC1mZjk3LTQxYjUtYWIxMS0wNTVlMWUzY2MzNGIiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODk1NSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IjJEWG5PTmM1RUFyNmFfM1Vya1JSYlFBdkdueHpxQWEtSExWczFyV3dndEkiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6Inl1Z2FuZ3dAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.fy4o2raFkNg7_jFMh7YDRNQuHLdZG2AKcxLdS0PbRgeWd52NIzQEYH-sCbNHsh5kecyVwxBJnqLLYs-FYjGic29jFK0jEeuZl55VKIB3kYaF2U2XXNcag2dfBTIHe9uyGRK5drmrpFT1g5bBA9qZQA_Gq0SoUp0yilVOIPNAg7wfi9fPIoEUzC2qoIxv0yxmZQTqHOi0WNTygVU2GrZqwLKdEegjc-t9eH3tECSBS2-HzBBfxWmYlzEP9CPxlcO-hrtbn9B-Wa97AStVWVSQS-TnMoRLETVVpWXkxiPBqdisyTzQ9rY2nHpr6e54trtul1wFIq26-1HQmp5NBi4Hag]
+      Connection: [keep-alive]
+      Content-Length: ['233']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.0 msrest_azure/0.4.1
+          authorizationmanagementclient/0.30.0rc5 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [6b584d82-535a-11e6-8398-64510658e3b3]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-role-assignment-test/providers/Microsoft.Authorization/roleAssignments/1518cef5-a2c8-48e1-acb5-eaadf2474f79?api-version=2015-07-01
+  response:
+    body: {string: '{"properties":{"roleDefinitionId":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"8078ead5-4654-4b65-847b-3bf7ca6a26f8","scope":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-role-assignment-test","createdOn":"2016-07-26T17:57:29.9180349Z","updatedOn":"2016-07-26T17:57:29.9180349Z","createdBy":null,"updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b"},"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-role-assignment-test/providers/Microsoft.Authorization/roleAssignments/1518cef5-a2c8-48e1-acb5-eaadf2474f79","type":"Microsoft.Authorization/roleAssignments","name":"1518cef5-a2c8-48e1-acb5-eaadf2474f79"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['766']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 26 Jul 2016 17:57:29 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Set-Cookie: [x-ms-gateway-slice=productionb; path=/]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY5NTU0MDQ1LCJuYmYiOjE0Njk1NTQwNDUsImV4cCI6MTQ2OTU1Nzk0NSwiYWNyIjoiMSIsImFsdHNlY2lkIjoiNTo6MTAwMzAwMDA4MDFDNDREMyIsImFtciI6WyJwd2QiLCJtZmEiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlbWFpbCI6Inl1Z2FuZ3dAbWljcm9zb2Z0LmNvbSIsImZhbWlseV9uYW1lIjoiV2FuZyIsImdpdmVuX25hbWUiOiJZdWdhbmciLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2Il0sImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0Ny8iLCJpbl9jb3JwIjoidHJ1ZSIsImlwYWRkciI6IjE2Ny4yMjAuMS4xMzAiLCJuYW1lIjoiWXVnYW5nIFdhbmciLCJvaWQiOiI4OWVkNWJlOC1mZjk3LTQxYjUtYWIxMS0wNTVlMWUzY2MzNGIiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODk1NSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IjJEWG5PTmM1RUFyNmFfM1Vya1JSYlFBdkdueHpxQWEtSExWczFyV3dndEkiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6Inl1Z2FuZ3dAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.fy4o2raFkNg7_jFMh7YDRNQuHLdZG2AKcxLdS0PbRgeWd52NIzQEYH-sCbNHsh5kecyVwxBJnqLLYs-FYjGic29jFK0jEeuZl55VKIB3kYaF2U2XXNcag2dfBTIHe9uyGRK5drmrpFT1g5bBA9qZQA_Gq0SoUp0yilVOIPNAg7wfi9fPIoEUzC2qoIxv0yxmZQTqHOi0WNTygVU2GrZqwLKdEegjc-t9eH3tECSBS2-HzBBfxWmYlzEP9CPxlcO-hrtbn9B-Wa97AStVWVSQS-TnMoRLETVVpWXkxiPBqdisyTzQ9rY2nHpr6e54trtul1wFIq26-1HQmp5NBi4Hag]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.0 msrest_azure/0.4.1
+          authorizationmanagementclient/0.30.0rc5 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [6c373806-535a-11e6-b5aa-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-role-assignment-test/providers/Microsoft.Authorization/roleAssignments?api-version=2015-07-01
   response:
     body:
       string: !!binary |
@@ -84,29 +294,50 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
         uc4/evS9X/zRqq5Wed0WefPRo1/8UV2V+dP8vFgWbVEtz2YfPfrobrOeNNO6WOGT5u7OZPf80/0H
         u9u7k/Od7f3ZLNvO8um97enk4d6DvfOdh/cf7twloJfFLK+bu18U07pqqvN2fLxu51Vd/CADnLth
-        R83de7t72f1P78+2pwe759v757OD7YOH97Pt/XxvN98/mN1/sDv9aETYFstpscpKRu1B9vDeQXaP
-        0Njb+5T+2cm3Hz78lF6f7R9Mptmns/v3HtBLzZSGSM2/zkjqvKnW9TT/vK7Wq+butFy3Tfvg04Pd
-        XQI8rfOszWdfLgn43s7up9s7u9s7D97s7Dzaf/Bo99Pxwd7ug539ez9FTder2W2bKtQn19T0/sNP
-        753f35luP5ju39ve37k/3c7OH+Tb9+/tPdyf5Q8+zSYzekWh3/6VXzL6qAAF736jJLnlvB83TXGx
-        XOTLtrm7l0+z83xvf3tnfzrd3n+Y59uTvU8J22x3b3o+vZfvHRzQANtrnsFbQqUXltkCL9wK/C8Z
-        /UgMbhhJdM4P9nd2BsXg0zd7e4927j+6dzC+d+/T/d0H98Hbyqi3aapQb8/TFvrtX/nGxYBJcst5
-        9xj27ux8Mnl4/2B3O39w/z7xKU3h5PzBhHqc7BLD3n+YH2CAX1cMbgX+R2Jw40iic77/YOfePgFW
-        hu3x9r1H93cf7ZOKv7e/8+ku87Yy6m2aKtTb87SFfvtXvnExYJLcct49hr1LnEkcOc23zx+cH2zv
-        H3w62X64O822d/cPDh7c39ndu39+nwb4dcXgVuB/JAY3jiQ65/cf7u7AVCvDdnl79+Gj/XuPdvbH
-        9w8eEqUPwNvKqLdpqlBvz9MW+u1f+cbFgElyy3n3GPbuw8nD6YNZdkD9HNAU5jv0W7aXb2f3Z7PZ
-        g/OdT/cmOzTArysGtwL/IzG4cSTROb/3cHd3jwArw4a8TQ7/w0c7e4/u3xvf2713n9QOeFsZ9TZN
-        FertedpCv/0r37gYMEluOe8ew96d7OztTSb797cfnE/3t/dJPW9PHpAT82Bvsv9weu9gku1C4Xxd
-        MbgV+B+JwY0jic753t69m2KDB4/2Howf3Pv0/v3dPfC2MuptmirU2/O0hX77V75xMWCS3HLePYa9
-        O93Zmc2m+c52vnf+kPj0wXR7MskR0u49nExIae/u5jTArysGtwL/S75P7fN37fNi+fajR8t1Wf6S
-        /wfdsSKsRRIAAA==
+        R83dyd7+w4ODbLr96e4Bgd3LdrazycHB9t7O+YN7B3uz2d7+9KMRYVssp8UqKxm1g50HB3k2u7+9
+        /+n9/e39yaf3tw/2H0y2703OH0yzT7O9T88P6KVmSkOk5l9nJHXeVOt6mn9eV+tVc3daFttAfTtr
+        muJiuciX7XabNy31Mq3zrM1nXy6pp72d3U+3dx5s7336ZvfBo/sPHt3bGX/66cHuvb17P0VN16vZ
+        bZsq1CfX1PTgYT67P8kPts/PHz7Y3t+d3Cca7e5u79y/n+/m96bTe/sTekWh3/6VXzL6qAA57/7s
+        0eeWHHFs32ru7t7fPZjm54Tw3vRge/8g393OpoR/nmWz8739B/vnDx7SaNtrnttbQqUXltkCL9wK
+        /C8Z/b9GQA7ye9n5p/cfbGcH5+fb+/v3ptvZg/vT7b3z/GC6P5lOPr13n0YXCsi96c7O/U+zcxIj
+        DPL+7r3tbDadbX96cL6fTXf38ofnGb30AQJCbyuLBty8u/dmb+fR/sNH9++NH+59uv/pvQfgZmXN
+        2zRVqMzF9x9+eu/8/s50+8F0/972/g4NOzt/kG/fv7f3cH+WP/g0m8zoFYV++1c+hPFvN4Me693d
+        zR/c//R8SqJ+fo+01U62RxyXZ9u7B/dnn5Iw0gzu0Si+NkPfBvz/1xn6YPfgYLZL+uzezkPChTTY
+        dpY9+HT73sH0fG9yf/pgcu9ng6HpDeLSvUf7nz7a2Rnf2919sHd/H1yqLHebpgqVufP84EGW7+ez
+        7el0b4/maofmandnZ3tyfv/TT2f3CM0sp1cU+u1f+SEz9EPiqvP9g+37033iuN0Hs+2DbHdve5rf
+        //Thw8lBPt2DPfraDH0b8P9fZ+jZ3sHOdI/08r175/n2/mSyuz25/3CyTZ9NZg/2D0hbw+/55hl6
+        bwdqd+fTR7v7452d3f37B6x2leVu01ShMnfem+zk5wfnk+2cZHB7n5TNdnb/4T69fe/BwcF0Mnt4
+        H7pNod/+lR8uQ+8/IPdx9/ze9qf5hIwG/bH9cPZgZzvfnz6493Dv4OH55EMY+lbg/1/E0Nl0Nnuw
+        lz0g3jwgH/sgP9+ezPb3ts8/3fn0fJId7Gb5AxpdyNA709nO9OEuNX2AaX14f7JN49rf3t3b3z3f
+        uU9sfv8evfRNMzSZvftQu7v3H+0cjA/u37u/+4C5VFnuNk0VKnPng+zhvYPsHuGwt/cp/bOTbz98
+        +CmJ9Wz/YEKxxez+PYxdod/+lR8uQ98jqmcTGvH+wT3y/zCDD6fnu9vTB9Ppw093znc/3dulUXxd
+        hr4V+P+vMzRN5MMHswmZoR0EmQd7FNzs7d0jPsqyT/cPPp3t7/5saOj79L83O7uPdh+SKzF+8IBM
+        3t4euFRZ7jZNFSpz563UrYV++1d+uAx9f+detouA5uDhhLygPTKvD89n6ICcgfuf7j7I7mMyvi5D
+        3wr8/9cZ+uGD6b0H+Tl5khlwmd6bbT/MdzKKlPL7D3YpEXOwf04vffMMvXcPaheR3qcU6bFnDC5V
+        lrtNU4XK3HmrCM9Cv/0rP1yG/vTBbD8/IJ25M6PE1f4km21TGiuj3+5/upfvfZpnezCXX5ehbwX+
+        /0UMTdz3/mnAnYP7WXafcjf3ZgiN7p1Ptye75Ld+mj+cfprPznfzh3DbvmmG/nSbuJR07h5x6cH4
+        3s7ug92HrHaV5W7TVKEyd+YP8t37B7N72w/I59/ep3+3Dw727m/fP7hPbmI2IQ2E+EGh3/6VHy5D
+        ZwfZQ3ILPt0+v0ew9/M98gnOpyRok73dezn5CfQdjeLrMvStwP9/naF3yYmaZBQenH/6kBh6SrhM
+        KMOxfY8C4Xt7++f7exOkB34WGJpSF7uP7h082tkfPzy495D+A5cqy92mqUK9PXda6Ld/5YfL0Af3
+        stnep6Q4KVtOYA8otHl4j6Kac0pNzGYUPkymH6KhbwX+/+sM/WAyfUhRLk3mhOLdfRrW9sMHNMh7
+        s/zeJCPlne+CJb9phn5AjIrUxe7uo53d8c7e3u7O/kNwqbLcbZoq1Ntzp4V++1d+uAx9794OOYD7
+        59u7u/cpOt2ZEMftTnYoh5ofUFZ1f+9h9iEa+lbg/7/O0NO9e5/uT3cpd5M9oNBob+/h9mRvRsts
+        nz6c5J/Odui9nw0fmtTuvTc79x7tPXi0tzu+t//w4YODHXCpstxtmirU23OnhX77V364DJ19ev/T
+        B5ODc4qC9mbb++f38+2D6acEezLZ2ZtkDw4+nWIUX5ehbwX+/1MMHWPo/cm9/FMyPuc7M0pend8/
+        2KYM++72LMspSDh4+Cki358lhibH+P7+o90dysU9oPUdVrvKcrdpqlBvz50W+u1f+eEy9P1ZdrCT
+        Ew73aIV2e//T/P72hNTU9qf3D/bOz7OHDw/yfRrF12XoW4H//zpDnx88pCQHuVSThw8htfn+NuU1
+        HlAu63x2P9+fPdzPDuilb5qh2Y8gLt0/eLS/P95DYuGAHWNluds0Vai3504L/fav/HAZ+sF+dk4Y
+        nVNmmJI7RHmaQcq0bX+6M9vZpzzMg2wfycevy9C3Av9Lvk/t83ft82L59qNHy3VZ/pL/B7yWcuAI
+        JQAA
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 10 Jun 2016 15:44:22 GMT']
+      Date: ['Tue, 26 Jul 2016 17:57:30 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
+      Set-Cookie: [x-ms-gateway-slice=productionb; path=/]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
       X-Content-Type-Options: [nosniff]
@@ -117,100 +348,398 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY1NTcxNDYzLCJuYmYiOjE0NjU1NzE0NjMsImV4cCI6MTQ2NTU3NTM2MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2Il0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.fZ7oSJMxpVQE8-0USIDYNmgQHzQO-vl2r9-M2h0mU67VapcCJ2xNTBQ8FU4wkj2zdd2coKEZJpL6dKBNvyELWIKYdxxPjVl7I5DRl6mJNWMKgsxfRghxsCZnudDFxh6ZrpaY7G3vCyc8hU7FY_xh0SSnVFroay4EUv7cmMh6THQDfM6WZ6JukkTZqdBydU-s0Nf0fHQdvplUCpjHKmYCAvHld1RIl3EoRtZrv_4EIDO42don3WBHUMGFnJu_jOYUQfFK3nlUgpNqapMNAUgJMzSTBo6LOrwYEuADT11nl7fjqS-aYFggTk_rszPyGcMmgG4proBxQdH7MMAZeb1PEw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY5NTU0MDQ1LCJuYmYiOjE0Njk1NTQwNDUsImV4cCI6MTQ2OTU1Nzk0NSwiYWNyIjoiMSIsImFsdHNlY2lkIjoiNTo6MTAwMzAwMDA4MDFDNDREMyIsImFtciI6WyJwd2QiLCJtZmEiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlbWFpbCI6Inl1Z2FuZ3dAbWljcm9zb2Z0LmNvbSIsImZhbWlseV9uYW1lIjoiV2FuZyIsImdpdmVuX25hbWUiOiJZdWdhbmciLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2Il0sImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0Ny8iLCJpbl9jb3JwIjoidHJ1ZSIsImlwYWRkciI6IjE2Ny4yMjAuMS4xMzAiLCJuYW1lIjoiWXVnYW5nIFdhbmciLCJvaWQiOiI4OWVkNWJlOC1mZjk3LTQxYjUtYWIxMS0wNTVlMWUzY2MzNGIiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODk1NSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IjJEWG5PTmM1RUFyNmFfM1Vya1JSYlFBdkdueHpxQWEtSExWczFyV3dndEkiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6Inl1Z2FuZ3dAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.fy4o2raFkNg7_jFMh7YDRNQuHLdZG2AKcxLdS0PbRgeWd52NIzQEYH-sCbNHsh5kecyVwxBJnqLLYs-FYjGic29jFK0jEeuZl55VKIB3kYaF2U2XXNcag2dfBTIHe9uyGRK5drmrpFT1g5bBA9qZQA_Gq0SoUp0yilVOIPNAg7wfi9fPIoEUzC2qoIxv0yxmZQTqHOi0WNTygVU2GrZqwLKdEegjc-t9eH3tECSBS2-HzBBfxWmYlzEP9CPxlcO-hrtbn9B-Wa97AStVWVSQS-TnMoRLETVVpWXkxiPBqdisyTzQ9rY2nHpr6e54trtul1wFIq26-1HQmp5NBi4Hag]
       Connection: [keep-alive]
+      Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 requests/2.9.1 msrest/0.3.0 msrest_azure/0.3.0 authorizationmanagementclient/2015-07-01
-          Azure-SDK-For-Python AZURECLI_0.0.32]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.0 msrest_azure/0.4.1
+          authorizationmanagementclient/0.30.0rc5 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [33e14724-2f22-11e6-8729-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments?api-version=2015-07-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS9X/zRqq5Wed0WefPRo1/8UV2V+dP8vFgWbVEtz2YfPfrobrOeNNO6WOGT5u7OZPf80/0H
-        u9u7k/Od7f3ZLNvO8um97enk4d6DvfOdh/cf7twloJfFLK+bu18U07pqqvN2fLxu51Vd/CADnLth
-        R83dg/xedv7p/Qfb2cH5+fb+/r3pdvbg/nR77zw/mO5PppNP793/aETYFstpscpKRu1g9+Bgtpsf
-        bN/beUi45Hgpe/Dp9r2D6fne5P70weReRi81UxoiNf8aI6G3p3WetfnsyyVB2NvZ/XR7h97Ye7O3
-        92j/00c7O+N7u7sP9u7v/xQ1Xa9mt22qUJ9cU9PzgwdZvp/PtqfTvb3t/Z2dve1sd2dne3J+/9NP
-        Z/cIzSynVxT67V/5JaOPCpDpa4z7ljN43DTFxXKRL9vm7u7D/N7kfP9g+/50f397f/fBbPsg293b
-        nub3P334cHKQT/cmNIr2mufillDphWW2wAu3Av9LRv/fZujZ3sHOdG/33va9e+f59v5ksrs9uf9w
-        sk2fTWYP9g9m09mUXvrmGXpv583ezqOdTx/t7o93dnb37x88AJcqy92mqUJl7rw32cnPD84n2znJ
-        4Pb+vcmn29n9h/v09r0HBwfTyezh/T16RaHf/pUfLkPvPzggoOf3tj/NJ/e29+mP7YezBzvb+f70
-        wb2HewcPzycfwtC3Av//IobOprPZg73sAfHmwX3CNz/fnsz297bPP9359HySHexm+QMaXcjQ+3s7
-        Dx/MJiS1O/dJag/28u1sb+/e9s6DLPt0/+DT2f7uzwZD36f/vdnZfbT7kDTv+MED0hB7e+BSZbnb
-        NFWot+dOC/32r/xwGfr+zr1s99PsfPvg4YSMxh5po4fnM3RAuvP+p7sPsvuYjK/L0LcC//91hn74
-        YHrvQX5OhjcDLtN7s+2H+U62/YDs0IPdyR7J8Tm99M0z9N499iMePrr/6fjhHjsS4FJluds0VajM
-        nfcffnrv/P7OdPvBdJ+Uzw7NVXb+IN++f2/v4f4sf/BpNpnRKwr99q/8cBn60wez/fzgfHd7Z/Zg
-        QuYym21PPr2f0W/3P93L9z7Ns717NIqvy9C3Av//Ioa+t7uX3f/0PvHmwS65HOezAxJF4Jvv7ebk
-        PBCDQr5Dhn6QPbx3kN0jNPb2PqV/dvLthw8/pddn+weTafbp7P49SMEHMPTdOm+qdT3NP6+r9aq5
-        Oy3XbdM++PRgd5cAK1d6DEz0fvBmZ+fR/oNHu5+OD/Z2H+zs3wMDKzfepqlCvT3jWui3f+VDeH2Y
-        JLecd49h7+7lpIzyPbIt+9Pp9v7DPN+eEHdu3yf/eHo+vZfvHRzQAL+uGNwK/I/E4MaRROf8gGK3
-        QTH4FHp85/6jewfje/c+pZiH9bgy6m2aKtTb87SFfvtXvnExYJLcct49hr07I4f54f2D3e38wX2y
-        5w9pCifnpLinFEYRw95/mB9ggF9XDG4F/kdicONIonO+/2Dn3j4BVobt8fa9R/d34Z8f3Nvf+XSX
-        eVsZ9TZNFertedpCv/0r37gYMEluOe8ew94lziSOnObb5w/OD8it/XSy/XB3mm3v7h8cPLi/s7t3
-        /xyJh68rBrcC//8iMfhaeZh9isT3ZrvZ9uzTe5SH2SEvP8tJgO7Psk8PMorM83PIzjcoBlm9mJZF
-        01Z1diGf3ds9gKgp73psfn979wFre/Lxd8YP9u7dp0gabK48e5umCvX27G2h3/6Vb1Ai4tS5JTd4
-        bHx398HD808/fUDxGoVulEWcEeKEznY2I59+tkcZ5AmI/nWF41bg/18kHP+fshH3H+7uwI9V3vXY
-        nBU/Ejj3Hu3sj+8fPCQ1xGyuPHubpgr19uxtod/+lW9QIjyS3HLePYa9+3DycPpglh1QPwc0hfkO
-        /ZYhN3d/RjmR851P9ybIQ3xdMbgV+B+JwY0jic75vYe7u0g2KsOGvE3R8ENo+/v3aLHp3n2yyeBt
-        ZdTbNFWot+dpC/32r3zjYsAkueW8ewx7d7KztzeZ7N/ffnA+pew0+S7bkwfk4T/Ym+w/nN47mGS7
-        UDhfVwxuBf7/RWLwtVylW834NyoGxz9Y1/nrp7/Xq88JrvKrx9r0vwfQ8MTa5PMc7N27t/dgB6yt
-        fHqbpgqVWfqWcq7Qb//KNygFjiK3m3WfXe/mDw928vs5seV9yoXv36deD+7f292ezibk99JzkCEy
-        +7pCcCvw/y8Sgv9P2QJaSrspe/Tg0d6D8YN7n96/v8vLWsqnt2mqUJmlbynmCv32r3yDUuCR5Jbz
-        7jHs3enOzmw2zWn9de/8ISnrB9PtySRH0nPv4WRCnsvubk4D/LpicCvwv+T71D5/1z4vlm8/erRc
-        l+Uv+X8A+e54K6sjAAA=
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 10 Jun 2016 15:44:22 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY1NTcxNDYzLCJuYmYiOjE0NjU1NzE0NjMsImV4cCI6MTQ2NTU3NTM2MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2Il0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.fZ7oSJMxpVQE8-0USIDYNmgQHzQO-vl2r9-M2h0mU67VapcCJ2xNTBQ8FU4wkj2zdd2coKEZJpL6dKBNvyELWIKYdxxPjVl7I5DRl6mJNWMKgsxfRghxsCZnudDFxh6ZrpaY7G3vCyc8hU7FY_xh0SSnVFroay4EUv7cmMh6THQDfM6WZ6JukkTZqdBydU-s0Nf0fHQdvplUCpjHKmYCAvHld1RIl3EoRtZrv_4EIDO42don3WBHUMGFnJu_jOYUQfFK3nlUgpNqapMNAUgJMzSTBo6LOrwYEuADT11nl7fjqS-aYFggTk_rszPyGcMmgG4proBxQdH7MMAZeb1PEw]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 requests/2.9.1 msrest/0.3.0 msrest_azure/0.3.0 authorizationmanagementclient/2015-07-01
-          Azure-SDK-For-Python AZURECLI_0.0.32]
-      accept-language: [en-US]
-      x-ms-client-request-id: [343073be-2f22-11e6-905b-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clutst39112/providers/Microsoft.Authorization/roleAssignments/b022bb45-7fc4-4125-b781-72b49c38ba18?api-version=2015-07-01
+      x-ms-client-request-id: [6c822b76-535a-11e6-867d-64510658e3b3]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-role-assignment-test/providers/Microsoft.Authorization/roleAssignments/1518cef5-a2c8-48e1-acb5-eaadf2474f79?api-version=2015-07-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR6u6
         WuV1W+TNR49+8Ud1VeZP8/NiWbRFtTybffToo7vNetJM62KFT5q7O5Pd80/3H+xu707Od7b3Z7Ns
-        O8un97ank4d7D/bOdx7ef7hzl4BeFrO8bu5+UUzrqqnO2/Hxup1XdfGDDHDuhh01d+/t7mX3P70/
-        254e7J5v75/PDrYPHt7Ptvfzvd18/2B2/8Hu9KMRYVssp8UqKxm1B9nDewfZPUJjb+9T+mcn3374
-        8FN6fbZ/MJlmn87u33tALzVTGiI1/zojqfOmWtfT/PO6Wq+au9Ny3TbtvYe7u3sEeFrnWZvPvlwS
-        8L2d3U+3d3a3dx682Xn4aGfv0f1743u79+7vHxz8FDVdr2a3bapQn1xT0/sPP713fn9nuv1gun9v
-        e3/n/nQ7O3+Qb9+/t/dwf5Y/+DSbzOgVhX77V37J6KMCFLz7jZLklvN+3DTFxXKRL9vm7mRnb28y
-        2b+//eB8ur+9v7t3f3vy4GB3+8HeZP/h9N7BJNs9oAG21zyDt4RKLyyzBV64Ffhf8v8AoGOCQgYD
+        O8un97ank4d7D/bOdx7ef7hzl4BeFrO8bu5+UUzrqqnO2/Hxup1XdfGDDHDuhh01dyd7+w8PDrLp
+        9qe7BwR2L9vZziYHB9t7O+cP7h3szWZ7+9OPRoRtsZwWq6xk1A52Hhzk2ez+9v6n9/e39yef3t8+
+        2H8w2b43OX8wzT7N9j49P6CXmikNkZp/nZHUeVOt62n+eV2tV83daVlsA/XtrGmKi+UiX7bbbd60
+        1Mu0zrM2n325pJ72dnY/3d55sL336ZvdB4/uP3h0b2f86acHu/f27v0UNV2vZrdtqlCfXFPTg4f5
+        7P4kP9g+P3/4YHt/d3KfaLS7u71z/36+m9+bTu/tT+gVhX77V37J6KMC5Lz7s0efW3LEsX2rubt7
+        f/dgmp8TwnvTg+39g3x3O5sS/nmWzc739h/snz94SKNtr3lubwmVXlhmC7xwK/C/5P8BUTj2myAD
         AAA=
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 10 Jun 2016 15:44:23 GMT']
+      Date: ['Tue, 26 Jul 2016 17:57:31 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
+      Set-Cookie: [x-ms-gateway-slice=productionb; path=/]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY5NTU0MDQ1LCJuYmYiOjE0Njk1NTQwNDUsImV4cCI6MTQ2OTU1Nzk0NSwiYWNyIjoiMSIsImFsdHNlY2lkIjoiNTo6MTAwMzAwMDA4MDFDNDREMyIsImFtciI6WyJwd2QiLCJtZmEiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlbWFpbCI6Inl1Z2FuZ3dAbWljcm9zb2Z0LmNvbSIsImZhbWlseV9uYW1lIjoiV2FuZyIsImdpdmVuX25hbWUiOiJZdWdhbmciLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2Il0sImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0Ny8iLCJpbl9jb3JwIjoidHJ1ZSIsImlwYWRkciI6IjE2Ny4yMjAuMS4xMzAiLCJuYW1lIjoiWXVnYW5nIFdhbmciLCJvaWQiOiI4OWVkNWJlOC1mZjk3LTQxYjUtYWIxMS0wNTVlMWUzY2MzNGIiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODk1NSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IjJEWG5PTmM1RUFyNmFfM1Vya1JSYlFBdkdueHpxQWEtSExWczFyV3dndEkiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6Inl1Z2FuZ3dAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.fy4o2raFkNg7_jFMh7YDRNQuHLdZG2AKcxLdS0PbRgeWd52NIzQEYH-sCbNHsh5kecyVwxBJnqLLYs-FYjGic29jFK0jEeuZl55VKIB3kYaF2U2XXNcag2dfBTIHe9uyGRK5drmrpFT1g5bBA9qZQA_Gq0SoUp0yilVOIPNAg7wfi9fPIoEUzC2qoIxv0yxmZQTqHOi0WNTygVU2GrZqwLKdEegjc-t9eH3tECSBS2-HzBBfxWmYlzEP9CPxlcO-hrtbn9B-Wa97AStVWVSQS-TnMoRLETVVpWXkxiPBqdisyTzQ9rY2nHpr6e54trtul1wFIq26-1HQmp5NBi4Hag]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.0 msrest_azure/0.4.1
+          authorizationmanagementclient/0.30.0rc5 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [6d0364e8-535a-11e6-ba25-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-role-assignment-test/providers/Microsoft.Authorization/roleAssignments?api-version=2015-07-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/zRqq5Wed0WefPRo1/8UV2V+dP8vFgWbVEtz2YfPfrobrOeNNO6WOGT5u7OZPf80/0H
+        u9u7k/Od7f3ZLNvO8um97enk4d6DvfOdh/cf7twloJfFLK+bu18U07pqqvN2fLxu51Vd/CADnLth
+        R83dg/xedv7p/Qfb2cH5+fb+/r3pdvbg/nR77zw/mO5PppNP793/aETYFstpscpKRu3edGfn/qfZ
+        +fbezvRge//+7r3tbDadbX96cL6fTXf38ofnGb3UTGmI1PxrjITentZ51uazL5cEYW9n99PtnQfb
+        u3tv9nYe7T98dP/e+OHep/uf3nvwU9R0vZrdtqlCfXJNTe8//PTe+f2d6faD6f697f0dGnZ2/iDf
+        vn9v7+H+LH/waTaZ0SsK/fav/JLRRwXI9DXGfcsZPG6a4mK5yJdtc3c3f3D/0/PpA5qye/uEUra3
+        nU3zbHv34P7s0938Hs3gHo2ivea5uCVUemGZLfDCrcD/ktH/txn6YPfgYLabH2zf23lIuOR4KXvw
+        6fa9g+n53uT+9MHk3s8GQ9MbxKV7j/Y/fbSzM763u/tg7/4+uFRZ7jZNFSpz5/nBgyzfz2fb0+ne
+        Hs3VDs3V7s7O9uT8/qefzu4RmllOryj027/yQ2boh8RV5/sH2/en+8Rxuw9m2wfZ7t72NL//6cOH
+        k4N8ujehUXxthr4N+P+vM/Rs72Bnukd6+d6983x7fzLZ3Z7cfzjZps8mswf7B6Stp/TSN8/QeztQ
+        uzufPtrdH+/s7O7fP2C1qyx3m6YKlbnz3mQnPz84n2znJIPb+6RstrP7D/fp7XsPDg6mk9nD+9Bt
+        Cv32r/xwGXr/wQEBPb+3/Wk+IaNBf2w/nD3Y2c73pw/uPdw7eHg++RCGvhX4/xcxdDadzR7sZQ+I
+        Nw/uE775+fZktr+3ff7pzqfnk+xgN8sf0OhCht6ZznamD3ep6QNM68P7k20a1/727t7+7vnOfWLz
+        +/fopW+aocns3Yfa3b3/aOdgfHD/3v3dB8ylynK3aapQmTsfZA/vHWT3CIe9vU/pn518++HDT0ms
+        Z/sHk2n26ez+PYxdod/+lR8uQ98jqmcTGvH+wT3y/zCDD6fnu9vTB9Ppw093znc/3dulUXxdhr4V
+        +P+vMzRN5MMHswmZoZ37ZIYO9vLtbG/vHvFRln26f/DpbH/3Z0ND36f/vdnZfbT7kFyJ8YMHZPL2
+        9sClynK3aapQmTtvpW4t9Nu/8sNl6Ps797JdBDQHDyfkBe2ReX14PkMH5Azc/3T3QXYfk/F1GfpW
+        4P+/ztAPH0zvPcjPyZPMgMv03mz7Yb6TUaSU33+wO9kjw3ROL33zDL13D2oXkd6nFOmxZwwuVZa7
+        TVOFytx5qwjPQr/9Kz9chv70wWw/PyCduTN7MNnen2Sz7cmn9zP67f6ne/nep3m2B3P5dRn6VuD/
+        X8TQxH0PDw6y6fanuwcEdi/b2c4mBwfkgp4/uHewN5vt7UO+Q4beObifZfcn97fvzRAa3Tufbk92
+        yW/9NH84/TSfne/mD+G2fdMM/ek2cSnp3D3i0oPxvZ3dB7sPWe0qy92mqUJl7swf5Lv3D2b3th+Q
+        z7+9T/9uHxzs3d++f3Cf3MRsQhoI8YNCv/0rP1yGzg6yh+QWfLp9fo9g7+d75BOcT0nQJnu793Ly
+        E+g7GsXXZehbgf//OkPvkhM1ySg8OP/0ITH0lHCZUIZj+x4Fwvf29s/39yZID/wsMDSlLnYf3Tt4
+        tLM/fnhw7yH9By5VlrtNU4V6e+600G//yg+XoQ/uZbO9T0lx3ptOCewBhTYP71FUc06pidmMwofJ
+        9EM09K3A/3+doR9Mpg8pyqXJnFC8u0/D2n74gAZ5b5bfm2SkvPNdsOQ3zdAPiFGRutjdfbSzO97Z
+        29vd2X8ILlWWu01ThXp77rTQb//KD5eh793bIQdw/3x7d/c+Rac7E+K43ckO5VDzA8qq7u89zD5E
+        Q98K/P/XGXq6d+/T/eku5W6yBxQa7e093J7szQ6gsCf5p7Mdeu9nw4cmtXvvzc69R3sPHu3tju/t
+        P3z44GAHXKosd5umCvX23Gmh3/6VHy5DZ5/e//TB5OCcoqC92fb++f18+2D6KcGeTHb2JtmDg0+n
+        GMXXZehbgf//PEPvT+7ln5LxOd+ZUfLq/P7BNmXYd7dnWU5BwsHDTxH5/iwxNDnG9/cf7e5QLu4B
+        re+w2lWWu01ThXp77rTQb//KD5eh78+yg52ccLhHK7Tb+5/m97cnNKvbn94/2Ds/zx4+PMj3aRRf
+        l6FvBf7/6wx9fvCQkhzkUk0ePoTU5vvblNd4QLms89n9fH/2cD87oJfiDH2rkdDbynoel7IfQVy6
+        f/Bof3+8h8TCATvGynK3aapQb8+dFvrtX/nhMvSD/eycMDqnzDAld4jyNIOUadv+dGe2s095mAfZ
+        PpKPX5ehbwX+l3yf2ufv2ufF8u1Hj5brsvwl/w/oqslP5yEAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 26 Jul 2016 17:57:32 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Set-Cookie: [x-ms-gateway-slice=productionb; path=/]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY5NTU0MDQ1LCJuYmYiOjE0Njk1NTQwNDUsImV4cCI6MTQ2OTU1Nzk0NSwiYWNyIjoiMSIsImFsdHNlY2lkIjoiNTo6MTAwMzAwMDA4MDFDNDREMyIsImFtciI6WyJwd2QiLCJtZmEiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlbWFpbCI6Inl1Z2FuZ3dAbWljcm9zb2Z0LmNvbSIsImZhbWlseV9uYW1lIjoiV2FuZyIsImdpdmVuX25hbWUiOiJZdWdhbmciLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2Il0sImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0Ny8iLCJpbl9jb3JwIjoidHJ1ZSIsImlwYWRkciI6IjE2Ny4yMjAuMS4xMzAiLCJuYW1lIjoiWXVnYW5nIFdhbmciLCJvaWQiOiI4OWVkNWJlOC1mZjk3LTQxYjUtYWIxMS0wNTVlMWUzY2MzNGIiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODk1NSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IjJEWG5PTmM1RUFyNmFfM1Vya1JSYlFBdkdueHpxQWEtSExWczFyV3dndEkiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6Inl1Z2FuZ3dAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.fy4o2raFkNg7_jFMh7YDRNQuHLdZG2AKcxLdS0PbRgeWd52NIzQEYH-sCbNHsh5kecyVwxBJnqLLYs-FYjGic29jFK0jEeuZl55VKIB3kYaF2U2XXNcag2dfBTIHe9uyGRK5drmrpFT1g5bBA9qZQA_Gq0SoUp0yilVOIPNAg7wfi9fPIoEUzC2qoIxv0yxmZQTqHOi0WNTygVU2GrZqwLKdEegjc-t9eH3tECSBS2-HzBBfxWmYlzEP9CPxlcO-hrtbn9B-Wa97AStVWVSQS-TnMoRLETVVpWXkxiPBqdisyTzQ9rY2nHpr6e54trtul1wFIq26-1HQmp5NBi4Hag]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.0 msrest_azure/0.4.1
+          authorizationmanagementclient/0.30.0rc5 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [6d49c96e-535a-11e6-8a90-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-role-assignment-test/providers/Microsoft.Network/networkSecurityGroups/nsg1/providers/Microsoft.Authorization/roleDefinitions?api-version=2015-07-01&$filter=roleName%20eq%20%27contributor%27
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/zRqq5Wed0WefPRo1/8UV2V+YtsQV99dFIt27qYrNuq/mj0UXu9wodP1kXZni1fUTP6
+        cJY307pYtUW1pO+e522TXlfrdJEts4s8zS/z+rqdF8uLNH83zVdtmk2nedOkbZXWeVOta/prTGCy
+        pikultmkzF9PCRlC5Hsf3f3o+6OPCLFFQV9WS3z2iz/KpugKv3/0LXy/rNpj99EXxbSumuq8HR+v
+        23lVFz/I8N3db919mpd5C4SHm3y3LqjF938JQZ3Wedbmsy8xpp2dnd1t/t+bnYNHOzv0vzF9huen
+        CN56NbNN93Z2P93eub99b/fN3r1Hu/ce3T8Yf/pgf/feHjdVqE+uP3q0XJelfdd88EtGHxUzAnO3
+        WU8sVZu7O5Pd80/3H+xu707Od7b3Z7NsO8un97ank4d7D/bOdx7ef7hzl+bwspjldXN3aICY16f5
+        ebEs8Gdzd7K3//DgIJtuf7p7QGD3sp3tbHJwsL23c/7g3sHebLa3PyWkddZvCZVeWArv3Ao8aL3M
+        37XPi+VbpcH/A+KDerWZAgAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 26 Jul 2016 17:57:32 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Set-Cookie: [x-ms-gateway-slice=productionb; path=/]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL2dyYXBoLndpbmRvd3MubmV0LyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Njk1NTQ4NzMsIm5iZiI6MTQ2OTU1NDg3MywiZXhwIjoxNDY5NTU4NzczLCJhY3IiOiIxIiwiYWx0c2VjaWQiOiI1OjoxMDAzMDAwMDgwMUM0NEQzIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVtYWlsIjoieXVnYW5nd0BtaWNyb3NvZnQuY29tIiwiZmFtaWx5X25hbWUiOiJXYW5nIiwiZ2l2ZW5fbmFtZSI6Ill1Z2FuZyIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0Ny8iLCJpbl9jb3JwIjoidHJ1ZSIsImlwYWRkciI6IjE2Ny4yMjAuMS4xMzAiLCJuYW1lIjoiWXVnYW5nIFdhbmciLCJvaWQiOiI4OWVkNWJlOC1mZjk3LTQxYjUtYWIxMS0wNTVlMWUzY2MzNGIiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODk1NSIsInNjcCI6IjYyZTkwMzk0LTY5ZjUtNDIzNy05MTkwLTAxMjE3NzE0NWUxMCIsInN1YiI6ImhkcUE5WDBBZ2k5TDdfcjNXUDh2RXhFODJCZDlTVzlzY0ZtRGpPbTFPTUUiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6Inl1Z2FuZ3dAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCJ9.mOt4-DkLilfW_uya-TcnHtN1vUBzGUs-gJw2gtehDetYELnixPhbSRoKxBWWt-dVn_Cg538z4hBTIA45y5bzE-ONyTT7umCbU6f0fBNGbBY9e9n41-X6G85b-ZJ1l5IR0lRp6R6atRZT3ygTg4OWQN8ZytHcF_SmuR-8aCjWIHJO4-yQj0W7AaXHuKqBcPOGaoxVVm2Z01cHukNNeQl6qoblnsa1rMJEkF_sZYYzMZycobxcmsK3qtIrU5b4ooO4fGNGStEi1-ZRJcCfMxigZsexTjGFlALnK7uuUQuAfwfTfK1r4dOHeYuaZzoHEkfRvJHZiQQpNjL0B51LzrRB9A]
+      CommandName: [role assignment create]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.0 msrest_azure/0.4.1
+          graphrbacmanagementclient/0.30.0rc5 Azure-SDK-For-Python AZURECLI/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [4c322128-535a-11e6-a0cc-64510658e3b3]
+    method: GET
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/users?api-version=1.6&$filter=userPrincipalName%20eq%20%27testuser1%40azuresdkteam.onmicrosoft.com%27
+  response:
+    body: {string: '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.User","value":[{"odata.type":"Microsoft.DirectoryServices.User","objectType":"User","objectId":"8078ead5-4654-4b65-847b-3bf7ca6a26f8","deletionTimestamp":null,"accountEnabled":true,"signInNames":[],"assignedLicenses":[],"assignedPlans":[],"city":null,"companyName":null,"country":null,"creationType":null,"department":null,"dirSyncEnabled":null,"displayName":"tester123","facsimileTelephoneNumber":null,"givenName":null,"immutableId":null,"isCompromised":null,"jobTitle":null,"lastDirSyncTime":null,"mail":null,"mailNickname":"testuser1","mobile":null,"onPremisesSecurityIdentifier":null,"otherMails":[],"passwordPolicies":null,"passwordProfile":null,"physicalDeliveryOfficeName":null,"postalCode":null,"preferredLanguage":null,"provisionedPlans":[],"provisioningErrors":[],"proxyAddresses":[],"refreshTokensValidFromDateTime":"2016-07-26T17:56:38Z","sipProxyAddress":null,"state":null,"streetAddress":null,"surname":null,"telephoneNumber":null,"usageLocation":null,"userPrincipalName":"testuser1@azuresdkteam.onmicrosoft.com","userType":"Member"}]}'}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Cache-Control: [no-cache]
+      Content-Length: ['1186']
+      Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
+      DataServiceVersion: [3.0;]
+      Date: ['Tue, 26 Jul 2016 17:57:29 GMT']
+      Duration: ['1262021']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET, ASP.NET]
+      ocp-aad-diagnostics-server-name: [Vysq2vNZzcPtnjT1P5DAD3ODEK1mXogz2xu8HZBYqqY=]
+      ocp-aad-session-key: [0ZH4R3OAfmxL-FzEz2D0WKI9lEvupIaLM2XVVJ3wPH-nyaHZqkbEArAkl33qefKECXorlrTIM1Bra9vA1-ejsy4FDsNr6iCUuexDribNEP2GJYUL7SRJayKjkExUTNsdJIRFCXgNAiam09bcYKc63A.PE8W-E1mSSt_bOVs0jrUHgMuNzatUxbF04_75iBpAD8]
+      request-id: [74bb2aa1-cb60-43d5-a18a-e5987a8f1c4a]
+      x-ms-dirapi-data-contract-version: ['1.6']
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJwcm9wZXJ0aWVzIjogeyJyb2xlRGVmaW5pdGlvbklkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2
+      NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9wcm92aWRlcnMvTWljcm9zb2Z0LkF1dGhv
+      cml6YXRpb24vcm9sZURlZmluaXRpb25zL2IyNDk4OGFjLTYxODAtNDJhMC1hYjg4LTIwZjczODJk
+      ZDI0YyIsICJwcmluY2lwYWxJZCI6ICI4MDc4ZWFkNS00NjU0LTRiNjUtODQ3Yi0zYmY3Y2E2YTI2
+      ZjgifX0=
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY5NTU0MDQ1LCJuYmYiOjE0Njk1NTQwNDUsImV4cCI6MTQ2OTU1Nzk0NSwiYWNyIjoiMSIsImFsdHNlY2lkIjoiNTo6MTAwMzAwMDA4MDFDNDREMyIsImFtciI6WyJwd2QiLCJtZmEiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlbWFpbCI6Inl1Z2FuZ3dAbWljcm9zb2Z0LmNvbSIsImZhbWlseV9uYW1lIjoiV2FuZyIsImdpdmVuX25hbWUiOiJZdWdhbmciLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2Il0sImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0Ny8iLCJpbl9jb3JwIjoidHJ1ZSIsImlwYWRkciI6IjE2Ny4yMjAuMS4xMzAiLCJuYW1lIjoiWXVnYW5nIFdhbmciLCJvaWQiOiI4OWVkNWJlOC1mZjk3LTQxYjUtYWIxMS0wNTVlMWUzY2MzNGIiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODk1NSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IjJEWG5PTmM1RUFyNmFfM1Vya1JSYlFBdkdueHpxQWEtSExWczFyV3dndEkiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6Inl1Z2FuZ3dAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.fy4o2raFkNg7_jFMh7YDRNQuHLdZG2AKcxLdS0PbRgeWd52NIzQEYH-sCbNHsh5kecyVwxBJnqLLYs-FYjGic29jFK0jEeuZl55VKIB3kYaF2U2XXNcag2dfBTIHe9uyGRK5drmrpFT1g5bBA9qZQA_Gq0SoUp0yilVOIPNAg7wfi9fPIoEUzC2qoIxv0yxmZQTqHOi0WNTygVU2GrZqwLKdEegjc-t9eH3tECSBS2-HzBBfxWmYlzEP9CPxlcO-hrtbn9B-Wa97AStVWVSQS-TnMoRLETVVpWXkxiPBqdisyTzQ9rY2nHpr6e54trtul1wFIq26-1HQmp5NBi4Hag]
+      Connection: [keep-alive]
+      Content-Length: ['233']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.0 msrest_azure/0.4.1
+          authorizationmanagementclient/0.30.0rc5 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [6d9fe8be-535a-11e6-baa2-64510658e3b3]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-role-assignment-test/providers/Microsoft.Network/networkSecurityGroups/nsg1/providers/Microsoft.Authorization/roleAssignments/f13b65c4-7c62-4dd2-b2eb-2a348b57c25b?api-version=2015-07-01
+  response:
+    body: {string: '{"properties":{"roleDefinitionId":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"8078ead5-4654-4b65-847b-3bf7ca6a26f8","scope":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-role-assignment-test/providers/Microsoft.Network/networkSecurityGroups/nsg1","createdOn":"2016-07-26T17:57:33.7163938Z","updatedOn":"2016-07-26T17:57:33.7163938Z","createdBy":null,"updatedBy":"89ed5be8-ff97-41b5-ab11-055e1e3cc34b"},"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-role-assignment-test/providers/Microsoft.Network/networkSecurityGroups/nsg1/providers/Microsoft.Authorization/roleAssignments/f13b65c4-7c62-4dd2-b2eb-2a348b57c25b","type":"Microsoft.Authorization/roleAssignments","name":"f13b65c4-7c62-4dd2-b2eb-2a348b57c25b"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['876']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 26 Jul 2016 17:57:33 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Set-Cookie: [x-ms-gateway-slice=productionb; path=/]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY5NTU0MDQ1LCJuYmYiOjE0Njk1NTQwNDUsImV4cCI6MTQ2OTU1Nzk0NSwiYWNyIjoiMSIsImFsdHNlY2lkIjoiNTo6MTAwMzAwMDA4MDFDNDREMyIsImFtciI6WyJwd2QiLCJtZmEiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlbWFpbCI6Inl1Z2FuZ3dAbWljcm9zb2Z0LmNvbSIsImZhbWlseV9uYW1lIjoiV2FuZyIsImdpdmVuX25hbWUiOiJZdWdhbmciLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2Il0sImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0Ny8iLCJpbl9jb3JwIjoidHJ1ZSIsImlwYWRkciI6IjE2Ny4yMjAuMS4xMzAiLCJuYW1lIjoiWXVnYW5nIFdhbmciLCJvaWQiOiI4OWVkNWJlOC1mZjk3LTQxYjUtYWIxMS0wNTVlMWUzY2MzNGIiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODk1NSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IjJEWG5PTmM1RUFyNmFfM1Vya1JSYlFBdkdueHpxQWEtSExWczFyV3dndEkiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6Inl1Z2FuZ3dAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.fy4o2raFkNg7_jFMh7YDRNQuHLdZG2AKcxLdS0PbRgeWd52NIzQEYH-sCbNHsh5kecyVwxBJnqLLYs-FYjGic29jFK0jEeuZl55VKIB3kYaF2U2XXNcag2dfBTIHe9uyGRK5drmrpFT1g5bBA9qZQA_Gq0SoUp0yilVOIPNAg7wfi9fPIoEUzC2qoIxv0yxmZQTqHOi0WNTygVU2GrZqwLKdEegjc-t9eH3tECSBS2-HzBBfxWmYlzEP9CPxlcO-hrtbn9B-Wa97AStVWVSQS-TnMoRLETVVpWXkxiPBqdisyTzQ9rY2nHpr6e54trtul1wFIq26-1HQmp5NBi4Hag]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.0 msrest_azure/0.4.1
+          authorizationmanagementclient/0.30.0rc5 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [6e558c10-535a-11e6-bfe0-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-role-assignment-test/providers/Microsoft.Network/networkSecurityGroups/nsg1/providers/Microsoft.Authorization/roleAssignments?api-version=2015-07-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/zRqq5Wed0WefPRo1/8UV2V+dP8vFgWbVEtz2YfPfrobrOeNNO6WOGT5u7OZPf80/0H
+        u9u7k/Od7f3ZLNvO8um97enk4d6DvfOdh/cf7twloJfFLK+bu18U07pqqvN2fLxu51Vd/CADnLth
+        R83dyd7+w4ODbLr96e4Bgd3LdrazycHB9t7O+YN7B3uz2d7+9KMRYVssp8UqKxm1g50HB3k2u7+9
+        /+n9/e39yaf3tw/2H0y2703OH0yzT7O9T88P6KVmSkOk5l9nJHXeVOt6mn9eV+tVc3daFttAfTtr
+        muJiuciX7XabN210xC/y9qqq395dys/X+XRdF+21glo2F7uE3LTOszaffbkkBPd2dj/d3nmwvffp
+        m90Hj+4/eHRvf7y3d/Dpw929n6Km69Xstk0V6pNranrwMJ/dn+QH2+fnDx9s7+9O7hNpd3e3d+7f
+        z3fze9Ppvf0JvaLQb//KLxl9VGAW7v6/jqzR1/r8d2w7a+6e794j9pnubz+YfroHrPe2J3v5ZHsv
+        u7d/MLn/YLp3H0Rqr5mTbgmVXlhmC7xwK/C/ZPT/GnE8yO9l55/ef7CdHZyfb+/v35tuZw/uT7f3
+        zvOD6f5kOvn03n0aXSiO96Y7O/c/zc5JaKcH2/v3d+9tZ7PpbPvTg/P9bLq7lz88z+ilDxBHels5
+        OxCC3b03ezuP9h8+un9v/HDv0/1P7z2AEChH36apQmXmv//w03vn93emNFf797b3d2jY2fmDfPv+
+        vb2H+7P8wafZZEavKPTbv/Ih8nK7GfRY7+5u/uD+p+dT0hDn90g37mR729k0z7Z3D+7PPiUZphnc
+        o1F8XYa+Ffj/rzP0we7BwWyX1OC9nYeECym+7Sx78On2vYPp+d7k/vTB5N7PBkPTG8Sle4/2P320
+        szO+t7v7YO/+PrhUWe42TRUqc+f5wYMs389n29PpHimfnR2aq92dne3J+f1PP53dIzSznF5R6Ld/
+        5YfM0A+Jq873D7ZJjRLH7T6YbR9ku3vb0/z+pw8fTg7y6d6HaOhbgf//OkPP9g52pnukl+/dO8+3
+        9yeT3e3J/YeTbfpsMnuwf0DaGl7WN8/QeztQuzufPtrdH+/s7O7fP2C1qyx3m6YKlbnz3mQnPz84
+        n2znJIPb+6RstrP7D/fp7XsPDg6mk9nD+9BtCv32r/xwGXr/ATmru+f3tj/NJ2Q06I/th7MHO9v5
+        /vTBvYd7Bw/PJx/C0LcC//8ihs6ms9mDvewB8eYBefQH+fn2ZLa/t33+6c6n55PsYDfLH9DoQobe
+        mc52pg93qekDTOvD+5NtGtf+9u7e/u75zn1i8/v36KVvmqHJ7N2H2t29/2jnYHxw/9793QfMpcpy
+        t2mqUJk7H2QP7x1k9wiHvb1P6Z+dfPvhw09JrGfkHVIkM7t/D2NX6Ld/5YfL0PeI6tmERrx/cI/8
+        P8zgw+n57vb0wXT68NOd891P9xDxfF2GvhX4/68zNE3kwwezCZmhHYS0B3sUE+3t3SM+yrJP9w8+
+        ne3v/mxo6Pv0vzc7u492H5IrMX7wgEzeHgeSynK3aapQmTtvpW4t9Nu/8sNl6Ps797JdBDQHDyfk
+        Be2ReX14PkMH5Azc/3T3QXYfk/F1GfpW4P+/ztAPH0zvPcjPyZPMgMv03mz7Yb6TUaSU33+wS2mf
+        g/1zeumbZ+i9e1C7iPQ+pUiPPWNwqbLcbZoqVObOW0V4FvrtX/nhMvSnD2b7+QHpzJ0Zpcn2J9ls
+        m9ISGf12/9O9fO/TPNuDufy6DH0r8P8vYmjivvdPOu4c3M+y+5QRuzdDaHTvfLo92SW/9dP84fTT
+        fHa+mz+E2/ZNM/Sn28SlpHP3iEsPxvd2dh/sPmS1qyx3m6YKlbkzf5Dv3j+Y3dt+QD7/9j79u31w
+        sHd/+/7BfXITswlpIMQPCv32r/xwGTo7yB6SW/Dp9vk9gr2f75FPcD4lQZvs7d7LyU+g72gUX5eh
+        bwX+/+sMvUtO1CSj8OD804fE0FPCZUIZju17FAjf29s/39+bID3ws8DQlLrYfXTv4NHO/vjhwb2H
+        9B+4VFnuNk0V6u2500K//Ss/XIY+uJfN9j4lxUlJdgJ7QKHNw3sU1ZxTamI2o/BhMv0QDX0r8P9f
+        Z+gHk+lDinJpMicU7+7TsLYfPqBB3pvl9yYZKe98Fyz5TTP0A2JUpC52dx/t7I539vZ2d/YfgkuV
+        5W7TVKHenjst9Nu/8sNl6Hv3dsgB3D/f3t29T9HpzoQ4bneyQznU/ICyqvt7D7MP0dC3Av//dYae
+        7t37dH+6S7mb7AGFRnt7D2n1aEarc58+nOSfznbovZ8NH5rU7r03O/ce7T14tLc7vrf/8OGDgx1w
+        qbLcbZoq1Ntzp4V++1d+uAydfXr/0weTg3OKgvZm2/vn9/Ptg+mnBHsy2dmbZA8OPp1iFF+XoW8F
+        /gMZ+kPJ8eEMvT+5l39Kxud8Z0bJq/P7B9uUYd/dnmU5BQkHDz9F5PuzxNDkGN/ff7S7Q7m4B7S+
+        w2pXWe42TRXq7bnTQr/9Kz9chr4/yw52csLhHq3Qbu9/mt/fntCsbn96/2Dv/Dx7+PAg36dRfF2G
+        vhX4/68z9PnBQ0pykEs1efgQUpvvb1Ne4wHlss5n9/P92cP97IBe+qYZmv0I4tL9g0f7++M9JBYO
+        2DFWlrtNU4V6e+600G//yg+XoR/sZ+eE0Tllhim5Q5SnGaRM2/anO7OdfcrDPMj2kXz8ugx9K/C/
+        5PvUPn/XPi+Wbz96tFyX5S/5fwB+DSwGdiUAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 26 Jul 2016 17:57:33 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Set-Cookie: [x-ms-gateway-slice=productionb; path=/]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY5NTU0MDQ1LCJuYmYiOjE0Njk1NTQwNDUsImV4cCI6MTQ2OTU1Nzk0NSwiYWNyIjoiMSIsImFsdHNlY2lkIjoiNTo6MTAwMzAwMDA4MDFDNDREMyIsImFtciI6WyJwd2QiLCJtZmEiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlbWFpbCI6Inl1Z2FuZ3dAbWljcm9zb2Z0LmNvbSIsImZhbWlseV9uYW1lIjoiV2FuZyIsImdpdmVuX25hbWUiOiJZdWdhbmciLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2Il0sImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0Ny8iLCJpbl9jb3JwIjoidHJ1ZSIsImlwYWRkciI6IjE2Ny4yMjAuMS4xMzAiLCJuYW1lIjoiWXVnYW5nIFdhbmciLCJvaWQiOiI4OWVkNWJlOC1mZjk3LTQxYjUtYWIxMS0wNTVlMWUzY2MzNGIiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODk1NSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IjJEWG5PTmM1RUFyNmFfM1Vya1JSYlFBdkdueHpxQWEtSExWczFyV3dndEkiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6Inl1Z2FuZ3dAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.fy4o2raFkNg7_jFMh7YDRNQuHLdZG2AKcxLdS0PbRgeWd52NIzQEYH-sCbNHsh5kecyVwxBJnqLLYs-FYjGic29jFK0jEeuZl55VKIB3kYaF2U2XXNcag2dfBTIHe9uyGRK5drmrpFT1g5bBA9qZQA_Gq0SoUp0yilVOIPNAg7wfi9fPIoEUzC2qoIxv0yxmZQTqHOi0WNTygVU2GrZqwLKdEegjc-t9eH3tECSBS2-HzBBfxWmYlzEP9CPxlcO-hrtbn9B-Wa97AStVWVSQS-TnMoRLETVVpWXkxiPBqdisyTzQ9rY2nHpr6e54trtul1wFIq26-1HQmp5NBi4Hag]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.0 msrest_azure/0.4.1
+          authorizationmanagementclient/0.30.0rc5 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [6e96b240-535a-11e6-aa17-64510658e3b3]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-role-assignment-test/providers/Microsoft.Network/networkSecurityGroups/nsg1/providers/Microsoft.Authorization/roleAssignments/f13b65c4-7c62-4dd2-b2eb-2a348b57c25b?api-version=2015-07-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR6u6
+        WuV1W+TNR49+8Ud1VeZP8/NiWbRFtTybffToo7vNetJM62KFT5q7O5Pd80/3H+xu707Od7b3Z7Ns
+        O8un97ank4d7D/bOdx7ef7hzl4BeFrO8bu5+UUzrqqnO2/Hxup1XdfGDDHDuhh01dyd7+w8PDrLp
+        9qe7BwR2L9vZziYHB9t7O+cP7h3szWZ7+9OPRoRtsZwWq6xk1A52Hhzk2ez+9v6n9/e39yef3t8+
+        2H8w2b43OX8wzT7N9j49P6CXmikNkZp/nZHUeVOt62n+eV2tV83daVlsA/XtrGmKi+UiX7bbbd60
+        0RG/yNurqn57dyk/X+fTdV201wpq2VzsEnLTOs/afPblkhDc29n9dHvnwfbep292Hzy6/+DRvf3x
+        3t7Bpw93936Kmq5Xs9s2VahPrqnpwcN8dn+SH2yfnz98sL2/O7lPpN3d3d65fz/fze9Np/f2J/SK
+        Qr/9K79k9FGBWbj7/zqyRl/r89+x7ay5e757j9hnur/9YPrpHrDe257s5ZPtveze/sHk/oPp3n0Q
+        qb1mTrolVHphmS3wwq3A/5L/B9mVGK2OAwAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 26 Jul 2016 17:57:35 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Set-Cookie: [x-ms-gateway-slice=productionb; path=/]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY5NTU0MDQ1LCJuYmYiOjE0Njk1NTQwNDUsImV4cCI6MTQ2OTU1Nzk0NSwiYWNyIjoiMSIsImFsdHNlY2lkIjoiNTo6MTAwMzAwMDA4MDFDNDREMyIsImFtciI6WyJwd2QiLCJtZmEiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlbWFpbCI6Inl1Z2FuZ3dAbWljcm9zb2Z0LmNvbSIsImZhbWlseV9uYW1lIjoiV2FuZyIsImdpdmVuX25hbWUiOiJZdWdhbmciLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2Il0sImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0Ny8iLCJpbl9jb3JwIjoidHJ1ZSIsImlwYWRkciI6IjE2Ny4yMjAuMS4xMzAiLCJuYW1lIjoiWXVnYW5nIFdhbmciLCJvaWQiOiI4OWVkNWJlOC1mZjk3LTQxYjUtYWIxMS0wNTVlMWUzY2MzNGIiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODk1NSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IjJEWG5PTmM1RUFyNmFfM1Vya1JSYlFBdkdueHpxQWEtSExWczFyV3dndEkiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6Inl1Z2FuZ3dAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.fy4o2raFkNg7_jFMh7YDRNQuHLdZG2AKcxLdS0PbRgeWd52NIzQEYH-sCbNHsh5kecyVwxBJnqLLYs-FYjGic29jFK0jEeuZl55VKIB3kYaF2U2XXNcag2dfBTIHe9uyGRK5drmrpFT1g5bBA9qZQA_Gq0SoUp0yilVOIPNAg7wfi9fPIoEUzC2qoIxv0yxmZQTqHOi0WNTygVU2GrZqwLKdEegjc-t9eH3tECSBS2-HzBBfxWmYlzEP9CPxlcO-hrtbn9B-Wa97AStVWVSQS-TnMoRLETVVpWXkxiPBqdisyTzQ9rY2nHpr6e54trtul1wFIq26-1HQmp5NBi4Hag]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.0 msrest_azure/0.4.1
+          authorizationmanagementclient/0.30.0rc5 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [6f2ad06c-535a-11e6-bcf0-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-role-assignment-test/providers/Microsoft.Network/networkSecurityGroups/nsg1/providers/Microsoft.Authorization/roleAssignments?api-version=2015-07-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/zRqq5Wed0WefPRo1/8UV2V+dP8vFgWbVEtz2YfPfrobrOeNNO6WOGT5u7OZPf80/0H
+        u9u7k/Od7f3ZLNvO8um97enk4d6DvfOdh/cf7twloJfFLK+bu18U07pqqvN2fLxu51Vd/CADnLth
+        R83dg/xedv7p/Qfb2cH5+fb+/r3pdvbg/nR77zw/mO5PppNP793/aETYFstpscpKRu3edGfn/qfZ
+        +fbezvRge//+7r3tbDadbX96cL6fTXf38ofnGb3UTGmI1PxrjITentZ51uazL5cEYW9n99PtnQfb
+        u3tv9nYe7T98dP/e+OHep/uf3nvwU9R0vZrdtqlCfXJNTe8//PTe+f2d6faD6f697f0dGnZ2/iDf
+        vn9v7+H+LH/waTaZ0SsK/fav/JLRRwXI9DXGfcsZPG6a4mK5yJdtc3c3f3D/0/PpA5qye/uEUra3
+        nU3zbHv34P7s0938Hs3gHo2ivea5uCVUemGZLfDCrcD/ktH/txn6YPfgYLabH2zf23lIuOR4KXvw
+        6fa9g+n53uT+9MHk3s8GQ9MbxKV7j/Y/fbSzM763u/tg7/4+uFRZ7jZNFSpz5/nBgyzfz2fb0+ne
+        Hs3VDs3V7s7O9uT8/qefzu4RmllOryj027/yQ2boh8RV5/sH2/en+8Rxuw9m2wfZ7t72NL//6cOH
+        k4N8ujehUXxthr4N+P+vM/Rs72Bnukd6+d6983x7fzLZ3Z7cfzjZps8mswf7B6Stp/TSN8/QeztQ
+        uzufPtrdH+/s7O7fP2C1qyx3m6YKlbnz3mQnPz84n2znJIPb+6RstrP7D/fp7XsPDg6mk9nD+9Bt
+        Cv32r/xwGXr/wQEBPb+3/Wk+IaNBf2w/nD3Y2c73pw/uPdw7eHg++RCGvhX4/xcxdDadzR7sZQ+I
+        Nw/uE775+fZktr+3ff7pzqfnk+xgN8sf0OhCht6ZznamD3ep6QNM68P7k20a1/727t7+7vnOfWLz
+        +/fopW+aocns3Yfa3b3/aOdgfHD/3v3dB8ylynK3aapQmTsfZA/vHWT3CIe9vU/pn518++HDT0ms
+        Z/sHk2n26ez+PYxdod/+lR8uQ98jqmcTGvH+wT3y/zCDD6fnu9vTB9Ppw093znc/3dulUXxdhr4V
+        +P+vMzRN5MMHswmZoZ37ZIYO9vLtbG/vHvFRln26f/DpbH/3Z0ND36f/vdnZfbT7kFyJ8YMHZPL2
+        9sClynK3aapQmTtvpW4t9Nu/8sNl6Ps797JdBDQHDyfkBe2ReX14PkMH5Azc/3T3QXYfk/F1GfpW
+        4P+/ztAPH0zvPcjPyZPMgMv03mz7Yb6TUaSU33+wO9kjw3ROL33zDL13D2oXkd6nFOmxZwwuVZa7
+        TVOFytx5qwjPQr/9Kz9chv70wWw/PyCduTN7MNnen2Sz7cmn9zP67f6ne/nep3m2B3P5dRn6VuD/
+        X8TQxH0PDw6y6fanuwcEdi/b2c4mBwfkgp4/uHewN5vt7UO+Q4beObifZfcn97fvzRAa3Tufbk92
+        yW/9NH84/TSfne/mD+G2fdMM/ek2cSnp3D3i0oPxvZ3dB7sPWe0qy92mqUJl7swf5Lv3D2b3th+Q
+        z7+9T/9uHxzs3d++f3Cf3MRsQhoI8YNCv/0rP1yGzg6yh+QWfLp9fo9g7+d75BOcT0nQJnu793Ly
+        E+g7GsXXZehbgf//OkPvkhM1ySg8OP/0ITH0lHCZUIZj+x4Fwvf29s/39yZID/wsMDSlLnYf3Tt4
+        tLM/fnhw7yH9By5VlrtNU4V6e+600G//yg+XoQ/uZbO9T0lx3ptOCewBhTYP71FUc06pidmMwofJ
+        9EM09K3A/3+doR9Mpg8pyqXJnFC8u0/D2n74gAZ5b5bfm2SkvPNdsOQ3zdAPiFGRutjdfbSzO97Z
+        29vd2X8ILlWWu01ThXp77rTQb//KD5eh793bIQdw/3x7d/c+Rac7E+K43ckO5VDzA8qq7u89zD5E
+        Q98K/P/XGXq6d+/T/eku5W6yBxQa7e093J7szQ6gsCf5p7Mdeu9nw4cmtXvvzc69R3sPHu3tju/t
+        P3z44GAHXKosd5umCvX23Gmh3/6VHy5DZ5/e//TB5OCcoqC92fb++f18+2D6KcGeTHb2JtmDg0+n
+        GMXXZehbgf//PEPvT+7ln5LxOd+ZUfLq/P7BNmXYd7dnWU5BwsHDTxH5/iwxNDnG9/cf7e5QLu4B
+        re+w2lWWu01ThXp77rTQb//KD5eh78+yg52ccLhHK7Tb+5/m97cnNKvbn94/2Ds/zx4+PMj3aRRf
+        l6FvBf7/6wx9fvCQkhzkUk0ePoTU5vvblNd4QLms89n9fH/2cD87oJfiDH2rkdDbynoel7IfQVy6
+        f/Bof3+8h8TCATvGynK3aapQb8+dFvrtX/nhMvSD/eycMDqnzDAld4jyNIOUadv+dGe2s095mAfZ
+        PpKPX5ehbwX+l3yf2ufv2ufF8u1Hj5brsvwl/w/oqslP5yEAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 26 Jul 2016 17:57:35 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Set-Cookie: [x-ms-gateway-slice=productionb; path=/]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
       X-Content-Type-Options: [nosniff]


### PR DESCRIPTION
Notes:
1. The main focus is on the role assignment creation. The PR also contains graph object query command and `user create` so that i can test end to end
2. The new command greatly simplifies the interface, with no function loss, this PR shrinks parameters number from 10 down to 4
    xplat's
   ```
 role assignment create [objectId] [signInName] [spn] [roleName] [roleId] [scope] [resource-group] [resource-type] [resource-name]
  ```
   cli's
  ```
  role assignment create <assignee> <role> [resource_group] [resource_id]
  Arguments
    --assignee [Required]: Represent a user, group, or service principal. supported format: object
                           id, user sign-in name, or service principal name.
    --role     [Required]: Role name or id.
    --resource-group -g  : Name of resource group.
    --resource-id        : Resource id.
 ``` 