### PR TITLE
Generic Update Command support.  

### DIFF
--- a/azure-cli.pyproj
+++ b/azure-cli.pyproj
@@ -45,6 +45,7 @@
     <Compile Include="azure\cli\main.py" />
     <Compile Include="azure\cli\tests\test_add_resourcegroup_transform.py" />
     <Compile Include="azure\cli\tests\test_extensions_query.py" />
+    <Compile Include="azure\cli\tests\test_generic_update.py" />
     <Compile Include="azure\cli\tests\test_logging.py" />
     <Compile Include="azure\cli\tests\test_resource_id.py">
       <SubType>Code</SubType>
@@ -56,6 +57,7 @@
     <Compile Include="azure\cli\tests\test_vcr_security.py">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="azure\cli\tests\__init__.py" />
     <Compile Include="command_modules\azure-cli-feedback\azure\cli\command_modules\feedback\__init__.py" />
     <Compile Include="command_modules\azure-cli-feedback\azure\cli\command_modules\__init__.py" />
     <Compile Include="command_modules\azure-cli-feedback\azure\cli\__init__.py" />

--- a/scripts/command_modules/pylint.py
+++ b/scripts/command_modules/pylint.py
@@ -16,7 +16,7 @@ print("Running pylint on command modules.")
 failed_module_names = []
 for name, fullpath in all_command_modules:
     path_to_module = os.path.join(fullpath, 'azure')
-    success = exec_command("python -m pylint -r n "+path_to_module)
+    success = exec_command("python -m pylint -d I0013 -r n "+path_to_module)
     if not success:
         failed_module_names.append(name)
 

--- a/src/azure/cli/commands/__init__.py
+++ b/src/azure/cli/commands/__init__.py
@@ -227,7 +227,7 @@ def create_command(name, operation, transform_result, client_factory):
 
     name = ' '.join(name.split())
     cmd = CliCommand(name, _execute_command)
-    extract_args_from_signature(cmd, operation)
+    cmd.arguments.update(extract_args_from_signature(operation))
     return cmd
 
 

--- a/src/azure/cli/commands/_introspection.py
+++ b/src/azure/cli/commands/_introspection.py
@@ -41,8 +41,9 @@ def _option_descriptions(operation):
 EXCLUDED_PARAMS = frozenset(['self', 'raw', 'custom_headers', 'operation_config',
                              'content_version', 'kwargs', 'client'])
 
-def extract_args_from_signature(command, operation):
+def extract_args_from_signature(operation):
     """ Extracts basic argument data from an operation's signature and docstring """
+    from azure.cli.commands import CliCommandArgument
     args = []
     try:
         # only supported in python3 - falling back to argspec if not available
@@ -74,10 +75,10 @@ def extract_args_from_signature(command, operation):
         except AttributeError:
             pass
 
-        command.add_argument(arg_name,
-                             *['--' + arg_name.replace('_', '-')],
-                             required=required,
-                             default=default,
-                             help=arg_docstring_help.get(arg_name),
-                             action=action)
+        yield (arg_name, CliCommandArgument(arg_name,
+                                            options_list=['--' + arg_name.replace('_', '-')],
+                                            required=required,
+                                            default=default,
+                                            help=arg_docstring_help.get(arg_name),
+                                            action=action))
 

--- a/src/azure/cli/tests/test_command_registration.py
+++ b/src/azure/cli/tests/test_command_registration.py
@@ -99,7 +99,7 @@ class Test_command_registration(unittest.TestCase):
             self.assertDictContainsSubset(some_expected_arguments[existing].settings,
                                           command_metadata.arguments[existing].options)
         self.assertEqual(command_metadata.arguments['resource_group_name'].options_list,
-                         ('--resource-group-name',))
+                         ['--resource-group-name'])
 
     def test_register_cli_argument_with_overrides(self):
         command_table.clear()
@@ -130,6 +130,7 @@ class Test_command_registration(unittest.TestCase):
         self.assertTrue(command1.options['help'] == 'foo help')
         self.assertTrue(command2.options['help'] == 'first modification')
         self.assertTrue(command3.options['help'] == 'second modification')
+        command_table.clear()
 
     def test_register_extra_cli_argument(self):
         command_table.clear()
