### PR TITLE
Add missing completer for network_interface_name parameter

### DIFF
--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -112,7 +112,7 @@ register_cli_argument('network express-route circuit', 'circuit_name', name_arg_
 register_cli_argument('network local-gateway', 'local_network_gateway_name', name_arg_type, completer=get_resource_name_completion_list('Microsoft.Network/localNetworkGateways'), id_part='name')
 
 # NIC
-register_cli_argument('network nic', 'network_interface_name', name_arg_type, id_part='name')
+register_cli_argument('network nic', 'network_interface_name', name_arg_type, id_part='name', completer=get_resource_name_completion_list('Microsoft.Network/networkInterfaces'))
 register_cli_argument('network nic', 'private_ip_address_allocation', help=argparse.SUPPRESS)
 register_cli_argument('network nic', 'network_security_group_type', help=argparse.SUPPRESS)
 register_cli_argument('network nic', 'public_ip_address_type', help=argparse.SUPPRESS)


### PR DESCRIPTION
NIC names were not being completed.

e.g.
`az network nic show -g myrg -n <tab>`
Should list the available nics in myrg but this did not happen.

This PR resolves this.