@@ -155,6 +156,8 @@ class Test_command_registration(unittest.TestCase):
             existing = next(arg for arg in command_metadata.arguments if arg == probe)
             self.assertDictContainsSubset(some_expected_arguments[existing].settings,
                                           command_metadata.arguments[existing].options)
+
+        command_table.clear()
 
     def test_command_build_argument_help_text(self):
         def sample_sdk_method_with_weird_docstring(param_a, param_b, param_c): # pylint: disable=unused-argument
@@ -187,6 +190,7 @@ class Test_command_registration(unittest.TestCase):
             existing = next(arg for arg in command_metadata.arguments if arg == probe)
             self.assertDictContainsSubset(some_expected_arguments[existing].settings,
                                           command_metadata.arguments[existing].options)
+        command_table.clear()
 
     def test_override_existing_option_string(self):
         arg = CliArgumentType(options_list=('--funky', '-f'))
@@ -237,7 +241,7 @@ class Test_command_registration(unittest.TestCase):
         self.assertEqual(actual_arg.validator, test_validator_completer)
         self.assertEqual(actual_arg.completer, test_validator_completer)
         self.assertFalse(actual_arg.options['required'])
-
+        command_table.clear()
 
     def test_override_argtype_with_argtype(self):
         existing_options_list = ('--default', '-d')

--- a/src/azure/cli/tests/test_generic_update.py
+++ b/src/azure/cli/tests/test_generic_update.py
@@ -1,0 +1,148 @@
+#---------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+#---------------------------------------------------------------------------------------------
+
+import logging
+import unittest
+
+from azure.cli.application import Application, Configuration
+from azure.cli.commands.arm import register_generic_update
+from azure.cli._util import CLIError
+
+#pylint:disable=invalid-sequence-index
+
+class GenericUpdateTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        logging.getLogger().setLevel(logging.ERROR)
+
+    def test_generic_update(self):
+        my_obj = {
+            'prop': 'val',
+            'list': [
+                'a',
+                'b',
+                ['c', {'d': 'e'}]
+                ]
+            }
+
+        def my_get():
+            return my_obj
+
+        def my_set(**kwargs): #pylint:disable=unused-argument
+            return my_obj
+
+        config = Configuration([])
+        app = Application(config)
+
+        register_generic_update('gencommand', my_get, my_set)
+
+        app.execute('gencommand --set prop=val2'.split())
+        self.assertEqual(my_obj['prop'], 'val2', 'set simple property')
+
+        app.execute('gencommand --set prop=val3'.split())
+        self.assertEqual(my_obj['prop'], 'val3', 'set simple property again')
+
+        app.execute('gencommand --set list[0]=f'.split())
+        self.assertEqual(my_obj['list'][0], 'f', 'set simple list element')
+
+        app.execute('gencommand --set list[2][0]=g'.split())
+        self.assertEqual(my_obj['list'][2][0], 'g', 'set nested list element')
+
+        app.execute('gencommand --set list[2][1].d=h'.split())
+        self.assertEqual(my_obj['list'][2][1]['d'], 'h', 'set nested dict element')
+
+        app.execute('gencommand --set list[0]={} list[0].foo=bar'.split())
+        self.assertEqual(my_obj['list'][0]['foo'], 'bar', 'replace nested scalar with new dict')
+
+        app.execute('gencommand --set list[1]=[] --add list[1] key1=value1'
+                    ' --set list[1][0].key2=value2'.split())
+        self.assertEqual(my_obj['list'][1][0]['key1'], 'value1',
+                         'replace nested scalar with new list with one value')
+        self.assertEqual(my_obj['list'][1][0]['key2'], 'value2',
+                         'add a second value to the new list')
+
+        app.execute('gencommand --add list i=j k=l'.split())
+        self.assertEqual(my_obj['list'][-1]['k'], 'l',
+                         'add multiple values to a list at once (verify last element)')
+        self.assertEqual(my_obj['list'][-1]['i'], 'j',
+                         'add multiple values to a list at once (verify first element)')
+
+        app.execute('gencommand --add list[-2] prop2=val2'.split())
+        self.assertEqual(my_obj['list'][-2][-1]['prop2'], 'val2', 'add to list')
+        app.execute('gencommand --add list[-2] prop3=val3'.split())
+        self.assertEqual(my_obj['list'][-2][-1]['prop3'], 'val3',
+                         'add to list again, should make seperate list elements')
+
+        self.assertEqual(len(my_obj['list']), 4, 'pre-verify length of list')
+        app.execute('gencommand --remove list -2'.split())
+        self.assertEqual(len(my_obj['list']), 3, 'verify one item removed')
+        app.execute('gencommand --remove list -1'.split())
+        self.assertEqual(len(my_obj['list']), 2, 'verify another item removed')
+
+        self.assertEqual('key1' in my_obj['list'][1][0], True, 'verify dict item')
+        app.execute('gencommand --remove list[1][0].key1'.split())
+        self.assertEqual('key1' not in my_obj['list'][1][0], True,
+                         'verify dict item can be removed')
+
+    def test_generic_update_errors(self):
+        my_obj = {
+            'prop': 'val',
+            'list': [
+                'a',
+                'b',
+                ['c', {'d': 'e'}]
+                ]
+            }
+
+        def my_get(a1, a2): #pylint: disable=unused-argument
+            return my_obj
+
+        def my_set(**kwargs): #pylint:disable=unused-argument
+            return my_obj
+
+        config = Configuration([])
+        app = Application(config)
+
+        register_generic_update('gencommand', my_get, my_set)
+
+        def _execute_with_error(command, error, message):
+            try:
+                app.execute(command.split())
+            except CLIError as err:
+                self.assertEqual(error in str(err), True, message)
+            else:
+                raise AssertionError('exception not thrown')
+
+        missing_remove_message = """Couldn't find "doesntExist" in "".""" + \
+                                 """  Available options: ['list', 'prop']"""
+        _execute_with_error('gencommand --a1 1 --a2 2 --remove doesnt_exist',
+                            missing_remove_message,
+                            'remove non-existent property by name')
+        _execute_with_error('gencommand --a1 1 --a2 2 --remove doesntExist 2',
+                            missing_remove_message,
+                            'remove non-existent property by index')
+
+        remove_prop_message = """Couldn't find "doesntExist" in "list.doesntExist".""" + \
+                              """  Available options: [['c', {'d': 'e'}], 'a', 'b']"""
+        _execute_with_error('gencommand --a1 1 --a2 2 --remove list.doesnt_exist.missing 2',
+                            remove_prop_message,
+                            'remove non-existent sub-property by index')
+
+        _execute_with_error('gencommand --a1 1 --a2 2 --remove list 20',
+                            "index 20 doesn't exist on list",
+                            'remove out-of-range index')
+
+        set_on_list_message = """Couldn't find "doesntExist" in "list".""" + \
+                              """  Available options: [['c', {'d': 'e'}], 'a', 'b']"""
+        _execute_with_error('gencommand --a1 1 --a2 2 --set list.doesnt_exist=foo',
+                            set_on_list_message,
+                            'set shouldn\'t work on a list')
+        _execute_with_error('gencommand --a1 1 --a2 2 --set list.doesnt_exist.doesnt_exist2=foo',
+                            set_on_list_message,
+                            'set shouldn\'t work on a list')
+
+        _execute_with_error('gencommand --a1 1 --a2 2 --set list[2][3].doesnt_exist=foo',
+                            "index 3 doesn't exist on [2]",
+                            'index out of range in path')

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
@@ -85,3 +85,24 @@ helps['container create'] = """
             type: command
             long-summary: See https://azure.microsoft.com/en-us/documentation/articles/container-service-intro/ for an intro to Container Service.
 """
+
+generic_update_help = """
+                - name: Add or update a tag
+                  text: az <command> -n name -g group --set tags.tagName=tagValue
+                - name: Remove a tag
+                  text: az <command> -n name -g group --remove tags.tagName
+"""
+
+helps['vm update'] = """
+            type: command
+            short-summary: Update VM properties.
+            long-summary: Update VM objects and properties using paths that correspond to 'az vm show'.  See examples.
+            examples:
+{0}
+                - name: Set primary NIC
+                  text: az <command> -n name -g group --set network_profile.network_interfaces[1].primary=false network_profile.network_interfaces[0].primary=true
+                - name: Add new non-primary NIC
+                  text: az <command> -n name -g group --add network_profile.network_interfaces primary=false id=<NIC_ID>
+                - name: Remove fourth NIC
+                  text: az <command> -n name -g group --remove network_profile.network_interfaces 3
+            """.format(generic_update_help)

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
@@ -100,9 +100,9 @@ helps['vm update'] = """
             examples:
 {0}
                 - name: Set primary NIC
-                  text: az <command> -n name -g group --set network_profile.network_interfaces[1].primary=false network_profile.network_interfaces[0].primary=true
+                  text: az <command> -n name -g group --set networkProfile.networkInterfaces[1].primary=false networkProfile.networkInterfaces[0].primary=true
                 - name: Add new non-primary NIC
-                  text: az <command> -n name -g group --add network_profile.network_interfaces primary=false id=<NIC_ID>
+                  text: az <command> -n name -g group --add networkProfile.networkInterfaces primary=false id=<NIC_ID>
                 - name: Remove fourth NIC
-                  text: az <command> -n name -g group --remove network_profile.network_interfaces 3
+                  text: az <command> -n name -g group --remove networkProfile.networkInterfaces 3
             """.format(generic_update_help)

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -14,6 +14,7 @@ except ImportError:
     from urlparse import urlparse # pylint: disable=import-error
 from six.moves.urllib.request import urlopen #pylint: disable=import-error,unused-import
 
+from azure.cli.commands.arm import register_generic_update
 from azure.mgmt.compute.models import (DataDisk,
                                        VirtualMachineScaleSet,
                                        VirtualMachineCaptureParameters)
@@ -885,3 +886,13 @@ def vmss_start(resource_group_name, vm_scale_set_name, instance_ids=None):
         return client.virtual_machine_scale_sets.start(resource_group_name,
                                                        vm_scale_set_name,
                                                        instance_ids=instance_ids)
+
+def get_vm(resource_group_name, vm_name):
+    vmsc = _compute_client_factory().virtual_machines
+    return vmsc.get(resource_group_name, vm_name)
+
+def set_vm(**kwargs):
+    vmsc = _compute_client_factory().virtual_machines
+    return vmsc.create_or_update(**kwargs)
+
+register_generic_update('vm update', get_vm, set_vm)


### PR DESCRIPTION
Allows an update command to be registered, which then updates fields with a generic
set/add/remove syntax.  I added az vm update along with the infrastructure.

```
Command
    az vm update: Update VM properties.
        Update VM objects and properties using paths that correspond to 'az vm show'.  See examples.

Arguments
    --add              : Add an object to a list of objects by specifying a path and key value
                         pairs.  Example: --add property1.list id=<id>.
    --api-version      : Client Api Version.  Default: 2016-03-30.
    --expand           : The expand expression to apply on the operation.
    --ids              : ID of resource.
    --name -n          : The name of the virtual machine.
    --remove           : Remove a property or an element from a list.  Example: --remove
                         property1.list <index>.
    --resource-group -g: Name of resource group.
    --set              : Update an object by specifying a property path and value to set.  Example:
                         --set property1.property2=value.

Global Arguments
    --debug            : Increase logging verbosity to show all debug logs.
    --help -h          : Show this help message and exit.
    --output -o        : Output format.  Allowed values: json, tsv, list.  Default: json.
    --query            : JMESPath query string. See http://jmespath.org/ for more information and
                         examples.
    --verbose          : Increase logging verbosity. Use --debug for full debug logs.

Examples
    Add or update a tag
        az <command> -n name -g group --set tags.tagName=tagValue
    Remove a tag
        az <command> -n name -g group --remove tags.tagName
    Set primary NIC
        az <command> -n name -g group --set network_profile.network_interfaces[1].primary=false
        network_profile.network_interfaces[0].primary=true
    Add new non-primary NIC
        az <command> -n name -g group --add network_profile.network_interfaces primary=false
        id=<NIC_ID>
    Remove fourth NIC
        az <command> -n name -g group --remove network_profile.network_interfaces 3
```