### PR TITLE
Application-Gateway Commands

### DIFF
--- a/src/azure/cli/commands/arm.py
+++ b/src/azure/cli/commands/arm.py
@@ -22,9 +22,7 @@ regex = re.compile('/subscriptions/(?P<subscription>[^/]*)/resourceGroups/(?P<re
 
 def resource_id(**kwargs):
     '''Create a valid resource id string from the given parts
-
     The method accepts the following keyword arguments:
-
         - subscription      Subscription id
         - resource_group    Name of resource group
         - namespace         Namespace for the resource provider (i.e. Microsoft.Compute)

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -12,14 +12,13 @@ from azure.mgmt.network.models.network_management_client_enums import \
      ApplicationGatewayTier, ApplicationGatewayProtocol,
      ApplicationGatewayRequestRoutingRuleType)
 
-from azure.cli._util import CLIError
 from azure.cli.commands import CliArgumentType, register_cli_argument, register_extra_cli_argument
 from azure.cli.commands.parameters import (location_type, get_resource_name_completion_list, get_enum_type_completion_list, tags_type)
 from azure.cli.commands.validators import MarkSpecifiedAction
 from azure.cli.commands.template_create import register_folded_cli_argument
 from azure.cli.command_modules.network._factory import _network_client_factory
 from azure.cli.command_modules.network._validators import \
-    (process_app_gateway_namespace, process_ag_listener_create_namespace,
+    (process_ag_create_namespace, process_ag_listener_create_namespace,
      process_ag_http_settings_create_namespace, process_ag_url_path_map_create_namespace,
      process_nic_create_namespace, process_lb_create_namespace, process_ag_rule_create_namespace,
      process_ag_url_path_map_rule_create_namespace,
@@ -81,8 +80,6 @@ def get_ag_url_map_rule_completion_list():
         if parsed_args.resource_group_name and ag_name:
             ag = client.application_gateways.get(parsed_args.resource_group_name, ag_name)
             url_map = next((x for x in ag.url_path_maps if x.name == parsed_args.url_path_map_name), None) # pylint: disable=no-member
-            if not url_map:
-                raise CLIError('URL path map "{}" not found.'.format(parsed_args.url_path_map_name))
             return [r.name for r in url_map.path_rules]
     return completer
 
@@ -122,10 +119,10 @@ register_folded_cli_argument('network application-gateway', 'subnet', 'subnets',
 register_folded_cli_argument('network application-gateway', 'public_ip', 'Microsoft.Network/publicIPAddresses', completer=get_resource_name_completion_list('Microsoft.Network/publicIPAddresses'))
 register_cli_argument('network application-gateway', 'virtual_network_type', help=argparse.SUPPRESS)
 register_cli_argument('network application-gateway', 'private_ip_address_allocation', help=argparse.SUPPRESS)
-register_cli_argument('network application-gateway', 'frontend_type', help=argparse.SUPPRESS, validator=process_app_gateway_namespace)
+register_cli_argument('network application-gateway', 'frontend_type', help=argparse.SUPPRESS, validator=process_ag_create_namespace)
 register_cli_argument('network application-gateway', 'servers', nargs='+', validator=validate_servers)
 register_cli_argument('network application-gateway', 'cert_data', options_list=('--cert-file',), help='The path to the PFX certificate file.', validator=validate_cert)
-register_cli_argument('network application-gateway', 'http_listener_protocol', help=argparse.SUPPRESS)
+register_cli_argument('network application-gateway', 'http_listener_protocol', default=None, help=argparse.SUPPRESS)
 register_cli_argument('network application-gateway', 'http_settings_cookie_based_affinity', cookie_based_affinity_type)
 register_cli_argument('network application-gateway', 'http_settings_protocol', http_protocol_type)
 

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
@@ -14,6 +14,17 @@ from azure.cli.commands.client_factory import get_subscription_id
 
 # PARAMETER VALIDATORS
 
+def _generate_ag_subproperty_id(
+        resource_group, application_gateway_name, child_type, child_name, subscription=None):
+    return resource_id(
+        subscription=subscription or get_subscription_id(),
+        resource_group=resource_group,
+        namespace='Microsoft.Network',
+        type='applicationGateways',
+        name=application_gateway_name,
+        child_type=child_type,
+        child_name=child_name)
+
 def _generate_lb_subproperty_id(
         resource_group, load_balancer_name, child_type, child_name, subscription=None):
     return resource_id(
@@ -49,29 +60,9 @@ def _generate_lb_id_list_from_names_or_ids(namespace, prop, child_type):
                     child_name=item)})
     setattr(namespace, prop, result)
 
-def validate_inbound_nat_rule_id_list(namespace):
-    _generate_lb_id_list_from_names_or_ids(
-        namespace, 'load_balancer_inbound_nat_rule_ids', 'inboundNatRules')
-
 def validate_address_pool_id_list(namespace):
     _generate_lb_id_list_from_names_or_ids(
         namespace, 'load_balancer_backend_address_pool_ids', 'backendAddressPools')
-
-def validate_inbound_nat_rule_name_or_id(namespace):
-    rule_name = namespace.inbound_nat_rule
-    lb_name = namespace.load_balancer_name
-
-    if is_valid_resource_id(rule_name):
-        if lb_name:
-            raise CLIError('Please omit --lb-name when specifying an inbound NAT rule ID.')
-    else:
-        if not lb_name:
-            raise CLIError('Please specify --lb-name when specifying an inbound NAT rule name.')
-        namespace.inbound_nat_rule = _generate_lb_subproperty_id(
-            resource_group=namespace.resource_group_name,
-            load_balancer_name=lb_name,
-            child_type='inboundNatRules',
-            child_name=rule_name)
 
 def validate_address_pool_name_or_id(namespace):
     pool_name = namespace.backend_address_pool
@@ -89,35 +80,82 @@ def validate_address_pool_name_or_id(namespace):
             child_type='backendAddressPools',
             child_name=pool_name)
 
-def validate_subnet_name_or_id(namespace):
-    """ Validates a subnet ID or, if a name is provided, formats it as an ID. """
-    if namespace.virtual_network_name is None and namespace.subnet is None:
-        return
-    if namespace.subnet == '':
-        return
+def validate_address_prefixes(namespace):
 
-    # error if vnet-name is provided without subnet
-    if namespace.virtual_network_name and not namespace.subnet:
-        raise CLIError('You must specify --subnet name when using --vnet-name.')
+    subnet_prefix_set = SPECIFIED_SENTINEL in namespace.subnet_address_prefix
+    vnet_prefix_set = SPECIFIED_SENTINEL in namespace.vnet_address_prefix
+    namespace.subnet_address_prefix = \
+        namespace.subnet_address_prefix.replace(SPECIFIED_SENTINEL, '')
+    namespace.vnet_address_prefix = namespace.vnet_address_prefix.replace(SPECIFIED_SENTINEL, '')
 
-    # determine if subnet is name or ID
-    is_id = is_valid_resource_id(namespace.subnet)
+    if namespace.subnet_type != 'new' and (subnet_prefix_set or vnet_prefix_set):
+        raise CLIError('Existing subnet ({}) found. Cannot specify address prefixes when '
+                       'reusing an existing subnet.'.format(namespace.subnet))
 
-    # error if vnet-name is provided along with a subnet ID
-    if is_id and namespace.virtual_network_name:
-        raise argparse.ArgumentError(None, 'Please omit --vnet-name when specifying a subnet ID')
-    elif not is_id and not namespace.virtual_network_name:
-        raise argparse.ArgumentError(None,
-                                     'Please specify --vnet-name when specifying a subnet name')
-    if not is_id:
-        namespace.subnet = resource_id(
-            subscription=get_subscription_id(),
+def validate_cert(namespace):
+
+    params = [namespace.cert_data, namespace.cert_password]
+    if all([not x for x in params]):
+        # no cert supplied -- use HTTP
+        namespace.http_listener_protocol = 'http'
+        if not namespace.frontend_port:
+            namespace.frontend_port = 80
+    else:
+        # cert supplied -- use HTTPS
+        if not all(params):
+            raise argparse.ArgumentError(
+                None, 'To use SSL certificate, you must specify both the filename and password')
+
+        # extract the certificate data from the provided file
+        with open(namespace.cert_data, 'rb') as f:
+            contents = f.read()
+            base64_data = base64.b64encode(contents)
+            try:
+                namespace.cert_data = base64_data.decode('utf-8')
+            except UnicodeDecodeError:
+                namespace.cert_data = str(base64_data)
+
+        try:
+            # change default to frontend port 443 for https
+            if not namespace.frontend_port:
+                namespace.frontend_port = 443
+            namespace.http_listener_protocol = 'https'
+        except AttributeError:
+            # app-gateway ssl-cert create does not have these fields and that is okay
+            pass
+
+def validate_inbound_nat_rule_id_list(namespace):
+    _generate_lb_id_list_from_names_or_ids(
+        namespace, 'load_balancer_inbound_nat_rule_ids', 'inboundNatRules')
+
+def validate_inbound_nat_rule_name_or_id(namespace):
+    rule_name = namespace.inbound_nat_rule
+    lb_name = namespace.load_balancer_name
+
+    if is_valid_resource_id(rule_name):
+        if lb_name:
+            raise CLIError('Please omit --lb-name when specifying an inbound NAT rule ID.')
+    else:
+        if not lb_name:
+            raise CLIError('Please specify --lb-name when specifying an inbound NAT rule name.')
+        namespace.inbound_nat_rule = _generate_lb_subproperty_id(
             resource_group=namespace.resource_group_name,
-            namespace='Microsoft.Network',
-            type='virtualNetworks',
-            name=namespace.virtual_network_name,
-            child_type='subnets',
-            child_name=namespace.subnet)
+            load_balancer_name=lb_name,
+            child_type='inboundNatRules',
+            child_name=rule_name)
+
+def validate_nsg_name_or_id(namespace):
+    """ Validates a NSG ID or, if a name is provided, formats it as an ID. """
+    if namespace.network_security_group:
+        # determine if network_security_group is name or ID
+        is_id = is_valid_resource_id(namespace.network_security_group)
+        if not is_id:
+            namespace.network_security_group = resource_id(
+                subscription=get_subscription_id(),
+                resource_group=namespace.resource_group_name,
+                namespace='Microsoft.Network',
+                type='networkSecurityGroups',
+                name=namespace.network_security_group)
 
 def validate_private_ip_address(namespace):
     if namespace.private_ip_address:
@@ -150,70 +188,138 @@ def validate_public_ip_type(namespace): # pylint: disable=unused-argument
                 None, 'Can only specify --public-ip-dns-name when creating a new public '
                       'IP address.')
 
-def validate_nsg_name_or_id(namespace):
-    """ Validates a NSG ID or, if a name is provided, formats it as an ID. """
-    if namespace.network_security_group:
-        # determine if network_security_group is name or ID
-        is_id = is_valid_resource_id(namespace.network_security_group)
-        if not is_id:
-            namespace.network_security_group = resource_id(
-                subscription=get_subscription_id(),
-                resource_group=namespace.resource_group_name,
-                namespace='Microsoft.Network',
-                type='networkSecurityGroups',
-                name=namespace.network_security_group)
-
-def validate_address_prefixes(namespace):
-
-    subnet_prefix_set = SPECIFIED_SENTINEL in namespace.subnet_address_prefix
-    vnet_prefix_set = SPECIFIED_SENTINEL in namespace.vnet_address_prefix
-    namespace.subnet_address_prefix = \
-        namespace.subnet_address_prefix.replace(SPECIFIED_SENTINEL, '')
-    namespace.vnet_address_prefix = namespace.vnet_address_prefix.replace(SPECIFIED_SENTINEL, '')
-
-    if namespace.subnet_type != 'new' and (subnet_prefix_set or vnet_prefix_set):
-        raise CLIError('Existing subnet ({}) found. Cannot specify address prefixes when '
-                       'reusing an existing subnet.'.format(namespace.subnet))
-
 def validate_servers(namespace):
+    from azure.mgmt.network.models import ApplicationGatewayBackendAddress
     servers = []
     for item in namespace.servers if namespace.servers else []:
         try:
             socket.inet_aton(item) #pylint:disable=no-member
-            servers.append({'IpAddress': item})
+            servers.append(ApplicationGatewayBackendAddress(ip_address=item))
         except socket.error: #pylint:disable=no-member
-            servers.append({'Fqdn': item})
+            servers.append(ApplicationGatewayBackendAddress(fqdn=item))
     namespace.servers = servers
 
-def validate_cert(namespace):
+def validate_subnet_name_or_id(namespace):
+    """ Validates a subnet ID or, if a name is provided, formats it as an ID. """
+    if namespace.virtual_network_name is None and namespace.subnet is None:
+        return
+    if namespace.subnet == '':
+        return
+    # error if vnet-name is provided without subnet
+    if namespace.virtual_network_name and not namespace.subnet:
+        raise CLIError('You must specify --subnet name when using --vnet-name.')
 
-    params = [namespace.cert_data, namespace.cert_password]
-    if all([not x for x in params]):
-        # no cert supplied -- use HTTP
-        namespace.http_listener_protocol = 'http'
-        if not namespace.frontend_port:
-            namespace.frontend_port = 80
-    else:
-        # cert supplied -- use HTTPS
-        if not all(params):
-            raise argparse.ArgumentError(
-                None, 'To use SSL certificate, you must specify both the filename and password')
+    # determine if subnet is name or ID
+    is_id = is_valid_resource_id(namespace.subnet)
 
-        # extract the certificate data from the provided file
-        with open(namespace.cert_data, 'rb') as f:
-            contents = f.read()
-            base64_data = base64.b64encode(contents)
-            try:
-                namespace.cert_data = base64_data.decode('utf-8')
-            except UnicodeDecodeError:
-                namespace.cert_data = str(base64_data)
-
-        # change default to frontend port 443 for https
-        namespace.http_listener_protocol = 'https'
-        if not namespace.frontend_port:
-            namespace.frontend_port = 443
+    # error if vnet-name is provided along with a subnet ID
+    if is_id and namespace.virtual_network_name:
+        raise argparse.ArgumentError(None, 'Please omit --vnet-name when specifying a subnet ID')
+    elif not is_id and not namespace.virtual_network_name:
+        raise argparse.ArgumentError(None,
+                                     'Please specify --vnet-name when specifying a subnet name')
+    if not is_id:
+        namespace.subnet = resource_id(
+            subscription=get_subscription_id(),
+            resource_group=namespace.resource_group_name,
+            namespace='Microsoft.Network',
+            type='virtualNetworks',
+            name=namespace.virtual_network_name,
+            child_type='subnets',
+            child_name=namespace.subnet)
 
 # COMMAND NAMESPACE VALIDATORS
+
+def process_ag_listener_create_namespace(namespace): # pylint: disable=unused-argument
+    if not is_valid_resource_id(namespace.frontend_ip):
+        namespace.frontend_ip = _generate_ag_subproperty_id(
+            resource_group=namespace.resource_group_name,
+            application_gateway_name=namespace.application_gateway_name,
+            child_type='frontendIpConfigurations',
+            child_name=namespace.frontend_ip)
+
+    if not is_valid_resource_id(namespace.frontend_port):
+        namespace.frontend_port = _generate_ag_subproperty_id(
+            resource_group=namespace.resource_group_name,
+            application_gateway_name=namespace.application_gateway_name,
+            child_type='frontendPorts',
+            child_name=namespace.frontend_port)
+
+    if not is_valid_resource_id(namespace.ssl_cert):
+        namespace.ssl_cert = _generate_ag_subproperty_id(
+            resource_group=namespace.resource_group_name,
+            application_gateway_name=namespace.application_gateway_name,
+            child_type='sslCertificates',
+            child_name=namespace.ssl_cert)
+
+def process_ag_http_settings_create_namespace(namespace): # pylint: disable=unused-argument
+    if not is_valid_resource_id(namespace.probe):
+        namespace.probe = _generate_ag_subproperty_id(
+            resource_group=namespace.resource_group_name,
+            application_gateway_name=namespace.application_gateway_name,
+            child_type='probes',
+            child_name=namespace.probe)
+
+def process_ag_rule_create_namespace(namespace): # pylint: disable=unused-argument
+    if not is_valid_resource_id(namespace.address_pool):
+        namespace.address_pool = _generate_ag_subproperty_id(
+            resource_group=namespace.resource_group_name,
+            application_gateway_name=namespace.application_gateway_name,
+            child_type='backendAddressPools',
+            child_name=namespace.address_pool)
+
+    if not is_valid_resource_id(namespace.http_listener):
+        namespace.http_listener = _generate_ag_subproperty_id(
+            resource_group=namespace.resource_group_name,
+            application_gateway_name=namespace.application_gateway_name,
+            child_type='httpListeners',
+            child_name=namespace.http_listener)
+
+    if not is_valid_resource_id(namespace.http_settings):
+        namespace.http_settings = _generate_ag_subproperty_id(
+            resource_group=namespace.resource_group_name,
+            application_gateway_name=namespace.application_gateway_name,
+            child_type='backendHttpSettingsCollection',
+            child_name=namespace.http_settings)
+
+    if not is_valid_resource_id(namespace.url_path_map):
+        namespace.url_path_map = _generate_ag_subproperty_id(
+            resource_group=namespace.resource_group_name,
+            application_gateway_name=namespace.application_gateway_name,
+            child_type='urlPathMaps',
+            child_name=namespace.url_path_map)
+
+def process_ag_url_path_map_create_namespace(namespace): # pylint: disable=unused-argument
+    if namespace.default_address_pool and not is_valid_resource_id(namespace.default_address_pool):
+        namespace.default_address_pool = _generate_ag_subproperty_id(
+            resource_group=namespace.resource_group_name,
+            application_gateway_name=namespace.application_gateway_name,
+            child_type='backendAddressPools',
+            child_name=namespace.default_address_pool)
+
+    if namespace.default_http_settings and not is_valid_resource_id(namespace.default_http_settings): # pylint: disable=line-too-long
+        namespace.default_http_settings = _generate_ag_subproperty_id(
+            resource_group=namespace.resource_group_name,
+            application_gateway_name=namespace.application_gateway_name,
+            child_type='backendHttpSettingsCollection',
+            child_name=namespace.default_http_settings)
+
+    process_ag_url_path_map_rule_create_namespace(namespace)
+
+def process_ag_url_path_map_rule_create_namespace(namespace): # pylint: disable=unused-argument
+    if namespace.address_pool and not is_valid_resource_id(namespace.address_pool):
+        namespace.address_pool = _generate_ag_subproperty_id(
+            resource_group=namespace.resource_group_name,
+            application_gateway_name=namespace.application_gateway_name,
+            child_type='backendAddressPools',
+            child_name=namespace.address_pool)
+
+    if namespace.http_settings and not is_valid_resource_id(namespace.http_settings):
+        namespace.http_settings = _generate_ag_subproperty_id(
+            resource_group=namespace.resource_group_name,
+            application_gateway_name=namespace.application_gateway_name,
+            child_type='backendHttpSettingsCollection',
+            child_name=namespace.http_settings)
 
 def process_app_gateway_namespace(namespace):
 
@@ -226,7 +332,6 @@ def process_app_gateway_namespace(namespace):
 
     if not namespace.public_ip_type:
         namespace.public_ip_type = 'none'
-
 
 def process_lb_create_namespace(namespace):
     if namespace.public_ip_dns_name:
@@ -245,6 +350,10 @@ def process_nic_create_namespace(namespace):
 
     if not namespace.network_security_group:
         namespace.network_security_group_type = 'none'
+
+def process_nic_namespace(namespace):
+    if namespace.public_ip_address_name:
+        namespace.public_ip_address_type = 'existing'
 
 def process_public_ip_create_namespace(namespace):
     if namespace.dns_name:

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -7,111 +7,17 @@
 from azure.mgmt.network.models import \
     (Subnet, SecurityRule, PublicIPAddress, NetworkSecurityGroup, InboundNatRule, InboundNatPool,
      FrontendIPConfiguration, BackendAddressPool, Probe, LoadBalancingRule,
-     NetworkInterfaceIPConfiguration)
+     NetworkInterfaceIPConfiguration, SubResource)
 
 from azure.cli._util import CLIError
+from azure.cli.command_modules.network._factory import _network_client_factory
+from azure.cli.command_modules.network.mgmt_app_gateway.lib.operations.app_gateway_operations \
+    import AppGatewayOperations
 
 from ._factory import _network_client_factory
 from azure.cli.command_modules.network.mgmt_nic.lib.operations.nic_operations import NicOperations
 
-def _generic_list(operation_name, resource_group_name):
-    ncf = _network_client_factory()
-    operation_group = getattr(ncf, operation_name)
-    if resource_group_name:
-        return operation_group.list(resource_group_name)
-    else:
-        return operation_group.list_all()
-
-def list_vnet(resource_group_name=None):
-    return _generic_list('virtual_networks', resource_group_name)
-
-def list_express_route_circuits(resource_group_name=None):
-    return _generic_list('express_route_circuits', resource_group_name)
-
-def list_lbs(resource_group_name=None):
-    return _generic_list('load_balancers', resource_group_name)
-
-def list_nics(resource_group_name=None):
-    return _generic_list('network_interfaces', resource_group_name)
-
-def list_nsgs(resource_group_name=None):
-    return _generic_list('network_security_groups', resource_group_name)
-
-def list_public_ips(resource_group_name=None):
-    return _generic_list('public_ip_addresses', resource_group_name)
-
-def list_route_tables(resource_group_name=None):
-    return _generic_list('route_tables', resource_group_name)
-
-def list_application_gateways(resource_group_name=None):
-    return _generic_list('application_gateways', resource_group_name)
-
-def create_nsg_rule(resource_group_name, network_security_group_name, security_rule_name,
-                    protocol, source_address_prefix, destination_address_prefix,
-                    access, direction, source_port_range, destination_port_range,
-                    description=None, priority=None):
-    settings = SecurityRule(protocol=protocol, source_address_prefix=source_address_prefix,
-                            destination_address_prefix=destination_address_prefix, access=access,
-                            direction=direction,
-                            description=description, source_port_range=source_port_range,
-                            destination_port_range=destination_port_range, priority=priority,
-                            name=security_rule_name)
-    ncf = _network_client_factory()
-    return ncf.security_rules.create_or_update(
-        resource_group_name, network_security_group_name, security_rule_name, settings)
-create_nsg_rule.__doc__ = SecurityRule.__doc__
-
-def update_vnet(resource_group_name, virtual_network_name, address_prefixes):
-    '''update existing virtual network
-    :param address_prefixes: update address spaces. Use space separated address prefixes,
-        for example, "10.0.0.0/24 10.0.1.0/24"
-    '''
-    ncf = _network_client_factory()
-    vnet = ncf.virtual_networks.get(resource_group_name, virtual_network_name)
-    #server side validation reports pretty good error message on invalid CIDR,
-    #so we don't validate at client side
-    vnet.address_space.address_prefixes = address_prefixes
-    return ncf.virtual_networks.create_or_update(resource_group_name, virtual_network_name, vnet)
-
-def create_subnet(resource_group_name, virtual_network_name, subnet_name,
-                  address_prefix='10.0.0.0/24', network_security_group=None):
-    '''Create a virtual network (VNet) subnet
-    :param str address_prefix: address prefix in CIDR format.
-    :param str network_security_group: attach with existing network security group,
-        both name or id are accepted.
-    '''
-    ncf = _network_client_factory()
-    subnet = Subnet(name=subnet_name, address_prefix=address_prefix)
-    subnet.address_prefix = address_prefix
-
-    if network_security_group:
-        subnet.network_security_group = NetworkSecurityGroup(network_security_group)
-
-    return ncf.subnets.create_or_update(resource_group_name, virtual_network_name,
-                                        subnet_name, subnet)
-
-def update_subnet(resource_group_name, virtual_network_name, subnet_name,
-                  address_prefix=None, network_security_group=None):
-    '''update existing virtual sub network
-    :param str address_prefix: New address prefix in CIDR format, for example 10.0.0.0/24.
-    :param str network_security_group: attach with existing network security group,
-        both name or id are accepted. Use empty string "" to detach it.
-    '''
-    ncf = _network_client_factory()
-    subnet = ncf.subnets.get(resource_group_name, virtual_network_name, subnet_name)#pylint: disable=redefined-variable-type
-
-    if address_prefix:
-        subnet.address_prefix = address_prefix
-
-    if network_security_group:
-        subnet.network_security_group = NetworkSecurityGroup(network_security_group)
-    elif network_security_group == '': #clear it
-        subnet.network_security_group = None
-
-    return ncf.subnets.create_or_update(resource_group_name, virtual_network_name,
-                                        subnet_name, subnet)
-
-# network subresource factory methods
+#region Network subresource factory methods
 
 def list_network_resource_property(resource, prop):
     """ Factory method for creating list functions. """
@@ -157,8 +63,210 @@ def _set_param(item, prop, value):
         setattr(item, prop, None)
     elif value is not None:
         setattr(item, prop, value)
+#endregion
 
-# Inbound NAT Rules
+#region Generic list commands
+def _generic_list(operation_name, resource_group_name):
+    ncf = _network_client_factory()
+    operation_group = getattr(ncf, operation_name)
+    if resource_group_name:
+        return operation_group.list(resource_group_name)
+    else:
+        return operation_group.list_all()
+
+def list_vnet(resource_group_name=None):
+    return _generic_list('virtual_networks', resource_group_name)
+
+def list_express_route_circuits(resource_group_name=None):
+    return _generic_list('express_route_circuits', resource_group_name)
+
+def list_lbs(resource_group_name=None):
+    return _generic_list('load_balancers', resource_group_name)
+
+def list_nics(resource_group_name=None):
+    return _generic_list('network_interfaces', resource_group_name)
+
+def list_nsgs(resource_group_name=None):
+    return _generic_list('network_security_groups', resource_group_name)
+
+def list_public_ips(resource_group_name=None):
+    return _generic_list('public_ip_addresses', resource_group_name)
+
+def list_route_tables(resource_group_name=None):
+    return _generic_list('route_tables', resource_group_name)
+
+def list_application_gateways(resource_group_name=None):
+    return _generic_list('application_gateways', resource_group_name)
+#endregion
+
+#region Application Gateway subresource commands
+
+def create_ag_address_pool(resource_group_name, application_gateway_name, item_name, servers):
+    from azure.mgmt.network.models import ApplicationGatewayBackendAddressPool
+    ncf = _network_client_factory()
+    ag = ncf.application_gateways.get(resource_group_name, application_gateway_name)
+    ag.backend_address_pools.append(ApplicationGatewayBackendAddressPool(
+        name=item_name, backend_addresses=servers))
+    return ncf.application_gateways.create_or_update(
+        resource_group_name, application_gateway_name, ag)
+create_ag_address_pool.__doc__ = AppGatewayOperations.create_or_update.__doc__
+
+def create_ag_frontend_ip(resource_group_name, application_gateway_name, item_name,
+                          public_ip_address=None, subnet=None, virtual_network_name=None, # pylint: disable=unused-argument
+                          private_ip_address=None, private_ip_address_allocation=None): # pylint: disable=unused-argument
+    from azure.mgmt.network.models import ApplicationGatewayFrontendIPConfiguration
+    ncf = _network_client_factory()
+    ag = ncf.application_gateways.get(resource_group_name, application_gateway_name)
+    ag.frontend_ip_configurations.append(ApplicationGatewayFrontendIPConfiguration(
+        name=item_name,
+        private_ip_address=private_ip_address if private_ip_address else None,
+        private_ip_allocation_method='static' if private_ip_address else 'dynamic',
+        public_ip_address=SubResource(public_ip_address) if public_ip_address else None,
+        subnet=SubResource(subnet) if subnet else None))
+    return ncf.application_gateways.create_or_update(
+        resource_group_name, application_gateway_name, ag)
+create_ag_frontend_ip.__doc__ = AppGatewayOperations.create_or_update.__doc__
+
+def create_ag_frontend_port(resource_group_name, application_gateway_name, item_name, port):
+    from azure.mgmt.network.models import ApplicationGatewayFrontendPort
+    ncf = _network_client_factory()
+    ag = ncf.application_gateways.get(resource_group_name, application_gateway_name)
+    ag.frontend_ports.append(ApplicationGatewayFrontendPort(name=item_name, port=port))
+    return ncf.application_gateways.create_or_update(
+        resource_group_name, application_gateway_name, ag)
+
+def create_ag_http_listener(resource_group_name, application_gateway_name, item_name,
+                            frontend_ip, frontend_port, ssl_cert=None):
+    from azure.mgmt.network.models import ApplicationGatewayHttpListener
+    ncf = _network_client_factory()
+    ag = ncf.application_gateways.get(resource_group_name, application_gateway_name)
+    ag.http_listeners.append(ApplicationGatewayHttpListener(
+        name=item_name,
+        frontend_ip_configuration=SubResource(frontend_ip),
+        frontend_port=SubResource(frontend_port),
+        protocol='https' if ssl_cert else 'http',
+        ssl_certificate=SubResource(ssl_cert) if ssl_cert else None))
+    return ncf.application_gateways.create_or_update(
+        resource_group_name, application_gateway_name, ag)
+
+def create_ag_http_settings(resource_group_name, application_gateway_name, item_name,
+                            port, probe=None, protocol='http', cookie_based_affinity=None,
+                            timeout=None):
+    from azure.mgmt.network.models import ApplicationGatewayBackendHttpSettings
+    ncf = _network_client_factory()
+    ag = ncf.application_gateways.get(resource_group_name, application_gateway_name)
+    ag.backend_http_settings_collection.append(ApplicationGatewayBackendHttpSettings(
+        port=port,
+        protocol=protocol,
+        cookie_based_affinity=cookie_based_affinity or 'Disabled',
+        request_timeout=timeout,
+        probe=SubResource(probe) if probe else None,
+        name=item_name
+    ))
+    return ncf.application_gateways.create_or_update(
+        resource_group_name, application_gateway_name, ag)
+
+def create_ag_probe(resource_group_name, application_gateway_name, item_name, protocol, host,
+                    path, interval=30, timeout=120, threshold=8):
+    from azure.mgmt.network.models import ApplicationGatewayProbe
+    ncf = _network_client_factory()
+    ag = ncf.application_gateways.get(resource_group_name, application_gateway_name)
+    ag.probes.append(ApplicationGatewayProbe(
+        name=item_name,
+        protocol=protocol,
+        host=host,
+        path=path,
+        interval=interval,
+        timeout=timeout,
+        unhealthy_threshold=threshold
+    ))
+    return ncf.application_gateways.create_or_update(
+        resource_group_name, application_gateway_name, ag)
+
+def create_ag_rule(resource_group_name, application_gateway_name, item_name,
+                   address_pool, http_settings, http_listener, url_path_map=None,
+                   rule_type='Basic'):
+    from azure.mgmt.network.models import ApplicationGatewayRequestRoutingRule
+    ncf = _network_client_factory()
+    ag = ncf.application_gateways.get(resource_group_name, application_gateway_name)
+    ag.request_routing_rules.append(ApplicationGatewayRequestRoutingRule(
+        name=item_name,
+        rule_type=rule_type,
+        backend_address_pool=SubResource(address_pool),
+        backend_http_settings=SubResource(http_settings),
+        http_listener=SubResource(http_listener),
+        url_path_map=SubResource(url_path_map) if url_path_map else None
+    ))
+    return ncf.application_gateways.create_or_update(
+        resource_group_name, application_gateway_name, ag)
+
+def create_ag_ssl_cert(resource_group_name, application_gateway_name, item_name, cert_data,
+                       cert_password):
+    from azure.mgmt.network.models import ApplicationGatewaySslCertificate
+    ncf = _network_client_factory()
+    ag = ncf.application_gateways.get(resource_group_name, application_gateway_name)
+    ag.ssl_certificates.append(ApplicationGatewaySslCertificate(
+        name=item_name, data=cert_data, password=cert_password))
+    return ncf.application_gateways.create_or_update(
+        resource_group_name, application_gateway_name, ag)
+create_ag_ssl_cert.__doc__ = AppGatewayOperations.create_or_update.__doc__
+
+def create_ag_url_path_map(resource_group_name, application_gateway_name, item_name,
+                           paths, address_pool, http_settings, rule_name='default',
+                           default_address_pool=None, default_http_settings=None):
+    from azure.mgmt.network.models import ApplicationGatewayUrlPathMap, ApplicationGatewayPathRule
+    ncf = _network_client_factory()
+    ag = ncf.application_gateways.get(resource_group_name, application_gateway_name)
+    ag.url_path_maps.append(ApplicationGatewayUrlPathMap(
+        name=item_name,
+        default_backend_address_pool=SubResource(default_address_pool) \
+            if default_address_pool else SubResource(address_pool),
+        default_backend_http_settings=SubResource(default_http_settings) \
+            if default_http_settings else SubResource(http_settings),
+        path_rules=[ApplicationGatewayPathRule(
+            name=rule_name,
+            backend_address_pool=SubResource(address_pool),
+            backend_http_settings=SubResource(http_settings),
+            paths=paths
+        )]
+    ))
+    return ncf.application_gateways.create_or_update(
+        resource_group_name, application_gateway_name, ag)
+
+def create_ag_url_path_map_rule(resource_group_name, application_gateway_name, url_path_map_name,
+                                item_name, paths, address_pool=None, http_settings=None):
+    from azure.mgmt.network.models import ApplicationGatewayPathRule
+    ncf = _network_client_factory()
+    ag = ncf.application_gateways.get(resource_group_name, application_gateway_name)
+    url_map = next((x for x in ag.url_path_maps if x.name == url_path_map_name), None)
+    if not url_map:
+        raise CLIError('URL path map "{}" not found.'.format(url_path_map_name))
+    url_map.path_rules.append(ApplicationGatewayPathRule(
+        name=item_name,
+        paths=paths,
+        backend_address_pool=SubResource(address_pool) \
+            if address_pool else SubResource(url_map.default_backend_address_pool.id),
+        backend_http_settings=SubResource(http_settings) \
+            if http_settings else SubResource(url_map.default_backend_http_settings.id)
+    ))
+    return ncf.application_gateways.create_or_update(
+        resource_group_name, application_gateway_name, ag)
+
+def delete_ag_url_path_map_rule(resource_group_name, application_gateway_name, url_path_map_name,
+                                item_name):
+    ncf = _network_client_factory()
+    ag = ncf.application_gateways.get(resource_group_name, application_gateway_name)
+    url_map = next((x for x in ag.url_path_maps if x.name == url_path_map_name), None)
+    if not url_map:
+        raise CLIError('URL path map "{}" not found.'.format(url_path_map_name))
+    url_map.path_rules = \
+        [x for x in url_map.path_rules if x.name.lower() != item_name.lower()]
+    return ncf.application_gateways.create_or_update(
+        resource_group_name, application_gateway_name, ag)
+
+#endregion
+
+#region Load Balancer subresource commands
 
 def create_lb_inbound_nat_rule(
         resource_group_name, load_balancer_name, item_name, protocol, frontend_port,
@@ -194,8 +302,6 @@ def set_lb_inbound_nat_rule(
     _set_param(item, 'idle_timeout_in_minutes', idle_timeout)
 
     return ncf.load_balancers.create_or_update(resource_group_name, load_balancer_name, lb)
-
-# Inbound NAT Pools
 
 def create_lb_inbound_nat_pool(
         resource_group_name, load_balancer_name, item_name, protocol, frontend_port_range_start,
@@ -233,8 +339,6 @@ def set_lb_inbound_nat_pool(
             _get_property(lb.frontend_ip_configurations, frontend_ip_name)
 
     return ncf.load_balancers.create_or_update(resource_group_name, load_balancer_name, lb)
-
-# Frontend IP Configuration
 
 def create_lb_frontend_ip_configuration(
         resource_group_name, load_balancer_name, item_name, public_ip_address=None,
@@ -277,15 +381,11 @@ def set_lb_frontend_ip_configuration(
 
     return ncf.load_balancers.create_or_update(resource_group_name, load_balancer_name, lb)
 
-# Backend Address Pools
-
 def create_lb_backend_address_pool(resource_group_name, load_balancer_name, item_name):
     ncf = _network_client_factory()
     lb = ncf.load_balancers.get(resource_group_name, load_balancer_name)
     lb.backend_address_pools.append(BackendAddressPool(name=item_name))
     return ncf.load_balancers.create_or_update(resource_group_name, load_balancer_name, lb)
-
-# Load Balancer Probe
 
 def create_lb_probe(resource_group_name, load_balancer_name, item_name, protocol, port,
                     path=None, interval=None, threshold=None):
@@ -309,8 +409,6 @@ def set_lb_probe(resource_group_name, load_balancer_name, item_name, protocol=No
     _set_param(item, 'number_of_probes', threshold)
 
     return ncf.load_balancers.create_or_update(resource_group_name, load_balancer_name, lb)
-
-# Load Balancer Rule
 
 def create_lb_rule(
         resource_group_name, load_balancer_name, item_name,
@@ -366,8 +464,9 @@ def set_lb_rule(
         item.probe = _get_property(lb.probes, probe_name)
 
     return ncf.load_balancers.create_or_update(resource_group_name, load_balancer_name, lb)
+#endregion
 
-# NIC commands
+#region NIC commands
 
 def set_nic(resource_group_name, network_interface_name, network_security_group=None,
             enable_ip_forwarding=None, internal_dns_name_label=None):
@@ -515,6 +614,25 @@ def remove_nic_ip_config_inbound_nat_rule(
     ip_config.load_balancer_inbound_nat_rules = keep_items
     return client.create_or_update(resource_group_name, network_interface_name, nic)
 
+#endregion
+
+#region Network Security Group commands
+
+def create_nsg_rule(resource_group_name, network_security_group_name, security_rule_name,
+                    protocol, source_address_prefix, destination_address_prefix,
+                    access, direction, source_port_range, destination_port_range,
+                    description=None, priority=None):
+    settings = SecurityRule(protocol=protocol, source_address_prefix=source_address_prefix,
+                            destination_address_prefix=destination_address_prefix, access=access,
+                            direction=direction,
+                            description=description, source_port_range=source_port_range,
+                            destination_port_range=destination_port_range, priority=priority,
+                            name=security_rule_name)
+    ncf = _network_client_factory()
+    return ncf.security_rules.create_or_update(
+        resource_group_name, network_security_group_name, security_rule_name, settings)
+create_nsg_rule.__doc__ = SecurityRule.__doc__
+
 def update_nsg_rule(resource_group_name, network_security_group_name, security_rule_name,
                     protocol=None, source_address_prefix=None, destination_address_prefix=None,
                     access=None, direction=None, description=None, source_port_range=None,
@@ -545,5 +663,59 @@ def update_nsg_rule(resource_group_name, network_security_group_name, security_r
     r.priority = priority if priority is not None else r.priority
 
     return ncf.security_rules.create_or_update(resource_group_name, network_security_group_name, security_rule_name, r)
-
 update_nsg_rule.__doc__ = SecurityRule.__doc__
+#endregion
+
+#region Vnet/Subnet commands
+
+def update_vnet(resource_group_name, virtual_network_name, address_prefixes):
+    '''update existing virtual network
+    :param address_prefixes: update address spaces. Use space separated address prefixes,
+        for example, "10.0.0.0/24 10.0.1.0/24"
+    '''
+    ncf = _network_client_factory()
+    vnet = ncf.virtual_networks.get(resource_group_name, virtual_network_name)
+    #server side validation reports pretty good error message on invalid CIDR,
+    #so we don't validate at client side
+    vnet.address_space.address_prefixes = address_prefixes
+    return ncf.virtual_networks.create_or_update(resource_group_name, virtual_network_name, vnet)
+
+def create_subnet(resource_group_name, virtual_network_name, subnet_name,
+                  address_prefix='10.0.0.0/24', network_security_group=None):
+    '''Create a virtual network (VNet) subnet
+    :param str address_prefix: address prefix in CIDR format.
+    :param str network_security_group: attach with existing network security group,
+        both name or id are accepted.
+    '''
+    ncf = _network_client_factory()
+    subnet = Subnet(name=subnet_name, address_prefix=address_prefix)
+    subnet.address_prefix = address_prefix
+
+    if network_security_group:
+        subnet.network_security_group = NetworkSecurityGroup(network_security_group)
+
+    return ncf.subnets.create_or_update(resource_group_name, virtual_network_name,
+                                        subnet_name, subnet)
+
+def update_subnet(resource_group_name, virtual_network_name, subnet_name,
+                  address_prefix=None, network_security_group=None):
+    '''update existing virtual sub network
+    :param str address_prefix: New address prefix in CIDR format, for example 10.0.0.0/24.
+    :param str network_security_group: attach with existing network security group,
+        both name or id are accepted. Use empty string "" to detach it.
+    '''
+    ncf = _network_client_factory()
+    subnet = ncf.subnets.get(resource_group_name, virtual_network_name, subnet_name)#pylint: disable=redefined-variable-type
+
+    if address_prefix:
+        subnet.address_prefix = address_prefix
+
+    if network_security_group:
+        subnet.network_security_group = NetworkSecurityGroup(network_security_group)
+    elif network_security_group == '': #clear it
+        subnet.network_security_group = None
+
+    return ncf.subnets.create_or_update(resource_group_name, virtual_network_name,
+                                        subnet_name, subnet)
+
+#endregion

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_load_balancer_subresources.yaml
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_load_balancer_subresources.yaml
@@ -4,14 +4,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [44d7bbd2-4518-11e6-8e61-a0b3ccf7272a]
+      x-ms-client-request-id: [83e64cee-494e-11e6-bdca-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -21,19 +21,19 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o/3Zpw/PJ/v59vnk4Wx7/1PqdHIwybc/nX16/9P9g09nu9OHv+9H
-        +mJ7veLR3NCVti6raYbh4Y2rvGnX5gvCeZXXbZE39BXTST68LBpqXiwvXrdZyx29Xk+neT7LZ/Im
-        NbNEWAsh7+0/3N99MM22J/mn97f3H9wn/O/f39neeXjv/qf3H3y6P9t5YF8+r6tlmy9nZy9PquV5
-        cbGuGUGg8T1pkhp88NjZe+6N7hlgnC4tRnh+Tif17tCo7t6I9tdlBHkwZb15lAdf3WI25aHGxSU1
-        OXt5XBqe+SJv5xUT9ek1zUIx7b6ynpTFlN6YzYiCvf6pxQ9xSjrI5M3dl/oJTc9HPl6/xP1hf9Vf
-        vq8D/GiSTd/SbCqwl1VVYngb+ZO6meQraulT6YdJgT5TRkaBzyNo/pwxoWurU2B/sXPhxkUgXq1L
-        7uR79mvqYNL5qFhOqvVy9iJr+82rdTv8pXuRicXf4StC6Zf8P7aEME5MBgAA
+        J1mZLaf43qGQt9kFkPju3d/3o0mWTc4nD2fb0+xetr2/k9/bfrj/4MF2nu/n5/n0/v2dT3d+34/0
+        xfZ6xaO5oSttXVbTDMPDG1d5067NF4TzKq/bIm/oK6aTfHhZNNS8WF68brOWO3q9nk7zfJbP5E1q
+        ZomwFkKeH+x+evDp+d72zmyyv70/efhwe7KfTbbzXVDx/OH989lD+/J5XS3bfDk7e3lSLc+Li3XN
+        CAKN70mT1OCDx87ec290zwDjdGkxwvNzOql3h0Z190a0vy4jyIMp682jPPjqFrMpDzUuLqnJ2cvj
+        0vDMF3k7r5ioT69pFopp95X1pCym9MZsRhTs9U8tfohT0kEmb+6+1E9oej7y8fol7g/7q/7yfR0g
+        TcT0Lc2mAntZVSWGt5E/qZtJvqKWPpV+mBToM2VkFPg8gubPGRO6tjoF9hc7F25cBOLVuuROvme/
+        pg4mnY+K5aRaL2cvsrbfvFq3w1+6F5lY/B2+IpR+yf8Dx0E99EwGAAA=
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:28:42 GMT']
-      ETag: [W/"4d69fb4e-fb9d-46c3-b8be-6d656486d1c9"]
+      Date: ['Wed, 13 Jul 2016 23:07:05 GMT']
+      ETag: [W/"baabfb9d-ca3a-40e3-9477-ee4efec55060"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -42,44 +42,44 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9u
-      dGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJuYW1lIjogIkxvYWRCYWxhbmNlckZyb250RW5kIiwg
-      InByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJwcml2YXRl
-      SVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVibGljSVBBZGRyZXNzIjogeyJpZCI6
-      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
-      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3B1YmxpY0lQQWRk
-      cmVzc2VzL1B1YmxpY0lQbGIxIn19LCAiZXRhZyI6ICJXL1wiNGQ2OWZiNGUtZmI5ZC00NmMzLWI4
-      YmUtNmQ2NTY0ODZkMWM5XCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00
-      ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNy
-      b3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMv
-      TG9hZEJhbGFuY2VyRnJvbnRFbmQifV0sICJyZXNvdXJjZUd1aWQiOiAiMzQ5NDE3Y2EtYmU2NS00
-      NzUzLWI1NTAtMDkzNTY1NzY0ZDA3IiwgIm91dGJvdW5kTmF0UnVsZXMiOiBbXSwgImxvYWRCYWxh
-      bmNpbmdSdWxlcyI6IFtdLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImluYm91
-      bmROYXRSdWxlcyI6IFt7Im5hbWUiOiAicnVsZTEiLCAicHJvcGVydGllcyI6IHsiZnJvbnRlbmRJ
-      UENvbmZpZ3VyYXRpb24iOiB7Im5hbWUiOiAiTG9hZEJhbGFuY2VyRnJvbnRFbmQiLCAicHJvcGVy
-      dGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgInByaXZhdGVJUEFsbG9j
-      YXRpb25NZXRob2QiOiAiRHluYW1pYyIsICJwdWJsaWNJUEFkZHJlc3MiOiB7ImlkIjogIi9zdWJz
-      Y3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdy
-      b3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvcHVibGljSVBBZGRyZXNzZXMv
-      UHVibGljSVBsYjEifX0sICJldGFnIjogIlcvXCI0ZDY5ZmI0ZS1mYjlkLTQ2YzMtYjhiZS02ZDY1
-      NjQ4NmQxYzlcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVj
-      My1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5O
-      ZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9ucy9Mb2FkQmFs
-      YW5jZXJGcm9udEVuZCJ9LCAicHJvdG9jb2wiOiAidGNwIiwgImJhY2tlbmRQb3J0IjogMSwgImZy
-      b250ZW5kUG9ydCI6IDEsICJlbmFibGVGbG9hdGluZ0lQIjogZmFsc2V9fV0sICJpbmJvdW5kTmF0
-      UG9vbHMiOiBbXSwgImJhY2tlbmRBZGRyZXNzUG9vbHMiOiBbeyJuYW1lIjogImxiMWJlcG9vbCIs
-      ICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQifSwgImV0YWci
-      OiAiVy9cIjRkNjlmYjRlLWZiOWQtNDZjMy1iOGJlLTZkNjU2NDg2ZDFjOVwiIiwgImlkIjogIi9z
-      dWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJj
-      ZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9s
-      YjEvYmFja2VuZEFkZHJlc3NQb29scy9sYjFiZXBvb2wifV19LCAiZXRhZyI6ICJXL1wiNGQ2OWZi
-      NGUtZmI5ZC00NmMzLWI4YmUtNmQ2NTY0ODZkMWM5XCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMv
+      eyJldGFnIjogIlcvXCJiYWFiZmI5ZC1jYTNhLTQwZTMtOTQ3Ny1lZTRlZmVjNTUwNjBcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9udGVu
+      ZElQQ29uZmlndXJhdGlvbnMiOiBbeyJldGFnIjogIlcvXCJiYWFiZmI5ZC1jYTNhLTQwZTMtOTQ3
+      Ny1lZTRlZmVjNTUwNjBcIiIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1Ymxp
+      Y0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
+      YzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQu
+      TmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9QdWJsaWNJUGxiMSJ9fSwgImlkIjogIi9zdWJzY3Jp
+      cHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vw
+      cy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJv
+      bnRlbmRJUENvbmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNlckZyb250RW5kIiwgIm5hbWUiOiAiTG9h
+      ZEJhbGFuY2VyRnJvbnRFbmQifV0sICJvdXRib3VuZE5hdFJ1bGVzIjogW10sICJwcm92aXNpb25p
+      bmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAiaW5ib3VuZE5hdFJ1bGVzIjogW3sicHJvcGVydGllcyI6
+      IHsiZnJvbnRlbmRJUENvbmZpZ3VyYXRpb24iOiB7ImV0YWciOiAiVy9cImJhYWJmYjlkLWNhM2Et
+      NDBlMy05NDc3LWVlNGVmZWM1NTA2MFwiIiwgInByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0
+      YXRlIjogIlN1Y2NlZWRlZCIsICJwcml2YXRlSVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFtaWMi
+      LCAicHVibGljSVBBZGRyZXNzIjogeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYw
+      LTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01p
+      Y3Jvc29mdC5OZXR3b3JrL3B1YmxpY0lQQWRkcmVzc2VzL1B1YmxpY0lQbGIxIn19LCAiaWQiOiAi
+      L3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291
+      cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJz
+      L2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMvTG9hZEJhbGFuY2VyRnJvbnRFbmQiLCAibmFt
+      ZSI6ICJMb2FkQmFsYW5jZXJGcm9udEVuZCJ9LCAiZW5hYmxlRmxvYXRpbmdJUCI6IGZhbHNlLCAi
+      ZnJvbnRlbmRQb3J0IjogMSwgImJhY2tlbmRQb3J0IjogMSwgInByb3RvY29sIjogInRjcCJ9LCAi
+      bmFtZSI6ICJydWxlMSJ9XSwgImJhY2tlbmRBZGRyZXNzUG9vbHMiOiBbeyJldGFnIjogIlcvXCJi
+      YWFiZmI5ZC1jYTNhLTQwZTMtOTQ3Ny1lZTRlZmVjNTUwNjBcIiIsICJuYW1lIjogImxiMWJlcG9v
+      bCIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJm
+      MDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xv
+      YWRCYWxhbmNlcnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMvbGIxYmVwb29sIiwgInByb3BlcnRp
+      ZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCJ9fV0sICJpbmJvdW5kTmF0UG9v
+      bHMiOiBbXSwgInJlc291cmNlR3VpZCI6ICJmODE2ODZmMi0wZGI0LTRiOTktYjRhYi1lMTRkZGFm
+      OTVmZDkiLCAibG9hZEJhbGFuY2luZ1J1bGVzIjogW119LCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMv
       MGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3Jn
       L3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMSJ9
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Length: ['1929']
       Content-Type: [application/json; charset=utf-8]
@@ -87,7 +87,7 @@ interactions:
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [4514da5e-4518-11e6-b927-a0b3ccf7272a]
+      x-ms-client-request-id: [840b814c-494e-11e6-ba52-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -97,42 +97,42 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o53zvfv39x6eb59/+uDe9v7003vb2Xl2sL1zb+/h/U+znBCb/r4f
-        6Yvt9YpHc0NX2rqsphmGhzeu8qZdmy8I51Vet0Xe0FdMJ/nwsmioebG8eN1mLXf0ej2d5vksn8mb
-        1MwSYS2EvLf/cH/3wTTbnuSf3t/ef3D/3vbk/v2d7Z2H9+5/ev/Bp/uznQf25fO6Wrb5cnb28qRa
-        nhcX65oRBBrfkyapwQePnb3n3uieAcbp0mKE5+d0Uu8OjerujWh/XUaQB1PWm0d58NUtZlMealxc
-        UpOzl8el4Zkv8nZeMVGfXtMsFNPuK+tJWUzpjdmMKNjrn1r8EKekg0ze3H2pn9D0fOTj9UvCURTL
-        SbVezl5k7at1yVS0bChPZ1B45Yc3rD6ndfC9W9O/4QBpiP6f33d/2M/1l+8rKT6aZNO3xL1KvJdV
-        VQaE8Ehg5ZFwmeQraulzxc8taSKjwOcRNH/OhM611Smwv9i5cOMiEDzHBOJ79mvqYNL5qMMS+E6+
-        ic+ccIy+jOfndtY62CtD++j9nM2WB4UaD+h4eiUASi1/Tuk5gOaAKfIx72hGA+hlVbc0nt3wWxW2
-        +Jf5MpuU+TNCriXKnr2kFudZ2eRhq2JW5m+KRV6t27PlF8Vy3fIU7YetaPRtNSUBJpK+ma48jFVy
-        7C9WIAhgwFP0akxaWEPwd/iKgPyS/wfBaEWNMQoAAA==
+        J1mZLaf43qGQt9kFkPju3d/3o4P8wcHD3U+n2/ezh/vb+/eyh9uTnb2H2w+y6c5Otjvd3Zk++H0/
+        0hfb6xWP5oautHVZTTMMD29c5U27Nl8Qzqu8bou8oa+YTvLhZdFQ82J58brNWu7o9Xo6zfNZPpM3
+        qZklwloIeX6w++nBp+d72zuzCeE/eUj472eT7XwXVDx/eP989tC+fF5XyzZfzs5enlTL8+JiXTOC
+        QON70iQ1+OCxs/fcG90zwDhdWozw/JxO6t2hUd29Ee2vywjyYMp68ygPvrrFbMpDjYtLanL28rg0
+        PPNF3s4rJurTa5qFYtp9ZT0piym9MZsRBXv9U4sf4pR0kMmbuy/1E5qej3y8fkk4imI5qdbL2Yus
+        fbUumYqWDeXpDAqv/PCG1ee0Dr53a/o3HCAN0f/z++4P+7n+8n0lxUeTbPqWuFeJ97KqyoAQHgms
+        PBIuk3xFLX2u+LklTWQU+DyC5s+Z0Lm2OgX2FzsXblwEgueYQHzPfk0dTDofdVgC38k38ZkTjtGX
+        8fzczloHe2VoH72fs9nyoFDjAR1PrwRAqeXPKT0H0BwwRT7mHc1oAL2s6pbGsxt+q8IW/zJfZpMy
+        f0bItUTZs5fU4jwrmzxsVczK/E2xyKt1e7b8oliuW56i/bAVjb6tpiTARNI305WHsUqO/cUKBAEM
+        eIpejUkLawj+Dl8RkF/y/wAzYizCMQoAAA==
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/f520ff54-38d6-48de-940e-4f40ef812f14?api-version=2016-03-30']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/f2718687-de6e-4644-9c48-858bdc1c7386?api-version=2016-03-30']
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:28:42 GMT']
+      Date: ['Wed, 13 Jul 2016 23:07:05 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [45b7f814-4518-11e6-a569-a0b3ccf7272a]
+      x-ms-client-request-id: [84b15a7a-494e-11e6-aeac-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -142,22 +142,22 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o53zvfv39x6eb59/+uDe9v7003vb2Xl2sL1zb+/h/U+znBCb/r4f
-        6Yvt9YpHc0NX2rqsphmGhzeu8qZdmy8I51Vet0Xe0FdMJ/nwsmioebG8eN1mLXf0ej2d5vksn8mb
-        1MwSYS2EvLf/cH/3wTTbnuSf3t/ef3D/3vbk/v2d7Z2H9+5/ev/Bp/uznQf25fO6Wrb5cnb28qRa
-        nhcX65oRBBrfkyapwQePnb3n3uieAcbp0mKE5+d0Uu8OjerujWh/XUaQB1PWm0d58NUtZlMealxc
-        UpOzl8el4Zkv8nZeMVGfXtMsFNPuK+tJWUzpjdmMKNjrn1r8EKekg0ze3H2pn9D0fOTj9UvCURTL
-        SbVezl5k7at1yVS0bChPZ1B45Yc3rD6ndfC9W9O/4QBpiP6f33d/2M/1l+8rKT6aZNO3xL1KvJdV
-        VQaE8Ehg5ZFwmeQraulzxc8taSKjwOcRNH/OhM611Smwv9i5cOMiEDzHBOJ79mvqYNL5qMMS+E6+
-        ic+ccIy+jOfndtY62CtD++j9nM2WB4UaD+h4eiUASi1/Tuk5gOaAKfIx72hGA+hlVbc0nt3wWxW2
-        +Jf5MpuU+TNCriXKnr2kFudZ2eRhq2JW5m+KRV6t27PlF8Vy3fIU7YetaPRtNSUBJpK+ma48jFVy
-        7C9WIAhgwFP0akxaWEPwd/iKgPyS/wfBaEWNMQoAAA==
+        J1mZLaf43qGQt9kFkPju3d/3o4P8wcHD3U+n2/ezh/vb+/eyh9uTnb2H2w+y6c5Otjvd3Zk++H0/
+        0hfb6xWP5oautHVZTTMMD29c5U27Nl8Qzqu8bou8oa+YTvLhZdFQ82J58brNWu7o9Xo6zfNZPpM3
+        qZklwloIeX6w++nBp+d72zuzCeE/eUj472eT7XwXVDx/eP989tC+fF5XyzZfzs5enlTL8+JiXTOC
+        QON70iQ1+OCxs/fcG90zwDhdWozw/JxO6t2hUd29Ee2vywjyYMp68ygPvrrFbMpDjYtLanL28rg0
+        PPNF3s4rJurTa5qFYtp9ZT0piym9MZsRBXv9U4sf4pR0kMmbuy/1E5qej3y8fkk4imI5qdbL2Yus
+        fbUumYqWDeXpDAqv/PCG1ee0Dr53a/o3HCAN0f/z++4P+7n+8n0lxUeTbPqWuFeJ97KqyoAQHgms
+        PBIuk3xFLX2u+LklTWQU+DyC5s+Z0Lm2OgX2FzsXblwEgueYQHzPfk0dTDofdVgC38k38ZkTjtGX
+        8fzczloHe2VoH72fs9nyoFDjAR1PrwRAqeXPKT0H0BwwRT7mHc1oAL2s6pbGsxt+q8IW/zJfZpMy
+        f0bItUTZs5fU4jwrmzxsVczK/E2xyKt1e7b8oliuW56i/bAVjb6tpiTARNI305WHsUqO/cUKBAEM
+        eIpejUkLawj+Dl8RkF/y/wAzYizCMQoAAA==
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:28:42 GMT']
-      ETag: [W/"0f25529f-f673-4c63-afa8-032956aeb1fc"]
+      Date: ['Wed, 13 Jul 2016 23:07:06 GMT']
+      ETag: [W/"8e78916c-5a94-43a9-b029-7ac00a1c10c7"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -166,61 +166,61 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9u
-      dGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJuYW1lIjogIkxvYWRCYWxhbmNlckZyb250RW5kIiwg
-      InByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJpbmJvdW5k
-      TmF0UnVsZXMiOiBbeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVj
-      My1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5O
-      ZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2luYm91bmROYXRSdWxlcy9ydWxlMSJ9XSwgInByaXZh
-      dGVJUEFsbG9jYXRpb25NZXRob2QiOiAiRHluYW1pYyIsICJwdWJsaWNJUEFkZHJlc3MiOiB7Imlk
-      IjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9y
-      ZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvcHVibGljSVBB
-      ZGRyZXNzZXMvUHVibGljSVBsYjEifX0sICJldGFnIjogIlcvXCIwZjI1NTI5Zi1mNjczLTRjNjMt
-      YWZhOC0wMzI5NTZhZWIxZmNcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYw
-      LTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01p
-      Y3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9u
-      cy9Mb2FkQmFsYW5jZXJGcm9udEVuZCJ9XSwgInJlc291cmNlR3VpZCI6ICIzNDk0MTdjYS1iZTY1
-      LTQ3NTMtYjU1MC0wOTM1NjU3NjRkMDciLCAib3V0Ym91bmROYXRSdWxlcyI6IFtdLCAibG9hZEJh
-      bGFuY2luZ1J1bGVzIjogW10sICJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAiaW5i
-      b3VuZE5hdFJ1bGVzIjogW3sibmFtZSI6ICJydWxlMSIsICJwcm9wZXJ0aWVzIjogeyJmcm9udGVu
-      ZElQQ29uZmlndXJhdGlvbiI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00
-      ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNy
-      b3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMv
-      TG9hZEJhbGFuY2VyRnJvbnRFbmQifSwgInByb3RvY29sIjogIlRjcCIsICJpZGxlVGltZW91dElu
-      TWludXRlcyI6IDQsICJlbmFibGVGbG9hdGluZ0lQIjogZmFsc2UsICJmcm9udGVuZFBvcnQiOiAx
-      LCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImJhY2tlbmRQb3J0IjogMX0sICJl
-      dGFnIjogIlcvXCIwZjI1NTI5Zi1mNjczLTRjNjMtYWZhOC0wMzI5NTZhZWIxZmNcIiIsICJpZCI6
-      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
-      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNl
-      cnMvbGIxL2luYm91bmROYXRSdWxlcy9ydWxlMSJ9LCB7Im5hbWUiOiAicnVsZTIiLCAicHJvcGVy
-      dGllcyI6IHsiZnJvbnRlbmRJUENvbmZpZ3VyYXRpb24iOiB7Im5hbWUiOiAiTG9hZEJhbGFuY2Vy
-      RnJvbnRFbmQiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVk
-      IiwgImluYm91bmROYXRSdWxlcyI6IFt7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFi
+      eyJldGFnIjogIlcvXCI4ZTc4OTE2Yy01YTk0LTQzYTktYjAyOS03YWMwMGExYzEwYzdcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9udGVu
+      ZElQQ29uZmlndXJhdGlvbnMiOiBbeyJldGFnIjogIlcvXCI4ZTc4OTE2Yy01YTk0LTQzYTktYjAy
+      OS03YWMwMGExYzEwYzdcIiIsICJwcm9wZXJ0aWVzIjogeyJpbmJvdW5kTmF0UnVsZXMiOiBbeyJp
+      ZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAv
+      cmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxh
+      bmNlcnMvbGIxL2luYm91bmROYXRSdWxlcy9ydWxlMSJ9XSwgInByb3Zpc2lvbmluZ1N0YXRlIjog
+      IlN1Y2NlZWRlZCIsICJwcml2YXRlSVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVi
+      bGljSVBBZGRyZXNzIjogeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEt
+      YWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29m
+      dC5OZXR3b3JrL3B1YmxpY0lQQWRkcmVzc2VzL1B1YmxpY0lQbGIxIn19LCAiaWQiOiAiL3N1YnNj
+      cmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3Jv
+      dXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9m
+      cm9udGVuZElQQ29uZmlndXJhdGlvbnMvTG9hZEJhbGFuY2VyRnJvbnRFbmQiLCAibmFtZSI6ICJM
+      b2FkQmFsYW5jZXJGcm9udEVuZCJ9XSwgIm91dGJvdW5kTmF0UnVsZXMiOiBbXSwgInByb3Zpc2lv
+      bmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJpbmJvdW5kTmF0UnVsZXMiOiBbeyJldGFnIjogIlcv
+      XCI4ZTc4OTE2Yy01YTk0LTQzYTktYjAyOS03YWMwMGExYzEwYzdcIiIsICJuYW1lIjogInJ1bGUx
+      IiwgInByb3BlcnRpZXMiOiB7ImlkbGVUaW1lb3V0SW5NaW51dGVzIjogNCwgImVuYWJsZUZsb2F0
+      aW5nSVAiOiBmYWxzZSwgImZyb250ZW5kUG9ydCI6IDEsICJwcm90b2NvbCI6ICJUY3AiLCAiZnJv
+      bnRlbmRJUENvbmZpZ3VyYXRpb24iOiB7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFi
+      ZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMv
+      TWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJvbnRlbmRJUENvbmZpZ3VyYXRp
+      b25zL0xvYWRCYWxhbmNlckZyb250RW5kIn0sICJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVk
+      ZWQiLCAiYmFja2VuZFBvcnQiOiAxfSwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFi
       ZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMv
       TWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvaW5ib3VuZE5hdFJ1bGVzL3J1bGUx
-      In1dLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1YmxpY0lQQWRk
-      cmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5
-      MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29y
-      ay9wdWJsaWNJUEFkZHJlc3Nlcy9QdWJsaWNJUGxiMSJ9fSwgImV0YWciOiAiVy9cIjBmMjU1Mjlm
-      LWY2NzMtNGM2My1hZmE4LTAzMjk1NmFlYjFmY1wiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBi
-      MWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9w
-      cm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJvbnRlbmRJUENv
-      bmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNlckZyb250RW5kIn0sICJwcm90b2NvbCI6ICJ0Y3AiLCAi
-      YmFja2VuZFBvcnQiOiAyLCAiZnJvbnRlbmRQb3J0IjogMiwgImVuYWJsZUZsb2F0aW5nSVAiOiBm
-      YWxzZX19XSwgImluYm91bmROYXRQb29scyI6IFtdLCAiYmFja2VuZEFkZHJlc3NQb29scyI6IFt7
-      Im5hbWUiOiAibGIxYmVwb29sIiwgInByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjog
-      IlN1Y2NlZWRlZCJ9LCAiZXRhZyI6ICJXL1wiMGYyNTUyOWYtZjY3My00YzYzLWFmYTgtMDMyOTU2
-      YWViMWZjXCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMt
-      Y2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0
-      d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVzc1Bvb2xzL2xiMWJlcG9vbCJ9XX0s
-      ICJldGFnIjogIlcvXCIwZjI1NTI5Zi1mNjczLTRjNjMtYWZhOC0wMzI5NTZhZWIxZmNcIiIsICJp
+      In0sIHsicHJvcGVydGllcyI6IHsiZnJvbnRlbmRJUENvbmZpZ3VyYXRpb24iOiB7ImV0YWciOiAi
+      Vy9cIjhlNzg5MTZjLTVhOTQtNDNhOS1iMDI5LTdhYzAwYTFjMTBjN1wiIiwgInByb3BlcnRpZXMi
+      OiB7ImluYm91bmROYXRSdWxlcyI6IFt7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFi
+      ZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMv
+      TWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvaW5ib3VuZE5hdFJ1bGVzL3J1bGUx
+      In1dLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgInByaXZhdGVJUEFsbG9jYXRp
+      b25NZXRob2QiOiAiRHluYW1pYyIsICJwdWJsaWNJUEFkZHJlc3MiOiB7ImlkIjogIi9zdWJzY3Jp
+      cHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vw
+      cy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvcHVibGljSVBBZGRyZXNzZXMvUHVi
+      bGljSVBsYjEifX0sICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVj
+      My1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5O
+      ZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9ucy9Mb2FkQmFs
+      YW5jZXJGcm9udEVuZCIsICJuYW1lIjogIkxvYWRCYWxhbmNlckZyb250RW5kIn0sICJlbmFibGVG
+      bG9hdGluZ0lQIjogZmFsc2UsICJmcm9udGVuZFBvcnQiOiAyLCAiYmFja2VuZFBvcnQiOiAyLCAi
+      cHJvdG9jb2wiOiAidGNwIn0sICJuYW1lIjogInJ1bGUyIn1dLCAiYmFja2VuZEFkZHJlc3NQb29s
+      cyI6IFt7ImV0YWciOiAiVy9cIjhlNzg5MTZjLTVhOTQtNDNhOS1iMDI5LTdhYzAwYTFjMTBjN1wi
+      IiwgIm5hbWUiOiAibGIxYmVwb29sIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFi
+      ZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMv
+      TWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvYmFja2VuZEFkZHJlc3NQb29scy9s
+      YjFiZXBvb2wiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVk
+      In19XSwgImluYm91bmROYXRQb29scyI6IFtdLCAicmVzb3VyY2VHdWlkIjogImY4MTY4NmYyLTBk
+      YjQtNGI5OS1iNGFiLWUxNGRkYWY5NWZkOSIsICJsb2FkQmFsYW5jaW5nUnVsZXMiOiBbXX0sICJp
       ZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAv
       cmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxh
       bmNlcnMvbGIxIn0=
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Length: ['2861']
       Content-Type: [application/json; charset=utf-8]
@@ -228,7 +228,7 @@ interactions:
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [45f2d918-4518-11e6-81b1-a0b3ccf7272a]
+      x-ms-client-request-id: [84d3c4d4-494e-11e6-be94-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -238,43 +238,43 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o+m92ezh+c7B9oMH+f3t/U/3Hm5PPr032Z7ks9n96f3pbn6+//t+
-        pC+21ysezQ1daeuymmYYHt64ypt2bb4gnFd53RZ5Q18xneTDy6Kh5sXy4nWbtdzR6/V0muezfCZv
-        UjNLhLUQ8t7+w/3dB9OMEP6U8H9w/9725P79ne2dh/fuf3r/waf7s50H9uXzulq2+XJ29vKkWp4X
-        F+uaEQQa35MmqcEHj529597ongHG6dJihOfndFLvDo3q7o1of11GkAdT1ptHefDVLWZTHmpcXFKT
-        s5fHpeGZL/J2XjFRn17TLBTT7ivrSVlM6Y3ZjCjY659a/BCnpINM3tx9qZ/Q9Hzk4/VLwlEUy0m1
-        Xs5eZO2rdclUtGwoT2dQeOWHN6w+p3XwvVvTv+EAu0P8/8QQ9rpD8P/8vvvDfq6/fF+H+tEkm74l
-        AdT5f1lVZTCXHgmsSiFcJvmKWvqM/XNLmsgo8HkEzZ8zveHa6hTYX+xcuHERCJ5jAvE9+zV1MOl8
-        1GEJfCffxGcOHKOWVJ6f21nrYM8MHaL3czZbHhRqPGCm6JUAKLX8OaXnAJoD1tTHPNR8drwvq7ql
-        8eyG36qwxb/Ml9mkzJ8Rci1R9uwltTjPyiYPWxWzMn9TLPJq3Z4tvyiW65anaD9sRaNvqykJMJH0
-        zXTlYaySQ7/YN7yZCPh9z59L6hif3/25mZ8Yv4fo/YjfCctb03MAzQ/m973w25DfO1/+sPldfrEG
-        gAAGPEWvxqwDW0T+Dl8RkF/y/wCmQn4a5A0AAA==
+        J1mZLaf43qGQt9kFkPju3d/3o+ze/l6WP9jb3sl29rb39/cfbh/sTM+3H2a7k8mD/Qc7Dw/y3/cj
+        fbG9XvFobuhKW5fVNMPw8MZV3rRr8wXhvMrrtsgb+orpJB9eFg01L5YXr9us5Y5er6fTPJ/lM3mT
+        mlkirIWQ5we7nx58ek74zyb72/uThw+3J/vZZDvfBRXPH94/nz20L5/X1bLNl7OzlyfV8ry4WNeM
+        IND4njRJDT547Ow990b3DDBOlxYjPD+nk3p3aFR3b0T76zKCPJiy3jzKg69uMZvyUOPikpqcvTwu
+        Dc98kbfzion69JpmoZh2X1lPymJKb8xmRMFe/9TihzglHWTy5u5L/YSm5yMfr18SjqJYTqr1cvYi
+        a1+tS6aiZUN5OoPCKz+8YfU5rYPv3Zr+DQfYHeL/J4aw1x2C/+f33R/2c/3l+zrUjybZ9C0JoM7/
+        y6oqg7n0SGBVCuEyyVfU0mfsn1vSREaBzyNo/pzpDddWp8D+YufCjYtA8BwTiO/Zr6mDSeejDkvg
+        O/kmPnPgGLWk8vzczloHe2boEL2fs9nyoFDjATNFrwRAqeXPKT0H0Bywpj7moeaz431Z1S2NZzf8
+        VoUt/mW+zCZl/oyQa4myZy+pxXlWNnnYqpiV+ZtikVfr9mz5RbFctzxF+2ErGn1bTUmAiaRvpisP
+        Y5Uc+sW+4c1EwO97/lxSx/j87s/N/MT4PUTvR/xOWN6angNofjC/74Xfhvze+fKHze/yizUABDDg
+        KXo1Zh3YIvJ3+IqA/JL/B8tXDs7kDQAA
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/1ab3a8b2-da04-4db9-a693-616441caa672?api-version=2016-03-30']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/7af02962-96d0-4671-abbc-b8522245219d?api-version=2016-03-30']
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:28:43 GMT']
+      Date: ['Wed, 13 Jul 2016 23:07:06 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1193']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [4698fa58-4518-11e6-b4fb-a0b3ccf7272a]
+      x-ms-client-request-id: [85797a02-494e-11e6-a2af-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -284,23 +284,23 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o+m92ezh+c7B9oMH+f3t/U/3Hm5PPr032Z7ks9n96f3pbn6+//t+
-        pC+21ysezQ1daeuymmYYHt64ypt2bb4gnFd53RZ5Q18xneTDy6Kh5sXy4nWbtdzR6/V0muezfCZv
-        UjNLhLUQ8t7+w/3dB9OMEP6U8H9w/9725P79ne2dh/fuf3r/waf7s50H9uXzulq2+XJ29vKkWp4X
-        F+uaEQQa35MmqcEHj529597ongHG6dJihOfndFLvDo3q7o1of11GkAdT1ptHefDVLWZTHmpcXFKT
-        s5fHpeGZL/J2XjFRn17TLBTT7ivrSVlM6Y3ZjCjY659a/BCnpINM3tx9qZ/Q9Hzk4/VLwlEUy0m1
-        Xs5eZO2rdclUtGwoT2dQeOWHN6w+p3XwvVvTv+EAu0P8/8QQ9rpD8P/8vvvDfq6/fF+H+tEkm74l
-        AdT5f1lVZTCXHgmsSiFcJvmKWvqM/XNLmsgo8HkEzZ8zveHa6hTYX+xcuHERCJ5jAvE9+zV1MOl8
-        1GEJfCffxGcOHKOWVJ6f21nrYM8MHaL3czZbHhRqPGCm6JUAKLX8OaXnAJoD1tTHPNR8drwvq7ql
-        8eyG36qwxb/Ml9mkzJ8Rci1R9uwltTjPyiYPWxWzMn9TLPJq3Z4tvyiW65anaD9sRaNvqykJMJH0
-        zXTlYaySQ7/YN7yZCPh9z59L6hif3/25mZ8Yv4fo/YjfCctb03MAzQ/m973w25DfO1/+sPldfrEG
-        gAAGPEWvxqwDW0T+Dl8RkF/y/wCmQn4a5A0AAA==
+        J1mZLaf43qGQt9kFkPju3d/3o+ze/l6WP9jb3sl29rb39/cfbh/sTM+3H2a7k8mD/Qc7Dw/y3/cj
+        fbG9XvFobuhKW5fVNMPw8MZV3rRr8wXhvMrrtsgb+orpJB9eFg01L5YXr9us5Y5er6fTPJ/lM3mT
+        mlkirIWQ5we7nx58ek74zyb72/uThw+3J/vZZDvfBRXPH94/nz20L5/X1bLNl7OzlyfV8ry4WNeM
+        IND4njRJDT547Ow990b3DDBOlxYjPD+nk3p3aFR3b0T76zKCPJiy3jzKg69uMZvyUOPikpqcvTwu
+        Dc98kbfzion69JpmoZh2X1lPymJKb8xmRMFe/9TihzglHWTy5u5L/YSm5yMfr18SjqJYTqr1cvYi
+        a1+tS6aiZUN5OoPCKz+8YfU5rYPv3Zr+DQfYHeL/J4aw1x2C/+f33R/2c/3l+zrUjybZ9C0JoM7/
+        y6oqg7n0SGBVCuEyyVfU0mfsn1vSREaBzyNo/pzpDddWp8D+YufCjYtA8BwTiO/Zr6mDSeejDkvg
+        O/kmPnPgGLWk8vzczloHe2boEL2fs9nyoFDjATNFrwRAqeXPKT0H0Bywpj7moeaz431Z1S2NZzf8
+        VoUt/mW+zCZl/oyQa4myZy+pxXlWNnnYqpiV+ZtikVfr9mz5RbFctzxF+2ErGn1bTUmAiaRvpisP
+        Y5Uc+sW+4c1EwO97/lxSx/j87s/N/MT4PUTvR/xOWN6angNofjC/74Xfhvze+fKHze/yizUABDDg
+        KXo1Zh3YIvJ3+IqA/JL/B8tXDs7kDQAA
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:28:44 GMT']
-      ETag: [W/"c3dd9f08-77e5-4629-b63b-bedd5c5c1ef4"]
+      Date: ['Wed, 13 Jul 2016 23:07:08 GMT']
+      ETag: [W/"a342ae72-0a02-4449-80cf-9a1bb747098e"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -309,76 +309,76 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9u
-      dGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJuYW1lIjogIkxvYWRCYWxhbmNlckZyb250RW5kIiwg
-      InByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJpbmJvdW5k
-      TmF0UnVsZXMiOiBbeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVj
-      My1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5O
-      ZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2luYm91bmROYXRSdWxlcy9ydWxlMSJ9LCB7ImlkIjog
-      Ii9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNv
-      dXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vy
-      cy9sYjEvaW5ib3VuZE5hdFJ1bGVzL3J1bGUyIn1dLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhv
-      ZCI6ICJEeW5hbWljIiwgInB1YmxpY0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMv
-      MGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3Jn
-      L3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9QdWJsaWNJUGxi
-      MSJ9fSwgImV0YWciOiAiVy9cImMzZGQ5ZjA4LTc3ZTUtNDYyOS1iNjNiLWJlZGQ1YzVjMWVmNFwi
-      IiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYw
-      OTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9h
-      ZEJhbGFuY2Vycy9sYjEvZnJvbnRlbmRJUENvbmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNlckZyb250
-      RW5kIn1dLCAicmVzb3VyY2VHdWlkIjogIjM0OTQxN2NhLWJlNjUtNDc1My1iNTUwLTA5MzU2NTc2
-      NGQwNyIsICJvdXRib3VuZE5hdFJ1bGVzIjogW10sICJsb2FkQmFsYW5jaW5nUnVsZXMiOiBbXSwg
-      InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJpbmJvdW5kTmF0UnVsZXMiOiBbeyJu
-      YW1lIjogInJ1bGUxIiwgInByb3BlcnRpZXMiOiB7ImZyb250ZW5kSVBDb25maWd1cmF0aW9uIjog
-      eyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1
-      OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRC
-      YWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9ucy9Mb2FkQmFsYW5jZXJGcm9udEVu
-      ZCJ9LCAicHJvdG9jb2wiOiAiVGNwIiwgImlkbGVUaW1lb3V0SW5NaW51dGVzIjogNCwgImVuYWJs
-      ZUZsb2F0aW5nSVAiOiBmYWxzZSwgImZyb250ZW5kUG9ydCI6IDEsICJwcm92aXNpb25pbmdTdGF0
-      ZSI6ICJTdWNjZWVkZWQiLCAiYmFja2VuZFBvcnQiOiAxfSwgImV0YWciOiAiVy9cImMzZGQ5ZjA4
-      LTc3ZTUtNDYyOS1iNjNiLWJlZGQ1YzVjMWVmNFwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBi
-      MWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9w
-      cm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvaW5ib3VuZE5hdFJ1
-      bGVzL3J1bGUxIn0sIHsibmFtZSI6ICJydWxlMiIsICJwcm9wZXJ0aWVzIjogeyJmcm9udGVuZElQ
-      Q29uZmlndXJhdGlvbiI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRh
-      LWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3Nv
-      ZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMvTG9h
-      ZEJhbGFuY2VyRnJvbnRFbmQifSwgInByb3RvY29sIjogIlRjcCIsICJpZGxlVGltZW91dEluTWlu
-      dXRlcyI6IDQsICJlbmFibGVGbG9hdGluZ0lQIjogZmFsc2UsICJmcm9udGVuZFBvcnQiOiAyLCAi
-      cHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImJhY2tlbmRQb3J0IjogMn0sICJldGFn
-      IjogIlcvXCJjM2RkOWYwOC03N2U1LTQ2MjktYjYzYi1iZWRkNWM1YzFlZjRcIiIsICJpZCI6ICIv
-      c3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3Vy
-      Y2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMv
-      bGIxL2luYm91bmROYXRSdWxlcy9ydWxlMiJ9LCB7Im5hbWUiOiAicnVsZTMiLCAicHJvcGVydGll
-      cyI6IHsiZnJvbnRlbmRJUENvbmZpZ3VyYXRpb24iOiB7Im5hbWUiOiAiTG9hZEJhbGFuY2VyRnJv
-      bnRFbmQiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwg
+      eyJldGFnIjogIlcvXCJhMzQyYWU3Mi0wYTAyLTQ0NDktODBjZi05YTFiYjc0NzA5OGVcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9udGVu
+      ZElQQ29uZmlndXJhdGlvbnMiOiBbeyJldGFnIjogIlcvXCJhMzQyYWU3Mi0wYTAyLTQ0NDktODBj
+      Zi05YTFiYjc0NzA5OGVcIiIsICJwcm9wZXJ0aWVzIjogeyJpbmJvdW5kTmF0UnVsZXMiOiBbeyJp
+      ZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAv
+      cmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxh
+      bmNlcnMvbGIxL2luYm91bmROYXRSdWxlcy9ydWxlMSJ9LCB7ImlkIjogIi9zdWJzY3JpcHRpb25z
+      LzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNy
+      Zy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvaW5ib3VuZE5h
+      dFJ1bGVzL3J1bGUyIn1dLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgInByaXZh
+      dGVJUEFsbG9jYXRpb25NZXRob2QiOiAiRHluYW1pYyIsICJwdWJsaWNJUEFkZHJlc3MiOiB7Imlk
+      IjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9y
+      ZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvcHVibGljSVBB
+      ZGRyZXNzZXMvUHVibGljSVBsYjEifX0sICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0x
+      YmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJz
+      L01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0
+      aW9ucy9Mb2FkQmFsYW5jZXJGcm9udEVuZCIsICJuYW1lIjogIkxvYWRCYWxhbmNlckZyb250RW5k
+      In1dLCAib3V0Ym91bmROYXRSdWxlcyI6IFtdLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2Vl
+      ZGVkIiwgImluYm91bmROYXRSdWxlcyI6IFt7ImV0YWciOiAiVy9cImEzNDJhZTcyLTBhMDItNDQ0
+      OS04MGNmLTlhMWJiNzQ3MDk4ZVwiIiwgIm5hbWUiOiAicnVsZTEiLCAicHJvcGVydGllcyI6IHsi
+      aWRsZVRpbWVvdXRJbk1pbnV0ZXMiOiA0LCAiZW5hYmxlRmxvYXRpbmdJUCI6IGZhbHNlLCAiZnJv
+      bnRlbmRQb3J0IjogMSwgInByb3RvY29sIjogIlRjcCIsICJmcm9udGVuZElQQ29uZmlndXJhdGlv
+      biI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5Mjcy
+      ZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9s
+      b2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMvTG9hZEJhbGFuY2VyRnJv
+      bnRFbmQifSwgInByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJiYWNrZW5kUG9ydCI6
+      IDF9LCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5Mjcy
+      ZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9s
+      b2FkQmFsYW5jZXJzL2xiMS9pbmJvdW5kTmF0UnVsZXMvcnVsZTEifSwgeyJldGFnIjogIlcvXCJh
+      MzQyYWU3Mi0wYTAyLTQ0NDktODBjZi05YTFiYjc0NzA5OGVcIiIsICJuYW1lIjogInJ1bGUyIiwg
+      InByb3BlcnRpZXMiOiB7ImlkbGVUaW1lb3V0SW5NaW51dGVzIjogNCwgImVuYWJsZUZsb2F0aW5n
+      SVAiOiBmYWxzZSwgImZyb250ZW5kUG9ydCI6IDIsICJwcm90b2NvbCI6ICJUY3AiLCAiZnJvbnRl
+      bmRJUENvbmZpZ3VyYXRpb24iOiB7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAt
+      NGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWlj
+      cm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJvbnRlbmRJUENvbmZpZ3VyYXRpb25z
+      L0xvYWRCYWxhbmNlckZyb250RW5kIn0sICJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQi
+      LCAiYmFja2VuZFBvcnQiOiAyfSwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAt
+      NGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWlj
+      cm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvaW5ib3VuZE5hdFJ1bGVzL3J1bGUyIn0s
+      IHsicHJvcGVydGllcyI6IHsiZnJvbnRlbmRJUENvbmZpZ3VyYXRpb24iOiB7ImV0YWciOiAiVy9c
+      ImEzNDJhZTcyLTBhMDItNDQ0OS04MGNmLTlhMWJiNzQ3MDk4ZVwiIiwgInByb3BlcnRpZXMiOiB7
       ImluYm91bmROYXRSdWxlcyI6IFt7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAt
       NGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWlj
       cm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvaW5ib3VuZE5hdFJ1bGVzL3J1bGUxIn0s
       IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5
       NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2Fk
-      QmFsYW5jZXJzL2xiMS9pbmJvdW5kTmF0UnVsZXMvcnVsZTIifV0sICJwcml2YXRlSVBBbGxvY2F0
-      aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVibGljSVBBZGRyZXNzIjogeyJpZCI6ICIvc3Vic2Ny
-      aXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91
-      cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3B1YmxpY0lQQWRkcmVzc2VzL1B1
-      YmxpY0lQbGIxIn19LCAiZXRhZyI6ICJXL1wiYzNkZDlmMDgtNzdlNS00NjI5LWI2M2ItYmVkZDVj
-      NWMxZWY0XCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMt
-      Y2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0
-      d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMvTG9hZEJhbGFu
-      Y2VyRnJvbnRFbmQifSwgInByb3RvY29sIjogInRjcCIsICJiYWNrZW5kUG9ydCI6IDMsICJmcm9u
-      dGVuZFBvcnQiOiAzLCAiZW5hYmxlRmxvYXRpbmdJUCI6IGZhbHNlfX1dLCAiaW5ib3VuZE5hdFBv
-      b2xzIjogW10sICJiYWNrZW5kQWRkcmVzc1Bvb2xzIjogW3sibmFtZSI6ICJsYjFiZXBvb2wiLCAi
-      cHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn0sICJldGFnIjog
-      IlcvXCJjM2RkOWYwOC03N2U1LTQ2MjktYjYzYi1iZWRkNWM1YzFlZjRcIiIsICJpZCI6ICIvc3Vi
-      c2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VH
-      cm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIx
-      L2JhY2tlbmRBZGRyZXNzUG9vbHMvbGIxYmVwb29sIn1dfSwgImV0YWciOiAiVy9cImMzZGQ5ZjA4
-      LTc3ZTUtNDYyOS1iNjNiLWJlZGQ1YzVjMWVmNFwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBi
+      QmFsYW5jZXJzL2xiMS9pbmJvdW5kTmF0UnVsZXMvcnVsZTIifV0sICJwcm92aXNpb25pbmdTdGF0
+      ZSI6ICJTdWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwg
+      InB1YmxpY0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00
+      ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNy
+      b3NvZnQuTmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9QdWJsaWNJUGxiMSJ9fSwgImlkIjogIi9z
+      dWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJj
+      ZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9s
+      YjEvZnJvbnRlbmRJUENvbmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNlckZyb250RW5kIiwgIm5hbWUi
+      OiAiTG9hZEJhbGFuY2VyRnJvbnRFbmQifSwgImVuYWJsZUZsb2F0aW5nSVAiOiBmYWxzZSwgImZy
+      b250ZW5kUG9ydCI6IDMsICJiYWNrZW5kUG9ydCI6IDMsICJwcm90b2NvbCI6ICJ0Y3AifSwgIm5h
+      bWUiOiAicnVsZTMifV0sICJiYWNrZW5kQWRkcmVzc1Bvb2xzIjogW3siZXRhZyI6ICJXL1wiYTM0
+      MmFlNzItMGEwMi00NDQ5LTgwY2YtOWExYmI3NDcwOThlXCIiLCAibmFtZSI6ICJsYjFiZXBvb2wi
+      LCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5
+      NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2Fk
+      QmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVzc1Bvb2xzL2xiMWJlcG9vbCIsICJwcm9wZXJ0aWVz
+      IjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQifX1dLCAiaW5ib3VuZE5hdFBvb2xz
+      IjogW10sICJyZXNvdXJjZUd1aWQiOiAiZjgxNjg2ZjItMGRiNC00Yjk5LWI0YWItZTE0ZGRhZjk1
+      ZmQ5IiwgImxvYWRCYWxhbmNpbmdSdWxlcyI6IFtdfSwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBi
       MWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9w
       cm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEifQ==
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Length: ['3751']
       Content-Type: [application/json; charset=utf-8]
@@ -386,7 +386,7 @@ interactions:
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [46ede386-4518-11e6-92be-a0b3ccf7272a]
+      x-ms-client-request-id: [85a3b1be-494e-11e6-ae81-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -396,44 +396,44 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o4PJZLa7f4/62929v71/sL+/nX368NPtfLYzPd/fy3YnD3d+34/0
-        xfZ6xaO5oSttXVbTDMPDG1d5067NF4TzKq/bIm/oK6aTfHhZNNS8WF68brOWO3q9nk7zfJbP5E1q
-        ZomwFkLe23+4v/tgmm1P8k8J/wf3721P7t/f2d55eO/+p/cffLo/23lgXz6vq2WbL2dnL0+q5Xlx
-        sa4ZQaDxPWmSGnzw2Nl77o3uGWCcLi1GeH5OJ/Xu0Kju3oj212UEeTBlvXmUB1/dYjblocbFJTU5
-        e3lcGp75Im/nFRP16TXNQjHtvrKelMWU3pjNiIK9/qnFD3FKOsjkzd2X+glNz0c+Xr8kHEWxnFTr
-        5exF1r5al0xFy4bydAaFV354w+pzWgffuzX9Gw6wO8T/Twxh7//7Q7jXHYL/5/fdH/Zz/eX7OtSP
-        Jtn0LekQZeGXVVUG7OiRwGpFwmWSr6ilL5s/t6SJjAKfR9D8OVN9rq1Ogf3FzoUbF4HgOSYQ37Nf
-        UweTzkcdlsB38k185sAx6gzI83M7ax3smaFD9H7OZsuDQo0HLC29EgCllj+n9BxAc8Ah8DEPNZ8d
-        78uqbmk8u+G3KmzxL/NlNinzZ4RcS5Q9e0ktzrOyycNWxazM3xSLvFq3Z8sviuW65SnaD1vR6Ntq
-        SgJMJH0zXXkYq+TQL/YNbyYCft/z55I6xud3f27mJ8bvIXo/4nfC8tb0HEDzg/l9L/w25PfOl/+v
-        4/d7/lxSx/j87s/N/MT4PUTvR/xOWN6angNofjC/3wu/Dfm98+UPm9/lF+vwEMCAp+jVmDfEHiB/
-        h68IyC/5fwB6TH3YlxEAAA==
+        J1mZLaf43qGQt9kFkPju3d/3o737ew8e3M8PtvfybLq9f3/6cHuy+2B/e2fyILs/uT89yD49+H0/
+        0hfb6xWP5oautHVZTTMMD29c5U27Nl8Qzqu8bou8oa+YTvLhZdFQ82J58brNWu7o9Xo6zfNZPpM3
+        qZklwloIeX6w++nBp+d72zuzyf72/uQh4b+fTbbzXVDx/OH989lD+/J5XS3bfDk7e3lSLc+Li3XN
+        CAKN70mT1OCDx87ec290zwDjdGkxwvNzOql3h0Z190a0vy4jyIMp682jPPjqFrMpDzUuLqnJ2cvj
+        0vDMF3k7r5ioT69pFopp95X1pCym9MZsRhTs9U8tfohT0kEmb+6+1E9oej7y8fol4SiK5aRaL2cv
+        svbVumQqWjaUpzMovPLDG1af0zr43q3p33CA3SH+f2IIe//fH8K97hD8P7/v/rCf6y/f16F+NMmm
+        b0mHKAu/rKoyYEePBFYrEi6TfEUtfdn8uSVNZBT4PILmz5nqc211Cuwvdi7cuAgEzzGB+J79mjqY
+        dD7qsAS+k2/iMweOUWdAnp/bWetgzwwdovdzNlseFGo8YGnplQAotfw5pecAmgMOgY95qPnseF9W
+        dUvj2Q2/VWGLf5kvs0mZPyPkWqLs2UtqcZ6VTR62KmZl/qZY5NW6PVt+USzXLU/RftiKRt9WUxJg
+        Iumb6crDWCWHfrFveDMR8PueP5fUMT6/+3MzPzF+D9H7Eb8Tlrem5wCaH8zve+G3Ib93vvx/Hb/f
+        8+eSOsbnd39u5ifG7yF6P+J3wvLW9BxA84P5/V74bcjvnS9/2Pwuv1iHhwAGPEWvxrwh9gD5O3xF
+        QH7J/wOCmS7NlxEAAA==
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/9a2cac2e-0f53-43e5-aa61-89bc96ef6fb3?api-version=2016-03-30']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/4c741abb-4488-441e-92ff-bd0c8992db08?api-version=2016-03-30']
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:28:45 GMT']
+      Date: ['Wed, 13 Jul 2016 23:07:08 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1194']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [479273ec-4518-11e6-a616-a0b3ccf7272a]
+      x-ms-client-request-id: [86491d18-494e-11e6-892c-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -443,24 +443,24 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o4PJZLa7f4/62929v71/sL+/nX368NPtfLYzPd/fy3YnD3d+34/0
-        xfZ6xaO5oSttXVbTDMPDG1d5067NF4TzKq/bIm/oK6aTfHhZNNS8WF68brOWO3q9nk7zfJbP5E1q
-        ZomwFkLe23+4v/tgmm1P8k8J/wf3721P7t/f2d55eO/+p/cffLo/23lgXz6vq2WbL2dnL0+q5Xlx
-        sa4ZQaDxPWmSGnzw2Nl77o3uGWCcLi1GeH5OJ/Xu0Kju3oj212UEeTBlvXmUB1/dYjblocbFJTU5
-        e3lcGp75Im/nFRP16TXNQjHtvrKelMWU3pjNiIK9/qnFD3FKOsjkzd2X+glNz0c+Xr8kHEWxnFTr
-        5exF1r5al0xFy4bydAaFV354w+pzWgffuzX9Gw6wO8T/Twxh7//7Q7jXHYL/5/fdH/Zz/eX7OtSP
-        Jtn0LekQZeGXVVUG7OiRwGpFwmWSr6ilL5s/t6SJjAKfR9D8OVN9rq1Ogf3FzoUbF4HgOSYQ37Nf
-        UweTzkcdlsB38k185sAx6gzI83M7ax3smaFD9H7OZsuDQo0HLC29EgCllj+n9BxAc8Ah8DEPNZ8d
-        78uqbmk8u+G3KmzxL/NlNinzZ4RcS5Q9e0ktzrOyycNWxazM3xSLvFq3Z8sviuW65SnaD1vR6Ntq
-        SgJMJH0zXXkYq+TQL/YNbyYCft/z55I6xud3f27mJ8bvIXo/4nfC8tb0HEDzg/l9L/w25PfOl/+v
-        4/d7/lxSx/j87s/N/MT4PUTvR/xOWN6angNofjC/3wu/Dfm98+UPm9/lF+vwEMCAp+jVmDfEHiB/
-        h68IyC/5fwB6TH3YlxEAAA==
+        J1mZLaf43qGQt9kFkPju3d/3o737ew8e3M8PtvfybLq9f3/6cHuy+2B/e2fyILs/uT89yD49+H0/
+        0hfb6xWP5oautHVZTTMMD29c5U27Nl8Qzqu8bou8oa+YTvLhZdFQ82J58brNWu7o9Xo6zfNZPpM3
+        qZklwloIeX6w++nBp+d72zuzyf72/uQh4b+fTbbzXVDx/OH989lD+/J5XS3bfDk7e3lSLc+Li3XN
+        CAKN70mT1OCDx87ec290zwDjdGkxwvNzOql3h0Z190a0vy4jyIMp682jPPjqFrMpDzUuLqnJ2cvj
+        0vDMF3k7r5ioT69pFopp95X1pCym9MZsRhTs9U8tfohT0kEmb+6+1E9oej7y8fol4SiK5aRaL2cv
+        svbVumQqWjaUpzMovPLDG1af0zr43q3p33CA3SH+f2IIe//fH8K97hD8P7/v/rCf6y/f16F+NMmm
+        b0mHKAu/rKoyYEePBFYrEi6TfEUtfdn8uSVNZBT4PILmz5nqc211Cuwvdi7cuAgEzzGB+J79mjqY
+        dD7qsAS+k2/iMweOUWdAnp/bWetgzwwdovdzNlseFGo8YGnplQAotfw5pecAmgMOgY95qPnseF9W
+        dUvj2Q2/VWGLf5kvs0mZPyPkWqLs2UtqcZ6VTR62KmZl/qZY5NW6PVt+USzXLU/RftiKRt9WUxJg
+        Iumb6crDWCWHfrFveDMR8PueP5fUMT6/+3MzPzF+D9H7Eb8Tlrem5wCaH8zve+G3Ib93vvx/Hb/f
+        8+eSOsbnd39u5ifG7yF6P+J3wvLW9BxA84P5/V74bcjvnS9/2Pwuv1iHhwAGPEWvxrwh9gD5O3xF
+        QH7J/wOCmS7NlxEAAA==
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:28:46 GMT']
-      ETag: [W/"8bbd143a-a115-4844-a696-ed0cf42a1b90"]
+      Date: ['Wed, 13 Jul 2016 23:07:09 GMT']
+      ETag: [W/"252775e8-2eac-45c9-b174-0b7a5b5c8a68"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -472,14 +472,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [47dbb088-4518-11e6-a87a-a0b3ccf7272a]
+      x-ms-client-request-id: [8682c8a2-494e-11e6-95ed-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -489,24 +489,24 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o4PJZLa7f4/62929v71/sL+/nX368NPtfLYzPd/fy3YnD3d+34/0
-        xfZ6xaO5oSttXVbTDMPDG1d5067NF4TzKq/bIm/oK6aTfHhZNNS8WF68brOWO3q9nk7zfJbP5E1q
-        ZomwFkLe23+4v/tgmm1P8k8J/wf3721P7t/f2d55eO/+p/cffLo/23lgXz6vq2WbL2dnL0+q5Xlx
-        sa4ZQaDxPWmSGnzw2Nl77o3uGWCcLi1GeH5OJ/Xu0Kju3oj212UEeTBlvXmUB1/dYjblocbFJTU5
-        e3lcGp75Im/nFRP16TXNQjHtvrKelMWU3pjNiIK9/qnFD3FKOsjkzd2X+glNz0c+Xr8kHEWxnFTr
-        5exF1r5al0xFy4bydAaFV354w+pzWgffuzX9Gw6wO8T/Twxh7//7Q7jXHYL/5/fdH/Zz/eX7OtSP
-        Jtn0LekQZeGXVVUG7OiRwGpFwmWSr6ilL5s/t6SJjAKfR9D8OVN9rq1Ogf3FzoUbF4HgOSYQ37Nf
-        UweTzkcdlsB38k185sAx6gzI83M7ax3smaFD9H7OZsuDQo0HLC29EgCllj+n9BxAc8Ah8DEPNZ8d
-        78uqbmk8u+G3KmzxL/NlNinzZ4RcS5Q9e0ktzrOyycNWxazM3xSLvFq3Z8sviuW65SnaD1vR6Ntq
-        SgJMJH0zXXkYq+TQL/YNbyYCft/z55I6xud3f27mJ8bvIXo/4nfC8tb0HEDzg/l9L/w25PfOl/+v
-        4/d7/lxSx/j87s/N/MT4PUTvR/xOWN6angNofjC/3wu/Dfm98+UPm9/lF+vwEMCAp+jVmDfEHiB/
-        h68IyC/5fwB6TH3YlxEAAA==
+        J1mZLaf43qGQt9kFkPju3d/3o737ew8e3M8PtvfybLq9f3/6cHuy+2B/e2fyILs/uT89yD49+H0/
+        0hfb6xWP5oautHVZTTMMD29c5U27Nl8Qzqu8bou8oa+YTvLhZdFQ82J58brNWu7o9Xo6zfNZPpM3
+        qZklwloIeX6w++nBp+d72zuzyf72/uQh4b+fTbbzXVDx/OH989lD+/J5XS3bfDk7e3lSLc+Li3XN
+        CAKN70mT1OCDx87ec290zwDjdGkxwvNzOql3h0Z190a0vy4jyIMp682jPPjqFrMpDzUuLqnJ2cvj
+        0vDMF3k7r5ioT69pFopp95X1pCym9MZsRhTs9U8tfohT0kEmb+6+1E9oej7y8fol4SiK5aRaL2cv
+        svbVumQqWjaUpzMovPLDG1af0zr43q3p33CA3SH+f2IIe//fH8K97hD8P7/v/rCf6y/f16F+NMmm
+        b0mHKAu/rKoyYEePBFYrEi6TfEUtfdn8uSVNZBT4PILmz5nqc211Cuwvdi7cuAgEzzGB+J79mjqY
+        dD7qsAS+k2/iMweOUWdAnp/bWetgzwwdovdzNlseFGo8YGnplQAotfw5pecAmgMOgY95qPnseF9W
+        dUvj2Q2/VWGLf5kvs0mZPyPkWqLs2UtqcZ6VTR62KmZl/qZY5NW6PVt+USzXLU/RftiKRt9WUxJg
+        Iumb6crDWCWHfrFveDMR8PueP5fUMT6/+3MzPzF+D9H7Eb8Tlrem5wCaH8zve+G3Ib93vvx/Hb/f
+        8+eSOsbnd39u5ifG7yF6P+J3wvLW9BxA84P5/V74bcjvnS9/2Pwuv1iHhwAGPEWvxrwh9gD5O3xF
+        QH7J/wOCmS7NlxEAAA==
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:28:47 GMT']
-      ETag: [W/"8bbd143a-a115-4844-a696-ed0cf42a1b90"]
+      Date: ['Wed, 13 Jul 2016 23:07:10 GMT']
+      ETag: [W/"252775e8-2eac-45c9-b174-0b7a5b5c8a68"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -515,72 +515,72 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9u
-      dGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJuYW1lIjogIkxvYWRCYWxhbmNlckZyb250RW5kIiwg
-      InByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJpbmJvdW5k
-      TmF0UnVsZXMiOiBbeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVj
-      My1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5O
-      ZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2luYm91bmROYXRSdWxlcy9ydWxlMSJ9LCB7ImlkIjog
-      Ii9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNv
-      dXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vy
-      cy9sYjEvaW5ib3VuZE5hdFJ1bGVzL3J1bGUyIn0sIHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIx
-      ZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3By
-      b3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9pbmJvdW5kTmF0UnVs
-      ZXMvcnVsZTMifV0sICJwcml2YXRlSVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVi
-      bGljSVBBZGRyZXNzIjogeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEt
-      YWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29m
-      dC5OZXR3b3JrL3B1YmxpY0lQQWRkcmVzc2VzL1B1YmxpY0lQbGIxIn19LCAiZXRhZyI6ICJXL1wi
-      OGJiZDE0M2EtYTExNS00ODQ0LWE2OTYtZWQwY2Y0MmExYjkwXCIiLCAiaWQiOiAiL3N1YnNjcmlw
-      dGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBz
-      L2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9u
-      dGVuZElQQ29uZmlndXJhdGlvbnMvTG9hZEJhbGFuY2VyRnJvbnRFbmQifV0sICJyZXNvdXJjZUd1
-      aWQiOiAiMzQ5NDE3Y2EtYmU2NS00NzUzLWI1NTAtMDkzNTY1NzY0ZDA3IiwgIm91dGJvdW5kTmF0
-      UnVsZXMiOiBbXSwgImxvYWRCYWxhbmNpbmdSdWxlcyI6IFtdLCAicHJvdmlzaW9uaW5nU3RhdGUi
-      OiAiU3VjY2VlZGVkIiwgImluYm91bmROYXRSdWxlcyI6IFt7Im5hbWUiOiAicnVsZTEiLCAicHJv
-      cGVydGllcyI6IHsiZnJvbnRlbmRJUENvbmZpZ3VyYXRpb24iOiB7ImlkIjogIi9zdWJzY3JpcHRp
-      b25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9s
-      YnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJvbnRl
-      bmRJUENvbmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNlckZyb250RW5kIn0sICJwcm90b2NvbCI6ICJU
-      Y3AiLCAiaWRsZVRpbWVvdXRJbk1pbnV0ZXMiOiAxMCwgImVuYWJsZUZsb2F0aW5nSVAiOiB0cnVl
-      LCAiZnJvbnRlbmRQb3J0IjogMSwgInByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJi
-      YWNrZW5kUG9ydCI6IDF9LCAiZXRhZyI6ICJXL1wiOGJiZDE0M2EtYTExNS00ODQ0LWE2OTYtZWQw
-      Y2Y0MmExYjkwXCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
-      YzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQu
-      TmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9pbmJvdW5kTmF0UnVsZXMvcnVsZTEifSwgeyJuYW1l
-      IjogInJ1bGUyIiwgInByb3BlcnRpZXMiOiB7ImZyb250ZW5kSVBDb25maWd1cmF0aW9uIjogeyJp
+      eyJldGFnIjogIlcvXCIyNTI3NzVlOC0yZWFjLTQ1YzktYjE3NC0wYjdhNWI1YzhhNjhcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9udGVu
+      ZElQQ29uZmlndXJhdGlvbnMiOiBbeyJldGFnIjogIlcvXCIyNTI3NzVlOC0yZWFjLTQ1YzktYjE3
+      NC0wYjdhNWI1YzhhNjhcIiIsICJwcm9wZXJ0aWVzIjogeyJpbmJvdW5kTmF0UnVsZXMiOiBbeyJp
       ZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAv
       cmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxh
-      bmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9ucy9Mb2FkQmFsYW5jZXJGcm9udEVuZCJ9
-      LCAicHJvdG9jb2wiOiAiVGNwIiwgImlkbGVUaW1lb3V0SW5NaW51dGVzIjogNCwgImVuYWJsZUZs
-      b2F0aW5nSVAiOiBmYWxzZSwgImZyb250ZW5kUG9ydCI6IDIsICJwcm92aXNpb25pbmdTdGF0ZSI6
-      ICJTdWNjZWVkZWQiLCAiYmFja2VuZFBvcnQiOiAyfSwgImV0YWciOiAiVy9cIjhiYmQxNDNhLWEx
-      MTUtNDg0NC1hNjk2LWVkMGNmNDJhMWI5MFwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2
-      NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92
-      aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvaW5ib3VuZE5hdFJ1bGVz
-      L3J1bGUyIn0sIHsibmFtZSI6ICJydWxlMyIsICJwcm9wZXJ0aWVzIjogeyJmcm9udGVuZElQQ29u
-      ZmlndXJhdGlvbiI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
-      YzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQu
-      TmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMvTG9hZEJh
-      bGFuY2VyRnJvbnRFbmQifSwgInByb3RvY29sIjogIlRjcCIsICJpZGxlVGltZW91dEluTWludXRl
-      cyI6IDQsICJlbmFibGVGbG9hdGluZ0lQIjogZmFsc2UsICJmcm9udGVuZFBvcnQiOiAzLCAicHJv
-      dmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImJhY2tlbmRQb3J0IjogM30sICJldGFnIjog
-      IlcvXCI4YmJkMTQzYS1hMTE1LTQ4NDQtYTY5Ni1lZDBjZjQyYTFiOTBcIiIsICJpZCI6ICIvc3Vi
-      c2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VH
-      cm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIx
-      L2luYm91bmROYXRSdWxlcy9ydWxlMyJ9XSwgImluYm91bmROYXRQb29scyI6IFtdLCAiYmFja2Vu
-      ZEFkZHJlc3NQb29scyI6IFt7Im5hbWUiOiAibGIxYmVwb29sIiwgInByb3BlcnRpZXMiOiB7InBy
-      b3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCJ9LCAiZXRhZyI6ICJXL1wiOGJiZDE0M2EtYTEx
-      NS00ODQ0LWE2OTYtZWQwY2Y0MmExYjkwXCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0
-      NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3Zp
-      ZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVzc1Bv
-      b2xzL2xiMWJlcG9vbCJ9XX0sICJldGFnIjogIlcvXCI4YmJkMTQzYS1hMTE1LTQ4NDQtYTY5Ni1l
-      ZDBjZjQyYTFiOTBcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEt
+      bmNlcnMvbGIxL2luYm91bmROYXRSdWxlcy9ydWxlMSJ9LCB7ImlkIjogIi9zdWJzY3JpcHRpb25z
+      LzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNy
+      Zy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvaW5ib3VuZE5h
+      dFJ1bGVzL3J1bGUyIn0sIHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRh
+      LWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3Nv
+      ZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9pbmJvdW5kTmF0UnVsZXMvcnVsZTMifV0sICJw
+      cm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhv
+      ZCI6ICJEeW5hbWljIiwgInB1YmxpY0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMv
+      MGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3Jn
+      L3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9QdWJsaWNJUGxi
+      MSJ9fSwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3
+      MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsv
+      bG9hZEJhbGFuY2Vycy9sYjEvZnJvbnRlbmRJUENvbmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNlckZy
+      b250RW5kIiwgIm5hbWUiOiAiTG9hZEJhbGFuY2VyRnJvbnRFbmQifV0sICJvdXRib3VuZE5hdFJ1
+      bGVzIjogW10sICJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAiaW5ib3VuZE5hdFJ1
+      bGVzIjogW3siZXRhZyI6ICJXL1wiMjUyNzc1ZTgtMmVhYy00NWM5LWIxNzQtMGI3YTViNWM4YTY4
+      XCIiLCAibmFtZSI6ICJydWxlMSIsICJwcm9wZXJ0aWVzIjogeyJpZGxlVGltZW91dEluTWludXRl
+      cyI6IDEwLCAiZW5hYmxlRmxvYXRpbmdJUCI6IHRydWUsICJmcm9udGVuZFBvcnQiOiAxLCAicHJv
+      dG9jb2wiOiAiVGNwIiwgImZyb250ZW5kSVBDb25maWd1cmF0aW9uIjogeyJpZCI6ICIvc3Vic2Ny
+      aXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91
+      cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zy
+      b250ZW5kSVBDb25maWd1cmF0aW9ucy9Mb2FkQmFsYW5jZXJGcm9udEVuZCJ9LCAicHJvdmlzaW9u
+      aW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImJhY2tlbmRQb3J0IjogMX0sICJpZCI6ICIvc3Vic2Ny
+      aXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91
+      cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2lu
+      Ym91bmROYXRSdWxlcy9ydWxlMSJ9LCB7ImV0YWciOiAiVy9cIjI1Mjc3NWU4LTJlYWMtNDVjOS1i
+      MTc0LTBiN2E1YjVjOGE2OFwiIiwgIm5hbWUiOiAicnVsZTIiLCAicHJvcGVydGllcyI6IHsiaWRs
+      ZVRpbWVvdXRJbk1pbnV0ZXMiOiA0LCAiZW5hYmxlRmxvYXRpbmdJUCI6IGZhbHNlLCAiZnJvbnRl
+      bmRQb3J0IjogMiwgInByb3RvY29sIjogIlRjcCIsICJmcm9udGVuZElQQ29uZmlndXJhdGlvbiI6
+      IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5
+      NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2Fk
+      QmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMvTG9hZEJhbGFuY2VyRnJvbnRF
+      bmQifSwgInByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJiYWNrZW5kUG9ydCI6IDJ9
+      LCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5
+      NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2Fk
+      QmFsYW5jZXJzL2xiMS9pbmJvdW5kTmF0UnVsZXMvcnVsZTIifSwgeyJldGFnIjogIlcvXCIyNTI3
+      NzVlOC0yZWFjLTQ1YzktYjE3NC0wYjdhNWI1YzhhNjhcIiIsICJuYW1lIjogInJ1bGUzIiwgInBy
+      b3BlcnRpZXMiOiB7ImlkbGVUaW1lb3V0SW5NaW51dGVzIjogNCwgImVuYWJsZUZsb2F0aW5nSVAi
+      OiBmYWxzZSwgImZyb250ZW5kUG9ydCI6IDMsICJwcm90b2NvbCI6ICJUY3AiLCAiZnJvbnRlbmRJ
+      UENvbmZpZ3VyYXRpb24iOiB7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRk
+      YS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9z
+      b2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJvbnRlbmRJUENvbmZpZ3VyYXRpb25zL0xv
+      YWRCYWxhbmNlckZyb250RW5kIn0sICJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAi
+      YmFja2VuZFBvcnQiOiAzfSwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRk
+      YS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9z
+      b2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvaW5ib3VuZE5hdFJ1bGVzL3J1bGUzIn1dLCAi
+      YmFja2VuZEFkZHJlc3NQb29scyI6IFt7ImV0YWciOiAiVy9cIjI1Mjc3NWU4LTJlYWMtNDVjOS1i
+      MTc0LTBiN2E1YjVjOGE2OFwiIiwgIm5hbWUiOiAibGIxYmVwb29sIiwgImlkIjogIi9zdWJzY3Jp
+      cHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vw
+      cy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvYmFj
+      a2VuZEFkZHJlc3NQb29scy9sYjFiZXBvb2wiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5n
+      U3RhdGUiOiAiU3VjY2VlZGVkIn19XSwgImluYm91bmROYXRQb29scyI6IFtdLCAicmVzb3VyY2VH
+      dWlkIjogImY4MTY4NmYyLTBkYjQtNGI5OS1iNGFiLWUxNGRkYWY5NWZkOSIsICJsb2FkQmFsYW5j
+      aW5nUnVsZXMiOiBbXX0sICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEt
       YWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29m
       dC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxIn0=
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Length: ['3506']
       Content-Type: [application/json; charset=utf-8]
@@ -588,7 +588,7 @@ interactions:
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [4819d188-4518-11e6-b4b1-a0b3ccf7272a]
+      x-ms-client-request-id: [874476f8-494e-11e6-9078-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -598,44 +598,44 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o/P8YDrb3Z1sz3b39tHzwfZkb7K/PT2fTSeTvQfTSb77+36kL7bX
-        Kx7NDV1p67KaZhge3rjKm3ZtviCcV3ndFnlDXzGd5MPLoqHmxfLidZu13NHr9XSa57N8Jm9SM0uE
-        tRDy3v7D/d0H02x7kn96f3v/wf1725P793e2dx7eu//p/Qef7s92HtiXz+tq2ebL2dnLk2p5Xlys
-        a0YQaHxPmqQGHzx29p57o3sGGKdLixGen9NJvTs0qrs3ov11GUEeTFlvHuXBV7eYTXmocXFJTc5e
-        HpeGZ77I23nFRH16TbNQTLuvrCdlMaU3ZjOiYK9/avFDnJIOMnlz96V+QtPzkY/XLwlHUSwn1Xo5
-        e5G1r9YlU9GyoTydQeGVH96w+pzWwfduTf+GA+wO8f8TQ9j7//4Q7nWH4P/5ffeH/Vx/+b4O9aNJ
-        Nn1LOkRZ+GVVlQE7eiSwWpFwmeQraunL5s8taSKjwOcRNH/OVJ9rq1Ngf7Fz4cZFIHiOCcT37NfU
-        waTzUYcl8J18E585cIw6A/L83M5aB3tm6BC9n7PZ8qBQ4wFLS68EQKnlzyk9B9AccAh8zEPNZ8f7
-        sqpbGs9u+K0KW/zLfJlNyvwZIdcSZc9eUou2Xudho2JW5m+KRV6t27PlF8Vy3fIM7e6EzWj0bTUl
-        ASaSvpmuPIxVcugX+4Y3EwG/7/lzST3j87s/N/MT4/cQvR/xO2F5a3oOoPnB/L4Xfhvye+fLCL+f
-        Z2VzO4bfD1vR6D+c3+/5c0kd4/O7PzfzE+P3EL0f8TtheWt6DqD5wfx+L/w25PfOlz9sfpdfrMND
-        AAOeoldj3hB7gPwdviIgv+T/AZoDcyKXEQAA
+        J1mZLaf43qGQt9kFkPju3d/3o7379/Ye7s6m2zsP96jnTycPt7OHe7vb92f3p3sHB/cePsw//X0/
+        0hfb6xWP5oautHVZTTMMD29c5U27Nl8Qzqu8bou8oa+YTvLhZdFQ82J58brNWu7o9Xo6zfNZPpM3
+        qZklwloIeX6w++nBp+d72zuzyf72/uThw+3JfjbZzndBxfOH989nD+3L53W1bPPl7OzlSbU8Ly7W
+        NSMINL4nTVKDDx47e8+90T0DjNOlxQjPz+mk3h0a1d0b0f66jCAPpqw3j/Lgq1vMpjzUuLikJmcv
+        j0vDM1/k7bxioj69plkopt1X1pOymNIbsxlRsNc/tfghTkkHmby5+1I/oen5yMfrl4SjKJaTar2c
+        vcjaV+uSqWjZUJ7OoPDKD29YfU7r4Hu3pn/DAXaH+P+JIez9f38I97pD8P/8vvvDfq6/fF+H+tEk
+        m74lHaIs/LKqyoAdPRJYrUi4TPIVtfRl8+eWNJFR4PMImj9nqs+11Smwv9i5cOMiEDzHBOJ79mvq
+        YNL5qMMS+E6+ic8cOEadAXl+bmetgz0zdIjez9lseVCo8YClpVcCoNTy55SeA2gOOAQ+5qHms+N9
+        WdUtjWc3/FaFLf5lvswmZf6MkGuJsmcvqUVbr/OwUTEr8zfFIq/W7dnyi2K5bnmGdnfCZjT6tpqS
+        ABNJ30xXHsYqOfSLfcObiYDf9/y5pJ7x+d2fm/mJ8XuI3o/4nbC8NT0H0Pxgft8Lvw35vfNlhN/P
+        s7K5HcPvh61o9B/O7/f8uaSO8fndn5v5ifF7iN6P+J2wvDU9B9D8YH6/F34b8nvnyx82v8sv1uEh
+        gAFP0asxb4g9QP4OXxGQX/L/AMaEMeuXEQAA
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/91d1f8a2-1cec-4129-a2e7-b84975fd852d?api-version=2016-03-30']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/a943c21d-0e56-43e2-b8ca-c60cd15469e8?api-version=2016-03-30']
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:28:47 GMT']
+      Date: ['Wed, 13 Jul 2016 23:07:12 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1192']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [48bdae02-4518-11e6-96c4-a0b3ccf7272a]
+      x-ms-client-request-id: [88833092-494e-11e6-88ff-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -645,24 +645,24 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o/P8YDrb3Z1sz3b39tHzwfZkb7K/PT2fTSeTvQfTSb77+36kL7bX
-        Kx7NDV1p67KaZhge3rjKm3ZtviCcV3ndFnlDXzGd5MPLoqHmxfLidZu13NHr9XSa57N8Jm9SM0uE
-        tRDy3v7D/d0H02x7kn96f3v/wf1725P793e2dx7eu//p/Qef7s92HtiXz+tq2ebL2dnLk2p5Xlys
-        a0YQaHxPmqQGHzx29p57o3sGGKdLixGen9NJvTs0qrs3ov11GUEeTFlvHuXBV7eYTXmocXFJTc5e
-        HpeGZ77I23nFRH16TbNQTLuvrCdlMaU3ZjOiYK9/avFDnJIOMnlz96V+QtPzkY/XLwlHUSwn1Xo5
-        e5G1r9YlU9GyoTydQeGVH96w+pzWwfduTf+GA+wO8f8TQ9j7//4Q7nWH4P/5ffeH/Vx/+b4O9aNJ
-        Nn1LOkRZ+GVVlQE7eiSwWpFwmeQraunL5s8taSKjwOcRNH/OVJ9rq1Ngf7Fz4cZFIHiOCcT37NfU
-        waTzUYcl8J18E585cIw6A/L83M5aB3tm6BC9n7PZ8qBQ4wFLS68EQKnlzyk9B9AccAh8zEPNZ8f7
-        sqpbGs9u+K0KW/zLfJlNyvwZIdcSZc9eUou2Xudho2JW5m+KRV6t27PlF8Vy3fIM7e6EzWj0bTUl
-        ASaSvpmuPIxVcugX+4Y3EwG/7/lzST3j87s/N/MT4/cQvR/xO2F5a3oOoPnB/L4Xfhvye+fLCL+f
-        Z2VzO4bfD1vR6D+c3+/5c0kd4/O7PzfzE+P3EL0f8TtheWt6DqD5wfx+L/w25PfOlz9sfpdfrMND
-        AAOeoldj3hB7gPwdviIgv+T/AZoDcyKXEQAA
+        J1mZLaf43qGQt9kFkPju3d/3o7379/Ye7s6m2zsP96jnTycPt7OHe7vb92f3p3sHB/cePsw//X0/
+        0hfb6xWP5oautHVZTTMMD29c5U27Nl8Qzqu8bou8oa+YTvLhZdFQ82J58brNWu7o9Xo6zfNZPpM3
+        qZklwloIeX6w++nBp+d72zuzyf72/uThw+3JfjbZzndBxfOH989nD+3L53W1bPPl7OzlSbU8Ly7W
+        NSMINL4nTVKDDx47e8+90T0DjNOlxQjPz+mk3h0a1d0b0f66jCAPpqw3j/Lgq1vMpjzUuLikJmcv
+        j0vDM1/k7bxioj69plkopt1X1pOymNIbsxlRsNc/tfghTkkHmby5+1I/oen5yMfrl4SjKJaTar2c
+        vcjaV+uSqWjZUJ7OoPDKD29YfU7r4Hu3pn/DAXaH+P+JIez9f38I97pD8P/8vvvDfq6/fF+H+tEk
+        m74lHaIs/LKqyoAdPRJYrUi4TPIVtfRl8+eWNJFR4PMImj9nqs+11Smwv9i5cOMiEDzHBOJ79mvq
+        YNL5qMMS+E6+ic8cOEadAXl+bmetgz0zdIjez9lseVCo8YClpVcCoNTy55SeA2gOOAQ+5qHms+N9
+        WdUtjWc3/FaFLf5lvswmZf6MkGuJsmcvqUVbr/OwUTEr8zfFIq/W7dnyi2K5bnmGdnfCZjT6tpqS
+        ABNJ30xXHsYqOfSLfcObiYDf9/y5pJ7x+d2fm/mJ8XuI3o/4nbC8NT0H0Pxgft8Lvw35vfNlhN/P
+        s7K5HcPvh61o9B/O7/f8uaSO8fndn5v5ifF7iN6P+J2wvDU9B9D8YH6/F34b8nvnyx82v8sv1uEh
+        gAFP0asxb4g9QP4OXxGQX/L/AMaEMeuXEQAA
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:28:47 GMT']
-      ETag: [W/"fe8cd11b-d124-4dd8-b2b4-cfdcbb27cbe1"]
+      Date: ['Wed, 13 Jul 2016 23:07:13 GMT']
+      ETag: [W/"253291dc-0920-46b9-a921-5d5c288399e6"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -674,14 +674,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [48fcd768-4518-11e6-9b0a-a0b3ccf7272a]
+      x-ms-client-request-id: [88b4e300-494e-11e6-9ef2-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -691,24 +691,24 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o/P8YDrb3Z1sz3b39tHzwfZkb7K/PT2fTSeTvQfTSb77+36kL7bX
-        Kx7NDV1p67KaZhge3rjKm3ZtviCcV3ndFnlDXzGd5MPLoqHmxfLidZu13NHr9XSa57N8Jm9SM0uE
-        tRDy3v7D/d0H02x7kn96f3v/wf1725P793e2dx7eu//p/Qef7s92HtiXz+tq2ebL2dnLk2p5Xlys
-        a0YQaHxPmqQGHzx29p57o3sGGKdLixGen9NJvTs0qrs3ov11GUEeTFlvHuXBV7eYTXmocXFJTc5e
-        HpeGZ77I23nFRH16TbNQTLuvrCdlMaU3ZjOiYK9/avFDnJIOMnlz96V+QtPzkY/XLwlHUSwn1Xo5
-        e5G1r9YlU9GyoTydQeGVH96w+pzWwfduTf+GA+wO8f8TQ9j7//4Q7nWH4P/5ffeH/Vx/+b4O9aNJ
-        Nn1LOkRZ+GVVlQE7eiSwWpFwmeQraunL5s8taSKjwOcRNH/OVJ9rq1Ngf7Fz4cZFIHiOCcT37NfU
-        waTzUYcl8J18E585cIw6A/L83M5aB3tm6BC9n7PZ8qBQ4wFLS68EQKnlzyk9B9AccAh8zEPNZ8f7
-        sqpbGs9u+K0KW/zLfJlNyvwZIdcSZc9eUou2Xudho2JW5m+KRV6t27PlF8Vy3fIM7e6EzWj0bTUl
-        ASaSvpmuPIxVcugX+4Y3EwG/7/lzST3j87s/N/MT4/cQvR/xO2F5a3oOoPnB/L4Xfhvye+fLCL+f
-        Z2VzO4bfD1vR6D+c3+/5c0kd4/O7PzfzE+P3EL0f8TtheWt6DqD5wfx+L/w25PfOlz9sfpdfrMND
-        AAOeoldj3hB7gPwdviIgv+T/AZoDcyKXEQAA
+        J1mZLaf43qGQt9kFkPju3d/3o7379/Ye7s6m2zsP96jnTycPt7OHe7vb92f3p3sHB/cePsw//X0/
+        0hfb6xWP5oautHVZTTMMD29c5U27Nl8Qzqu8bou8oa+YTvLhZdFQ82J58brNWu7o9Xo6zfNZPpM3
+        qZklwloIeX6w++nBp+d72zuzyf72/uThw+3JfjbZzndBxfOH989nD+3L53W1bPPl7OzlSbU8Ly7W
+        NSMINL4nTVKDDx47e8+90T0DjNOlxQjPz+mk3h0a1d0b0f66jCAPpqw3j/Lgq1vMpjzUuLikJmcv
+        j0vDM1/k7bxioj69plkopt1X1pOymNIbsxlRsNc/tfghTkkHmby5+1I/oen5yMfrl4SjKJaTar2c
+        vcjaV+uSqWjZUJ7OoPDKD29YfU7r4Hu3pn/DAXaH+P+JIez9f38I97pD8P/8vvvDfq6/fF+H+tEk
+        m74lHaIs/LKqyoAdPRJYrUi4TPIVtfRl8+eWNJFR4PMImj9nqs+11Smwv9i5cOMiEDzHBOJ79mvq
+        YNL5qMMS+E6+ic8cOEadAXl+bmetgz0zdIjez9lseVCo8YClpVcCoNTy55SeA2gOOAQ+5qHms+N9
+        WdUtjWc3/FaFLf5lvswmZf6MkGuJsmcvqUVbr/OwUTEr8zfFIq/W7dnyi2K5bnmGdnfCZjT6tpqS
+        ABNJ30xXHsYqOfSLfcObiYDf9/y5pJ7x+d2fm/mJ8XuI3o/4nbC8NT0H0Pxgft8Lvw35vfNlhN/P
+        s7K5HcPvh61o9B/O7/f8uaSO8fndn5v5ifF7iN6P+J2wvDU9B9D8YH6/F34b8nvnyx82v8sv1uEh
+        gAFP0asxb4g9QP4OXxGQX/L/AMaEMeuXEQAA
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:28:48 GMT']
-      ETag: [W/"fe8cd11b-d124-4dd8-b2b4-cfdcbb27cbe1"]
+      Date: ['Wed, 13 Jul 2016 23:07:13 GMT']
+      ETag: [W/"253291dc-0920-46b9-a921-5d5c288399e6"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -717,62 +717,62 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9u
-      dGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJuYW1lIjogIkxvYWRCYWxhbmNlckZyb250RW5kIiwg
-      InByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJpbmJvdW5k
-      TmF0UnVsZXMiOiBbeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVj
-      My1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5O
-      ZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2luYm91bmROYXRSdWxlcy9ydWxlMSJ9LCB7ImlkIjog
-      Ii9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNv
-      dXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vy
-      cy9sYjEvaW5ib3VuZE5hdFJ1bGVzL3J1bGUyIn0sIHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIx
-      ZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3By
-      b3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9pbmJvdW5kTmF0UnVs
-      ZXMvcnVsZTMifV0sICJwcml2YXRlSVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVi
-      bGljSVBBZGRyZXNzIjogeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEt
-      YWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29m
-      dC5OZXR3b3JrL3B1YmxpY0lQQWRkcmVzc2VzL1B1YmxpY0lQbGIxIn19LCAiZXRhZyI6ICJXL1wi
-      ZmU4Y2QxMWItZDEyNC00ZGQ4LWIyYjQtY2ZkY2JiMjdjYmUxXCIiLCAiaWQiOiAiL3N1YnNjcmlw
-      dGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBz
-      L2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9u
-      dGVuZElQQ29uZmlndXJhdGlvbnMvTG9hZEJhbGFuY2VyRnJvbnRFbmQifV0sICJyZXNvdXJjZUd1
-      aWQiOiAiMzQ5NDE3Y2EtYmU2NS00NzUzLWI1NTAtMDkzNTY1NzY0ZDA3IiwgIm91dGJvdW5kTmF0
-      UnVsZXMiOiBbXSwgImxvYWRCYWxhbmNpbmdSdWxlcyI6IFtdLCAicHJvdmlzaW9uaW5nU3RhdGUi
-      OiAiU3VjY2VlZGVkIiwgImluYm91bmROYXRSdWxlcyI6IFt7Im5hbWUiOiAicnVsZTIiLCAicHJv
-      cGVydGllcyI6IHsiZnJvbnRlbmRJUENvbmZpZ3VyYXRpb24iOiB7ImlkIjogIi9zdWJzY3JpcHRp
-      b25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9s
-      YnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJvbnRl
-      bmRJUENvbmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNlckZyb250RW5kIn0sICJwcm90b2NvbCI6ICJU
-      Y3AiLCAiaWRsZVRpbWVvdXRJbk1pbnV0ZXMiOiA0LCAiZW5hYmxlRmxvYXRpbmdJUCI6IGZhbHNl
-      LCAiZnJvbnRlbmRQb3J0IjogMiwgInByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJi
-      YWNrZW5kUG9ydCI6IDJ9LCAiZXRhZyI6ICJXL1wiZmU4Y2QxMWItZDEyNC00ZGQ4LWIyYjQtY2Zk
-      Y2JiMjdjYmUxXCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
-      YzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQu
-      TmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9pbmJvdW5kTmF0UnVsZXMvcnVsZTIifSwgeyJuYW1l
-      IjogInJ1bGUzIiwgInByb3BlcnRpZXMiOiB7ImZyb250ZW5kSVBDb25maWd1cmF0aW9uIjogeyJp
+      eyJldGFnIjogIlcvXCIyNTMyOTFkYy0wOTIwLTQ2YjktYTkyMS01ZDVjMjg4Mzk5ZTZcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9udGVu
+      ZElQQ29uZmlndXJhdGlvbnMiOiBbeyJldGFnIjogIlcvXCIyNTMyOTFkYy0wOTIwLTQ2YjktYTky
+      MS01ZDVjMjg4Mzk5ZTZcIiIsICJwcm9wZXJ0aWVzIjogeyJpbmJvdW5kTmF0UnVsZXMiOiBbeyJp
       ZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAv
       cmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxh
-      bmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9ucy9Mb2FkQmFsYW5jZXJGcm9udEVuZCJ9
-      LCAicHJvdG9jb2wiOiAiVGNwIiwgImlkbGVUaW1lb3V0SW5NaW51dGVzIjogNCwgImVuYWJsZUZs
-      b2F0aW5nSVAiOiBmYWxzZSwgImZyb250ZW5kUG9ydCI6IDMsICJwcm92aXNpb25pbmdTdGF0ZSI6
-      ICJTdWNjZWVkZWQiLCAiYmFja2VuZFBvcnQiOiAzfSwgImV0YWciOiAiVy9cImZlOGNkMTFiLWQx
-      MjQtNGRkOC1iMmI0LWNmZGNiYjI3Y2JlMVwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2
-      NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92
-      aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvaW5ib3VuZE5hdFJ1bGVz
-      L3J1bGUzIn1dLCAiaW5ib3VuZE5hdFBvb2xzIjogW10sICJiYWNrZW5kQWRkcmVzc1Bvb2xzIjog
-      W3sibmFtZSI6ICJsYjFiZXBvb2wiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUi
-      OiAiU3VjY2VlZGVkIn0sICJldGFnIjogIlcvXCJmZThjZDExYi1kMTI0LTRkZDgtYjJiNC1jZmRj
-      YmIyN2NiZTFcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVj
-      My1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5O
-      ZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMvbGIxYmVwb29sIn1d
-      fSwgImV0YWciOiAiVy9cImZlOGNkMTFiLWQxMjQtNGRkOC1iMmI0LWNmZGNiYjI3Y2JlMVwiIiwg
+      bmNlcnMvbGIxL2luYm91bmROYXRSdWxlcy9ydWxlMSJ9LCB7ImlkIjogIi9zdWJzY3JpcHRpb25z
+      LzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNy
+      Zy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvaW5ib3VuZE5h
+      dFJ1bGVzL3J1bGUyIn0sIHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRh
+      LWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3Nv
+      ZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9pbmJvdW5kTmF0UnVsZXMvcnVsZTMifV0sICJw
+      cm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhv
+      ZCI6ICJEeW5hbWljIiwgInB1YmxpY0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMv
+      MGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3Jn
+      L3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9QdWJsaWNJUGxi
+      MSJ9fSwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3
+      MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsv
+      bG9hZEJhbGFuY2Vycy9sYjEvZnJvbnRlbmRJUENvbmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNlckZy
+      b250RW5kIiwgIm5hbWUiOiAiTG9hZEJhbGFuY2VyRnJvbnRFbmQifV0sICJvdXRib3VuZE5hdFJ1
+      bGVzIjogW10sICJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAiaW5ib3VuZE5hdFJ1
+      bGVzIjogW3siZXRhZyI6ICJXL1wiMjUzMjkxZGMtMDkyMC00NmI5LWE5MjEtNWQ1YzI4ODM5OWU2
+      XCIiLCAibmFtZSI6ICJydWxlMiIsICJwcm9wZXJ0aWVzIjogeyJpZGxlVGltZW91dEluTWludXRl
+      cyI6IDQsICJlbmFibGVGbG9hdGluZ0lQIjogZmFsc2UsICJmcm9udGVuZFBvcnQiOiAyLCAicHJv
+      dG9jb2wiOiAiVGNwIiwgImZyb250ZW5kSVBDb25maWd1cmF0aW9uIjogeyJpZCI6ICIvc3Vic2Ny
+      aXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91
+      cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zy
+      b250ZW5kSVBDb25maWd1cmF0aW9ucy9Mb2FkQmFsYW5jZXJGcm9udEVuZCJ9LCAicHJvdmlzaW9u
+      aW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImJhY2tlbmRQb3J0IjogMn0sICJpZCI6ICIvc3Vic2Ny
+      aXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91
+      cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2lu
+      Ym91bmROYXRSdWxlcy9ydWxlMiJ9LCB7ImV0YWciOiAiVy9cIjI1MzI5MWRjLTA5MjAtNDZiOS1h
+      OTIxLTVkNWMyODgzOTllNlwiIiwgIm5hbWUiOiAicnVsZTMiLCAicHJvcGVydGllcyI6IHsiaWRs
+      ZVRpbWVvdXRJbk1pbnV0ZXMiOiA0LCAiZW5hYmxlRmxvYXRpbmdJUCI6IGZhbHNlLCAiZnJvbnRl
+      bmRQb3J0IjogMywgInByb3RvY29sIjogIlRjcCIsICJmcm9udGVuZElQQ29uZmlndXJhdGlvbiI6
+      IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5
+      NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2Fk
+      QmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMvTG9hZEJhbGFuY2VyRnJvbnRF
+      bmQifSwgInByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJiYWNrZW5kUG9ydCI6IDN9
+      LCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5
+      NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2Fk
+      QmFsYW5jZXJzL2xiMS9pbmJvdW5kTmF0UnVsZXMvcnVsZTMifV0sICJiYWNrZW5kQWRkcmVzc1Bv
+      b2xzIjogW3siZXRhZyI6ICJXL1wiMjUzMjkxZGMtMDkyMC00NmI5LWE5MjEtNWQ1YzI4ODM5OWU2
+      XCIiLCAibmFtZSI6ICJsYjFiZXBvb2wiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEt
+      MWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVy
+      cy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVzc1Bvb2xz
+      L2xiMWJlcG9vbCIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVk
+      ZWQifX1dLCAiaW5ib3VuZE5hdFBvb2xzIjogW10sICJyZXNvdXJjZUd1aWQiOiAiZjgxNjg2ZjIt
+      MGRiNC00Yjk5LWI0YWItZTE0ZGRhZjk1ZmQ5IiwgImxvYWRCYWxhbmNpbmdSdWxlcyI6IFtdfSwg
       ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5
       MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJh
       bGFuY2Vycy9sYjEifQ==
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Length: ['2920']
       Content-Type: [application/json; charset=utf-8]
@@ -780,7 +780,7 @@ interactions:
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [494ac9c2-4518-11e6-99ab-a0b3ccf7272a]
+      x-ms-client-request-id: [88debc26-494e-11e6-9732-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -790,1129 +790,23 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3ozybHTw83znYPsgmu9v7Ow/vbT98kO1t7+4e3Lu3m9+fHDy49/t+
-        pC+21ysezQ1daeuymmYYHt64ypt2bb4gnFd53RZ5Q18xneTDy6Kh5sXy4nWbtdzR6/V0muezfCZv
-        UjNLhLUQ8t7+w/3dB9Nse5J/en97/8H9e9uT+/d3tmkg9z+9/+DT/dnOA/vyeV0t23w5O3t5Ui3P
-        i4t1zQgCje9Jk9Tgg8fO3nNvdM8A43RpMcLzczqpd4dGdfdGtL8uI8iDKevNozz46hazKQ81Li6p
-        ydnL49LwzBd5O6+YqE+vaRaKafeV9aQspvTGbEYU7PVPLX6IU9JBJm/uvtRPaHo+8vH6JeEoiuWk
-        Wi9nL7L21bpkKlo2lKczKLzywxtWn9M6+N6t6d+9YIDdIf5/Ygj3ukPw//y++8N+rr98X4f60SSb
-        viUB1Pl/WVVlMJceCaxKIVwm+Ypa+oz9c0uayCjweQTNnzO94drqFNhf7Fy4cREInmMC8T37NXUw
-        6XzUYQl8J9/EZw4csxeM5+d01jrYM0OH6P2czZYHhRoPmCl6JQBKLX9O6TmA5oA19TEPNZ8d78uq
-        bmk8e+G3KmzxL/NlNinzZ4RcS5Q9e0ktzrOyycNWxazM3xSLvFq3Z8sviuW65SnaD1vR6NtqSgJM
-        JH0zXXkYq+TQL/YNbyYCfr/nzyV1jM/v/tzMT4zfQ/R+xO+E5a3pOYDmB/P7vfDbkN87X/6w+V1+
-        sQaAAAY8Ra/GrANbRP4OXxGQX/L/AOHo+4vkDQAA
+        J1mZLaf43qGQt9kFkPju3d/3o3xvem8nO9jZ/nRv53x7/+Gnu9sPp/Tb+SzL93b2dw4O8nu/70f6
+        Ynu94tHc0JW2LqtphuHhjau8adfmC8J5lddtkTf0FdNJPrwsGmpeLC9et1nLHb1eT6d5Pstn8iY1
+        s0RYCyHPD3Y/Pfj0fG97ZzbZ396fPHy4PdnPJtv5Lqh4/vD++eyhffm8rpZtvpydvTyplufFxbpm
+        BIHG96RJavDBY2fvuTe6Z4BxurQY4fk5ndS7Q6O6eyPaX5cR5MGU9eZRHnx1i9mUhxoXl9Tk7OVx
+        aXjmi7ydV0zUp9c0C8W0+8p6UhZTemM2Iwr2+qcWP8Qp6SCTN3df6ic0PR/5eP2ScBTFclKtl7MX
+        WftqXTIVLRvK0xkUXvnhDavPaR1879b0714wwO4Q/z8xhHvdIfh/ft/9YT/XX76vQ/1okk3fkgDq
+        /L+sqjKYS48EVqUQLpN8RS19xv65JU1kFPg8gubPmd5wbXUK7C92Lty4CATPMYH4nv2aOph0Puqw
+        BL6Tb+IzB47ZC8bzczprHeyZoUP0fs5my4NCjQfMFL0SAKWWP6f0HEBzwJr6mIeaz473ZVW3NJ69
+        8FsVtviX+TKblPkzQq4lyp69pBbnWdnkYatiVuZvikVerduz5RfFct3yFO2HrWj0bTUlASaSvpmu
+        PIxVcugX+4Y3EwG/3/PnkjrG53d/buYnxu8hej/id8Ly1vQcQPOD+f1e+G3I750vf9j8Lr9YA0AA
+        A56iV2PWgS0if4evCMgv+X8A4iHUpeQNAAA=
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/2cbd3936-f8f4-4d82-8a50-041c5403f2a7?api-version=2016-03-30']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/8264fcf4-d04a-4412-b16f-c4d2f47a91ce?api-version=2016-03-30']
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:28:49 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [49eecfd0-4518-11e6-931e-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3ozybHTw83znYPsgmu9v7Ow/vbT98kO1t7+4e3Lu3m9+fHDy49/t+
-        pC+21ysezQ1daeuymmYYHt64ypt2bb4gnFd53RZ5Q18xneTDy6Kh5sXy4nWbtdzR6/V0muezfCZv
-        UjNLhLUQ8t7+w/3dB9Nse5J/en97/8H9e9uT+/d3tmkg9z+9/+DT/dnOA/vyeV0t23w5O3t5Ui3P
-        i4t1zQgCje9Jk9Tgg8fO3nNvdM8A43RpMcLzczqpd4dGdfdGtL8uI8iDKevNozz46hazKQ81Li6p
-        ydnL49LwzBd5O6+YqE+vaRaKafeV9aQspvTGbEYU7PVPLX6IU9JBJm/uvtRPaHo+8vH6JeEoiuWk
-        Wi9nL7L21bpkKlo2lKczKLzywxtWn9M6+N6t6d+9YIDdIf5/Ygj3ukPw//y++8N+rr98X4f60SSb
-        viUB1Pl/WVVlMJceCaxKIVwm+Ypa+oz9c0uayCjweQTNnzO94drqFNhf7Fy4cREInmMC8T37NXUw
-        6XzUYQl8J9/EZw4csxeM5+d01jrYM0OH6P2czZYHhRoPmCl6JQBKLX9O6TmA5oA19TEPNZ8d78uq
-        bmk8e+G3KmzxL/NlNinzZ4RcS5Q9e0ktzrOyycNWxazM3xSLvFq3Z8sviuW65SnaD1vR6NtqSgJM
-        JH0zXXkYq+TQL/YNbyYCfr/nzyV1jM/v/tzMT4zfQ/R+xO+E5a3pOYDmB/P7vfDbkN87X/6w+V1+
-        sQaAAAY8Ra/GrANbRP4OXxGQX/L/AOHo+4vkDQAA
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:28:50 GMT']
-      ETag: [W/"ead89f08-8ab1-4093-97a2-118331e5b873"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9u
-      dGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJuYW1lIjogIkxvYWRCYWxhbmNlckZyb250RW5kIiwg
-      InByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJpbmJvdW5k
-      TmF0UnVsZXMiOiBbeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVj
-      My1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5O
-      ZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2luYm91bmROYXRSdWxlcy9ydWxlMiJ9LCB7ImlkIjog
-      Ii9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNv
-      dXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vy
-      cy9sYjEvaW5ib3VuZE5hdFJ1bGVzL3J1bGUzIn1dLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhv
-      ZCI6ICJEeW5hbWljIiwgInB1YmxpY0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMv
-      MGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3Jn
-      L3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9QdWJsaWNJUGxi
-      MSJ9fSwgImV0YWciOiAiVy9cImVhZDg5ZjA4LThhYjEtNDA5My05N2EyLTExODMzMWU1Yjg3M1wi
-      IiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYw
-      OTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9h
-      ZEJhbGFuY2Vycy9sYjEvZnJvbnRlbmRJUENvbmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNlckZyb250
-      RW5kIn1dLCAicmVzb3VyY2VHdWlkIjogIjM0OTQxN2NhLWJlNjUtNDc1My1iNTUwLTA5MzU2NTc2
-      NGQwNyIsICJvdXRib3VuZE5hdFJ1bGVzIjogW10sICJsb2FkQmFsYW5jaW5nUnVsZXMiOiBbXSwg
-      InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJpbmJvdW5kTmF0UnVsZXMiOiBbeyJu
-      YW1lIjogInJ1bGUzIiwgInByb3BlcnRpZXMiOiB7ImZyb250ZW5kSVBDb25maWd1cmF0aW9uIjog
-      eyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1
-      OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRC
-      YWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9ucy9Mb2FkQmFsYW5jZXJGcm9udEVu
-      ZCJ9LCAicHJvdG9jb2wiOiAiVGNwIiwgImlkbGVUaW1lb3V0SW5NaW51dGVzIjogNCwgImVuYWJs
-      ZUZsb2F0aW5nSVAiOiBmYWxzZSwgImZyb250ZW5kUG9ydCI6IDMsICJwcm92aXNpb25pbmdTdGF0
-      ZSI6ICJTdWNjZWVkZWQiLCAiYmFja2VuZFBvcnQiOiAzfSwgImV0YWciOiAiVy9cImVhZDg5ZjA4
-      LThhYjEtNDA5My05N2EyLTExODMzMWU1Yjg3M1wiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBi
-      MWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9w
-      cm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvaW5ib3VuZE5hdFJ1
-      bGVzL3J1bGUzIn1dLCAiaW5ib3VuZE5hdFBvb2xzIjogW10sICJiYWNrZW5kQWRkcmVzc1Bvb2xz
-      IjogW3sibmFtZSI6ICJsYjFiZXBvb2wiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3Rh
-      dGUiOiAiU3VjY2VlZGVkIn0sICJldGFnIjogIlcvXCJlYWQ4OWYwOC04YWIxLTQwOTMtOTdhMi0x
-      MTgzMzFlNWI4NzNcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEt
-      YWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29m
-      dC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMvbGIxYmVwb29s
-      In1dfSwgImV0YWciOiAiVy9cImVhZDg5ZjA4LThhYjEtNDA5My05N2EyLTExODMzMWU1Yjg3M1wi
-      IiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYw
-      OTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9h
-      ZEJhbGFuY2Vycy9sYjEifQ==
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Length: ['2182']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [4a310526-4518-11e6-81ee-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o/0H+fTT+5O97d3ZNKOepwfbB5PJg+3zvU8JgcnubOfh/u/7kb7Y
-        Xq94NDd0pa3LappheHjjKm/atfmCcF7ldVvkDX3FdJIPL4uGmhfLi9dt1nJHr9fTaZ7P8pm8Sc0s
-        EdZCyHv7D/d3HxDqk/zT+9v7D+7f257cv7+zvfPw3v1P7z/4dH+288C+fF5XyzZfzs5enlTL8+Ji
-        XTOCQON70iQ1+OCxs/fcG90zwDhdWozw/JxO6t2hUd29Ee2vywjyYMp68ygPvrrFbMpDjYtLanL2
-        8rg0PPNF3s4rJurTa5qFYtp9ZT0piym9MZsRBXv9U4sf4pR0kMmbuy/1E5qej3y8fkk4imI5qdbL
-        2YusfbUumYqWDeXpDAqv/PCG1ee0Dr53a/r3XjBAGqL/5/fdH/Zz/eX7SoqPJtn0LXGvEu9lVZUB
-        ITwSWHkkXCb5ilr6XPFzS5rIKPB5BM2fM6FzbXUK7C92Lty4CATPMYH4nv2aOph0PuqwBL6Tb+Iz
-        JxyjL+P5uZ21DvbK0D56P2ez5UGhxgM6nl4JgFLLn1N6DqA5YIp8zDua0QB6WdUtjede+K0KW/zL
-        fJlNyvwZIdcSZc9eUovzrGzysFUxK/M3xSKv1u3Z8otiuW55ivbDVjT6tpqSABNJ30xXHsYqOfYX
-        KxAEMOApejUmLawh+Dt8RUB+yf8DZ+Q7ojEKAAA=
-    headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/df87f80e-db96-4ab3-a781-71098df65e05?api-version=2016-03-30']
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:28:50 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [4ad9a45a-4518-11e6-8fb0-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o/0H+fTT+5O97d3ZNKOepwfbB5PJg+3zvU8JgcnubOfh/u/7kb7Y
-        Xq94NDd0pa3LappheHjjKm/atfmCcF7ldVvkDX3FdJIPL4uGmhfLi9dt1nJHr9fTaZ7P8pm8Sc0s
-        EdZCyHv7D/d3HxDqk/zT+9v7D+7f257cv7+zvfPw3v1P7z/4dH+288C+fF5XyzZfzs5enlTL8+Ji
-        XTOCQON70iQ1+OCxs/fcG90zwDhdWozw/JxO6t2hUd29Ee2vywjyYMp68ygPvrrFbMpDjYtLanL2
-        8rg0PPNF3s4rJurTa5qFYtp9ZT0piym9MZsRBXv9U4sf4pR0kMmbuy/1E5qej3y8fkk4imI5qdbL
-        2YusfbUumYqWDeXpDAqv/PCG1ee0Dr53a/r3XjBAGqL/5/fdH/Zz/eX7SoqPJtn0LXGvEu9lVZUB
-        ITwSWHkkXCb5ilr6XPFzS5rIKPB5BM2fM6FzbXUK7C92Lty4CATPMYH4nv2aOph0PuqwBL6Tb+Iz
-        JxyjL+P5uZ21DvbK0D56P2ez5UGhxgM6nl4JgFLLn1N6DqA5YIp8zDua0QB6WdUtjede+K0KW/zL
-        fJlNyvwZIdcSZc9eUovzrGzysFUxK/M3xSKv1u3Z8otiuW55ivbDVjT6tpqSABNJ30xXHsYqOfYX
-        KxAEMOApejUmLawh+Dt8RUB+yf8DZ+Q7ojEKAAA=
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:28:52 GMT']
-      ETag: [W/"47ec65b2-1dca-4dc8-8bb7-f26ec3b1d094"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9u
-      dGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJuYW1lIjogIkxvYWRCYWxhbmNlckZyb250RW5kIiwg
-      InByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJpbmJvdW5k
-      TmF0UnVsZXMiOiBbeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVj
-      My1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5O
-      ZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2luYm91bmROYXRSdWxlcy9ydWxlMyJ9XSwgInByaXZh
-      dGVJUEFsbG9jYXRpb25NZXRob2QiOiAiRHluYW1pYyIsICJwdWJsaWNJUEFkZHJlc3MiOiB7Imlk
-      IjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9y
-      ZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvcHVibGljSVBB
-      ZGRyZXNzZXMvUHVibGljSVBsYjEifX0sICJldGFnIjogIlcvXCI0N2VjNjViMi0xZGNhLTRkYzgt
-      OGJiNy1mMjZlYzNiMWQwOTRcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYw
-      LTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01p
-      Y3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9u
-      cy9Mb2FkQmFsYW5jZXJGcm9udEVuZCJ9XSwgInJlc291cmNlR3VpZCI6ICIzNDk0MTdjYS1iZTY1
-      LTQ3NTMtYjU1MC0wOTM1NjU3NjRkMDciLCAib3V0Ym91bmROYXRSdWxlcyI6IFtdLCAibG9hZEJh
-      bGFuY2luZ1J1bGVzIjogW10sICJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAiaW5i
-      b3VuZE5hdFJ1bGVzIjogW10sICJpbmJvdW5kTmF0UG9vbHMiOiBbXSwgImJhY2tlbmRBZGRyZXNz
-      UG9vbHMiOiBbeyJuYW1lIjogImxiMWJlcG9vbCIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25p
-      bmdTdGF0ZSI6ICJTdWNjZWVkZWQifSwgImV0YWciOiAiVy9cIjQ3ZWM2NWIyLTFkY2EtNGRjOC04
-      YmI3LWYyNmVjM2IxZDA5NFwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAt
-      NGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWlj
-      cm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvYmFja2VuZEFkZHJlc3NQb29scy9sYjFi
-      ZXBvb2wifV19LCAiZXRhZyI6ICJXL1wiNDdlYzY1YjItMWRjYS00ZGM4LThiYjctZjI2ZWMzYjFk
-      MDk0XCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5
-      MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29y
-      ay9sb2FkQmFsYW5jZXJzL2xiMSJ9
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Length: ['1446']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [4b1b0aae-4518-11e6-8c4c-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o2x6/mB39+HB9oPdTw+29/fzbHvyYP/+9vnOg8ne/iSfHexNf9+P
-        9MX2esWjuaErbV1W0wzDwxtXedOuzReE8yqv2yJv6Cumk3x4WTTUvFhevG6zljt6vZ5O83yWz+RN
-        amaJsBZC3tt/uL/7YEpY55/e395/cP/e9uT+/Z3tnYf37n96/8Gn+7OdB/bl87patvlydvbypFqe
-        FxfrmhEEGt+TJqnBB4+dvefe6J4BxunSYoTn53RS7w6N6u6NaH9dRpAHU9abR3nw1S1mUx5qXFxS
-        k7OXx6XhmS/ydl4xUZ9e0ywU0+4r60lZTOmN2Ywo2OufWvwQp6SDTN7cfamf0PR85OP1S9wf9lf9
-        5fs6wI8m2fQtzaYCe1lVJYa3kT+pm0m+opY+lX6YFOgzZWQU+DyC5s8ZE7q2OgX2FzsXblwE4tW6
-        5E6+Z7+mDiadj4rlpFovZy+ytt+8WrfDX7oXmVj8Hb4ilH7J/wMELgGJTAYAAA==
-    headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/b27cea70-14bf-4bb6-a416-8e743e06ceb1?api-version=2016-03-30']
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:28:53 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [4bbe3d50-4518-11e6-ab63-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o2x6/mB39+HB9oPdTw+29/fzbHvyYP/+9vnOg8ne/iSfHexNf9+P
-        9MX2esWjuaErbV1W0wzDwxtXedOuzReE8yqv2yJv6Cumk3x4WTTUvFhevG6zljt6vZ5O83yWz+RN
-        amaJsBZC3tt/uL/7YEpY55/e395/cP/e9uT+/Z3tnYf37n96/8Gn+7OdB/bl87patvlydvbypFqe
-        FxfrmhEEGt+TJqnBB4+dvefe6J4BxunSYoTn53RS7w6N6u6NaH9dRpAHU9abR3nw1S1mUx5qXFxS
-        k7OXx6XhmS/ydl4xUZ9e0ywU0+4r60lZTOmN2Ywo2OufWvwQp6SDTN7cfamf0PR85OP1S9wf9lf9
-        5fs6wI8m2fQtzaYCe1lVJYa3kT+pm0m+opY+lX6YFOgzZWQU+DyC5s8ZE7q2OgX2FzsXblwE4tW6
-        5E6+Z7+mDiadj4rlpFovZy+ytt+8WrfDX7oXmVj8Hb4ilH7J/wMELgGJTAYAAA==
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:28:53 GMT']
-      ETag: [W/"acf71198-7168-44ea-b745-f07b24bed82c"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [4c000366-4518-11e6-99a1-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o2x6/mB39+HB9oPdTw+29/fzbHvyYP/+9vnOg8ne/iSfHexNf9+P
-        9MX2esWjuaErbV1W0wzDwxtXedOuzReE8yqv2yJv6Cumk3x4WTTUvFhevG6zljt6vZ5O83yWz+RN
-        amaJsBZC3tt/uL/7YEpY55/e395/cP/e9uT+/Z3tnYf37n96/8Gn+7OdB/bl87patvlydvbypFqe
-        FxfrmhEEGt+TJqnBB4+dvefe6J4BxunSYoTn53RS7w6N6u6NaH9dRpAHU9abR3nw1S1mUx5qXFxS
-        k7OXx6XhmS/ydl4xUZ9e0ywU0+4r60lZTOmN2Ywo2OufWvwQp6SDTN7cfamf0PR85OP1S9wf9lf9
-        5fs6wI8m2fQtzaYCe1lVJYa3kT+pm0m+opY+lX6YFOgzZWQU+DyC5s8ZE7q2OgX2FzsXblwE4tW6
-        5E6+Z7+mDiadj4rlpFovZy+ytt+8WrfDX7oXmVj8Hb4ilH7J/wMELgGJTAYAAA==
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:28:54 GMT']
-      ETag: [W/"acf71198-7168-44ea-b745-f07b24bed82c"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9u
-      dGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJuYW1lIjogIkxvYWRCYWxhbmNlckZyb250RW5kIiwg
-      InByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJwcml2YXRl
-      SVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVibGljSVBBZGRyZXNzIjogeyJpZCI6
-      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
-      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3B1YmxpY0lQQWRk
-      cmVzc2VzL1B1YmxpY0lQbGIxIn19LCAiZXRhZyI6ICJXL1wiYWNmNzExOTgtNzE2OC00NGVhLWI3
-      NDUtZjA3YjI0YmVkODJjXCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00
-      ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNy
-      b3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMv
-      TG9hZEJhbGFuY2VyRnJvbnRFbmQifV0sICJyZXNvdXJjZUd1aWQiOiAiMzQ5NDE3Y2EtYmU2NS00
-      NzUzLWI1NTAtMDkzNTY1NzY0ZDA3IiwgIm91dGJvdW5kTmF0UnVsZXMiOiBbXSwgImxvYWRCYWxh
-      bmNpbmdSdWxlcyI6IFtdLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImluYm91
-      bmROYXRSdWxlcyI6IFtdLCAiaW5ib3VuZE5hdFBvb2xzIjogW3sibmFtZSI6ICJydWxlMTAwMCIs
-      ICJwcm9wZXJ0aWVzIjogeyJwcm90b2NvbCI6ICJ0Y3AiLCAiYmFja2VuZFBvcnQiOiAxMDAwLCAi
-      ZnJvbnRlbmRQb3J0UmFuZ2VTdGFydCI6IDEwMDAsICJmcm9udGVuZFBvcnRSYW5nZUVuZCI6IDE5
-      OTl9fV0sICJiYWNrZW5kQWRkcmVzc1Bvb2xzIjogW3sibmFtZSI6ICJsYjFiZXBvb2wiLCAicHJv
-      cGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn0sICJldGFnIjogIlcv
-      XCJhY2Y3MTE5OC03MTY4LTQ0ZWEtYjc0NS1mMDdiMjRiZWQ4MmNcIiIsICJpZCI6ICIvc3Vic2Ny
-      aXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91
-      cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Jh
-      Y2tlbmRBZGRyZXNzUG9vbHMvbGIxYmVwb29sIn1dfSwgImV0YWciOiAiVy9cImFjZjcxMTk4LTcx
-      NjgtNDRlYS1iNzQ1LWYwN2IyNGJlZDgyY1wiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2
-      NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92
-      aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEifQ==
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Length: ['1411']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [4c5828fe-4518-11e6-aba6-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o4f5/Xt7s/u72wf72b3t/YN7k+3J7qf3t/fPZ7v5g92dfHZ+/vt+
-        pC+21ysezQ1daeuymmYYHt64ypt2bb4gnFd53RZ5Q18xneTDy6Kh5sXy4nWbtdzR6/V0muezfCZv
-        UjNLhLUQ8t7+w/3dB9Nse5ID6wf3721P7t/f2d55eO/+p/cffLo/23lgXz6vq2WbL2dnL0+q5Xlx
-        sa4ZQaDxPWmSGnzw2Nl77o3uGWCcLi1GeH5OJ/Xu0Kju3oj212UEeTBlvXmUB1/dYjblocbFJTU5
-        e3lcGp75Im/nFRP16TXNQjHtvrKelMWU3pjNiIK9/qnFD3FKOsjkzd2X+glNz0c+Xr/E/WF/1V++
-        rwP8aJJN39JsKrCXVVVieBv5k7qZ5Ctq6VPph0mBPlNGRoHPI2j+nDGha6tTYH+xc+HGRSBerUvu
-        5Hv2a+pg0vmoWE6q9XL2Imv7zat1O/yle5GJhe/km/iU1wRgd2dnJ6DFz+mMdwZwN4rhz9lke1Co
-        sVGZL6u6fZUtL3J6o27pDSB8Q1MoUWr48OHDsKFyPNrh+x4gQrCtpsT8hNeb6WoT++EH/f5L/h/7
-        RvheRAgAAA==
-    headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/1fd44f33-7ec5-411c-83df-004da1e3c8f7?api-version=2016-03-30']
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:28:54 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [4cfd1150-4518-11e6-be5d-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o4f5/Xt7s/u72wf72b3t/YN7k+3J7qf3t/fPZ7v5g92dfHZ+/vt+
-        pC+21ysezQ1daeuymmYYHt64ypt2bb4gnFd53RZ5Q18xneTDy6Kh5sXy4nWbtdzR6/V0muezfCZv
-        UjNLhLUQ8t7+w/3dB9Nse5ID6wf3721P7t/f2d55eO/+p/cffLo/23lgXz6vq2WbL2dnL0+q5Xlx
-        sa4ZQaDxPWmSGnzw2Nl77o3uGWCcLi1GeH5OJ/Xu0Kju3oj212UEeTBlvXmUB1/dYjblocbFJTU5
-        e3lcGp75Im/nFRP16TXNQjHtvrKelMWU3pjNiIK9/qnFD3FKOsjkzd2X+glNz0c+Xr/E/WF/1V++
-        rwP8aJJN39JsKrCXVVVieBv5k7qZ5Ctq6VPph0mBPlNGRoHPI2j+nDGha6tTYH+xc+HGRSBerUvu
-        5Hv2a+pg0vmoWE6q9XL2Imv7zat1O/yle5GJhe/km/iU1wRgd2dnJ6DFz+mMdwZwN4rhz9lke1Co
-        sVGZL6u6fZUtL3J6o27pDSB8Q1MoUWr48OHDsKFyPNrh+x4gQrCtpsT8hNeb6WoT++EH/f5L/h/7
-        RvheRAgAAA==
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:28:55 GMT']
-      ETag: [W/"9e532d51-84a3-483b-b165-4fd1e710edff"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9u
-      dGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJuYW1lIjogIkxvYWRCYWxhbmNlckZyb250RW5kIiwg
-      InByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJwcml2YXRl
-      SVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVibGljSVBBZGRyZXNzIjogeyJpZCI6
-      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
-      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3B1YmxpY0lQQWRk
-      cmVzc2VzL1B1YmxpY0lQbGIxIn19LCAiZXRhZyI6ICJXL1wiOWU1MzJkNTEtODRhMy00ODNiLWIx
-      NjUtNGZkMWU3MTBlZGZmXCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00
-      ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNy
-      b3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMv
-      TG9hZEJhbGFuY2VyRnJvbnRFbmQifV0sICJyZXNvdXJjZUd1aWQiOiAiMzQ5NDE3Y2EtYmU2NS00
-      NzUzLWI1NTAtMDkzNTY1NzY0ZDA3IiwgIm91dGJvdW5kTmF0UnVsZXMiOiBbXSwgImxvYWRCYWxh
-      bmNpbmdSdWxlcyI6IFtdLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImluYm91
-      bmROYXRSdWxlcyI6IFtdLCAiaW5ib3VuZE5hdFBvb2xzIjogW3sibmFtZSI6ICJydWxlMTAwMCIs
-      ICJwcm9wZXJ0aWVzIjogeyJwcm90b2NvbCI6ICJUY3AiLCAiYmFja2VuZFBvcnQiOiAxMDAwLCAi
-      cHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImZyb250ZW5kUG9ydFJhbmdlU3RhcnQi
-      OiAxMDAwLCAiZnJvbnRlbmRQb3J0UmFuZ2VFbmQiOiAxOTk5fSwgImV0YWciOiAiVy9cIjllNTMy
-      ZDUxLTg0YTMtNDgzYi1iMTY1LTRmZDFlNzEwZWRmZlwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25z
-      LzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNy
-      Zy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvaW5ib3VuZE5h
-      dFBvb2xzL3J1bGUxMDAwIn0sIHsibmFtZSI6ICJydWxlMjAwMCIsICJwcm9wZXJ0aWVzIjogeyJw
-      cm90b2NvbCI6ICJ0Y3AiLCAiYmFja2VuZFBvcnQiOiAyMDAwLCAiZnJvbnRlbmRQb3J0UmFuZ2VT
-      dGFydCI6IDIwMDAsICJmcm9udGVuZFBvcnRSYW5nZUVuZCI6IDI5OTl9fV0sICJiYWNrZW5kQWRk
-      cmVzc1Bvb2xzIjogW3sibmFtZSI6ICJsYjFiZXBvb2wiLCAicHJvcGVydGllcyI6IHsicHJvdmlz
-      aW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn0sICJldGFnIjogIlcvXCI5ZTUzMmQ1MS04NGEzLTQ4
-      M2ItYjE2NS00ZmQxZTcxMGVkZmZcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0x
-      YmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJz
-      L01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMv
-      bGIxYmVwb29sIn1dfSwgImV0YWciOiAiVy9cIjllNTMyZDUxLTg0YTMtNDgzYi1iMTY1LTRmZDFl
-      NzEwZWRmZlwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMz
-      LWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5l
-      dHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEifQ==
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Length: ['1792']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [4d34cd98-4518-11e6-9c07-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o/z+g+n+7v6n2/uTaba9P30w2z7I9rPt6ezThwd7e9N7D6cPf9+P
-        9MX2esWjuaErbV1W0wzDwxtXedOuzReE8yqv2yJv6Cumk3x4WTTUvFhevG6zljt6vZ5O83yWz+RN
-        amaJsBZC3tt/uL/7gFCf5J/e395/cP/e9uT+/Z3tnYf37n96/8Gn+7OdB/bl87patvlydvbypFqe
-        FxfrmhEEGt+TJqnBB4+dvefe6J4BxunSYoTn53RS7w6N6u6NaH9dRpAHU9abR3nw1S1mUx5qXFxS
-        k7OXx6XhmS/ydl4xUZ9e0ywU0+4r60lZTOmN2Ywo2OufWvwQp6SDTN7cfamf0PR85OP1S9wf9lf9
-        5fs6wI8m2fQtzaYCe1lVJYa3kT+pm0m+opY+lX6YFOgzZWQU+DyC5s8ZE7q2OgX2FzsXblwE4tW6
-        5E6+Z7+mDiadj4rlpFovZy+ytt+8WrfDX7oXmVj4Tr6JT3lNAHZ3dnYCWvycznhnAHejGP6cTbYH
-        hRoblfmyqttX2fIipzfqlt4Awjc0hRKlhg8fPgwbKsejHb7vASIE22pKzE94vZmuouxn3/DGFkz5
-        HoH1x/L/vinvYfj/9ikHwjc0lSnfu2HK+4AIwRunXH75Pn7Q77/k/wFM4yMRNwoAAA==
-    headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/df1da4d5-3c8a-4eaa-adff-61a1fcb4a125?api-version=2016-03-30']
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:28:55 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [4dd85d62-4518-11e6-a8b4-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o/z+g+n+7v6n2/uTaba9P30w2z7I9rPt6ezThwd7e9N7D6cPf9+P
-        9MX2esWjuaErbV1W0wzDwxtXedOuzReE8yqv2yJv6Cumk3x4WTTUvFhevG6zljt6vZ5O83yWz+RN
-        amaJsBZC3tt/uL/7gFCf5J/e395/cP/e9uT+/Z3tnYf37n96/8Gn+7OdB/bl87patvlydvbypFqe
-        FxfrmhEEGt+TJqnBB4+dvefe6J4BxunSYoTn53RS7w6N6u6NaH9dRpAHU9abR3nw1S1mUx5qXFxS
-        k7OXx6XhmS/ydl4xUZ9e0ywU0+4r60lZTOmN2Ywo2OufWvwQp6SDTN7cfamf0PR85OP1S9wf9lf9
-        5fs6wI8m2fQtzaYCe1lVJYa3kT+pm0m+opY+lX6YFOgzZWQU+DyC5s8ZE7q2OgX2FzsXblwE4tW6
-        5E6+Z7+mDiadj4rlpFovZy+ytt+8WrfDX7oXmVj4Tr6JT3lNAHZ3dnYCWvycznhnAHejGP6cTbYH
-        hRoblfmyqttX2fIipzfqlt4Awjc0hRKlhg8fPgwbKsejHb7vASIE22pKzE94vZmuouxn3/DGFkz5
-        HoH1x/L/vinvYfj/9ikHwjc0lSnfu2HK+4AIwRunXH75Pn7Q77/k/wFM4yMRNwoAAA==
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:28:56 GMT']
-      ETag: [W/"e57c4146-4bca-4c7d-8a4a-cd69822c39c9"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9u
-      dGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJuYW1lIjogIkxvYWRCYWxhbmNlckZyb250RW5kIiwg
-      InByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJwcml2YXRl
-      SVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVibGljSVBBZGRyZXNzIjogeyJpZCI6
-      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
-      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3B1YmxpY0lQQWRk
-      cmVzc2VzL1B1YmxpY0lQbGIxIn19LCAiZXRhZyI6ICJXL1wiZTU3YzQxNDYtNGJjYS00YzdkLThh
-      NGEtY2Q2OTgyMmMzOWM5XCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00
-      ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNy
-      b3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMv
-      TG9hZEJhbGFuY2VyRnJvbnRFbmQifV0sICJyZXNvdXJjZUd1aWQiOiAiMzQ5NDE3Y2EtYmU2NS00
-      NzUzLWI1NTAtMDkzNTY1NzY0ZDA3IiwgIm91dGJvdW5kTmF0UnVsZXMiOiBbXSwgImxvYWRCYWxh
-      bmNpbmdSdWxlcyI6IFtdLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImluYm91
-      bmROYXRSdWxlcyI6IFtdLCAiaW5ib3VuZE5hdFBvb2xzIjogW3sibmFtZSI6ICJydWxlMTAwMCIs
-      ICJwcm9wZXJ0aWVzIjogeyJwcm90b2NvbCI6ICJUY3AiLCAiYmFja2VuZFBvcnQiOiAxMDAwLCAi
-      cHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImZyb250ZW5kUG9ydFJhbmdlU3RhcnQi
-      OiAxMDAwLCAiZnJvbnRlbmRQb3J0UmFuZ2VFbmQiOiAxOTk5fSwgImV0YWciOiAiVy9cImU1N2M0
-      MTQ2LTRiY2EtNGM3ZC04YTRhLWNkNjk4MjJjMzljOVwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25z
-      LzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNy
-      Zy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvaW5ib3VuZE5h
-      dFBvb2xzL3J1bGUxMDAwIn0sIHsibmFtZSI6ICJydWxlMjAwMCIsICJwcm9wZXJ0aWVzIjogeyJw
-      cm90b2NvbCI6ICJUY3AiLCAiYmFja2VuZFBvcnQiOiAyMDAwLCAicHJvdmlzaW9uaW5nU3RhdGUi
-      OiAiU3VjY2VlZGVkIiwgImZyb250ZW5kUG9ydFJhbmdlU3RhcnQiOiAyMDAwLCAiZnJvbnRlbmRQ
-      b3J0UmFuZ2VFbmQiOiAyOTk5fSwgImV0YWciOiAiVy9cImU1N2M0MTQ2LTRiY2EtNGM3ZC04YTRh
-      LWNkNjk4MjJjMzljOVwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRk
-      YS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9z
-      b2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvaW5ib3VuZE5hdFBvb2xzL3J1bGUyMDAwIn0s
-      IHsibmFtZSI6ICJydWxlMzAwMCIsICJwcm9wZXJ0aWVzIjogeyJwcm90b2NvbCI6ICJ0Y3AiLCAi
-      YmFja2VuZFBvcnQiOiAzMDAwLCAiZnJvbnRlbmRQb3J0UmFuZ2VTdGFydCI6IDMwMDAsICJmcm9u
-      dGVuZFBvcnRSYW5nZUVuZCI6IDM5OTl9fV0sICJiYWNrZW5kQWRkcmVzc1Bvb2xzIjogW3sibmFt
-      ZSI6ICJsYjFiZXBvb2wiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3Vj
-      Y2VlZGVkIn0sICJldGFnIjogIlcvXCJlNTdjNDE0Ni00YmNhLTRjN2QtOGE0YS1jZDY5ODIyYzM5
-      YzlcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjky
-      NzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3Jr
-      L2xvYWRCYWxhbmNlcnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMvbGIxYmVwb29sIn1dfSwgImV0
-      YWciOiAiVy9cImU1N2M0MTQ2LTRiY2EtNGM3ZC04YTRhLWNkNjk4MjJjMzljOVwiIiwgImlkIjog
-      Ii9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNv
-      dXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vy
-      cy9sYjEifQ==
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Length: ['2173']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [4e36004c-4518-11e6-af50-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o53d/XsPd3cebufnkwfb+/lstp3dm5xv7zzY2T3f3/t0b28v/30/
-        0hfb6xWP5oautHVZTTMMD29c5U27Nl8Qzqu8bou8oa+YTvLhZdFQ82J58brNWu7o9Xo6zfNZPpM3
-        qZklwloIeW//4f7ug2m2Pck/vb+9/+D+ve3J/fs72zsP793/9P6DT/dnOw/sy+d1tWzz5ezs5Um1
-        PC8u1jUjCDS+J01Sgw8eO3vPvdE9A4zTpcUIz8/ppN4dGtXdG9H+uowgD6asN4/y4KtbzKY81Li4
-        pCZnL49LwzNf5O28YqI+vaZZKKbdV9aTspjSG7MZUbDXP7X4IU5JB5m8uftSP6Hp+cjH65e4P+yv
-        +sv3dYAfTbLpW5pNBfayqkoMbyN/UjeTfEUtfSr9MCnQZ8rIKPB5BM2fMyZ0bXUK7C92Lty4CMSr
-        dcmdfM9+TR1MOh8Vy0m1Xs5eZG2/ebVuh790LzKx8J18E5/ymgDs7uzsBLT4OZ3xzgDuRjH8OZts
-        Dwo1NirzZVW3r7LlRU5v1C29AYRvaAolSg0fPnwYNlSORzt83wNECLbVlJif8HozXUXZz77hjS2Y
-        8j0C64/l/31T3sPw/+1TDoRvaCpTvnfDlPcBEYIfPuX3CKw/lv/3TXkPw/+3TzkQvqGpTPm9G6a8
-        D4gQvHHK5Zfv4wf9/kv+H9wfjgcqDAAA
-    headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/db74a82b-3c9f-4a51-8be5-8eae5bd89e24?api-version=2016-03-30']
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:28:57 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [4edbf3d4-4518-11e6-a4bb-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o53d/XsPd3cebufnkwfb+/lstp3dm5xv7zzY2T3f3/t0b28v/30/
-        0hfb6xWP5oautHVZTTMMD29c5U27Nl8Qzqu8bou8oa+YTvLhZdFQ82J58brNWu7o9Xo6zfNZPpM3
-        qZklwloIeW//4f7ug2m2Pck/vb+9/+D+ve3J/fs72zsP793/9P6DT/dnOw/sy+d1tWzz5ezs5Um1
-        PC8u1jUjCDS+J01Sgw8eO3vPvdE9A4zTpcUIz8/ppN4dGtXdG9H+uowgD6asN4/y4KtbzKY81Li4
-        pCZnL49LwzNf5O28YqI+vaZZKKbdV9aTspjSG7MZUbDXP7X4IU5JB5m8uftSP6Hp+cjH65e4P+yv
-        +sv3dYAfTbLpW5pNBfayqkoMbyN/UjeTfEUtfSr9MCnQZ8rIKPB5BM2fMyZ0bXUK7C92Lty4CMSr
-        dcmdfM9+TR1MOh8Vy0m1Xs5eZG2/ebVuh790LzKx8J18E5/ymgDs7uzsBLT4OZ3xzgDuRjH8OZts
-        Dwo1NirzZVW3r7LlRU5v1C29AYRvaAolSg0fPnwYNlSORzt83wNECLbVlJif8HozXUXZz77hjS2Y
-        8j0C64/l/31T3sPw/+1TDoRvaCpTvnfDlPcBEYIfPuX3CKw/lv/3TXkPw/+3TzkQvqGpTPm9G6a8
-        D4gQvHHK5Zfv4wf9/kv+H9wfjgcqDAAA
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:28:59 GMT']
-      ETag: [W/"01439109-efb7-4edd-a3bf-0701f426222e"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [4f39729e-4518-11e6-9b32-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o53d/XsPd3cebufnkwfb+/lstp3dm5xv7zzY2T3f3/t0b28v/30/
-        0hfb6xWP5oautHVZTTMMD29c5U27Nl8Qzqu8bou8oa+YTvLhZdFQ82J58brNWu7o9Xo6zfNZPpM3
-        qZklwloIeW//4f7ug2m2Pck/vb+9/+D+ve3J/fs72zsP793/9P6DT/dnOw/sy+d1tWzz5ezs5Um1
-        PC8u1jUjCDS+J01Sgw8eO3vPvdE9A4zTpcUIz8/ppN4dGtXdG9H+uowgD6asN4/y4KtbzKY81Li4
-        pCZnL49LwzNf5O28YqI+vaZZKKbdV9aTspjSG7MZUbDXP7X4IU5JB5m8uftSP6Hp+cjH65e4P+yv
-        +sv3dYAfTbLpW5pNBfayqkoMbyN/UjeTfEUtfSr9MCnQZ8rIKPB5BM2fMyZ0bXUK7C92Lty4CMSr
-        dcmdfM9+TR1MOh8Vy0m1Xs5eZG2/ebVuh790LzKx8J18E5/ymgDs7uzsBLT4OZ3xzgDuRjH8OZts
-        Dwo1NirzZVW3r7LlRU5v1C29AYRvaAolSg0fPnwYNlSORzt83wNECLbVlJif8HozXUXZz77hjS2Y
-        8j0C64/l/31T3sPw/+1TDoRvaCpTvnfDlPcBEYIfPuX3CKw/lv/3TXkPw/+3TzkQvqGpTPm9G6a8
-        D4gQvHHK5Zfv4wf9/kv+H9wfjgcqDAAA
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:28:59 GMT']
-      ETag: [W/"01439109-efb7-4edd-a3bf-0701f426222e"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9u
-      dGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJuYW1lIjogIkxvYWRCYWxhbmNlckZyb250RW5kIiwg
-      InByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJwcml2YXRl
-      SVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVibGljSVBBZGRyZXNzIjogeyJpZCI6
-      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
-      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3B1YmxpY0lQQWRk
-      cmVzc2VzL1B1YmxpY0lQbGIxIn19LCAiZXRhZyI6ICJXL1wiMDE0MzkxMDktZWZiNy00ZWRkLWEz
-      YmYtMDcwMWY0MjYyMjJlXCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00
-      ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNy
-      b3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMv
-      TG9hZEJhbGFuY2VyRnJvbnRFbmQifV0sICJyZXNvdXJjZUd1aWQiOiAiMzQ5NDE3Y2EtYmU2NS00
-      NzUzLWI1NTAtMDkzNTY1NzY0ZDA3IiwgIm91dGJvdW5kTmF0UnVsZXMiOiBbXSwgImxvYWRCYWxh
-      bmNpbmdSdWxlcyI6IFtdLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImluYm91
-      bmROYXRSdWxlcyI6IFtdLCAiaW5ib3VuZE5hdFBvb2xzIjogW3sibmFtZSI6ICJydWxlMTAwMCIs
-      ICJwcm9wZXJ0aWVzIjogeyJwcm90b2NvbCI6ICJ1ZHAiLCAiYmFja2VuZFBvcnQiOiA1MCwgInBy
-      b3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJmcm9udGVuZFBvcnRSYW5nZVN0YXJ0Ijog
-      MTAwMCwgImZyb250ZW5kUG9ydFJhbmdlRW5kIjogMTk5OX0sICJldGFnIjogIlcvXCIwMTQzOTEw
-      OS1lZmI3LTRlZGQtYTNiZi0wNzAxZjQyNjIyMmVcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8w
-      YjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcv
-      cHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2luYm91bmROYXRQ
-      b29scy9ydWxlMTAwMCJ9LCB7Im5hbWUiOiAicnVsZTIwMDAiLCAicHJvcGVydGllcyI6IHsicHJv
-      dG9jb2wiOiAiVGNwIiwgImJhY2tlbmRQb3J0IjogMjAwMCwgInByb3Zpc2lvbmluZ1N0YXRlIjog
-      IlN1Y2NlZWRlZCIsICJmcm9udGVuZFBvcnRSYW5nZVN0YXJ0IjogMjAwMCwgImZyb250ZW5kUG9y
-      dFJhbmdlRW5kIjogMjk5OX0sICJldGFnIjogIlcvXCIwMTQzOTEwOS1lZmI3LTRlZGQtYTNiZi0w
-      NzAxZjQyNjIyMmVcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEt
-      YWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29m
-      dC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2luYm91bmROYXRQb29scy9ydWxlMjAwMCJ9LCB7
-      Im5hbWUiOiAicnVsZTMwMDAiLCAicHJvcGVydGllcyI6IHsicHJvdG9jb2wiOiAiVGNwIiwgImJh
-      Y2tlbmRQb3J0IjogMzAwMCwgInByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJmcm9u
-      dGVuZFBvcnRSYW5nZVN0YXJ0IjogMzAwMCwgImZyb250ZW5kUG9ydFJhbmdlRW5kIjogMzk5OX0s
-      ICJldGFnIjogIlcvXCIwMTQzOTEwOS1lZmI3LTRlZGQtYTNiZi0wNzAxZjQyNjIyMmVcIiIsICJp
-      ZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAv
-      cmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxh
-      bmNlcnMvbGIxL2luYm91bmROYXRQb29scy9ydWxlMzAwMCJ9XSwgImJhY2tlbmRBZGRyZXNzUG9v
-      bHMiOiBbeyJuYW1lIjogImxiMWJlcG9vbCIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdT
-      dGF0ZSI6ICJTdWNjZWVkZWQifSwgImV0YWciOiAiVy9cIjAxNDM5MTA5LWVmYjctNGVkZC1hM2Jm
-      LTA3MDFmNDI2MjIyZVwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRk
-      YS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9z
-      b2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvYmFja2VuZEFkZHJlc3NQb29scy9sYjFiZXBv
-      b2wifV19LCAiZXRhZyI6ICJXL1wiMDE0MzkxMDktZWZiNy00ZWRkLWEzYmYtMDcwMWY0MjYyMjJl
-      XCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5Mjcy
-      ZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9s
-      b2FkQmFsYW5jZXJzL2xiMSJ9
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Length: ['2412']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [4f6c99dc-4518-11e6-8d2a-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o/37D3Z3D/KH2+f3ds+p54f3tif7+zvbe+fU82x2/2Dv4c7v+5G+
-        2F6veDQ3dKWty2qaYXh44ypv2rX5gnBe5XVb5A19xXSSDy+LhpoXy4vXbdZyR6/X02mez/KZvEnN
-        LBHWQsh7+w/3dx9Ms+1J/un97f0H9wn/+/d3tnce3rv/6f0Hn+7Pdh7Yl8/ratnmy9nZy5NqeV5c
-        rGtGEGh8T5qkBh88dvaee6N7BhinS4sRnp/TSb07NKq7N6L9dRlBHkxZbx7lwVe3mE15qHFxSU3O
-        Xh6Xhme+yNt5xUR9ek2zUEy7r6wnZTGlN2YzomCvf2rxQ5ySDjJ5c/elfkLT85GP1y9xf9hf9Zfv
-        6wA/mmTTtzSbCuxlVZUY3kb+pG4m+Ypa+lT6YVKgz5SRUeDzCJo/Z0zo2uoU2F/sXLhxEYhX65I7
-        +Z79mjqYdD4qlpNqvZy9yNp+82rdDn/pXmRi4Tv5Jj7lNQHY3dnZCWjxczrjnQHcjWL4czbZHhRq
-        bFTmy6puX2XLi5zeqFt6Awjf0BRKlBo+fPgwbKgcj3b0/f0OGEKvrabE+oTVV7NVlPnsG97Iggnf
-        I+z8kfy/b8J7GP6/fcKB8A1NZcL3bpjwPiBC0E75m+nXnPJ7BNYfy//7pryH4f/bpxwI39BUpvze
-        DVPeB0QI3jjl8sv38YN+/yX/D/Je71MoDAAA
-    headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/86fcd15d-4b74-429b-b76f-5ec67681b3ed?api-version=2016-03-30']
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:28:59 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [5013aca2-4518-11e6-9056-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o/37D3Z3D/KH2+f3ds+p54f3tif7+zvbe+fU82x2/2Dv4c7v+5G+
-        2F6veDQ3dKWty2qaYXh44ypv2rX5gnBe5XVb5A19xXSSDy+LhpoXy4vXbdZyR6/X02mez/KZvEnN
-        LBHWQsh7+w/3dx9Ms+1J/un97f0H9wn/+/d3tnce3rv/6f0Hn+7Pdh7Yl8/ratnmy9nZy5NqeV5c
-        rGtGEGh8T5qkBh88dvaee6N7BhinS4sRnp/TSb07NKq7N6L9dRlBHkxZbx7lwVe3mE15qHFxSU3O
-        Xh6Xhme+yNt5xUR9ek2zUEy7r6wnZTGlN2YzomCvf2rxQ5ySDjJ5c/elfkLT85GP1y9xf9hf9Zfv
-        6wA/mmTTtzSbCuxlVZUY3kb+pG4m+Ypa+lT6YVKgz5SRUeDzCJo/Z0zo2uoU2F/sXLhxEYhX65I7
-        +Z79mjqYdD4qlpNqvZy9yNp+82rdDn/pXmRi4Tv5Jj7lNQHY3dnZCWjxczrjnQHcjWL4czbZHhRq
-        bFTmy6puX2XLi5zeqFt6Awjf0BRKlBo+fPgwbKgcj3b0/f0OGEKvrabE+oTVV7NVlPnsG97Iggnf
-        I+z8kfy/b8J7GP6/fcKB8A1NZcL3bpjwPiBC0E75m+nXnPJ7BNYfy//7pryH4f/bpxwI39BUpvze
-        DVPeB0QI3jjl8sv38YN+/yX/D/Je71MoDAAA
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:00 GMT']
-      ETag: [W/"457118e9-f31f-4d93-b440-2f927dd58290"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [50543674-4518-11e6-800a-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o/37D3Z3D/KH2+f3ds+p54f3tif7+zvbe+fU82x2/2Dv4c7v+5G+
-        2F6veDQ3dKWty2qaYXh44ypv2rX5gnBe5XVb5A19xXSSDy+LhpoXy4vXbdZyR6/X02mez/KZvEnN
-        LBHWQsh7+w/3dx9Ms+1J/un97f0H9wn/+/d3tnce3rv/6f0Hn+7Pdh7Yl8/ratnmy9nZy5NqeV5c
-        rGtGEGh8T5qkBh88dvaee6N7BhinS4sRnp/TSb07NKq7N6L9dRlBHkxZbx7lwVe3mE15qHFxSU3O
-        Xh6Xhme+yNt5xUR9ek2zUEy7r6wnZTGlN2YzomCvf2rxQ5ySDjJ5c/elfkLT85GP1y9xf9hf9Zfv
-        6wA/mmTTtzSbCuxlVZUY3kb+pG4m+Ypa+lT6YVKgz5SRUeDzCJo/Z0zo2uoU2F/sXLhxEYhX65I7
-        +Z79mjqYdD4qlpNqvZy9yNp+82rdDn/pXmRi4Tv5Jj7lNQHY3dnZCWjxczrjnQHcjWL4czbZHhRq
-        bFTmy6puX2XLi5zeqFt6Awjf0BRKlBo+fPgwbKgcj3b0/f0OGEKvrabE+oTVV7NVlPnsG97Iggnf
-        I+z8kfy/b8J7GP6/fcKB8A1NZcL3bpjwPiBC0E75m+nXnPJ7BNYfy//7pryH4f/bpxwI39BUpvze
-        DVPeB0QI3jjl8sv38YN+/yX/D/Je71MoDAAA
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:01 GMT']
-      ETag: [W/"457118e9-f31f-4d93-b440-2f927dd58290"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9u
-      dGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJuYW1lIjogIkxvYWRCYWxhbmNlckZyb250RW5kIiwg
-      InByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJwcml2YXRl
-      SVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVibGljSVBBZGRyZXNzIjogeyJpZCI6
-      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
-      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3B1YmxpY0lQQWRk
-      cmVzc2VzL1B1YmxpY0lQbGIxIn19LCAiZXRhZyI6ICJXL1wiNDU3MTE4ZTktZjMxZi00ZDkzLWI0
-      NDAtMmY5MjdkZDU4MjkwXCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00
-      ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNy
-      b3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMv
-      TG9hZEJhbGFuY2VyRnJvbnRFbmQifV0sICJyZXNvdXJjZUd1aWQiOiAiMzQ5NDE3Y2EtYmU2NS00
-      NzUzLWI1NTAtMDkzNTY1NzY0ZDA3IiwgIm91dGJvdW5kTmF0UnVsZXMiOiBbXSwgImxvYWRCYWxh
-      bmNpbmdSdWxlcyI6IFtdLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImluYm91
-      bmROYXRSdWxlcyI6IFtdLCAiaW5ib3VuZE5hdFBvb2xzIjogW3sibmFtZSI6ICJydWxlMjAwMCIs
-      ICJwcm9wZXJ0aWVzIjogeyJwcm90b2NvbCI6ICJUY3AiLCAiYmFja2VuZFBvcnQiOiAyMDAwLCAi
-      cHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImZyb250ZW5kUG9ydFJhbmdlU3RhcnQi
-      OiAyMDAwLCAiZnJvbnRlbmRQb3J0UmFuZ2VFbmQiOiAyOTk5fSwgImV0YWciOiAiVy9cIjQ1NzEx
-      OGU5LWYzMWYtNGQ5My1iNDQwLTJmOTI3ZGQ1ODI5MFwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25z
-      LzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNy
-      Zy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvaW5ib3VuZE5h
-      dFBvb2xzL3J1bGUyMDAwIn0sIHsibmFtZSI6ICJydWxlMzAwMCIsICJwcm9wZXJ0aWVzIjogeyJw
-      cm90b2NvbCI6ICJUY3AiLCAiYmFja2VuZFBvcnQiOiAzMDAwLCAicHJvdmlzaW9uaW5nU3RhdGUi
-      OiAiU3VjY2VlZGVkIiwgImZyb250ZW5kUG9ydFJhbmdlU3RhcnQiOiAzMDAwLCAiZnJvbnRlbmRQ
-      b3J0UmFuZ2VFbmQiOiAzOTk5fSwgImV0YWciOiAiVy9cIjQ1NzExOGU5LWYzMWYtNGQ5My1iNDQw
-      LTJmOTI3ZGQ1ODI5MFwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRk
-      YS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9z
-      b2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvaW5ib3VuZE5hdFBvb2xzL3J1bGUzMDAwIn1d
-      LCAiYmFja2VuZEFkZHJlc3NQb29scyI6IFt7Im5hbWUiOiAibGIxYmVwb29sIiwgInByb3BlcnRp
-      ZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCJ9LCAiZXRhZyI6ICJXL1wiNDU3
-      MTE4ZTktZjMxZi00ZDkzLWI0NDAtMmY5MjdkZDU4MjkwXCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlv
-      bnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xi
-      c3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5k
-      QWRkcmVzc1Bvb2xzL2xiMWJlcG9vbCJ9XX0sICJldGFnIjogIlcvXCI0NTcxMThlOS1mMzFmLTRk
-      OTMtYjQ0MC0yZjkyN2RkNTgyOTBcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0x
-      YmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJz
-      L01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxIn0=
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Length: ['2033']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [508cd564-4518-11e6-9b05-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o/PZw4MH+afT7fPJ/r3t/Um+u31wsHuwvbu3e+/BdG/vYb7/6e/7
-        kb7YXq94NDd0pa3LappheHjjKm/atfmCcF7ldVvkDX3FdJIPL4uGmhfLi9dt1nJHr9fTaZ7P8pm8
-        Sc0sEdZCyHv7D/d3H0yz7Un+6f3t/Qf3721P7t/f2d55eO/+p/cffLo/23lgXz6vq2WbL2dnL0+q
-        5Xlxsa4ZQaDxPWmSGnzw2Nl77o3uGWCcLi1GeH5OJ/Xu0Kju3oj212UEeTBlvXmUB1/dYjblocbF
-        JTU5e3lcGp75Im/nFRP16TXNQjHtvrKelMWU3pjNiIK9/qnFD3FKOsjkzd2X+glNz0c+Xr/E/WF/
-        1V++rwP8aJJN39JsKrCXVVVieBv5k7qZ5Ctq6VPph0mBPlNGRoHPI2j+nDGha6tTYH+xc+HGRSBe
-        rUvu5Hv2a+pg0vmoWE6q9XL2Imv7zat1O/yle5GJhe/km/iU1wRgb2dnJ6DFz+mMdwZwN4rhz9lk
-        e1CosVGZL6u6fZUtL3J6o27pDSB8Q1MoUWr48OHDsKFyPNrh+x4gQrCtpsT8hNeb6SrKfvYNb2zB
-        lN8jsP5Y/t835T0M/98+5UD4hqYy5fdumPI+IELwximXX76PH/T7L/l/ABokUVQ3CgAA
-    headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/fdb5a406-c06b-4d72-9b4f-1208e196f9d0?api-version=2016-03-30']
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:01 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [513177fa-4518-11e6-a71e-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o/PZw4MH+afT7fPJ/r3t/Um+u31wsHuwvbu3e+/BdG/vYb7/6e/7
-        kb7YXq94NDd0pa3LappheHjjKm/atfmCcF7ldVvkDX3FdJIPL4uGmhfLi9dt1nJHr9fTaZ7P8pm8
-        Sc0sEdZCyHv7D/d3H0yz7Un+6f3t/Qf3721P7t/f2d55eO/+p/cffLo/23lgXz6vq2WbL2dnL0+q
-        5Xlxsa4ZQaDxPWmSGnzw2Nl77o3uGWCcLi1GeH5OJ/Xu0Kju3oj212UEeTBlvXmUB1/dYjblocbF
-        JTU5e3lcGp75Im/nFRP16TXNQjHtvrKelMWU3pjNiIK9/qnFD3FKOsjkzd2X+glNz0c+Xr/E/WF/
-        1V++rwP8aJJN39JsKrCXVVVieBv5k7qZ5Ctq6VPph0mBPlNGRoHPI2j+nDGha6tTYH+xc+HGRSBe
-        rUvu5Hv2a+pg0vmoWE6q9XL2Imv7zat1O/yle5GJhe/km/iU1wRgb2dnJ6DFz+mMdwZwN4rhz9lk
-        e1CosVGZL6u6fZUtL3J6o27pDSB8Q1MoUWr48OHDsKFyPNrh+x4gQrCtpsT8hNeb6SrKfvYNb2zB
-        lN8jsP5Y/t835T0M/98+5UD4hqYy5fdumPI+IELwximXX76PH/T7L/l/ABokUVQ3CgAA
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:02 GMT']
-      ETag: [W/"fd987e6c-fb43-4be1-8818-12137c229e46"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9u
-      dGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJuYW1lIjogIkxvYWRCYWxhbmNlckZyb250RW5kIiwg
-      InByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJwcml2YXRl
-      SVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVibGljSVBBZGRyZXNzIjogeyJpZCI6
-      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
-      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3B1YmxpY0lQQWRk
-      cmVzc2VzL1B1YmxpY0lQbGIxIn19LCAiZXRhZyI6ICJXL1wiZmQ5ODdlNmMtZmI0My00YmUxLTg4
-      MTgtMTIxMzdjMjI5ZTQ2XCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00
-      ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNy
-      b3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMv
-      TG9hZEJhbGFuY2VyRnJvbnRFbmQifV0sICJyZXNvdXJjZUd1aWQiOiAiMzQ5NDE3Y2EtYmU2NS00
-      NzUzLWI1NTAtMDkzNTY1NzY0ZDA3IiwgIm91dGJvdW5kTmF0UnVsZXMiOiBbXSwgImxvYWRCYWxh
-      bmNpbmdSdWxlcyI6IFtdLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImluYm91
-      bmROYXRSdWxlcyI6IFtdLCAiaW5ib3VuZE5hdFBvb2xzIjogW3sibmFtZSI6ICJydWxlMzAwMCIs
-      ICJwcm9wZXJ0aWVzIjogeyJwcm90b2NvbCI6ICJUY3AiLCAiYmFja2VuZFBvcnQiOiAzMDAwLCAi
-      cHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImZyb250ZW5kUG9ydFJhbmdlU3RhcnQi
-      OiAzMDAwLCAiZnJvbnRlbmRQb3J0UmFuZ2VFbmQiOiAzOTk5fSwgImV0YWciOiAiVy9cImZkOTg3
-      ZTZjLWZiNDMtNGJlMS04ODE4LTEyMTM3YzIyOWU0NlwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25z
-      LzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNy
-      Zy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvaW5ib3VuZE5h
-      dFBvb2xzL3J1bGUzMDAwIn1dLCAiYmFja2VuZEFkZHJlc3NQb29scyI6IFt7Im5hbWUiOiAibGIx
-      YmVwb29sIiwgInByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCJ9
-      LCAiZXRhZyI6ICJXL1wiZmQ5ODdlNmMtZmI0My00YmUxLTg4MTgtMTIxMzdjMjI5ZTQ2XCIiLCAi
-      aWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkw
-      L3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFs
-      YW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVzc1Bvb2xzL2xiMWJlcG9vbCJ9XX0sICJldGFnIjogIlcv
-      XCJmZDk4N2U2Yy1mYjQzLTRiZTEtODgxOC0xMjEzN2MyMjllNDZcIiIsICJpZCI6ICIvc3Vic2Ny
-      aXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91
-      cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxIn0=
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Length: ['1652']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [51644810-4518-11e6-b76c-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o/sPJpO9bC/bzrPJwfb+wc6n25O9g93t6Sx/MMlm9OXD+7/vR/pi
-        e73i0dzQlbYuq2mG4eGNq7xp1+YLwnmV122RN/QV00k+vCwaal4sL163WcsdvV5Pp3k+y2fyJjWz
-        RFgLIe/tP9zffTDNtif5p/e39x/cv7c9uX9/Z3vn4b37n95/8On+bOeBffm8rpZtvpydvTyplufF
-        xbpmBIHG96RJavDBY2fvuTe6Z4BxurQY4fk5ndS7Q6O6eyPaX5cR5MGU9eZRHnx1i9mUhxoXl9Tk
-        7OVxaXjmi7ydV0zUp9c0C8W0+8p6UhZTemM2Iwr2+qcWP8Qp6SCTN3df6ic0PR/5eP0S94f9VX/5
-        vg7wo0k2fUuzqcBeVlWJ4W3kT+pmkq+opU+lHyYF+kwZGQU+j6D5c8aErq1Ogf3FzoUbF4F4tS65
-        k+/Zr6mDSeejYjmp1svZi6ztN6/W7fCX7kUmFr6Tb+JTXhOAezs7OwEtfk5nvDOAu1EMf84m24NC
-        jY3KfFnV7atseZHTG3VLbwDhG5pCiVLDhw8fhg2V49EO3/cAEYJtNSXmJ7zeTFeb2A8/6Pdf8v8A
-        zwTHoUQIAAA=
-    headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/327061a0-48db-4a86-95ca-b8960e86a137?api-version=2016-03-30']
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:03 GMT']
+      Date: ['Wed, 13 Jul 2016 23:07:14 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1925,14 +819,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [5207c8dc-4518-11e6-b80a-a0b3ccf7272a]
+      x-ms-client-request-id: [8a1d3388-494e-11e6-a9da-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -1942,21 +836,23 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o/sPJpO9bC/bzrPJwfb+wc6n25O9g93t6Sx/MMlm9OXD+7/vR/pi
-        e73i0dzQlbYuq2mG4eGNq7xp1+YLwnmV122RN/QV00k+vCwaal4sL163WcsdvV5Pp3k+y2fyJjWz
-        RFgLIe/tP9zffTDNtif5p/e39x/cv7c9uX9/Z3vn4b37n95/8On+bOeBffm8rpZtvpydvTyplufF
-        xbpmBIHG96RJavDBY2fvuTe6Z4BxurQY4fk5ndS7Q6O6eyPaX5cR5MGU9eZRHnx1i9mUhxoXl9Tk
-        7OVxaXjmi7ydV0zUp9c0C8W0+8p6UhZTemM2Iwr2+qcWP8Qp6SCTN3df6ic0PR/5eP0S94f9VX/5
-        vg7wo0k2fUuzqcBeVlWJ4W3kT+pmkq+opU+lHyYF+kwZGQU+j6D5c8aErq1Ogf3FzoUbF4F4tS65
-        k+/Zr6mDSeejYjmp1svZi6ztN6/W7fCX7kUmFr6Tb+JTXhOAezs7OwEtfk5nvDOAu1EMf84m24NC
-        jY3KfFnV7atseZHTG3VLbwDhG5pCiVLDhw8fhg2V49EO3/cAEYJtNSXmJ7zeTFeb2A8/6Pdf8v8A
-        zwTHoUQIAAA=
+        J1mZLaf43qGQt9kFkPju3d/3o3xvem8nO9jZ/nRv53x7/+Gnu9sPp/Tb+SzL93b2dw4O8nu/70f6
+        Ynu94tHc0JW2LqtphuHhjau8adfmC8J5lddtkTf0FdNJPrwsGmpeLC9et1nLHb1eT6d5Pstn8iY1
+        s0RYCyHPD3Y/Pfj0fG97ZzbZ396fPHy4PdnPJtv5Lqh4/vD++eyhffm8rpZtvpydvTyplufFxbpm
+        BIHG96RJavDBY2fvuTe6Z4BxurQY4fk5ndS7Q6O6eyPaX5cR5MGU9eZRHnx1i9mUhxoXl9Tk7OVx
+        aXjmi7ydV0zUp9c0C8W0+8p6UhZTemM2Iwr2+qcWP8Qp6SCTN3df6ic0PR/5eP2ScBTFclKtl7MX
+        WftqXTIVLRvK0xkUXvnhDavPaR1879b0714wwO4Q/z8xhHvdIfh/ft/9YT/XX76vQ/1okk3fkgDq
+        /L+sqjKYS48EVqUQLpN8RS19xv65JU1kFPg8gubPmd5wbXUK7C92Lty4CATPMYH4nv2aOph0Puqw
+        BL6Tb+IzB47ZC8bzczprHeyZoUP0fs5my4NCjQfMFL0SAKWWP6f0HEBzwJr6mIeaz473ZVW3NJ69
+        8FsVtviX+TKblPkzQq4lyp69pBbnWdnkYatiVuZvikVerduz5RfFct3yFO2HrWj0bTUlASaSvpmu
+        PIxVcugX+4Y3EwG/3/PnkjrG53d/buYnxu8hej/id8Ly1vQcQPOD+f1e+G3I750vf9j8Lr9YA0AA
+        A56iV2PWgS0if4evCMgv+X8A4iHUpeQNAAA=
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:04 GMT']
-      ETag: [W/"57bb2a2a-eab8-4806-b281-cde7badbb295"]
+      Date: ['Wed, 13 Jul 2016 23:07:15 GMT']
+      ETag: [W/"e2c30a80-620f-4961-9c0f-fdae204088e3"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1965,41 +861,57 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9u
-      dGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJuYW1lIjogIkxvYWRCYWxhbmNlckZyb250RW5kIiwg
-      InByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJwcml2YXRl
-      SVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVibGljSVBBZGRyZXNzIjogeyJpZCI6
-      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
-      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3B1YmxpY0lQQWRk
-      cmVzc2VzL1B1YmxpY0lQbGIxIn19LCAiZXRhZyI6ICJXL1wiNTdiYjJhMmEtZWFiOC00ODA2LWIy
-      ODEtY2RlN2JhZGJiMjk1XCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00
-      ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNy
-      b3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMv
-      TG9hZEJhbGFuY2VyRnJvbnRFbmQifV0sICJyZXNvdXJjZUd1aWQiOiAiMzQ5NDE3Y2EtYmU2NS00
-      NzUzLWI1NTAtMDkzNTY1NzY0ZDA3IiwgIm91dGJvdW5kTmF0UnVsZXMiOiBbXSwgImxvYWRCYWxh
-      bmNpbmdSdWxlcyI6IFtdLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImluYm91
-      bmROYXRSdWxlcyI6IFtdLCAiaW5ib3VuZE5hdFBvb2xzIjogW10sICJiYWNrZW5kQWRkcmVzc1Bv
-      b2xzIjogW3sibmFtZSI6ICJsYjFiZXBvb2wiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5n
-      U3RhdGUiOiAiU3VjY2VlZGVkIn0sICJldGFnIjogIlcvXCI1N2JiMmEyYS1lYWI4LTQ4MDYtYjI4
-      MS1jZGU3YmFkYmIyOTVcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRk
-      ZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jv
-      c29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMvbGIxYmVw
-      b29sIn1dfSwgImV0YWciOiAiVy9cIjU3YmIyYTJhLWVhYjgtNDgwNi1iMjgxLWNkZTdiYWRiYjI5
-      NVwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3
-      MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsv
-      bG9hZEJhbGFuY2Vycy9sYjEifQ==
+      eyJldGFnIjogIlcvXCJlMmMzMGE4MC02MjBmLTQ5NjEtOWMwZi1mZGFlMjA0MDg4ZTNcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9udGVu
+      ZElQQ29uZmlndXJhdGlvbnMiOiBbeyJldGFnIjogIlcvXCJlMmMzMGE4MC02MjBmLTQ5NjEtOWMw
+      Zi1mZGFlMjA0MDg4ZTNcIiIsICJwcm9wZXJ0aWVzIjogeyJpbmJvdW5kTmF0UnVsZXMiOiBbeyJp
+      ZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAv
+      cmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxh
+      bmNlcnMvbGIxL2luYm91bmROYXRSdWxlcy9ydWxlMiJ9LCB7ImlkIjogIi9zdWJzY3JpcHRpb25z
+      LzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNy
+      Zy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvaW5ib3VuZE5h
+      dFJ1bGVzL3J1bGUzIn1dLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgInByaXZh
+      dGVJUEFsbG9jYXRpb25NZXRob2QiOiAiRHluYW1pYyIsICJwdWJsaWNJUEFkZHJlc3MiOiB7Imlk
+      IjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9y
+      ZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvcHVibGljSVBB
+      ZGRyZXNzZXMvUHVibGljSVBsYjEifX0sICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0x
+      YmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJz
+      L01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0
+      aW9ucy9Mb2FkQmFsYW5jZXJGcm9udEVuZCIsICJuYW1lIjogIkxvYWRCYWxhbmNlckZyb250RW5k
+      In1dLCAib3V0Ym91bmROYXRSdWxlcyI6IFtdLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2Vl
+      ZGVkIiwgImluYm91bmROYXRSdWxlcyI6IFt7ImV0YWciOiAiVy9cImUyYzMwYTgwLTYyMGYtNDk2
+      MS05YzBmLWZkYWUyMDQwODhlM1wiIiwgIm5hbWUiOiAicnVsZTMiLCAicHJvcGVydGllcyI6IHsi
+      aWRsZVRpbWVvdXRJbk1pbnV0ZXMiOiA0LCAiZW5hYmxlRmxvYXRpbmdJUCI6IGZhbHNlLCAiZnJv
+      bnRlbmRQb3J0IjogMywgInByb3RvY29sIjogIlRjcCIsICJmcm9udGVuZElQQ29uZmlndXJhdGlv
+      biI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5Mjcy
+      ZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9s
+      b2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMvTG9hZEJhbGFuY2VyRnJv
+      bnRFbmQifSwgInByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJiYWNrZW5kUG9ydCI6
+      IDN9LCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5Mjcy
+      ZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9s
+      b2FkQmFsYW5jZXJzL2xiMS9pbmJvdW5kTmF0UnVsZXMvcnVsZTMifV0sICJiYWNrZW5kQWRkcmVz
+      c1Bvb2xzIjogW3siZXRhZyI6ICJXL1wiZTJjMzBhODAtNjIwZi00OTYxLTljMGYtZmRhZTIwNDA4
+      OGUzXCIiLCAibmFtZSI6ICJsYjFiZXBvb2wiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0
+      NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3Zp
+      ZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVzc1Bv
+      b2xzL2xiMWJlcG9vbCIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNj
+      ZWVkZWQifX1dLCAiaW5ib3VuZE5hdFBvb2xzIjogW10sICJyZXNvdXJjZUd1aWQiOiAiZjgxNjg2
+      ZjItMGRiNC00Yjk5LWI0YWItZTE0ZGRhZjk1ZmQ5IiwgImxvYWRCYWxhbmNpbmdSdWxlcyI6IFtd
+      fSwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYw
+      OTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9h
+      ZEJhbGFuY2Vycy9sYjEifQ==
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
-      Content-Length: ['1273']
+      Content-Length: ['2182']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [523ba402-4518-11e6-b338-a0b3ccf7272a]
+      x-ms-client-request-id: [8a3f311e-494e-11e6-80eb-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -2009,19 +921,287 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o0/3Hk4+PZ8+2N47mO5u7386ybcf7kz3tyfT3Z3dB5NPs72d3d/3
-        I32xvV7xaG7oSluX1TTD8PDGVd60a/MF4bzK67bIG/qK6SQfXhYNNS+WF6/brOWOXq+n0zyf5TN5
-        k5pZIqyFkPf2H+7vPphm25P80/vb+w/u39ue3L+/s73z8N79T+8/+HR/tvPAvnxeV8s2X87OXp5U
-        y/PiYl0zgkDje9IkNfjgsbP33BvdM8A4XVqM8PycTurdoVHdvRHtr8sI8mDKevMoD766xWzKQ42L
-        S2py9vK4NDzzRd7OKybq02uahWLafWU9KYspvTGbEQV7/VOLH+KUdJDJm7sv9ROano98vH6J+8P+
-        qr98Xwf40SSbvqXZVGAvq6rE8DbyJ3UzyVfU0qfSD5MCfaaMjAKfR9D8OWNC11anwP5i58KNi0C8
-        Wpfcyffs19TBpPNRsZxU6+XsRdb2m1frdvhL9yITi7/DV4TSL/l/AGOJusRMBgAA
+        J1mZLaf43qGQt9kFkPju3d/3o9mnD88fTCf7259Oz+9v79+bzLYPzh/k2wef7u7sHezcP9ibnf++
+        H+mL7fWKR3NDV9q6rKYZhoc3rvKmXZsvCOdVXrdF3tBXTCf58LJoqHmxvHjdZi139Ho9neb5LJ/J
+        m9TMEmEthDw/2P304NPzve2dGQ1if/Lw4fZkP5ts57ug4vnD++ezh/bl87patvlydvbypFqeFxfr
+        mhEEGt+TJqnBB4+dvefe6J4BxunSYoTn53RS7w6N6u6NaH9dRpAHU9abR3nw1S1mUx5qXFxSk7OX
+        x6XhmS/ydl4xUZ9e0ywU0+4r60lZTOmN2Ywo2OufWvwQp6SDTN7cfamf0PR85OP1S8JRFMtJtV7O
+        XmTtq3XJVLRsKE9nUHjlhzesPqd18L1b07/3ggHSEP0/v+/+sJ/rL99XUnw0yaZviXuVeC+rqgwI
+        4ZHAyiPhMslX1NLnip9b0kRGgc8jaP6cCZ1rq1Ngf7Fz4cZFIHiOCcT37NfUwaTzUYcl8J18E585
+        4Rh9Gc/P7ax1sFeG9tH7OZstDwo1HtDx9EoAlFr+nNJzAM0BU+Rj3tGMBtDLqm5pPPfCb1XY4l/m
+        y2xS5s8IuZYoe/aSWpxnZZOHrYpZmb8pFnm1bs+WXxTLdctTtB+2otG31ZQEmEj6ZrryMFbJsb9Y
+        gSCAAU/RqzFpYQ3B3+ErAvJL/h8l69wbMQoAAA==
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/a9eb5db1-ea86-443c-8e8b-814e88ccbce6?api-version=2016-03-30']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/7537f95a-cb3a-431b-aa8e-4506a6f0428f?api-version=2016-03-30']
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:04 GMT']
+      Date: ['Wed, 13 Jul 2016 23:07:15 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [8ae5573a-494e-11e6-8a8a-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o9mnD88fTCf7259Oz+9v79+bzLYPzh/k2wef7u7sHezcP9ibnf++
+        H+mL7fWKR3NDV9q6rKYZhoc3rvKmXZsvCOdVXrdF3tBXTCf58LJoqHmxvHjdZi139Ho9neb5LJ/J
+        m9TMEmEthDw/2P304NPzve2dGQ1if/Lw4fZkP5ts57ug4vnD++ezh/bl87patvlydvbypFqeFxfr
+        mhEEGt+TJqnBB4+dvefe6J4BxunSYoTn53RS7w6N6u6NaH9dRpAHU9abR3nw1S1mUx5qXFxSk7OX
+        x6XhmS/ydl4xUZ9e0ywU0+4r60lZTOmN2Ywo2OufWvwQp6SDTN7cfamf0PR85OP1S8JRFMtJtV7O
+        XmTtq3XJVLRsKE9nUHjlhzesPqd18L1b07/3ggHSEP0/v+/+sJ/rL99XUnw0yaZviXuVeC+rqgwI
+        4ZHAyiPhMslX1NLnip9b0kRGgc8jaP6cCZ1rq1Ngf7Fz4cZFIHiOCcT37NfUwaTzUYcl8J18E585
+        4Rh9Gc/P7ax1sFeG9tH7OZstDwo1HtDx9EoAlFr+nNJzAM0BU+Rj3tGMBtDLqm5pPPfCb1XY4l/m
+        y2xS5s8IuZYoe/aSWpxnZZOHrYpZmb8pFnm1bs+WXxTLdctTtB+2otG31ZQEmEj6ZrryMFbJsb9Y
+        gSCAAU/RqzFpYQ3B3+ErAvJL/h8l69wbMQoAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:07:17 GMT']
+      ETag: [W/"d69f7cb4-6cf5-43bd-8f7e-8610280582df"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJldGFnIjogIlcvXCJkNjlmN2NiNC02Y2Y1LTQzYmQtOGY3ZS04NjEwMjgwNTgyZGZcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9udGVu
+      ZElQQ29uZmlndXJhdGlvbnMiOiBbeyJldGFnIjogIlcvXCJkNjlmN2NiNC02Y2Y1LTQzYmQtOGY3
+      ZS04NjEwMjgwNTgyZGZcIiIsICJwcm9wZXJ0aWVzIjogeyJpbmJvdW5kTmF0UnVsZXMiOiBbeyJp
+      ZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAv
+      cmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxh
+      bmNlcnMvbGIxL2luYm91bmROYXRSdWxlcy9ydWxlMyJ9XSwgInByb3Zpc2lvbmluZ1N0YXRlIjog
+      IlN1Y2NlZWRlZCIsICJwcml2YXRlSVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVi
+      bGljSVBBZGRyZXNzIjogeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEt
+      YWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29m
+      dC5OZXR3b3JrL3B1YmxpY0lQQWRkcmVzc2VzL1B1YmxpY0lQbGIxIn19LCAiaWQiOiAiL3N1YnNj
+      cmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3Jv
+      dXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9m
+      cm9udGVuZElQQ29uZmlndXJhdGlvbnMvTG9hZEJhbGFuY2VyRnJvbnRFbmQiLCAibmFtZSI6ICJM
+      b2FkQmFsYW5jZXJGcm9udEVuZCJ9XSwgIm91dGJvdW5kTmF0UnVsZXMiOiBbXSwgInByb3Zpc2lv
+      bmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJpbmJvdW5kTmF0UnVsZXMiOiBbXSwgImJhY2tlbmRB
+      ZGRyZXNzUG9vbHMiOiBbeyJldGFnIjogIlcvXCJkNjlmN2NiNC02Y2Y1LTQzYmQtOGY3ZS04NjEw
+      MjgwNTgyZGZcIiIsICJuYW1lIjogImxiMWJlcG9vbCIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8w
+      YjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcv
+      cHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2JhY2tlbmRBZGRy
+      ZXNzUG9vbHMvbGIxYmVwb29sIiwgInByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjog
+      IlN1Y2NlZWRlZCJ9fV0sICJpbmJvdW5kTmF0UG9vbHMiOiBbXSwgInJlc291cmNlR3VpZCI6ICJm
+      ODE2ODZmMi0wZGI0LTRiOTktYjRhYi1lMTRkZGFmOTVmZDkiLCAibG9hZEJhbGFuY2luZ1J1bGVz
+      IjogW119LCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5
+      MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29y
+      ay9sb2FkQmFsYW5jZXJzL2xiMSJ9
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Length: ['1446']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [8b43d594-494e-11e6-8b4a-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o4Odncns/mS2/enewf3t/Yez+9vZ3sOH2w9n03s79yef7t27d//3
+        /UhfbK9XPJobutLWZTXNMDy8cZU37dp8QTiv8rot8oa+YjrJh5dFQ82L5cXrNmu5o9fr6TTPZ/lM
+        3qRmlghrIeT5we6nB5+e723vzCb72/sTQn2yn022811Q8fzh/fPZQ/vyeV0t23w5O3t5Ui3Pi4t1
+        zQgCje9Jk9Tgg8fO3nNvdM8A43RpMcLzczqpd4dGdfdGtL8uI8iDKevNozz46hazKQ81Li6pydnL
+        49LwzBd5O6+YqE+vaRaKafeV9aQspvTGbEYU7PVPLX6IU9JBJm/uvtRPaHo+8vH6Je4P+6v+8n0d
+        4EeTbPqWZlOBvayqEsPbyJ/UzSRfUUufSj9MCvSZMjIKfB5B8+eMCV1bnQL7i50LNy4C8Wpdciff
+        s19TB5POR8VyUq2XsxdZ229erdvhL92LTCz+Dl8RSr/k/wHaE1okTAYAAA==
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/9307e127-d020-400a-b21e-339af2b38d8e?api-version=2016-03-30']
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:07:18 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [8be8c588-494e-11e6-a018-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o4Odncns/mS2/enewf3t/Yez+9vZ3sOH2w9n03s79yef7t27d//3
+        /UhfbK9XPJobutLWZTXNMDy8cZU37dp8QTiv8rot8oa+YjrJh5dFQ82L5cXrNmu5o9fr6TTPZ/lM
+        3qRmlghrIeT5we6nB5+e723vzCb72/sTQn2yn022811Q8fzh/fPZQ/vyeV0t23w5O3t5Ui3Pi4t1
+        zQgCje9Jk9Tgg8fO3nNvdM8A43RpMcLzczqpd4dGdfdGtL8uI8iDKevNozz46hazKQ81Li6pydnL
+        49LwzBd5O6+YqE+vaRaKafeV9aQspvTGbEYU7PVPLX6IU9JBJm/uvtRPaHo+8vH6Je4P+6v+8n0d
+        4EeTbPqWZlOBvayqEsPbyJ/UzSRfUUufSj9MCvSZMjIKfB5B8+eMCV1bnQL7i50LNy4C8Wpdciff
+        s19TB5POR8VyUq2XsxdZ229erdvhL92LTCz+Dl8RSr/k/wHaE1okTAYAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:07:18 GMT']
+      ETag: [W/"800bd5bd-6285-49d5-a299-9dc305b62335"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [8c2fa10a-494e-11e6-95a9-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o4Odncns/mS2/enewf3t/Yez+9vZ3sOH2w9n03s79yef7t27d//3
+        /UhfbK9XPJobutLWZTXNMDy8cZU37dp8QTiv8rot8oa+YjrJh5dFQ82L5cXrNmu5o9fr6TTPZ/lM
+        3qRmlghrIeT5we6nB5+e723vzCb72/sTQn2yn022811Q8fzh/fPZQ/vyeV0t23w5O3t5Ui3Pi4t1
+        zQgCje9Jk9Tgg8fO3nNvdM8A43RpMcLzczqpd4dGdfdGtL8uI8iDKevNozz46hazKQ81Li6pydnL
+        49LwzBd5O6+YqE+vaRaKafeV9aQspvTGbEYU7PVPLX6IU9JBJm/uvtRPaHo+8vH6Je4P+6v+8n0d
+        4EeTbPqWZlOBvayqEsPbyJ/UzSRfUUufSj9MCvSZMjIKfB5B8+eMCV1bnQL7i50LNy4C8Wpdciff
+        s19TB5POR8VyUq2XsxdZ229erdvhL92LTCz+Dl8RSr/k/wHaE1okTAYAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:07:19 GMT']
+      ETag: [W/"800bd5bd-6285-49d5-a299-9dc305b62335"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJldGFnIjogIlcvXCI4MDBiZDViZC02Mjg1LTQ5ZDUtYTI5OS05ZGMzMDViNjIzMzVcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9udGVu
+      ZElQQ29uZmlndXJhdGlvbnMiOiBbeyJldGFnIjogIlcvXCI4MDBiZDViZC02Mjg1LTQ5ZDUtYTI5
+      OS05ZGMzMDViNjIzMzVcIiIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1Ymxp
+      Y0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
+      YzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQu
+      TmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9QdWJsaWNJUGxiMSJ9fSwgImlkIjogIi9zdWJzY3Jp
+      cHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vw
+      cy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJv
+      bnRlbmRJUENvbmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNlckZyb250RW5kIiwgIm5hbWUiOiAiTG9h
+      ZEJhbGFuY2VyRnJvbnRFbmQifV0sICJvdXRib3VuZE5hdFJ1bGVzIjogW10sICJwcm92aXNpb25p
+      bmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAiaW5ib3VuZE5hdFJ1bGVzIjogW10sICJiYWNrZW5kQWRk
+      cmVzc1Bvb2xzIjogW3siZXRhZyI6ICJXL1wiODAwYmQ1YmQtNjI4NS00OWQ1LWEyOTktOWRjMzA1
+      YjYyMzM1XCIiLCAibmFtZSI6ICJsYjFiZXBvb2wiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIx
+      ZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3By
+      b3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVz
+      c1Bvb2xzL2xiMWJlcG9vbCIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQifX1dLCAiaW5ib3VuZE5hdFBvb2xzIjogW3sicHJvcGVydGllcyI6IHsiZnJvbnRl
+      bmRQb3J0UmFuZ2VTdGFydCI6IDEwMDAsICJwcm90b2NvbCI6ICJ0Y3AiLCAiZnJvbnRlbmRQb3J0
+      UmFuZ2VFbmQiOiAxOTk5LCAiYmFja2VuZFBvcnQiOiAxMDAwfSwgIm5hbWUiOiAicnVsZTEwMDAi
+      fV0sICJyZXNvdXJjZUd1aWQiOiAiZjgxNjg2ZjItMGRiNC00Yjk5LWI0YWItZTE0ZGRhZjk1ZmQ5
+      IiwgImxvYWRCYWxhbmNpbmdSdWxlcyI6IFtdfSwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2
+      NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92
+      aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEifQ==
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Length: ['1411']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [8c674846-494e-11e6-a50b-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o/Ppzr3pdLq7/en5dG97/2F2b3vycOdge38nm013s4cP93YOft+P
+        9MX2esWjuaErbV1W0wzDwxtXedOuzReE8yqv2yJv6Cumk3x4WTTUvFhevG6zljt6vZ5O83yWz+RN
+        amaJsBZCnh/sfnrw6fne9s5ssr+9P3n4cHuyn022811Q8fzh/fPZQ/vyeV0t23w5O3t5Ui3Pi4t1
+        zQgCje9Jk9Tgg8fO3nNvdM8A43RpMcLzczqpd4dGdfdGtL8uI8iDKevNozz46hazKQ81Li6pydnL
+        49LwzBd5O6+YqE+vaRaKafeV9aQspvTGbEYU7PVPLX6IU9JBJm/uvtRPaHo+8vH6Je4P+6v+8n0d
+        4EeTbPqWZlOBvayqEsPbyJ/UzSRfUUufSj9MCvSZMjIKfB5B8+eMCV1bnQL7i50LNy4C8Wpdciff
+        s19TB5POR8VyUq2XsxdZ229erdvhL92LTCx8J9/Ep7wmALs7OzsBLX5OZ7wzgLtRDH/OJtuDQo2N
+        ynxZ1e2rbHmR0xt1S28A4RuaQolSw4cPH4YNlePRDt/3ABGCbTUl5ie83kxXm9gPP+j3X/L/AH5u
+        IwFECAAA
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/2c2c6bb8-e2f5-49d7-bf85-adb4b7bdd2fa?api-version=2016-03-30']
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:07:19 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2034,14 +1214,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [52df5050-4518-11e6-8697-a0b3ccf7272a]
+      x-ms-client-request-id: [8d1204f8-494e-11e6-9038-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -2051,19 +1231,270 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o0/3Hk4+PZ8+2N47mO5u7386ybcf7kz3tyfT3Z3dB5NPs72d3d/3
-        I32xvV7xaG7oSluX1TTD8PDGVd60a/MF4bzK67bIG/qK6SQfXhYNNS+WF6/brOWOXq+n0zyf5TN5
-        k5pZIqyFkPf2H+7vPphm25P80/vb+w/u39ue3L+/s73z8N79T+8/+HR/tvPAvnxeV8s2X87OXp5U
-        y/PiYl0zgkDje9IkNfjgsbP33BvdM8A4XVqM8PycTurdoVHdvRHtr8sI8mDKevMoD766xWzKQ42L
-        S2py9vK4NDzzRd7OKybq02uahWLafWU9KYspvTGbEQV7/VOLH+KUdJDJm7sv9ROano98vH6J+8P+
-        qr98Xwf40SSbvqXZVGAvq6rE8DbyJ3UzyVfU0qfSD5MCfaaMjAKfR9D8OWNC11anwP5i58KNi0C8
-        Wpfcyffs19TBpPNRsZxU6+XsRdb2m1frdvhL9yITi7/DV4TSL/l/AGOJusRMBgAA
+        J1mZLaf43qGQt9kFkPju3d/3o/Ppzr3pdLq7/en5dG97/2F2b3vycOdge38nm013s4cP93YOft+P
+        9MX2esWjuaErbV1W0wzDwxtXedOuzReE8yqv2yJv6Cumk3x4WTTUvFhevG6zljt6vZ5O83yWz+RN
+        amaJsBZCnh/sfnrw6fne9s5ssr+9P3n4cHuyn022811Q8fzh/fPZQ/vyeV0t23w5O3t5Ui3Pi4t1
+        zQgCje9Jk9Tgg8fO3nNvdM8A43RpMcLzczqpd4dGdfdGtL8uI8iDKevNozz46hazKQ81Li6pydnL
+        49LwzBd5O6+YqE+vaRaKafeV9aQspvTGbEYU7PVPLX6IU9JBJm/uvtRPaHo+8vH6Je4P+6v+8n0d
+        4EeTbPqWZlOBvayqEsPbyJ/UzSRfUUufSj9MCvSZMjIKfB5B8+eMCV1bnQL7i50LNy4C8Wpdciff
+        s19TB5POR8VyUq2XsxdZ229erdvhL92LTCx8J9/Ep7wmALs7OzsBLX5OZ7wzgLtRDH/OJtuDQo2N
+        ynxZ1e2rbHmR0xt1S28A4RuaQolSw4cPH4YNlePRDt/3ABGCbTUl5ie83kxXm9gPP+j3X/L/AH5u
+        IwFECAAA
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:05 GMT']
-      ETag: [W/"629b6fc7-28c1-46be-90c4-bc1017b6a201"]
+      Date: ['Wed, 13 Jul 2016 23:07:20 GMT']
+      ETag: [W/"fc03ccc1-6fc2-49a3-b908-40adc1a99208"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJldGFnIjogIlcvXCJmYzAzY2NjMS02ZmMyLTQ5YTMtYjkwOC00MGFkYzFhOTkyMDhcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9udGVu
+      ZElQQ29uZmlndXJhdGlvbnMiOiBbeyJldGFnIjogIlcvXCJmYzAzY2NjMS02ZmMyLTQ5YTMtYjkw
+      OC00MGFkYzFhOTkyMDhcIiIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1Ymxp
+      Y0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
+      YzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQu
+      TmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9QdWJsaWNJUGxiMSJ9fSwgImlkIjogIi9zdWJzY3Jp
+      cHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vw
+      cy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJv
+      bnRlbmRJUENvbmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNlckZyb250RW5kIiwgIm5hbWUiOiAiTG9h
+      ZEJhbGFuY2VyRnJvbnRFbmQifV0sICJvdXRib3VuZE5hdFJ1bGVzIjogW10sICJwcm92aXNpb25p
+      bmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAiaW5ib3VuZE5hdFJ1bGVzIjogW10sICJiYWNrZW5kQWRk
+      cmVzc1Bvb2xzIjogW3siZXRhZyI6ICJXL1wiZmMwM2NjYzEtNmZjMi00OWEzLWI5MDgtNDBhZGMx
+      YTk5MjA4XCIiLCAibmFtZSI6ICJsYjFiZXBvb2wiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIx
+      ZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3By
+      b3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVz
+      c1Bvb2xzL2xiMWJlcG9vbCIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQifX1dLCAiaW5ib3VuZE5hdFBvb2xzIjogW3siZXRhZyI6ICJXL1wiZmMwM2NjYzEt
+      NmZjMi00OWEzLWI5MDgtNDBhZGMxYTk5MjA4XCIiLCAibmFtZSI6ICJydWxlMTAwMCIsICJpZCI6
+      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
+      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNl
+      cnMvbGIxL2luYm91bmROYXRQb29scy9ydWxlMTAwMCIsICJwcm9wZXJ0aWVzIjogeyJmcm9udGVu
+      ZFBvcnRSYW5nZVN0YXJ0IjogMTAwMCwgInByb3RvY29sIjogIlRjcCIsICJwcm92aXNpb25pbmdT
+      dGF0ZSI6ICJTdWNjZWVkZWQiLCAiZnJvbnRlbmRQb3J0UmFuZ2VFbmQiOiAxOTk5LCAiYmFja2Vu
+      ZFBvcnQiOiAxMDAwfX0sIHsicHJvcGVydGllcyI6IHsiZnJvbnRlbmRQb3J0UmFuZ2VTdGFydCI6
+      IDIwMDAsICJwcm90b2NvbCI6ICJ0Y3AiLCAiZnJvbnRlbmRQb3J0UmFuZ2VFbmQiOiAyOTk5LCAi
+      YmFja2VuZFBvcnQiOiAyMDAwfSwgIm5hbWUiOiAicnVsZTIwMDAifV0sICJyZXNvdXJjZUd1aWQi
+      OiAiZjgxNjg2ZjItMGRiNC00Yjk5LWI0YWItZTE0ZGRhZjk1ZmQ5IiwgImxvYWRCYWxhbmNpbmdS
+      dWxlcyI6IFtdfSwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMz
+      LWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5l
+      dHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEifQ==
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Length: ['1792']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [8d4b159a-494e-11e6-b014-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o8n988n9yXRn+/zh7r3t/QcHe9sH2c7e9l52fm/n/vTT2Xl+/vt+
+        pC+21ysezQ1daeuymmYYHt64ypt2bb4gnFd53RZ5Q18xneTDy6Kh5sXy4nWbtdzR6/V0muezfCZv
+        UjNLhLUQ8vxg99ODT8/3tndmk/3t/cnDh9uT/Wyyne+CiucP75/PHtqXz+tq2ebL2dnLk2p5Xlys
+        a0YQaHxPmqQGHzx29p57o3sGGKdLixGen9NJvTs0qrs3ov11GUEeTFlvHuXBV7eYTXmocXFJTc5e
+        HpeGZ77I23nFRH16TbNQTLuvrCdlMaU3ZjOiYK9/avFDnJIOMnlz96V+QtPzkY/XL3F/2F/1l+/r
+        AD+aZNO3NJsK7GVVlRjeRv6kbib5ilr6VPphUqDPlJFR4PMImj9nTOja6hTYX+xcuHERiFfrkjv5
+        nv2aOph0PiqWk2q9nL3I2n7zat0Of+leZGLhO/kmPuU1Adjd2dkJaPFzOuOdAdyNYvhzNtkeFGps
+        VObLqm5fZcuLnN6oW3oDCN/QFEqUGj58+DBsqByPdvi+B4gQbKspMT/h9Wa6irKffcMbWzDlewTW
+        H8v/+6a8h+H/26ccCN/QVKZ874Yp7wMiBG+ccvnl+/hBv/+S/weciFF7NwoAAA==
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/0328ca07-1ac1-4ccf-8fe3-ed5c691bcfc6?api-version=2016-03-30']
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:07:20 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [8df1592c-494e-11e6-9a37-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o8n988n9yXRn+/zh7r3t/QcHe9sH2c7e9l52fm/n/vTT2Xl+/vt+
+        pC+21ysezQ1daeuymmYYHt64ypt2bb4gnFd53RZ5Q18xneTDy6Kh5sXy4nWbtdzR6/V0muezfCZv
+        UjNLhLUQ8vxg99ODT8/3tndmk/3t/cnDh9uT/Wyyne+CiucP75/PHtqXz+tq2ebL2dnLk2p5Xlys
+        a0YQaHxPmqQGHzx29p57o3sGGKdLixGen9NJvTs0qrs3ov11GUEeTFlvHuXBV7eYTXmocXFJTc5e
+        HpeGZ77I23nFRH16TbNQTLuvrCdlMaU3ZjOiYK9/avFDnJIOMnlz96V+QtPzkY/XL3F/2F/1l+/r
+        AD+aZNO3NJsK7GVVlRjeRv6kbib5ilr6VPphUqDPlJFR4PMImj9nTOja6hTYX+xcuHERiFfrkjv5
+        nv2aOph0PiqWk2q9nL3I2n7zat0Of+leZGLhO/kmPuU1Adjd2dkJaPFzOuOdAdyNYvhzNtkeFGps
+        VObLqm5fZcuLnN6oW3oDCN/QFEqUGj58+DBsqByPdvi+B4gQbKspMT/h9Wa6irKffcMbWzDlewTW
+        H8v/+6a8h+H/26ccCN/QVKZ874Yp7wMiBG+ccvnl+/hBv/+S/weciFF7NwoAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:07:22 GMT']
+      ETag: [W/"b5fb5bc0-f913-4782-8a02-2af305c6dfef"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJldGFnIjogIlcvXCJiNWZiNWJjMC1mOTEzLTQ3ODItOGEwMi0yYWYzMDVjNmRmZWZcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9udGVu
+      ZElQQ29uZmlndXJhdGlvbnMiOiBbeyJldGFnIjogIlcvXCJiNWZiNWJjMC1mOTEzLTQ3ODItOGEw
+      Mi0yYWYzMDVjNmRmZWZcIiIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1Ymxp
+      Y0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
+      YzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQu
+      TmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9QdWJsaWNJUGxiMSJ9fSwgImlkIjogIi9zdWJzY3Jp
+      cHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vw
+      cy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJv
+      bnRlbmRJUENvbmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNlckZyb250RW5kIiwgIm5hbWUiOiAiTG9h
+      ZEJhbGFuY2VyRnJvbnRFbmQifV0sICJvdXRib3VuZE5hdFJ1bGVzIjogW10sICJwcm92aXNpb25p
+      bmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAiaW5ib3VuZE5hdFJ1bGVzIjogW10sICJiYWNrZW5kQWRk
+      cmVzc1Bvb2xzIjogW3siZXRhZyI6ICJXL1wiYjVmYjViYzAtZjkxMy00NzgyLThhMDItMmFmMzA1
+      YzZkZmVmXCIiLCAibmFtZSI6ICJsYjFiZXBvb2wiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIx
+      ZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3By
+      b3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVz
+      c1Bvb2xzL2xiMWJlcG9vbCIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQifX1dLCAiaW5ib3VuZE5hdFBvb2xzIjogW3siZXRhZyI6ICJXL1wiYjVmYjViYzAt
+      ZjkxMy00NzgyLThhMDItMmFmMzA1YzZkZmVmXCIiLCAibmFtZSI6ICJydWxlMTAwMCIsICJpZCI6
+      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
+      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNl
+      cnMvbGIxL2luYm91bmROYXRQb29scy9ydWxlMTAwMCIsICJwcm9wZXJ0aWVzIjogeyJmcm9udGVu
+      ZFBvcnRSYW5nZVN0YXJ0IjogMTAwMCwgInByb3RvY29sIjogIlRjcCIsICJwcm92aXNpb25pbmdT
+      dGF0ZSI6ICJTdWNjZWVkZWQiLCAiZnJvbnRlbmRQb3J0UmFuZ2VFbmQiOiAxOTk5LCAiYmFja2Vu
+      ZFBvcnQiOiAxMDAwfX0sIHsiZXRhZyI6ICJXL1wiYjVmYjViYzAtZjkxMy00NzgyLThhMDItMmFm
+      MzA1YzZkZmVmXCIiLCAibmFtZSI6ICJydWxlMjAwMCIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8w
+      YjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcv
+      cHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2luYm91bmROYXRQ
+      b29scy9ydWxlMjAwMCIsICJwcm9wZXJ0aWVzIjogeyJmcm9udGVuZFBvcnRSYW5nZVN0YXJ0Ijog
+      MjAwMCwgInByb3RvY29sIjogIlRjcCIsICJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQi
+      LCAiZnJvbnRlbmRQb3J0UmFuZ2VFbmQiOiAyOTk5LCAiYmFja2VuZFBvcnQiOiAyMDAwfX0sIHsi
+      cHJvcGVydGllcyI6IHsiZnJvbnRlbmRQb3J0UmFuZ2VTdGFydCI6IDMwMDAsICJwcm90b2NvbCI6
+      ICJ0Y3AiLCAiZnJvbnRlbmRQb3J0UmFuZ2VFbmQiOiAzOTk5LCAiYmFja2VuZFBvcnQiOiAzMDAw
+      fSwgIm5hbWUiOiAicnVsZTMwMDAifV0sICJyZXNvdXJjZUd1aWQiOiAiZjgxNjg2ZjItMGRiNC00
+      Yjk5LWI0YWItZTE0ZGRhZjk1ZmQ5IiwgImxvYWRCYWxhbmNpbmdSdWxlcyI6IFtdfSwgImlkIjog
+      Ii9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNv
+      dXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vy
+      cy9sYjEifQ==
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Length: ['2173']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [8e2e8e9a-494e-11e6-a2ef-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o9mnO9P9bDbdzvPpZHt/mj3cnnx6P9/eOd/ZeTjb2T+4/+n09/1I
+        X2yvVzyaG7rS1mU1zTA8vHGVN+3afEE4r/K6LfKGvmI6yYeXRUPNi+XF6zZruaPX6+k0z2f5TN6k
+        ZpYIayHk+cHupwefnu9t78wm+9v7k4eE/3422c53QcXzh/fPZw/ty+d1tWzz5ezs5Um1PC8u1jUj
+        CDS+J01Sgw8eO3vPvdE9A4zTpcUIz8/ppN4dGtXdG9H+uowgD6asN4/y4KtbzKY81Li4pCZnL49L
+        wzNf5O28YqI+vaZZKKbdV9aTspjSG7MZUbDXP7X4IU5JB5m8uftSP6Hp+cjH65e4P+yv+sv3dYAf
+        TbLpW5pNBfayqkoMbyN/UjeTfEUtfSr9MCnQZ8rIKPB5BM2fMyZ0bXUK7C92Lty4CMSrdcmdfM9+
+        TR1MOh8Vy0m1Xs5eZG2/ebVuh790LzKx8J18E5/ymgDs7uzsBLT4OZ3xzgDuRjH8OZtsDwo1Nirz
+        ZVW3r7LlRU5v1C29AYRvaAolSg0fPnwYNlSORzt83wNECLbVlJif8HozXUXZz77hjS2Y8j0C64/l
+        /31T3sPw/+1TDoRvaCpTvnfDlPcBEYIfPuX3CKw/lv/3TXkPw/+3TzkQvqGpTPm9G6a8D4gQvHHK
+        5Zfv4wf9/kv+H6S/Am8qDAAA
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/92f5a733-ca69-4e76-a841-094bb922bfd3?api-version=2016-03-30']
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:07:22 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [8ed4670a-494e-11e6-9d9c-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o9mnO9P9bDbdzvPpZHt/mj3cnnx6P9/eOd/ZeTjb2T+4/+n09/1I
+        X2yvVzyaG7rS1mU1zTA8vHGVN+3afEE4r/K6LfKGvmI6yYeXRUPNi+XF6zZruaPX6+k0z2f5TN6k
+        ZpYIayHk+cHupwefnu9t78wm+9v7k4eE/3422c53QcXzh/fPZw/ty+d1tWzz5ezs5Um1PC8u1jUj
+        CDS+J01Sgw8eO3vPvdE9A4zTpcUIz8/ppN4dGtXdG9H+uowgD6asN4/y4KtbzKY81Li4pCZnL49L
+        wzNf5O28YqI+vaZZKKbdV9aTspjSG7MZUbDXP7X4IU5JB5m8uftSP6Hp+cjH65e4P+yv+sv3dYAf
+        TbLpW5pNBfayqkoMbyN/UjeTfEUtfSr9MCnQZ8rIKPB5BM2fMyZ0bXUK7C92Lty4CMSrdcmdfM9+
+        TR1MOh8Vy0m1Xs5eZG2/ebVuh790LzKx8J18E5/ymgDs7uzsBLT4OZ3xzgDuRjH8OZtsDwo1Nirz
+        ZVW3r7LlRU5v1C29AYRvaAolSg0fPnwYNlSORzt83wNECLbVlJif8HozXUXZz77hjS2Y8j0C64/l
+        /31T3sPw/+1TDoRvaCpTvnfDlPcBEYIfPuX3CKw/lv/3TXkPw/+3TzkQvqGpTPm9G6a8D4gQvHHK
+        5Zfv4wf9/kv+H6S/Am8qDAAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:07:23 GMT']
+      ETag: [W/"d60c4adc-eecb-4ca9-b65e-0f009d04856c"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2075,14 +1506,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [5320d7b4-4518-11e6-97e1-a0b3ccf7272a]
+      x-ms-client-request-id: [8f130822-494e-11e6-bd69-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -2092,19 +1523,155 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o0/3Hk4+PZ8+2N47mO5u7386ybcf7kz3tyfT3Z3dB5NPs72d3d/3
-        I32xvV7xaG7oSluX1TTD8PDGVd60a/MF4bzK67bIG/qK6SQfXhYNNS+WF6/brOWOXq+n0zyf5TN5
-        k5pZIqyFkPf2H+7vPphm25P80/vb+w/u39ue3L+/s73z8N79T+8/+HR/tvPAvnxeV8s2X87OXp5U
-        y/PiYl0zgkDje9IkNfjgsbP33BvdM8A4XVqM8PycTurdoVHdvRHtr8sI8mDKevMoD766xWzKQ42L
-        S2py9vK4NDzzRd7OKybq02uahWLafWU9KYspvTGbEQV7/VOLH+KUdJDJm7sv9ROano98vH6J+8P+
-        qr98Xwf40SSbvqXZVGAvq6rE8DbyJ3UzyVfU0qfSD5MCfaaMjAKfR9D8OWNC11anwP5i58KNi0C8
-        Wpfcyffs19TBpPNRsZxU6+XsRdb2m1frdvhL9yITi7/DV4TSL/l/AGOJusRMBgAA
+        J1mZLaf43qGQt9kFkPju3d/3o9mnO9P9bDbdzvPpZHt/mj3cnnx6P9/eOd/ZeTjb2T+4/+n09/1I
+        X2yvVzyaG7rS1mU1zTA8vHGVN+3afEE4r/K6LfKGvmI6yYeXRUPNi+XF6zZruaPX6+k0z2f5TN6k
+        ZpYIayHk+cHupwefnu9t78wm+9v7k4eE/3422c53QcXzh/fPZw/ty+d1tWzz5ezs5Um1PC8u1jUj
+        CDS+J01Sgw8eO3vPvdE9A4zTpcUIz8/ppN4dGtXdG9H+uowgD6asN4/y4KtbzKY81Li4pCZnL49L
+        wzNf5O28YqI+vaZZKKbdV9aTspjSG7MZUbDXP7X4IU5JB5m8uftSP6Hp+cjH65e4P+yv+sv3dYAf
+        TbLpW5pNBfayqkoMbyN/UjeTfEUtfSr9MCnQZ8rIKPB5BM2fMyZ0bXUK7C92Lty4CMSrdcmdfM9+
+        TR1MOh8Vy0m1Xs5eZG2/ebVuh790LzKx8J18E5/ymgDs7uzsBLT4OZ3xzgDuRjH8OZtsDwo1Nirz
+        ZVW3r7LlRU5v1C29AYRvaAolSg0fPnwYNlSORzt83wNECLbVlJif8HozXUXZz77hjS2Y8j0C64/l
+        /31T3sPw/+1TDoRvaCpTvnfDlPcBEYIfPuX3CKw/lv/3TXkPw/+3TzkQvqGpTPm9G6a8D4gQvHHK
+        5Zfv4wf9/kv+H6S/Am8qDAAA
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:05 GMT']
-      ETag: [W/"629b6fc7-28c1-46be-90c4-bc1017b6a201"]
+      Date: ['Wed, 13 Jul 2016 23:07:23 GMT']
+      ETag: [W/"d60c4adc-eecb-4ca9-b65e-0f009d04856c"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJldGFnIjogIlcvXCJkNjBjNGFkYy1lZWNiLTRjYTktYjY1ZS0wZjAwOWQwNDg1NmNcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9udGVu
+      ZElQQ29uZmlndXJhdGlvbnMiOiBbeyJldGFnIjogIlcvXCJkNjBjNGFkYy1lZWNiLTRjYTktYjY1
+      ZS0wZjAwOWQwNDg1NmNcIiIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1Ymxp
+      Y0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
+      YzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQu
+      TmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9QdWJsaWNJUGxiMSJ9fSwgImlkIjogIi9zdWJzY3Jp
+      cHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vw
+      cy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJv
+      bnRlbmRJUENvbmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNlckZyb250RW5kIiwgIm5hbWUiOiAiTG9h
+      ZEJhbGFuY2VyRnJvbnRFbmQifV0sICJvdXRib3VuZE5hdFJ1bGVzIjogW10sICJwcm92aXNpb25p
+      bmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAiaW5ib3VuZE5hdFJ1bGVzIjogW10sICJiYWNrZW5kQWRk
+      cmVzc1Bvb2xzIjogW3siZXRhZyI6ICJXL1wiZDYwYzRhZGMtZWVjYi00Y2E5LWI2NWUtMGYwMDlk
+      MDQ4NTZjXCIiLCAibmFtZSI6ICJsYjFiZXBvb2wiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIx
+      ZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3By
+      b3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVz
+      c1Bvb2xzL2xiMWJlcG9vbCIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQifX1dLCAiaW5ib3VuZE5hdFBvb2xzIjogW3siZXRhZyI6ICJXL1wiZDYwYzRhZGMt
+      ZWVjYi00Y2E5LWI2NWUtMGYwMDlkMDQ4NTZjXCIiLCAibmFtZSI6ICJydWxlMTAwMCIsICJpZCI6
+      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
+      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNl
+      cnMvbGIxL2luYm91bmROYXRQb29scy9ydWxlMTAwMCIsICJwcm9wZXJ0aWVzIjogeyJmcm9udGVu
+      ZFBvcnRSYW5nZVN0YXJ0IjogMTAwMCwgInByb3RvY29sIjogInVkcCIsICJwcm92aXNpb25pbmdT
+      dGF0ZSI6ICJTdWNjZWVkZWQiLCAiZnJvbnRlbmRQb3J0UmFuZ2VFbmQiOiAxOTk5LCAiYmFja2Vu
+      ZFBvcnQiOiA1MH19LCB7ImV0YWciOiAiVy9cImQ2MGM0YWRjLWVlY2ItNGNhOS1iNjVlLTBmMDA5
+      ZDA0ODU2Y1wiIiwgIm5hbWUiOiAicnVsZTIwMDAiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIx
+      ZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3By
+      b3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9pbmJvdW5kTmF0UG9v
+      bHMvcnVsZTIwMDAiLCAicHJvcGVydGllcyI6IHsiZnJvbnRlbmRQb3J0UmFuZ2VTdGFydCI6IDIw
+      MDAsICJwcm90b2NvbCI6ICJUY3AiLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwg
+      ImZyb250ZW5kUG9ydFJhbmdlRW5kIjogMjk5OSwgImJhY2tlbmRQb3J0IjogMjAwMH19LCB7ImV0
+      YWciOiAiVy9cImQ2MGM0YWRjLWVlY2ItNGNhOS1iNjVlLTBmMDA5ZDA0ODU2Y1wiIiwgIm5hbWUi
+      OiAicnVsZTMwMDAiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
+      YzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQu
+      TmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9pbmJvdW5kTmF0UG9vbHMvcnVsZTMwMDAiLCAicHJv
+      cGVydGllcyI6IHsiZnJvbnRlbmRQb3J0UmFuZ2VTdGFydCI6IDMwMDAsICJwcm90b2NvbCI6ICJU
+      Y3AiLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImZyb250ZW5kUG9ydFJhbmdl
+      RW5kIjogMzk5OSwgImJhY2tlbmRQb3J0IjogMzAwMH19XSwgInJlc291cmNlR3VpZCI6ICJmODE2
+      ODZmMi0wZGI0LTRiOTktYjRhYi1lMTRkZGFmOTVmZDkiLCAibG9hZEJhbGFuY2luZ1J1bGVzIjog
+      W119LCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5Mjcy
+      ZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9s
+      b2FkQmFsYW5jZXJzL2xiMSJ9
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Length: ['2412']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [8f527f4a-494e-11e6-8e75-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o4cPdyc72fnB9t7B7NPt/Z2D6fbBw3yyPct2H+4/yPcnD/YPft+P
+        9MX2esWjuaErbV1W0wzDwxtXedOuzReE8yqv2yJv6Cumk3x4WTTUvFhevG6zljt6vZ5O83yWz+RN
+        amaJsBZCnh/sfnrw6fne9s5ssr+9P3n4cHuyn022811Q8fzh/fPZQ/vyeV0t23w5O3t5Ui3Pi4t1
+        zQgCje9Jk9Tgg8fO3nNvdM8A43RpMcLzczqpd4dGdfdGtL8uI8iDKevNozz46hazKQ81Li6pydnL
+        49LwzBd5O6+YqE+vaRaKafeV9aQspvTGbEYU7PVPLX6IU9JBJm/uvtRPaHo+8vH6Je4P+6v+8n0d
+        4EeTbPqWZlOBvayqEsPbyJ/UzSRfUUufSj9MCvSZMjIKfB5B8+eMCV1bnQL7i50LNy4C8Wpdciff
+        s19TB5POR8VyUq2XsxdZ229erdvhL92LTCx8J9/Ep7wmALs7OzsBLX5OZ7wzgLtRDH/OJtuDQo2N
+        ynxZ1e2rbHmR0xt1S28A4RuaQolSw4cPH4YNlePRjr6/3wFD6LXVlFifsPpqtooyn33DG1kw4XuE
+        nT+S//dNeA/D/7dPOBC+oalM+N4NE94HRAjaKX8z/ZpTfo/A+mP5f9+U9zD8f/uUA+EbmsqU37th
+        yvuACMEbp1x++T5+0O+/5P8B30GsQygMAAA=
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/4bdc9a8c-97f1-4d93-b4a6-cf73cdccd5bd?api-version=2016-03-30']
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:07:24 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [8ff80aec-494e-11e6-bb4e-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o4cPdyc72fnB9t7B7NPt/Z2D6fbBw3yyPct2H+4/yPcnD/YPft+P
+        9MX2esWjuaErbV1W0wzDwxtXedOuzReE8yqv2yJv6Cumk3x4WTTUvFhevG6zljt6vZ5O83yWz+RN
+        amaJsBZCnh/sfnrw6fne9s5ssr+9P3n4cHuyn022811Q8fzh/fPZQ/vyeV0t23w5O3t5Ui3Pi4t1
+        zQgCje9Jk9Tgg8fO3nNvdM8A43RpMcLzczqpd4dGdfdGtL8uI8iDKevNozz46hazKQ81Li6pydnL
+        49LwzBd5O6+YqE+vaRaKafeV9aQspvTGbEYU7PVPLX6IU9JBJm/uvtRPaHo+8vH6Je4P+6v+8n0d
+        4EeTbPqWZlOBvayqEsPbyJ/UzSRfUUufSj9MCvSZMjIKfB5B8+eMCV1bnQL7i50LNy4C8Wpdciff
+        s19TB5POR8VyUq2XsxdZ229erdvhL92LTCx8J9/Ep7wmALs7OzsBLX5OZ7wzgLtRDH/OJtuDQo2N
+        ynxZ1e2rbHmR0xt1S28A4RuaQolSw4cPH4YNlePRjr6/3wFD6LXVlFifsPpqtooyn33DG1kw4XuE
+        nT+S//dNeA/D/7dPOBC+oalM+N4NE94HRAjaKX8z/ZpTfo/A+mP5f9+U9zD8f/uUA+EbmsqU37th
+        yvuACMEbp1x++T5+0O+/5P8B30GsQygMAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:07:25 GMT']
+      ETag: [W/"991b0af8-28d6-408c-89eb-da1947e4b748"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2116,14 +1683,447 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [535a290c-4518-11e6-9bf0-a0b3ccf7272a]
+      x-ms-client-request-id: [90373e92-494e-11e6-9c48-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o4cPdyc72fnB9t7B7NPt/Z2D6fbBw3yyPct2H+4/yPcnD/YPft+P
+        9MX2esWjuaErbV1W0wzDwxtXedOuzReE8yqv2yJv6Cumk3x4WTTUvFhevG6zljt6vZ5O83yWz+RN
+        amaJsBZCnh/sfnrw6fne9s5ssr+9P3n4cHuyn022811Q8fzh/fPZQ/vyeV0t23w5O3t5Ui3Pi4t1
+        zQgCje9Jk9Tgg8fO3nNvdM8A43RpMcLzczqpd4dGdfdGtL8uI8iDKevNozz46hazKQ81Li6pydnL
+        49LwzBd5O6+YqE+vaRaKafeV9aQspvTGbEYU7PVPLX6IU9JBJm/uvtRPaHo+8vH6Je4P+6v+8n0d
+        4EeTbPqWZlOBvayqEsPbyJ/UzSRfUUufSj9MCvSZMjIKfB5B8+eMCV1bnQL7i50LNy4C8Wpdciff
+        s19TB5POR8VyUq2XsxdZ229erdvhL92LTCx8J9/Ep7wmALs7OzsBLX5OZ7wzgLtRDH/OJtuDQo2N
+        ynxZ1e2rbHmR0xt1S28A4RuaQolSw4cPH4YNlePRjr6/3wFD6LXVlFifsPpqtooyn33DG1kw4XuE
+        nT+S//dNeA/D/7dPOBC+oalM+N4NE94HRAjaKX8z/ZpTfo/A+mP5f9+U9zD8f/uUA+EbmsqU37th
+        yvuACMEbp1x++T5+0O+/5P8B30GsQygMAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:07:25 GMT']
+      ETag: [W/"991b0af8-28d6-408c-89eb-da1947e4b748"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJldGFnIjogIlcvXCI5OTFiMGFmOC0yOGQ2LTQwOGMtODllYi1kYTE5NDdlNGI3NDhcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9udGVu
+      ZElQQ29uZmlndXJhdGlvbnMiOiBbeyJldGFnIjogIlcvXCI5OTFiMGFmOC0yOGQ2LTQwOGMtODll
+      Yi1kYTE5NDdlNGI3NDhcIiIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1Ymxp
+      Y0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
+      YzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQu
+      TmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9QdWJsaWNJUGxiMSJ9fSwgImlkIjogIi9zdWJzY3Jp
+      cHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vw
+      cy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJv
+      bnRlbmRJUENvbmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNlckZyb250RW5kIiwgIm5hbWUiOiAiTG9h
+      ZEJhbGFuY2VyRnJvbnRFbmQifV0sICJvdXRib3VuZE5hdFJ1bGVzIjogW10sICJwcm92aXNpb25p
+      bmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAiaW5ib3VuZE5hdFJ1bGVzIjogW10sICJiYWNrZW5kQWRk
+      cmVzc1Bvb2xzIjogW3siZXRhZyI6ICJXL1wiOTkxYjBhZjgtMjhkNi00MDhjLTg5ZWItZGExOTQ3
+      ZTRiNzQ4XCIiLCAibmFtZSI6ICJsYjFiZXBvb2wiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIx
+      ZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3By
+      b3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVz
+      c1Bvb2xzL2xiMWJlcG9vbCIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQifX1dLCAiaW5ib3VuZE5hdFBvb2xzIjogW3siZXRhZyI6ICJXL1wiOTkxYjBhZjgt
+      MjhkNi00MDhjLTg5ZWItZGExOTQ3ZTRiNzQ4XCIiLCAibmFtZSI6ICJydWxlMjAwMCIsICJpZCI6
+      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
+      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNl
+      cnMvbGIxL2luYm91bmROYXRQb29scy9ydWxlMjAwMCIsICJwcm9wZXJ0aWVzIjogeyJmcm9udGVu
+      ZFBvcnRSYW5nZVN0YXJ0IjogMjAwMCwgInByb3RvY29sIjogIlRjcCIsICJwcm92aXNpb25pbmdT
+      dGF0ZSI6ICJTdWNjZWVkZWQiLCAiZnJvbnRlbmRQb3J0UmFuZ2VFbmQiOiAyOTk5LCAiYmFja2Vu
+      ZFBvcnQiOiAyMDAwfX0sIHsiZXRhZyI6ICJXL1wiOTkxYjBhZjgtMjhkNi00MDhjLTg5ZWItZGEx
+      OTQ3ZTRiNzQ4XCIiLCAibmFtZSI6ICJydWxlMzAwMCIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8w
+      YjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcv
+      cHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2luYm91bmROYXRQ
+      b29scy9ydWxlMzAwMCIsICJwcm9wZXJ0aWVzIjogeyJmcm9udGVuZFBvcnRSYW5nZVN0YXJ0Ijog
+      MzAwMCwgInByb3RvY29sIjogIlRjcCIsICJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQi
+      LCAiZnJvbnRlbmRQb3J0UmFuZ2VFbmQiOiAzOTk5LCAiYmFja2VuZFBvcnQiOiAzMDAwfX1dLCAi
+      cmVzb3VyY2VHdWlkIjogImY4MTY4NmYyLTBkYjQtNGI5OS1iNGFiLWUxNGRkYWY5NWZkOSIsICJs
+      b2FkQmFsYW5jaW5nUnVsZXMiOiBbXX0sICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0x
+      YmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJz
+      L01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxIn0=
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Length: ['2033']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [90724966-494e-11e6-bd23-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o+z++WTv3sMH27OdbLa9nz+4t53t5ve27+X3Z3sP73366WR67/f9
+        SF9sr1c8mhu60tZlNc0wPLxxlTft2nxBOK/yui3yhr5iOsmHl0VDzYvlxes2a7mj1+vpNM9n+Uze
+        pGaWCGsh5PnB7qcHn57vbe/MJvvb+5OHD7cn+9lkO98FFc8f3j+fPbQvn9fVss2Xs7OXJ9XyvLhY
+        14wg0PieNEkNPnjs7D33RvcMME6XFiM8P6eTendoVHdvRPvrMoI8mLLePMqDr24xm/JQ4+KSmpy9
+        PC4Nz3yRt/OKifr0mmahmHZfWU/KYkpvzGZEwV7/1OKHOCUdZPLm7kv9hKbnIx+vX+L+sL/qL9/X
+        AX40yaZvaTYV2MuqKjG8jfxJ3UzyFbX0qfTDpECfKSOjwOcRNH/OmNC11Smwv9i5cOMiEK/WJXfy
+        Pfs1dTDpfFQsJ9V6OXuRtf3m1bod/tK9yMTCd/JNfMprArC3s7MT0OLndMY7A7gbxfDnbLI9KNTY
+        qMyXVd2+ypYXOb1Rt/QGEL6hKZQoNXz48GHYUDke7fB9DxAh2FZTYn7C6810FWU/+4Y3tmDK7xFY
+        fyz/75vyHob/b59yIHxDU5nyezdMeR8QIXjjlMsv38cP+v2X/D8Qr7yWNwoAAA==
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/4dcbe629-7b26-4959-983c-a96fc2f9f543?api-version=2016-03-30']
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:07:25 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9117a362-494e-11e6-ba45-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o+z++WTv3sMH27OdbLa9nz+4t53t5ve27+X3Z3sP73366WR67/f9
+        SF9sr1c8mhu60tZlNc0wPLxxlTft2nxBOK/yui3yhr5iOsmHl0VDzYvlxes2a7mj1+vpNM9n+Uze
+        pGaWCGsh5PnB7qcHn57vbe/MJvvb+5OHD7cn+9lkO98FFc8f3j+fPbQvn9fVss2Xs7OXJ9XyvLhY
+        14wg0PieNEkNPnjs7D33RvcMME6XFiM8P6eTendoVHdvRPvrMoI8mLLePMqDr24xm/JQ4+KSmpy9
+        PC4Nz3yRt/OKifr0mmahmHZfWU/KYkpvzGZEwV7/1OKHOCUdZPLm7kv9hKbnIx+vX+L+sL/qL9/X
+        AX40yaZvaTYV2MuqKjG8jfxJ3UzyFbX0qfTDpECfKSOjwOcRNH/OmNC11Smwv9i5cOMiEK/WJXfy
+        Pfs1dTDpfFQsJ9V6OXuRtf3m1bod/tK9yMTCd/JNfMprArC3s7MT0OLndMY7A7gbxfDnbLI9KNTY
+        qMyXVd2+ypYXOb1Rt/QGEL6hKZQoNXz48GHYUDke7fB9DxAh2FZTYn7C6810FWU/+4Y3tmDK7xFY
+        fyz/75vyHob/b59yIHxDU5nyezdMeR8QIXjjlMsv38cP+v2X/D8Qr7yWNwoAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:07:27 GMT']
+      ETag: [W/"a5fb2397-d0ad-4e73-a1e3-3e5d29366bc3"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJldGFnIjogIlcvXCJhNWZiMjM5Ny1kMGFkLTRlNzMtYTFlMy0zZTVkMjkzNjZiYzNcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9udGVu
+      ZElQQ29uZmlndXJhdGlvbnMiOiBbeyJldGFnIjogIlcvXCJhNWZiMjM5Ny1kMGFkLTRlNzMtYTFl
+      My0zZTVkMjkzNjZiYzNcIiIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1Ymxp
+      Y0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
+      YzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQu
+      TmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9QdWJsaWNJUGxiMSJ9fSwgImlkIjogIi9zdWJzY3Jp
+      cHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vw
+      cy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJv
+      bnRlbmRJUENvbmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNlckZyb250RW5kIiwgIm5hbWUiOiAiTG9h
+      ZEJhbGFuY2VyRnJvbnRFbmQifV0sICJvdXRib3VuZE5hdFJ1bGVzIjogW10sICJwcm92aXNpb25p
+      bmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAiaW5ib3VuZE5hdFJ1bGVzIjogW10sICJiYWNrZW5kQWRk
+      cmVzc1Bvb2xzIjogW3siZXRhZyI6ICJXL1wiYTVmYjIzOTctZDBhZC00ZTczLWExZTMtM2U1ZDI5
+      MzY2YmMzXCIiLCAibmFtZSI6ICJsYjFiZXBvb2wiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIx
+      ZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3By
+      b3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVz
+      c1Bvb2xzL2xiMWJlcG9vbCIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQifX1dLCAiaW5ib3VuZE5hdFBvb2xzIjogW3siZXRhZyI6ICJXL1wiYTVmYjIzOTct
+      ZDBhZC00ZTczLWExZTMtM2U1ZDI5MzY2YmMzXCIiLCAibmFtZSI6ICJydWxlMzAwMCIsICJpZCI6
+      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
+      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNl
+      cnMvbGIxL2luYm91bmROYXRQb29scy9ydWxlMzAwMCIsICJwcm9wZXJ0aWVzIjogeyJmcm9udGVu
+      ZFBvcnRSYW5nZVN0YXJ0IjogMzAwMCwgInByb3RvY29sIjogIlRjcCIsICJwcm92aXNpb25pbmdT
+      dGF0ZSI6ICJTdWNjZWVkZWQiLCAiZnJvbnRlbmRQb3J0UmFuZ2VFbmQiOiAzOTk5LCAiYmFja2Vu
+      ZFBvcnQiOiAzMDAwfX1dLCAicmVzb3VyY2VHdWlkIjogImY4MTY4NmYyLTBkYjQtNGI5OS1iNGFi
+      LWUxNGRkYWY5NWZkOSIsICJsb2FkQmFsYW5jaW5nUnVsZXMiOiBbXX0sICJpZCI6ICIvc3Vic2Ny
+      aXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91
+      cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxIn0=
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Length: ['1652']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9150be64-494e-11e6-8799-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o/296WR68CDf3jnfz7b3s/xge7Lz6c72p/m9hw8/zT799NNs9/f9
+        SF9sr1c8mhu60tZlNc0wPLxxlTft2nxBOK/yui3yhr5iOsmHl0VDzYvlxes2a7mj1+vpNM9n+Uze
+        pGaWCGsh5PnB7qcHn57vbe/MJvvb+5OHD7cn+9lkO98FFc8f3j+fPbQvn9fVss2Xs7OXJ9XyvLhY
+        14wg0PieNEkNPnjs7D33RvcMME6XFiM8P6eTendoVHdvRPvrMoI8mLLePMqDr24xm/JQ4+KSmpy9
+        PC4Nz3yRt/OKifr0mmahmHZfWU/KYkpvzGZEwV7/1OKHOCUdZPLm7kv9hKbnIx+vX+L+sL/qL9/X
+        AX40yaZvaTYV2MuqKjG8jfxJ3UzyFbX0qfTDpECfKSOjwOcRNH/OmNC11Smwv9i5cOMiEK/WJXfy
+        Pfs1dTDpfFQsJ9V6OXuRtf3m1bod/tK9yMTCd/JNfMprAnBvZ2cnoMXP6Yx3BnA3iuHP2WR7UKix
+        UZkvq7p9lS0vcnqjbukNIHxDUyhRavjw4cOwoXI82uH7HiBCsK2mxPyE15vpahP74Qf9/kv+H8D5
+        X7pECAAA
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/bdeb5c33-9710-40ee-a613-ebd163461421?api-version=2016-03-30']
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:07:27 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [91f8078a-494e-11e6-a89b-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o/296WR68CDf3jnfz7b3s/xge7Lz6c72p/m9hw8/zT799NNs9/f9
+        SF9sr1c8mhu60tZlNc0wPLxxlTft2nxBOK/yui3yhr5iOsmHl0VDzYvlxes2a7mj1+vpNM9n+Uze
+        pGaWCGsh5PnB7qcHn57vbe/MJvvb+5OHD7cn+9lkO98FFc8f3j+fPbQvn9fVss2Xs7OXJ9XyvLhY
+        14wg0PieNEkNPnjs7D33RvcMME6XFiM8P6eTendoVHdvRPvrMoI8mLLePMqDr24xm/JQ4+KSmpy9
+        PC4Nz3yRt/OKifr0mmahmHZfWU/KYkpvzGZEwV7/1OKHOCUdZPLm7kv9hKbnIx+vX+L+sL/qL9/X
+        AX40yaZvaTYV2MuqKjG8jfxJ3UzyFbX0qfTDpECfKSOjwOcRNH/OmNC11Smwv9i5cOMiEK/WJXfy
+        Pfs1dTDpfFQsJ9V6OXuRtf3m1bod/tK9yMTCd/JNfMprAnBvZ2cnoMXP6Yx3BnA3iuHP2WR7UKix
+        UZkvq7p9lS0vcnqjbukNIHxDUyhRavjw4cOwoXI82uH7HiBCsK2mxPyE15vpahP74Qf9/kv+H8D5
+        X7pECAAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:07:28 GMT']
+      ETag: [W/"42cbc87e-0f4a-4ae8-b060-6e3996a666a1"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJldGFnIjogIlcvXCI0MmNiYzg3ZS0wZjRhLTRhZTgtYjA2MC02ZTM5OTZhNjY2YTFcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9udGVu
+      ZElQQ29uZmlndXJhdGlvbnMiOiBbeyJldGFnIjogIlcvXCI0MmNiYzg3ZS0wZjRhLTRhZTgtYjA2
+      MC02ZTM5OTZhNjY2YTFcIiIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1Ymxp
+      Y0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
+      YzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQu
+      TmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9QdWJsaWNJUGxiMSJ9fSwgImlkIjogIi9zdWJzY3Jp
+      cHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vw
+      cy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJv
+      bnRlbmRJUENvbmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNlckZyb250RW5kIiwgIm5hbWUiOiAiTG9h
+      ZEJhbGFuY2VyRnJvbnRFbmQifV0sICJvdXRib3VuZE5hdFJ1bGVzIjogW10sICJwcm92aXNpb25p
+      bmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAiaW5ib3VuZE5hdFJ1bGVzIjogW10sICJiYWNrZW5kQWRk
+      cmVzc1Bvb2xzIjogW3siZXRhZyI6ICJXL1wiNDJjYmM4N2UtMGY0YS00YWU4LWIwNjAtNmUzOTk2
+      YTY2NmExXCIiLCAibmFtZSI6ICJsYjFiZXBvb2wiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIx
+      ZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3By
+      b3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVz
+      c1Bvb2xzL2xiMWJlcG9vbCIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQifX1dLCAiaW5ib3VuZE5hdFBvb2xzIjogW10sICJyZXNvdXJjZUd1aWQiOiAiZjgx
+      Njg2ZjItMGRiNC00Yjk5LWI0YWItZTE0ZGRhZjk1ZmQ5IiwgImxvYWRCYWxhbmNpbmdSdWxlcyI6
+      IFtdfSwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3
+      MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsv
+      bG9hZEJhbGFuY2Vycy9sYjEifQ==
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Length: ['1273']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [92390162-494e-11e6-bae2-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o4NJtv9gtv9gO/90Sj3f39nffrh/MNn+9N40+/Tg4N7ew3vZ7/uR
+        vther3g0N3SlrctqmmF4eOMqb9q1+YJwXuV1W+QNfcV0kg8vi4aaF8uL123Wckev19Npns/ymbxJ
+        zSwR1kLI84PdTw8+Pd/b3plN9rf3Jw8fbk/2s8l2vgsqnj+8fz57aF8+r6tlmy9nZy9PquV5cbGu
+        GUGg8T1pkhp88NjZe+6N7hlgnC4tRnh+Tif17tCo7t6I9tdlBHkwZb15lAdf3WI25aHGxSU1OXt5
+        XBqe+SJv5xUT9ek1zUIx7b6ynpTFlN6YzYiCvf6pxQ9xSjrI5M3dl/oJTc9HPl6/xP1hf9Vfvq8D
+        /GiSTd/SbCqwl1VVYngb+ZO6meQraulT6YdJgT5TRkaBzyNo/pwxoWurU2B/sXPhxkUgXq1L7uR7
+        9mvqYNL5qFhOqvVy9iJr+82rdTv8pXuRicXf4StC6Zf8PzoC84BMBgAA
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/1f7529b8-3348-4643-89f0-6344cd6705a9?api-version=2016-03-30']
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:07:29 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [92dd8f1a-494e-11e6-b71c-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o4NJtv9gtv9gO/90Sj3f39nffrh/MNn+9N40+/Tg4N7ew3vZ7/uR
+        vther3g0N3SlrctqmmF4eOMqb9q1+YJwXuV1W+QNfcV0kg8vi4aaF8uL123Wckev19Npns/ymbxJ
+        zSwR1kLI84PdTw8+Pd/b3plN9rf3Jw8fbk/2s8l2vgsqnj+8fz57aF8+r6tlmy9nZy9PquV5cbGu
+        GUGg8T1pkhp88NjZe+6N7hlgnC4tRnh+Tif17tCo7t6I9tdlBHkwZb15lAdf3WI25aHGxSU1OXt5
+        XBqe+SJv5xUT9ek1zUIx7b6ynpTFlN6YzYiCvf6pxQ9xSjrI5M3dl/oJTc9HPl6/xP1hf9Vfvq8D
+        /GiSTd/SbCqwl1VVYngb+ZO6meQraulT6YdJgT5TRkaBzyNo/pwxoWurU2B/sXPhxkUgXq1L7uR7
+        9mvqYNL5qFhOqvVy9iJr+82rdTv8pXuRicXf4StC6Zf8PzoC84BMBgAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:07:30 GMT']
+      ETag: [W/"8ba47d47-e6c0-4504-948b-63ca6883293a"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9324e836-494e-11e6-acd9-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o4NJtv9gtv9gO/90Sj3f39nffrh/MNn+9N40+/Tg4N7ew3vZ7/uR
+        vther3g0N3SlrctqmmF4eOMqb9q1+YJwXuV1W+QNfcV0kg8vi4aaF8uL123Wckev19Npns/ymbxJ
+        zSwR1kLI84PdTw8+Pd/b3plN9rf3Jw8fbk/2s8l2vgsqnj+8fz57aF8+r6tlmy9nZy9PquV5cbGu
+        GUGg8T1pkhp88NjZe+6N7hlgnC4tRnh+Tif17tCo7t6I9tdlBHkwZb15lAdf3WI25aHGxSU1OXt5
+        XBqe+SJv5xUT9ek1zUIx7b6ynpTFlN6YzYiCvf6pxQ9xSjrI5M3dl/oJTc9HPl6/xP1hf9Vfvq8D
+        /GiSTd/SbCqwl1VVYngb+ZO6meQraulT6YdJgT5TRkaBzyNo/pwxoWurU2B/sXPhxkUgXq1L7uR7
+        9mvqYNL5qFhOqvVy9iJr+82rdTv8pXuRicXf4StC6Zf8PzoC84BMBgAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:07:31 GMT']
+      ETag: [W/"8ba47d47-e6c0-4504-948b-63ca6883293a"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [93f71f62-494e-11e6-bac0-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/publicIPAddresses/publicip1?api-version=2016-03-30
   response:
@@ -2133,17 +2133,17 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9aLWelMW0WO1+NOLPixk+vdusJ820LlZtUS2buzuT3fNP9x/sbu9Ozne292ezbDvL
         p/e2p5OHew/2znce3n+4c7fOm2pdT/PP62q9au6Wk6a+uLuqq8tiltfN3S+KaV011Xk7fpG3V1X9
-        9q50ffbyeDajd5u80U8cMnmbXQCd7979fT96+GByb+8g29k+mB7c297P7u9tP5zen2zvZrP9/fOd
-        bC/ff/D7fqQvttcrHt0tOtU3ymqaYbB46ypv2rX5gkawyuu2oJaPUqadfHhZNNS8WF68brOWO3u9
-        nk7zfJbP5E1qRj0ISdZC1v297N75LpHw092cxjDZm24f7O4+2L53vkfknJ5nnz6c2pc7mP4kEZE6
-        BJizl5f7/WalGcIXeTuvuL+n1zTNhQNZzMr8TbHIq3V7tvyiWK5bHtU+vv4lv3HyS/4fP929NBsC
-        AAA=
+        9q50ffbyeDajd5u80U8cMnmbXQCd7979fT/an+1Nz2efTrbvP5xOt/d3sp3th3uTh9uf5g8fzu4/
+        mO3v701/34/0xfZ6xaO7Raf6RllNMwwWb13lTbs2X9AIVnndFtTyUcq0kw8vi4aaF8uL123Wcmev
+        19Npns/ymbxJzagHIclayPrw3vl5tjc52N4/OH+4vX//Xr59sHP+6fbk4NPp/d0Hebazc25f7mD6
+        k0RE6hBgzl5e7veblWYIX+TtvOL+nl7TNBdT27aYlfmbYpFX6/Zs+UWxXLc8qn18/Ut+4+SX/D/7
+        FrzOGwIAAA==
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:06 GMT']
-      ETag: [W/"97b328a0-8c83-4a52-9c5b-1ad44f0a2e47"]
+      Date: ['Wed, 13 Jul 2016 23:07:31 GMT']
+      ETag: [W/"4d2cfd6b-59cc-40a0-92b9-6e99d57d442c"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2152,42 +2152,42 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9u
-      dGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJuYW1lIjogIkxvYWRCYWxhbmNlckZyb250RW5kIiwg
-      InByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJwcml2YXRl
-      SVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVibGljSVBBZGRyZXNzIjogeyJpZCI6
-      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
-      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3B1YmxpY0lQQWRk
-      cmVzc2VzL1B1YmxpY0lQbGIxIn19LCAiZXRhZyI6ICJXL1wiNjI5YjZmYzctMjhjMS00NmJlLTkw
-      YzQtYmMxMDE3YjZhMjAxXCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00
-      ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNy
-      b3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMv
-      TG9hZEJhbGFuY2VyRnJvbnRFbmQifSwgeyJuYW1lIjogImlwY29uZmlnMSIsICJwcm9wZXJ0aWVz
-      IjogeyJwcml2YXRlSVBBbGxvY2F0aW9uTWV0aG9kIjogImR5bmFtaWMiLCAicHVibGljSVBBZGRy
-      ZXNzIjogeyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHVibGljSVBBbGxv
-      Y2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVk
-      IiwgImlkbGVUaW1lb3V0SW5NaW51dGVzIjogNCwgInJlc291cmNlR3VpZCI6ICI0MmEzZjFmMC02
-      MWUzLTRiMmMtODExNy0zZjJlYzNjZmE2OWMiLCAicHVibGljSVBBZGRyZXNzVmVyc2lvbiI6ICJJ
-      UHY0In0sICJldGFnIjogIlcvXCI5N2IzMjhhMC04YzgzLTRhNTItOWM1Yi0xYWQ0NGYwYTJlNDdc
-      IiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJm
-      MDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3B1
-      YmxpY0lQQWRkcmVzc2VzL3B1YmxpY2lwMSJ9fX1dLCAicmVzb3VyY2VHdWlkIjogIjM0OTQxN2Nh
-      LWJlNjUtNDc1My1iNTUwLTA5MzU2NTc2NGQwNyIsICJvdXRib3VuZE5hdFJ1bGVzIjogW10sICJs
-      b2FkQmFsYW5jaW5nUnVsZXMiOiBbXSwgInByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIs
-      ICJpbmJvdW5kTmF0UnVsZXMiOiBbXSwgImluYm91bmROYXRQb29scyI6IFtdLCAiYmFja2VuZEFk
-      ZHJlc3NQb29scyI6IFt7Im5hbWUiOiAibGIxYmVwb29sIiwgInByb3BlcnRpZXMiOiB7InByb3Zp
-      c2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCJ9LCAiZXRhZyI6ICJXL1wiNjI5YjZmYzctMjhjMS00
-      NmJlLTkwYzQtYmMxMDE3YjZhMjAxXCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEt
-      MWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVy
-      cy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVzc1Bvb2xz
-      L2xiMWJlcG9vbCJ9XX0sICJldGFnIjogIlcvXCI2MjliNmZjNy0yOGMxLTQ2YmUtOTBjNC1iYzEw
-      MTdiNmEyMDFcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVj
+      eyJldGFnIjogIlcvXCI4YmE0N2Q0Ny1lNmMwLTQ1MDQtOTQ4Yi02M2NhNjg4MzI5M2FcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9udGVu
+      ZElQQ29uZmlndXJhdGlvbnMiOiBbeyJldGFnIjogIlcvXCI4YmE0N2Q0Ny1lNmMwLTQ1MDQtOTQ4
+      Yi02M2NhNjg4MzI5M2FcIiIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1Ymxp
+      Y0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
+      YzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQu
+      TmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9QdWJsaWNJUGxiMSJ9fSwgImlkIjogIi9zdWJzY3Jp
+      cHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vw
+      cy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJv
+      bnRlbmRJUENvbmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNlckZyb250RW5kIiwgIm5hbWUiOiAiTG9h
+      ZEJhbGFuY2VyRnJvbnRFbmQifSwgeyJwcm9wZXJ0aWVzIjogeyJwcml2YXRlSVBBbGxvY2F0aW9u
+      TWV0aG9kIjogImR5bmFtaWMiLCAicHVibGljSVBBZGRyZXNzIjogeyJldGFnIjogIlcvXCI0ZDJj
+      ZmQ2Yi01OWNjLTQwYTAtOTJiOS02ZTk5ZDU3ZDQ0MmNcIiIsICJsb2NhdGlvbiI6ICJ3ZXN0dXMi
+      LCAicHJvcGVydGllcyI6IHsicHVibGljSVBBZGRyZXNzVmVyc2lvbiI6ICJJUHY0IiwgImlkbGVU
+      aW1lb3V0SW5NaW51dGVzIjogNCwgInJlc291cmNlR3VpZCI6ICI5M2ZmYTJiOC00OGY5LTQ1M2Ut
+      ODBmNi1iODZjNTE3ZWEwMGYiLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgInB1
+      YmxpY0lQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIn0sICJpZCI6ICIvc3Vic2NyaXB0aW9u
+      cy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJz
+      cmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3B1YmxpY0lQQWRkcmVzc2VzL3B1YmxpY2lw
+      MSJ9fSwgIm5hbWUiOiAiaXBjb25maWcxIn1dLCAib3V0Ym91bmROYXRSdWxlcyI6IFtdLCAicHJv
+      dmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImluYm91bmROYXRSdWxlcyI6IFtdLCAiYmFj
+      a2VuZEFkZHJlc3NQb29scyI6IFt7ImV0YWciOiAiVy9cIjhiYTQ3ZDQ3LWU2YzAtNDUwNC05NDhi
+      LTYzY2E2ODgzMjkzYVwiIiwgIm5hbWUiOiAibGIxYmVwb29sIiwgImlkIjogIi9zdWJzY3JpcHRp
+      b25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9s
+      YnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvYmFja2Vu
+      ZEFkZHJlc3NQb29scy9sYjFiZXBvb2wiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3Rh
+      dGUiOiAiU3VjY2VlZGVkIn19XSwgImluYm91bmROYXRQb29scyI6IFtdLCAicmVzb3VyY2VHdWlk
+      IjogImY4MTY4NmYyLTBkYjQtNGI5OS1iNGFiLWUxNGRkYWY5NWZkOSIsICJsb2FkQmFsYW5jaW5n
+      UnVsZXMiOiBbXX0sICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVj
       My1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5O
       ZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxIn0=
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Length: ['1793']
       Content-Type: [application/json; charset=utf-8]
@@ -2195,7 +2195,7 @@ interactions:
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [53974d3e-4518-11e6-9260-a0b3ccf7272a]
+      x-ms-client-request-id: [94365540-494e-11e6-b1e9-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -2205,20 +2205,186 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o/uz2cF+dm9v++Dg/N72/s69+9sH0/PJdv7pvU8f7j3cn93PJ7/v
+        J1mZLaf43qGQt9kFkPju3d/3o2x3/8Hs3mS6vbM3+3R7P9+7t/3wPJtunx/ce3DvwcPzyb2Dh7/v
         R/pie73i0dzQlbYuq2mG4eGNq7xp1+YLwnmV122RN/QV00k+vCwaal4sL163WcsdvV5Pp3k+y2fy
-        JjWzRFgLIe/tP9zffTDNtif5p/e39x/cv7c9uX9/Z3vn4b37n95/8On+bOeBffm8rpZtvpydvTyp
-        lufFxbpmBIHG96RJavDBY2fvuTe6Z4BxurQY4fk5ndS7Q6O6eyPaX5cR5MGU9eZRHnx1i9mUhxoX
-        l9Tk7OVxaXjmi7ydV0zUp9c0C8W0+8p6UhZTemM2Iwr2+qcWP8Qp6SCTN3df6ic0PR/5eP0S94f9
-        9ZfYkXlDsKxXrKY8qSq78vwwB/ce/BbH9UdM9o3MQwcZYjL5pFjdgsXkl+/r8D6aZNO3NIEK6mVV
-        lRjcRhVIEz/JV9TSp9EPc/x9PoyMAp9H0Pw5Y0HXVqfA/mLnwo2LQLxal9zJ9+zX1MGk81GxnFTr
-        5exF1vabV+t2+Ev3IhOLv8NXhNIv+X8ABmrrdK8IAAA=
+        JjWzRFgLIc8Pdj89+PR8b3tnNtnf3p88fLg92c8m2/kuqHj+8P757KF9+byulm2+nJ29PKmW58XF
+        umYEgcb3pElq8MFjZ++5N7pngHG6tBjh+Tmd1LtDo7p7I9pflxHkwZT15lEefHWL2ZSHGheX1OTs
+        5XFpeOaLvJ1XTNSn1zQLxbT7ynpSFlN6YzYjCvb6pxY/xCnpIJM3d1/qJzQ9H/l4/RL3h/31l9iR
+        eUOwrFespjypKrvy/DAH9x78Fsf1R0z2jcxDBxliMvmkWN2CxeSX7+vwPppk07c0gQrqZVWVGNxG
+        FUgTP8lX1NKn0Q9z/H0+jIwCn0fQ/DljQddWp8D+YufCjYtAvFqX3Mn37NfUwaTzUbGcVOvl7EXW
+        9ptX63b4S/ciE4u/w1eE0i/5fwBpBVl7rwgAAA==
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/ab93fdee-30ea-4c34-b7a7-c7a1d858a607?api-version=2016-03-30']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/5e53a18f-e75a-4b8a-9e19-08cef064b54f?api-version=2016-03-30']
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:06 GMT']
+      Date: ['Wed, 13 Jul 2016 23:07:32 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [94e16e26-494e-11e6-891f-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o2x3/8Hs3mS6vbM3+3R7P9+7t/3wPJtunx/ce3DvwcPzyb2Dh7/v
+        R/pie73i0dzQlbYuq2mG4eGNq7xp1+YLwnmV122RN/QV00k+vCwaal4sL163WcsdvV5Pp3k+y2fy
+        JjWzRFgLIc8Pdj89+PR8b3tnNtnf3p88fLg92c8m2/kuqHj+8P757KF9+byulm2+nJ29PKmW58XF
+        umYEgcb3pElq8MFjZ++5N7pngHG6tBjh+Tmd1LtDo7p7I9pflxHkwZT15lEefHWL2ZSHGheX1OTs
+        5XFpeOaLvJ1XTNSn1zQLxbT7ynpSFlN6YzYjCvb6pxY/xCnpIJM3d1/qJzQ9H/l4/RL3h/31l9iR
+        eUOwrFespjypKrvy/DAH9x78Fsf1R0z2jcxDBxliMvmkWN2CxeSX7+vwPppk07c0gQrqZVWVGNxG
+        FUgTP8lX1NKn0Q9z/H0+jIwCn0fQ/DljQddWp8D+YufCjYtAvFqX3Mn37NfUwaTzUbGcVOvl7EXW
+        9ptX63b4S/ciE4u/w1eE0i/5fwBpBVl7rwgAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:07:33 GMT']
+      ETag: [W/"a147d3bc-02d6-4e23-9fac-f837379fb389"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9515c650-494e-11e6-befb-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/publicIPAddresses/publicip2?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9aLWelMW0WO19NOLPixk+vdusJ820LlZtUS2buzuT3fNP9x/sbu9Ozne292ezbDvL
+        p/e2p5OHew/2znce3n+4c7fOm2pdT/PP62q9au6Wk6a+uLuqq8tiltfN3S+KaV011Xk7fpG3V1X9
+        9q50ffbyeDajd5u80U8cMnmbXQCd7979fT+6t7d/b7azd749259Ntvd3du5vHzyY7G5P83z300n+
+        aT7ZefD7fqQvttcrHt0tOtU3ymqaYbB46ypv2rX5gkawyuu2oJaPUqadfHhZNNS8WF68brOWO3u9
+        nhIys3wmb1Iz6kFIshay3j+/N93Zvf9w+3x/b297/97uve2H+9lsO9uf3v90ure7vzvJ7MsdTH+S
+        iEgdAszZy8v9frPSDOGLvJ1X3N/Ta5rmYmrbFrMyf1Ms8mrdni2/KJbrlke1j69/yW+c/JL/B3ck
+        xK8bAgAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:07:33 GMT']
+      ETag: [W/"3243d02f-d4db-4005-87b1-cee16be6eb07"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJldGFnIjogIlcvXCJhMTQ3ZDNiYy0wMmQ2LTRlMjMtOWZhYy1mODM3Mzc5ZmIzODlcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9udGVu
+      ZElQQ29uZmlndXJhdGlvbnMiOiBbeyJldGFnIjogIlcvXCJhMTQ3ZDNiYy0wMmQ2LTRlMjMtOWZh
+      Yy1mODM3Mzc5ZmIzODlcIiIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1Ymxp
+      Y0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
+      YzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQu
+      TmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9QdWJsaWNJUGxiMSJ9fSwgImlkIjogIi9zdWJzY3Jp
+      cHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vw
+      cy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJv
+      bnRlbmRJUENvbmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNlckZyb250RW5kIiwgIm5hbWUiOiAiTG9h
+      ZEJhbGFuY2VyRnJvbnRFbmQifSwgeyJldGFnIjogIlcvXCJhMTQ3ZDNiYy0wMmQ2LTRlMjMtOWZh
+      Yy1mODM3Mzc5ZmIzODlcIiIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1Ymxp
+      Y0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
+      YzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQu
+      TmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9wdWJsaWNpcDEifX0sICJpZCI6ICIvc3Vic2NyaXB0
+      aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMv
+      bGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250
+      ZW5kSVBDb25maWd1cmF0aW9ucy9pcGNvbmZpZzEiLCAibmFtZSI6ICJpcGNvbmZpZzEifSwgeyJw
+      cm9wZXJ0aWVzIjogeyJwcml2YXRlSVBBbGxvY2F0aW9uTWV0aG9kIjogImR5bmFtaWMiLCAicHVi
+      bGljSVBBZGRyZXNzIjogeyJldGFnIjogIlcvXCIzMjQzZDAyZi1kNGRiLTQwMDUtODdiMS1jZWUx
+      NmJlNmViMDdcIiIsICJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHVibGlj
+      SVBBZGRyZXNzVmVyc2lvbiI6ICJJUHY0IiwgImlkbGVUaW1lb3V0SW5NaW51dGVzIjogNCwgInJl
+      c291cmNlR3VpZCI6ICI1ZjNjMDE1OS1mNDIyLTQzMTMtOTRhZC1hNGM1NmMyMTQxYmEiLCAicHJv
+      dmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgInB1YmxpY0lQQWxsb2NhdGlvbk1ldGhvZCI6
+      ICJEeW5hbWljIn0sICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVj
+      My1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5O
+      ZXR3b3JrL3B1YmxpY0lQQWRkcmVzc2VzL3B1YmxpY2lwMiJ9fSwgIm5hbWUiOiAiaXBjb25maWcy
+      In1dLCAib3V0Ym91bmROYXRSdWxlcyI6IFtdLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2Vl
+      ZGVkIiwgImluYm91bmROYXRSdWxlcyI6IFtdLCAiYmFja2VuZEFkZHJlc3NQb29scyI6IFt7ImV0
+      YWciOiAiVy9cImExNDdkM2JjLTAyZDYtNGUyMy05ZmFjLWY4MzczNzlmYjM4OVwiIiwgIm5hbWUi
+      OiAibGIxYmVwb29sIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1h
+      ZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0
+      Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvYmFja2VuZEFkZHJlc3NQb29scy9sYjFiZXBvb2wi
+      LCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn19XSwgImlu
+      Ym91bmROYXRQb29scyI6IFtdLCAicmVzb3VyY2VHdWlkIjogImY4MTY4NmYyLTBkYjQtNGI5OS1i
+      NGFiLWUxNGRkYWY5NWZkOSIsICJsb2FkQmFsYW5jaW5nUnVsZXMiOiBbXX0sICJpZCI6ICIvc3Vi
+      c2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VH
+      cm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIx
+      In0=
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Length: ['2282']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [95536010-494e-11e6-99d0-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o/2D+w8/fXA+297fz+iffHa+PZndn27f3znYfTC5f/Bg597O7/uR
+        vther3g0N3SlrctqmmF4eOMqb9q1+YJwXuV1W+QNfcV0kg8vi4aaF8uL123Wckev19Npns/ymbxJ
+        zSwR1kLI84PdTw8+Pd/b3plN9rf3Jw8fbk/2s8l2vgsqnj+8fz57aF8+r6tlmy9nZy9PquV5cbGu
+        GUGg8T1pkhp88NjZe+6N7hlgnC4tRnh+Tif17tCo7t6I9tdlBHkwZb15lAdf3WI25aHGxSU1OXt5
+        XBqe+SJv5xUT9ek1zUIx7b6ynpTFlN6YzYiCvf6pxQ9xSjrI5M3dl/oJTc9HPl6/xP1hf/0ldmTe
+        ECzrFaspT6rKrjw/zMG9B7/Fcf0Rk30j89BBhphMPilW3xSL7fnD/2EO7WuwWIjrj1jsG5mHDjIe
+        i+3dzGLyy/d1eB9NsulbmkAF9bKqSgxuo5WliZ/kK2rp0+iHOf4+H0ZGgc8jaP6csaBrq1Ngf7Fz
+        4cZFIF6tS+7ke/Zr6mDS+ahYTqr1cvYia/vNq3U7/KV7kYnF3+ErQumX/D+SC5bREgsAAA==
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/58308b47-27fc-48fa-be4b-8648cf904bea?api-version=2016-03-30']
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:07:34 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2231,14 +2397,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [543b0494-4518-11e6-99d4-a0b3ccf7272a]
+      x-ms-client-request-id: [95f900ae-494e-11e6-a6ac-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -2248,20 +2414,20 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o/uz2cF+dm9v++Dg/N72/s69+9sH0/PJdv7pvU8f7j3cn93PJ7/v
-        R/pie73i0dzQlbYuq2mG4eGNq7xp1+YLwnmV122RN/QV00k+vCwaal4sL163WcsdvV5Pp3k+y2fy
-        JjWzRFgLIe/tP9zffTDNtif5p/e39x/cv7c9uX9/Z3vn4b37n95/8On+bOeBffm8rpZtvpydvTyp
-        lufFxbpmBIHG96RJavDBY2fvuTe6Z4BxurQY4fk5ndS7Q6O6eyPaX5cR5MGU9eZRHnx1i9mUhxoX
-        l9Tk7OVxaXjmi7ydV0zUp9c0C8W0+8p6UhZTemM2Iwr2+qcWP8Qp6SCTN3df6ic0PR/5eP0S94f9
-        9ZfYkXlDsKxXrKY8qSq78vwwB/ce/BbH9UdM9o3MQwcZYjL5pFjdgsXkl+/r8D6aZNO3NIEK6mVV
-        lRjcRhVIEz/JV9TSp9EPc/x9PoyMAp9H0Pw5Y0HXVqfA/mLnwo2LQLxal9zJ9+zX1MGk81GxnFTr
-        5exF1vabV+t2+Ev3IhOLv8NXhNIv+X8ABmrrdK8IAAA=
+        J1mZLaf43qGQt9kFkPju3d/3o/2D+w8/fXA+297fz+iffHa+PZndn27f3znYfTC5f/Bg597O7/uR
+        vther3g0N3SlrctqmmF4eOMqb9q1+YJwXuV1W+QNfcV0kg8vi4aaF8uL123Wckev19Npns/ymbxJ
+        zSwR1kLI84PdTw8+Pd/b3plN9rf3Jw8fbk/2s8l2vgsqnj+8fz57aF8+r6tlmy9nZy9PquV5cbGu
+        GUGg8T1pkhp88NjZe+6N7hlgnC4tRnh+Tif17tCo7t6I9tdlBHkwZb15lAdf3WI25aHGxSU1OXt5
+        XBqe+SJv5xUT9ek1zUIx7b6ynpTFlN6YzYiCvf6pxQ9xSjrI5M3dl/oJTc9HPl6/xP1hf/0ldmTe
+        ECzrFaspT6rKrjw/zMG9B7/Fcf0Rk30j89BBhphMPilW3xSL7fnD/2EO7WuwWIjrj1jsG5mHDjIe
+        i+3dzGLyy/d1eB9NsulbmkAF9bKqSgxuo5WliZ/kK2rp0+iHOf4+H0ZGgc8jaP6csaBrq1Ngf7Fz
+        4cZFIF6tS+7ke/Zr6mDS+ahYTqr1cvYia/vNq3U7/KV7kYnF3+ErQumX/D+SC5bREgsAAA==
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:07 GMT']
-      ETag: [W/"5dd84a32-88f3-4035-8cfb-e6369294d5eb"]
+      Date: ['Wed, 13 Jul 2016 23:07:35 GMT']
+      ETag: [W/"485967fd-44ad-4edf-bd5c-50817b587030"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2273,180 +2439,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [54704fd0-4518-11e6-9e69-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/publicIPAddresses/publicip2?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9aLWelMW0WO19NOLPixk+vdusJ820LlZtUS2buzuT3fNP9x/sbu9Ozne292ezbDvL
-        p/e2p5OHew/2znce3n+4c7fOm2pdT/PP62q9au6Wk6a+uLuqq8tiltfN3S+KaV011Xk7fpG3V1X9
-        9q50ffbyeDajd5u80U8cMnmbXQCd7979fT/a37u3m93LJts7Dx8cbO/fe7i3TchMts8/nU13pp+e
-        TwiP3/cjfbG9XvHobtGpvlFW0wyDxVtXedOuzRc0glVetwW1fJQy7eTDy6Kh5sXy4nWbtdzZ6/V0
-        muezfCZvUjPqQUiyFrLmO9mD+/k+0XHvIdFxZ2dvO5veu7+9d35w/2A2mUzv75/blzuY/iQRkToE
-        mLOXl/v9ZqUZwhd5O6+4v6fXNM3F1LYtZmX+pljk1bo9W35RLNctj2ofX/+S3zj5Jf8PvFviJRsC
-        AAA=
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:08 GMT']
-      ETag: [W/"4231a3ab-0978-4392-bf0b-f6dc0c6fb2f0"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9u
-      dGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJuYW1lIjogIkxvYWRCYWxhbmNlckZyb250RW5kIiwg
-      InByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJwcml2YXRl
-      SVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVibGljSVBBZGRyZXNzIjogeyJpZCI6
-      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
-      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3B1YmxpY0lQQWRk
-      cmVzc2VzL1B1YmxpY0lQbGIxIn19LCAiZXRhZyI6ICJXL1wiNWRkODRhMzItODhmMy00MDM1LThj
-      ZmItZTYzNjkyOTRkNWViXCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00
-      ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNy
-      b3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMv
-      TG9hZEJhbGFuY2VyRnJvbnRFbmQifSwgeyJuYW1lIjogImlwY29uZmlnMSIsICJwcm9wZXJ0aWVz
-      IjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlv
-      bk1ldGhvZCI6ICJEeW5hbWljIiwgInB1YmxpY0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlw
-      dGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBz
-      L2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9wdWJs
-      aWNpcDEifX0sICJldGFnIjogIlcvXCI1ZGQ4NGEzMi04OGYzLTQwMzUtOGNmYi1lNjM2OTI5NGQ1
-      ZWJcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjky
-      NzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3Jr
-      L2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9ucy9pcGNvbmZpZzEifSwg
-      eyJuYW1lIjogImlwY29uZmlnMiIsICJwcm9wZXJ0aWVzIjogeyJwcml2YXRlSVBBbGxvY2F0aW9u
-      TWV0aG9kIjogImR5bmFtaWMiLCAicHVibGljSVBBZGRyZXNzIjogeyJsb2NhdGlvbiI6ICJ3ZXN0
-      dXMiLCAicHJvcGVydGllcyI6IHsicHVibGljSVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFtaWMi
-      LCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImlkbGVUaW1lb3V0SW5NaW51dGVz
-      IjogNCwgInJlc291cmNlR3VpZCI6ICJlMGE3NWU0MS0xMjkwLTQwMDItYWMzNS0yZjg1OGRiYmM1
-      NGYiLCAicHVibGljSVBBZGRyZXNzVmVyc2lvbiI6ICJJUHY0In0sICJldGFnIjogIlcvXCI0MjMx
-      YTNhYi0wOTc4LTQzOTItYmYwYi1mNmRjMGM2ZmIyZjBcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9u
-      cy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJz
-      cmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3B1YmxpY0lQQWRkcmVzc2VzL3B1YmxpY2lw
-      MiJ9fX1dLCAicmVzb3VyY2VHdWlkIjogIjM0OTQxN2NhLWJlNjUtNDc1My1iNTUwLTA5MzU2NTc2
-      NGQwNyIsICJvdXRib3VuZE5hdFJ1bGVzIjogW10sICJsb2FkQmFsYW5jaW5nUnVsZXMiOiBbXSwg
-      InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJpbmJvdW5kTmF0UnVsZXMiOiBbXSwg
-      ImluYm91bmROYXRQb29scyI6IFtdLCAiYmFja2VuZEFkZHJlc3NQb29scyI6IFt7Im5hbWUiOiAi
-      bGIxYmVwb29sIiwgInByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRl
-      ZCJ9LCAiZXRhZyI6ICJXL1wiNWRkODRhMzItODhmMy00MDM1LThjZmItZTYzNjkyOTRkNWViXCIi
-      LCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5
-      NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2Fk
-      QmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVzc1Bvb2xzL2xiMWJlcG9vbCJ9XX0sICJldGFnIjog
-      IlcvXCI1ZGQ4NGEzMi04OGYzLTQwMzUtOGNmYi1lNjM2OTI5NGQ1ZWJcIiIsICJpZCI6ICIvc3Vi
-      c2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VH
-      cm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIx
-      In0=
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Length: ['2282']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [54af0302-4518-11e6-833c-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o4Pz+/sHs4MD6mrnYHv/fC/fPphO9rcn2fR8dze7f7Czf/D7fqQv
-        ttcrHs0NXWnrsppmGB7euMqbdm2+IJxXed0WeUNfMZ3kw8uioebF8uJ1m7Xc0ev1dJrns3wmb1Iz
-        S4S1EPLe/sP93QfTbHuSf3p/e//B/Xvbk/v3d7Z3Ht67/+n9B5/uz3Ye2JfP62rZ5svZ2cuTanle
-        XKxrRhBofE+apAYfPHb2nnujewYYp0uLEZ6f00m9OzSquzei/XUZQR5MWW8e5cFXt5hNeahxcUlN
-        zl4el4ZnvsjbecVEfXpNs1BMu6+sJ2UxpTdmM6Jgr39q8UOckg4yeXP3pX5C0/ORj9cvcX/YX3+J
-        HZk3BMt6xWrKk6qyK88Pc3DvwW9xXH/EZN/IPHSQISaTT4rVN8Vie/7wf5hD+xosFuL6Ixb7Ruah
-        g4zHYns3s5j88n0d3kdE7rc0gQrqZVWVGNxGK0sTP8lX1NKn0Q9z/H0+jIwCn0fQ/DljQddWp8D+
-        YufCjYtAvFqX3Mn37NfUwaTzUbGcVOvl7EXW9ptX63b4S/ciE4u/w1eE0i/5fwAn7xrmEgsAAA==
-    headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/83cda491-8444-46a1-a575-25573734e73c?api-version=2016-03-30']
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:08 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [55524828-4518-11e6-a19d-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o4Pz+/sHs4MD6mrnYHv/fC/fPphO9rcn2fR8dze7f7Czf/D7fqQv
-        ttcrHs0NXWnrsppmGB7euMqbdm2+IJxXed0WeUNfMZ3kw8uioebF8uJ1m7Xc0ev1dJrns3wmb1Iz
-        S4S1EPLe/sP93QfTbHuSf3p/e//B/Xvbk/v3d7Z3Ht67/+n9B5/uz3Ye2JfP62rZ5svZ2cuTanle
-        XKxrRhBofE+apAYfPHb2nnujewYYp0uLEZ6f00m9OzSquzei/XUZQR5MWW8e5cFXt5hNeahxcUlN
-        zl4el4ZnvsjbecVEfXpNs1BMu6+sJ2UxpTdmM6Jgr39q8UOckg4yeXP3pX5C0/ORj9cvcX/YX3+J
-        HZk3BMt6xWrKk6qyK88Pc3DvwW9xXH/EZN/IPHSQISaTT4rVN8Vie/7wf5hD+xosFuL6Ixb7Ruah
-        g4zHYns3s5j88n0d3kdE7rc0gQrqZVWVGNxGK0sTP8lX1NKn0Q9z/H0+jIwCn0fQ/DljQddWp8D+
-        YufCjYtAvFqX3Mn37NfUwaTzUbGcVOvl7EXW9ptX63b4S/ciE4u/w1eE0i/5fwAn7xrmEgsAAA==
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:09 GMT']
-      ETag: [W/"8f548d88-cb08-4f2e-8cb4-bacf11a58048"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [55840376-4518-11e6-b389-a0b3ccf7272a]
+      x-ms-client-request-id: [962db594-494e-11e6-a876-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/virtualnetworks/vnet1/subnets/subnet1?api-version=2016-03-30
   response:
@@ -2456,15 +2456,15 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qFlPlnm7+9GIPy1m+OwufdhM62LVFtWyubsz2T3/dP/B7vbu5Hxne382y7azfHpv
         ezp5uPdg73zn4f2HO3frvKnW9TT/vK7Wq+ZuOWnqi7ururosZnnd3P2imNZVU5234xd5e1XVb+9e
-        FnW7zkr9s7l7CTTuUs/0s9GfBq28zS6A2Hfv/r4fPZzO9mcP7xMie3vT7f3dWb798N7D3e39T+/d
-        z3d3872H92a/70f6IiGwyuu2yBt6nQcuH14WDQ2tWF68brOW6fB6PZ3m+SyfyZvULJvNaFDNyzo/
-        L96hye7OmP+7u7f/Edr8kt84+SX/D9BTUI1NAQAA
+        FnW7zkr9s7l7CTTuUs/0s9GfBq28zS6A2Hfv/r4fPfz03sGnU0Lk4P6D/e39vd1Pt7NPzyfb2f7k
+        /sH+3t6DB5P7v+9H+iIhsMrrtsgbep0HLh9eFg0NrVhevG6zlunwej2d5vksn8mb1CybzWhQzcs6
+        Py/eocnuzpj/u7u3/xHa/JLfOPkl/w8peSnFTQEAAA==
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:10 GMT']
-      ETag: [W/"9cd4d950-422c-41de-9391-4635e11e293d"]
+      Date: ['Wed, 13 Jul 2016 23:07:35 GMT']
+      ETag: [W/"96386cf0-8574-4216-a6fb-a4b5842277b5"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2473,57 +2473,57 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9u
-      dGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJuYW1lIjogIkxvYWRCYWxhbmNlckZyb250RW5kIiwg
-      InByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJwcml2YXRl
-      SVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVibGljSVBBZGRyZXNzIjogeyJpZCI6
-      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
-      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3B1YmxpY0lQQWRk
-      cmVzc2VzL1B1YmxpY0lQbGIxIn19LCAiZXRhZyI6ICJXL1wiOGY1NDhkODgtY2IwOC00ZjJlLThj
-      YjQtYmFjZjExYTU4MDQ4XCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00
-      ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNy
-      b3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMv
-      TG9hZEJhbGFuY2VyRnJvbnRFbmQifSwgeyJuYW1lIjogImlwY29uZmlnMSIsICJwcm9wZXJ0aWVz
-      IjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlv
-      bk1ldGhvZCI6ICJEeW5hbWljIiwgInB1YmxpY0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlw
-      dGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBz
-      L2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9wdWJs
-      aWNpcDEifX0sICJldGFnIjogIlcvXCI4ZjU0OGQ4OC1jYjA4LTRmMmUtOGNiNC1iYWNmMTFhNTgw
-      NDhcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjky
-      NzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3Jr
-      L2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9ucy9pcGNvbmZpZzEifSwg
-      eyJuYW1lIjogImlwY29uZmlnMiIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6
-      ICJTdWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1
-      YmxpY0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRh
-      LWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3Nv
-      ZnQuTmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9wdWJsaWNpcDIifX0sICJldGFnIjogIlcvXCI4
-      ZjU0OGQ4OC1jYjA4LTRmMmUtOGNiNC1iYWNmMTFhNTgwNDhcIiIsICJpZCI6ICIvc3Vic2NyaXB0
+      eyJldGFnIjogIlcvXCI0ODU5NjdmZC00NGFkLTRlZGYtYmQ1Yy01MDgxN2I1ODcwMzBcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9udGVu
+      ZElQQ29uZmlndXJhdGlvbnMiOiBbeyJldGFnIjogIlcvXCI0ODU5NjdmZC00NGFkLTRlZGYtYmQ1
+      Yy01MDgxN2I1ODcwMzBcIiIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1Ymxp
+      Y0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
+      YzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQu
+      TmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9QdWJsaWNJUGxiMSJ9fSwgImlkIjogIi9zdWJzY3Jp
+      cHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vw
+      cy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJv
+      bnRlbmRJUENvbmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNlckZyb250RW5kIiwgIm5hbWUiOiAiTG9h
+      ZEJhbGFuY2VyRnJvbnRFbmQifSwgeyJldGFnIjogIlcvXCI0ODU5NjdmZC00NGFkLTRlZGYtYmQ1
+      Yy01MDgxN2I1ODcwMzBcIiIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1Ymxp
+      Y0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
+      YzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQu
+      TmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9wdWJsaWNpcDEifX0sICJpZCI6ICIvc3Vic2NyaXB0
       aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMv
       bGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250
-      ZW5kSVBDb25maWd1cmF0aW9ucy9pcGNvbmZpZzIifSwgeyJuYW1lIjogImlwY29uZmlnMyIsICJw
-      cm9wZXJ0aWVzIjogeyJzdWJuZXQiOiB7Im5hbWUiOiAic3VibmV0MSIsICJwcm9wZXJ0aWVzIjog
-      eyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAiYWRkcmVzc1ByZWZpeCI6ICIxMC4w
-      LjAuMC8yNCJ9LCAiZXRhZyI6ICJXL1wiOWNkNGQ5NTAtNDIyYy00MWRlLTkzOTEtNDYzNWUxMWUy
-      OTNkXCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5
-      MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29y
-      ay92aXJ0dWFsTmV0d29ya3Mvdm5ldDEvc3VibmV0cy9zdWJuZXQxIn0sICJwcml2YXRlSVBBbGxv
-      Y2F0aW9uTWV0aG9kIjogInN0YXRpYyIsICJwcml2YXRlSVBBZGRyZXNzIjogIjEwLjAuMC45OSJ9
-      fV0sICJyZXNvdXJjZUd1aWQiOiAiMzQ5NDE3Y2EtYmU2NS00NzUzLWI1NTAtMDkzNTY1NzY0ZDA3
-      IiwgIm91dGJvdW5kTmF0UnVsZXMiOiBbXSwgImxvYWRCYWxhbmNpbmdSdWxlcyI6IFtdLCAicHJv
-      dmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImluYm91bmROYXRSdWxlcyI6IFtdLCAiaW5i
-      b3VuZE5hdFBvb2xzIjogW10sICJiYWNrZW5kQWRkcmVzc1Bvb2xzIjogW3sibmFtZSI6ICJsYjFi
-      ZXBvb2wiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn0s
-      ICJldGFnIjogIlcvXCI4ZjU0OGQ4OC1jYjA4LTRmMmUtOGNiNC1iYWNmMTFhNTgwNDhcIiIsICJp
-      ZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAv
-      cmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxh
-      bmNlcnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMvbGIxYmVwb29sIn1dfSwgImV0YWciOiAiVy9c
-      IjhmNTQ4ZDg4LWNiMDgtNGYyZS04Y2I0LWJhY2YxMWE1ODA0OFwiIiwgImlkIjogIi9zdWJzY3Jp
+      ZW5kSVBDb25maWd1cmF0aW9ucy9pcGNvbmZpZzEiLCAibmFtZSI6ICJpcGNvbmZpZzEifSwgeyJl
+      dGFnIjogIlcvXCI0ODU5NjdmZC00NGFkLTRlZGYtYmQ1Yy01MDgxN2I1ODcwMzBcIiIsICJwcm9w
+      ZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxs
+      b2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1YmxpY0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1
+      YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNl
+      R3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9wdWJsaWNJUEFkZHJlc3Nl
+      cy9wdWJsaWNpcDIifX0sICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEt
+      YWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29m
+      dC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9ucy9pcGNv
+      bmZpZzIiLCAibmFtZSI6ICJpcGNvbmZpZzIifSwgeyJwcm9wZXJ0aWVzIjogeyJwcml2YXRlSVBB
+      ZGRyZXNzIjogIjEwLjAuMC45OSIsICJwcml2YXRlSVBBbGxvY2F0aW9uTWV0aG9kIjogInN0YXRp
+      YyIsICJzdWJuZXQiOiB7ImV0YWciOiAiVy9cIjk2Mzg2Y2YwLTg1NzQtNDIxNi1hNmZiLWE0YjU4
+      NDIyNzdiNVwiIiwgInByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRl
+      ZCIsICJhZGRyZXNzUHJlZml4IjogIjEwLjAuMC4wLzI0In0sICJpZCI6ICIvc3Vic2NyaXB0aW9u
+      cy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJz
+      cmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3ZpcnR1YWxOZXR3b3Jrcy92bmV0MS9zdWJu
+      ZXRzL3N1Ym5ldDEiLCAibmFtZSI6ICJzdWJuZXQxIn19LCAibmFtZSI6ICJpcGNvbmZpZzMifV0s
+      ICJvdXRib3VuZE5hdFJ1bGVzIjogW10sICJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQi
+      LCAiaW5ib3VuZE5hdFJ1bGVzIjogW10sICJiYWNrZW5kQWRkcmVzc1Bvb2xzIjogW3siZXRhZyI6
+      ICJXL1wiNDg1OTY3ZmQtNDRhZC00ZWRmLWJkNWMtNTA4MTdiNTg3MDMwXCIiLCAibmFtZSI6ICJs
+      YjFiZXBvb2wiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMt
+      Y2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0
+      d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVzc1Bvb2xzL2xiMWJlcG9vbCIsICJw
+      cm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQifX1dLCAiaW5ib3Vu
+      ZE5hdFBvb2xzIjogW10sICJyZXNvdXJjZUd1aWQiOiAiZjgxNjg2ZjItMGRiNC00Yjk5LWI0YWIt
+      ZTE0ZGRhZjk1ZmQ5IiwgImxvYWRCYWxhbmNpbmdSdWxlcyI6IFtdfSwgImlkIjogIi9zdWJzY3Jp
       cHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vw
       cy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEifQ==
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Length: ['2677']
       Content-Type: [application/json; charset=utf-8]
@@ -2531,7 +2531,7 @@ interactions:
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [55d7c2ba-4518-11e6-b6d9-a0b3ccf7272a]
+      x-ms-client-request-id: [967b1978-494e-11e6-ab8b-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -2544,7 +2544,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['275']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:10 GMT']
+      Date: ['Wed, 13 Jul 2016 23:07:36 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2556,14 +2556,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [567b7078-4518-11e6-bef7-a0b3ccf7272a]
+      x-ms-client-request-id: [971fdbe8-494e-11e6-b1fc-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -2573,20 +2573,20 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o4Pz+/sHs4MD6mrnYHv/fC/fPphO9rcn2fR8dze7f7Czf/D7fqQv
-        ttcrHs0NXWnrsppmGB7euMqbdm2+IJxXed0WeUNfMZ3kw8uioebF8uJ1m7Xc0ev1dJrns3wmb1Iz
-        S4S1EPLe/sP93QfTbHuSf3p/e//B/Xvbk/v3d7Z3Ht67/+n9B5/uz3Ye2JfP62rZ5svZ2cuTanle
-        XKxrRhBofE+apAYfPHb2nnujewYYp0uLEZ6f00m9OzSquzei/XUZQR5MWW8e5cFXt5hNeahxcUlN
-        zl4el4ZnvsjbecVEfXpNs1BMu6+sJ2UxpTdmM6Jgr39q8UOckg4yeXP3pX5C0/ORj9cvcX/YX3+J
-        HZk3BMt6xWrKk6qyK88Pc3DvwW9xXH/EZN/IPHSQISaTT4rVN8Vie/7wf5hD+xosFuL6Ixb7Ruah
-        g4zHYns3s5j88n0d3kdE7rc0gQrqZVWVGNxGK0sTP8lX1NKn0Q9z/H0+jIwCn0fQ/DljQddWp8D+
-        YufCjYtAvFqX3Mn37NfUwaTzUbGcVOvl7EXW9ptX63b4S/ciE4u/w1eE0i/5fwAn7xrmEgsAAA==
+        J1mZLaf43qGQt9kFkPju3d/3o/2D+w8/fXA+297fz+iffHa+PZndn27f3znYfTC5f/Bg597O7/uR
+        vther3g0N3SlrctqmmF4eOMqb9q1+YJwXuV1W+QNfcV0kg8vi4aaF8uL123Wckev19Npns/ymbxJ
+        zSwR1kLI84PdTw8+Pd/b3plN9rf3Jw8fbk/2s8l2vgsqnj+8fz57aF8+r6tlmy9nZy9PquV5cbGu
+        GUGg8T1pkhp88NjZe+6N7hlgnC4tRnh+Tif17tCo7t6I9tdlBHkwZb15lAdf3WI25aHGxSU1OXt5
+        XBqe+SJv5xUT9ek1zUIx7b6ynpTFlN6YzYiCvf6pxQ9xSjrI5M3dl/oJTc9HPl6/xP1hf/0ldmTe
+        ECzrFaspT6rKrjw/zMG9B7/Fcf0Rk30j89BBhphMPilW3xSL7fnD/2EO7WuwWIjrj1jsG5mHDjIe
+        i+3dzGLyy/d1eB9NsulbmkAF9bKqSgxuo5WliZ/kK2rp0+iHOf4+H0ZGgc8jaP6csaBrq1Ngf7Fz
+        4cZFIF6tS+7ke/Zr6mDS+ahYTqr1cvYia/vNq3U7/KV7kYnF3+ErQumX/D+SC5bREgsAAA==
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:11 GMT']
-      ETag: [W/"8f548d88-cb08-4f2e-8cb4-bacf11a58048"]
+      Date: ['Wed, 13 Jul 2016 23:07:37 GMT']
+      ETag: [W/"485967fd-44ad-4edf-bd5c-50817b587030"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2598,14 +2598,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [56bbbfd8-4518-11e6-b72c-a0b3ccf7272a]
+      x-ms-client-request-id: [975d527a-494e-11e6-b937-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -2615,20 +2615,20 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o4Pz+/sHs4MD6mrnYHv/fC/fPphO9rcn2fR8dze7f7Czf/D7fqQv
-        ttcrHs0NXWnrsppmGB7euMqbdm2+IJxXed0WeUNfMZ3kw8uioebF8uJ1m7Xc0ev1dJrns3wmb1Iz
-        S4S1EPLe/sP93QfTbHuSf3p/e//B/Xvbk/v3d7Z3Ht67/+n9B5/uz3Ye2JfP62rZ5svZ2cuTanle
-        XKxrRhBofE+apAYfPHb2nnujewYYp0uLEZ6f00m9OzSquzei/XUZQR5MWW8e5cFXt5hNeahxcUlN
-        zl4el4ZnvsjbecVEfXpNs1BMu6+sJ2UxpTdmM6Jgr39q8UOckg4yeXP3pX5C0/ORj9cvcX/YX3+J
-        HZk3BMt6xWrKk6qyK88Pc3DvwW9xXH/EZN/IPHSQISaTT4rVN8Vie/7wf5hD+xosFuL6Ixb7Ruah
-        g4zHYns3s5j88n0d3kdE7rc0gQrqZVWVGNxGK0sTP8lX1NKn0Q9z/H0+jIwCn0fQ/DljQddWp8D+
-        YufCjYtAvFqX3Mn37NfUwaTzUbGcVOvl7EXW9ptX63b4S/ciE4u/w1eE0i/5fwAn7xrmEgsAAA==
+        J1mZLaf43qGQt9kFkPju3d/3o/2D+w8/fXA+297fz+iffHa+PZndn27f3znYfTC5f/Bg597O7/uR
+        vther3g0N3SlrctqmmF4eOMqb9q1+YJwXuV1W+QNfcV0kg8vi4aaF8uL123Wckev19Npns/ymbxJ
+        zSwR1kLI84PdTw8+Pd/b3plN9rf3Jw8fbk/2s8l2vgsqnj+8fz57aF8+r6tlmy9nZy9PquV5cbGu
+        GUGg8T1pkhp88NjZe+6N7hlgnC4tRnh+Tif17tCo7t6I9tdlBHkwZb15lAdf3WI25aHGxSU1OXt5
+        XBqe+SJv5xUT9ek1zUIx7b6ynpTFlN6YzYiCvf6pxQ9xSjrI5M3dl/oJTc9HPl6/xP1hf/0ldmTe
+        ECzrFaspT6rKrjw/zMG9B7/Fcf0Rk30j89BBhphMPilW3xSL7fnD/2EO7WuwWIjrj1jsG5mHDjIe
+        i+3dzGLyy/d1eB9NsulbmkAF9bKqSgxuo5WliZ/kK2rp0+iHOf4+H0ZGgc8jaP6csaBrq1Ngf7Fz
+        4cZFIF6tS+7ke/Zr6mDS+ahYTqr1cvYia/vNq3U7/KV7kYnF3+ErQumX/D+SC5bREgsAAA==
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:11 GMT']
-      ETag: [W/"8f548d88-cb08-4f2e-8cb4-bacf11a58048"]
+      Date: ['Wed, 13 Jul 2016 23:07:37 GMT']
+      ETag: [W/"485967fd-44ad-4edf-bd5c-50817b587030"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2640,14 +2640,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [56f1cd8c-4518-11e6-9e38-a0b3ccf7272a]
+      x-ms-client-request-id: [97963a3a-494e-11e6-8902-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/publicIPAddresses/publicip3?api-version=2016-03-30
   response:
@@ -2657,17 +2657,17 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9aLWelMW0WN37aMSfFzN8erdZT5ppXazaolo2d3cmu+ef7j/Y3d6dnO9s789m2XaW
         T+9tTycP9x7sne88vP9w526dN9W6nuaf19V61dwtJ019cXdVV5fFLK+bu18U07pqqvN2/CJvr6r6
-        7V3p+uzl8WxG7zZ5o584ZPI2uwA63737+340m+w9eLDz6cPth+fT2fb+w3t725OHB9Ptezs7O9OH
-        93ZnD3d2f9+P9MX2esWju0Wn+kZZTTMMFm9d5U27Nl/QCFZ53RbU8lHKtJMPL4uGmhfLi9dt1nJn
-        r9fTaZ7P8pm8Sc2oByHJWsg6ze/dm832Hm4ffEqY7z88ONh++ODh3van+X7+4P45DWWa2Zc7mP4k
-        EZE6BJizl5f7/WalGcIXeTuvuL+n1zTNxdS2LWZl/qZY5NW6PVt+USzXLY9qH1//kt84+SX/D7ce
-        WX4bAgAA
+        7V3p+uzl8WxG7zZ5o584ZPI2uwA63737+350b//hvf38IN9+MNnf297f3d/Zfrh/sLt9cG96Lz+Y
+        zT7dP3jw+36kL7bXKx7dLTrVN8pqmmGweOsqb9q1+YJGsMrrtqCWj1KmnXx4WTTUvFhevG6zljt7
+        vZ5O83yWz+RNakY9CEnWQtb79yb5zsP9h9ufZue7RMfJwfZkOn24nc3u708+/XR3N79/377cwfQn
+        iYjUIcCcvbzc7zcrzRC+yNt5xf09vaZpLqa2bTEr8zfFIq/W7dnyi2K5bnlU+/j6l/zGyS/5fwAn
+        HrXUGwIAAA==
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:12 GMT']
-      ETag: [W/"db277069-9fcd-4932-b98c-3000c931d901"]
+      Date: ['Wed, 13 Jul 2016 23:07:38 GMT']
+      ETag: [W/"34934e8e-7b42-4140-9481-83c3e8dd6487"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2676,55 +2676,55 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9u
-      dGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJuYW1lIjogIkxvYWRCYWxhbmNlckZyb250RW5kIiwg
-      InByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJwcml2YXRl
-      SVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVibGljSVBBZGRyZXNzIjogeyJpZCI6
-      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
-      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3B1YmxpY0lQQWRk
-      cmVzc2VzL1B1YmxpY0lQbGIxIn19LCAiZXRhZyI6ICJXL1wiOGY1NDhkODgtY2IwOC00ZjJlLThj
-      YjQtYmFjZjExYTU4MDQ4XCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00
-      ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNy
-      b3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMv
-      TG9hZEJhbGFuY2VyRnJvbnRFbmQifSwgeyJuYW1lIjogImlwY29uZmlnMSIsICJwcm9wZXJ0aWVz
-      IjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlv
-      bk1ldGhvZCI6ICJEeW5hbWljIiwgInB1YmxpY0lQQWRkcmVzcyI6IHsibG9jYXRpb24iOiAid2Vz
-      dHVzIiwgInByb3BlcnRpZXMiOiB7InB1YmxpY0lQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWlj
-      IiwgInByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJpZGxlVGltZW91dEluTWludXRl
-      cyI6IDQsICJyZXNvdXJjZUd1aWQiOiAiY2UzM2RkMjktODY4Yy00OTg4LTk3OTItNmU0ZTc1ZjMw
-      MGNhIiwgInB1YmxpY0lQQWRkcmVzc1ZlcnNpb24iOiAiSVB2NCJ9LCAiZXRhZyI6ICJXL1wiZGIy
-      NzcwNjktOWZjZC00OTMyLWI5OGMtMzAwMGM5MzFkOTAxXCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlv
-      bnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xi
-      c3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9wdWJsaWNp
-      cDMifX0sICJldGFnIjogIlcvXCI4ZjU0OGQ4OC1jYjA4LTRmMmUtOGNiNC1iYWNmMTFhNTgwNDhc
-      IiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJm
-      MDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xv
-      YWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9ucy9pcGNvbmZpZzEifSwgeyJu
-      YW1lIjogImlwY29uZmlnMiIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      eyJldGFnIjogIlcvXCI0ODU5NjdmZC00NGFkLTRlZGYtYmQ1Yy01MDgxN2I1ODcwMzBcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9udGVu
+      ZElQQ29uZmlndXJhdGlvbnMiOiBbeyJldGFnIjogIlcvXCI0ODU5NjdmZC00NGFkLTRlZGYtYmQ1
+      Yy01MDgxN2I1ODcwMzBcIiIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
       dWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1Ymxp
       Y0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
       YzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQu
-      TmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9wdWJsaWNpcDIifX0sICJldGFnIjogIlcvXCI4ZjU0
-      OGQ4OC1jYjA4LTRmMmUtOGNiNC1iYWNmMTFhNTgwNDhcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9u
+      TmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9QdWJsaWNJUGxiMSJ9fSwgImlkIjogIi9zdWJzY3Jp
+      cHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vw
+      cy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJv
+      bnRlbmRJUENvbmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNlckZyb250RW5kIiwgIm5hbWUiOiAiTG9h
+      ZEJhbGFuY2VyRnJvbnRFbmQifSwgeyJldGFnIjogIlcvXCI0ODU5NjdmZC00NGFkLTRlZGYtYmQ1
+      Yy01MDgxN2I1ODcwMzBcIiIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1Ymxp
+      Y0lQQWRkcmVzcyI6IHsiZXRhZyI6ICJXL1wiMzQ5MzRlOGUtN2I0Mi00MTQwLTk0ODEtODNjM2U4
+      ZGQ2NDg3XCIiLCAibG9jYXRpb24iOiAid2VzdHVzIiwgInByb3BlcnRpZXMiOiB7InB1YmxpY0lQ
+      QWRkcmVzc1ZlcnNpb24iOiAiSVB2NCIsICJpZGxlVGltZW91dEluTWludXRlcyI6IDQsICJyZXNv
+      dXJjZUd1aWQiOiAiNTNiZTA5NDktNmFmMS00ZGI4LWJjYzktYWQ1NGI2NjExZTU1IiwgInByb3Zp
+      c2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJwdWJsaWNJUEFsbG9jYXRpb25NZXRob2QiOiAi
+      RHluYW1pYyJ9LCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMt
+      Y2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0
+      d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9wdWJsaWNpcDMifX0sICJpZCI6ICIvc3Vic2NyaXB0aW9u
       cy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJz
       cmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5k
-      SVBDb25maWd1cmF0aW9ucy9pcGNvbmZpZzIifV0sICJyZXNvdXJjZUd1aWQiOiAiMzQ5NDE3Y2Et
-      YmU2NS00NzUzLWI1NTAtMDkzNTY1NzY0ZDA3IiwgIm91dGJvdW5kTmF0UnVsZXMiOiBbXSwgImxv
-      YWRCYWxhbmNpbmdSdWxlcyI6IFtdLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwg
-      ImluYm91bmROYXRSdWxlcyI6IFtdLCAiaW5ib3VuZE5hdFBvb2xzIjogW10sICJiYWNrZW5kQWRk
-      cmVzc1Bvb2xzIjogW3sibmFtZSI6ICJsYjFiZXBvb2wiLCAicHJvcGVydGllcyI6IHsicHJvdmlz
-      aW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn0sICJldGFnIjogIlcvXCI4ZjU0OGQ4OC1jYjA4LTRm
-      MmUtOGNiNC1iYWNmMTFhNTgwNDhcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0x
-      YmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJz
-      L01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMv
-      bGIxYmVwb29sIn1dfSwgImV0YWciOiAiVy9cIjhmNTQ4ZDg4LWNiMDgtNGYyZS04Y2I0LWJhY2Yx
-      MWE1ODA0OFwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMz
+      SVBDb25maWd1cmF0aW9ucy9pcGNvbmZpZzEiLCAibmFtZSI6ICJpcGNvbmZpZzEifSwgeyJldGFn
+      IjogIlcvXCI0ODU5NjdmZC00NGFkLTRlZGYtYmQ1Yy01MDgxN2I1ODcwMzBcIiIsICJwcm9wZXJ0
+      aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2Nh
+      dGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1YmxpY0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNj
+      cmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3Jv
+      dXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9w
+      dWJsaWNpcDIifX0sICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVj
+      My1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5O
+      ZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9ucy9pcGNvbmZp
+      ZzIiLCAibmFtZSI6ICJpcGNvbmZpZzIifV0sICJvdXRib3VuZE5hdFJ1bGVzIjogW10sICJwcm92
+      aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAiaW5ib3VuZE5hdFJ1bGVzIjogW10sICJiYWNr
+      ZW5kQWRkcmVzc1Bvb2xzIjogW3siZXRhZyI6ICJXL1wiNDg1OTY3ZmQtNDRhZC00ZWRmLWJkNWMt
+      NTA4MTdiNTg3MDMwXCIiLCAibmFtZSI6ICJsYjFiZXBvb2wiLCAiaWQiOiAiL3N1YnNjcmlwdGlv
+      bnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xi
+      c3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5k
+      QWRkcmVzc1Bvb2xzL2xiMWJlcG9vbCIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0
+      ZSI6ICJTdWNjZWVkZWQifX1dLCAiaW5ib3VuZE5hdFBvb2xzIjogW10sICJyZXNvdXJjZUd1aWQi
+      OiAiZjgxNjg2ZjItMGRiNC00Yjk5LWI0YWItZTE0ZGRhZjk1ZmQ5IiwgImxvYWRCYWxhbmNpbmdS
+      dWxlcyI6IFtdfSwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMz
       LWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5l
       dHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEifQ==
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Length: ['2533']
       Content-Type: [application/json; charset=utf-8]
@@ -2732,7 +2732,7 @@ interactions:
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [573066d4-4518-11e6-9f45-a0b3ccf7272a]
+      x-ms-client-request-id: [97cd574a-494e-11e6-9fbd-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -2742,20 +2742,20 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o/2HO9T1p9n2w4MHn27v5/v59sOHk3vb+zs75/mMup/k93/fj/TF
-        9nrFo7mhK21dVtMMw8MbV3nTrs0XhPMqr9sib+grppN8eFk01LxYXrxus5Y7er2eTvN8ls/kTWpm
-        ibAWQt7bf7i/+2CabU/yT+9v7z+4f297cv/+zvbOw3v3P73/4NP92c4D+/J5XS3bfDk7e3lSLc+L
-        i3XNCAKN70mT1OCDx87ec290zwDjdGkxwvNzOql3h0Z190a0vy4jyIMp682jPPjqFrMpDzUuLqnJ
-        2cvj0vDMF3k7r5ioT69pFopp95X1pCym9MZsRhTs9U8tfohT0kEmb+6+1E9oej7y8fol7g/76y+x
-        I/OGYFmvWE15UlV25flhDu49+C2O64+Y7BuZhw4yxGTySbG69w2x2J4//B/m0L4Gi4W4/ojFvpF5
-        6CDjsdjezSwmv3xfh/fRJJu+pQlUUC+rqsTgNlpZmvhJvqKWPo1+mOPv82FkFPg8gubPGQu6tjoF
-        9hc7F25cBOLVuuROvme/pg4mnY+K5aRaL2cvsrbfvFq3w1+6F5lY/B2+IpR+yf8DjmyQoBILAAA=
+        J1mZLaf43qGQt9kFkPju3d/3o8mn9w8OJjv59r29B9Pt/ezTyXZ2bzrZnmZ7k7375/ce7px/+vt+
+        pC+21ysezQ1daeuymmYYHt64ypt2bb4gnFd53RZ5Q18xneTDy6Kh5sXy4nWbtdzR6/V0muezfCZv
+        UjNLhLUQ8vxg99ODT8/3tndmk/3t/cnDh9uT/Wyyne+CiucP75/PHtqXz+tq2ebL2dnLk2p5Xlys
+        a0YQaHxPmqQGHzx29p57o3sGGKdLixGen9NJvTs0qrs3ov11GUEeTFlvHuXBV7eYTXmocXFJTc5e
+        HpeGZ77I23nFRH16TbNQTLuvrCdlMaU3ZjOiYK9/avFDnJIOMnlz96V+QtPzkY/XL3F/2F9/iR2Z
+        NwTLesVqypOqsivPD3Nw78FvcVx/xGTfyDx0kCEmk0+K1b1viMX2/OH/MIf2NVgsxPVHLPaNzEMH
+        GY/F9m5mMfnl+zq8jybZ9C1NoIJ6WVUlBrfRytLET/IVtfRp9MMcf58PI6PA5xE0f85Y0LXVKbC/
+        2Llw4yIQr9Yld/I9+zV1MOl8VCwn1Xo5e5G1/ebVuh3+0r3IxOLv8BWh9Ev+H48r//wSCwAA
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/6c1086f1-65c1-4d94-b47a-d4e3404a9760?api-version=2016-03-30']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/41d10b08-708e-4fcd-b2d6-4c82928fe1c9?api-version=2016-03-30']
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:13 GMT']
+      Date: ['Wed, 13 Jul 2016 23:07:38 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2768,14 +2768,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [57d3d57a-4518-11e6-8791-a0b3ccf7272a]
+      x-ms-client-request-id: [9872df40-494e-11e6-9a07-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -2785,20 +2785,20 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o/2HO9T1p9n2w4MHn27v5/v59sOHk3vb+zs75/mMup/k93/fj/TF
-        9nrFo7mhK21dVtMMw8MbV3nTrs0XhPMqr9sib+grppN8eFk01LxYXrxus5Y7er2eTvN8ls/kTWpm
-        ibAWQt7bf7i/+2CabU/yT+9v7z+4f297cv/+zvbOw3v3P73/4NP92c4D+/J5XS3bfDk7e3lSLc+L
-        i3XNCAKN70mT1OCDx87ec290zwDjdGkxwvNzOql3h0Z190a0vy4jyIMp682jPPjqFrMpDzUuLqnJ
-        2cvj0vDMF3k7r5ioT69pFopp95X1pCym9MZsRhTs9U8tfohT0kEmb+6+1E9oej7y8fol7g/76y+x
-        I/OGYFmvWE15UlV25flhDu49+C2O64+Y7BuZhw4yxGTySbG69w2x2J4//B/m0L4Gi4W4/ojFvpF5
-        6CDjsdjezSwmv3xfh/fRJJu+pQlUUC+rqsTgNlpZmvhJvqKWPo1+mOPv82FkFPg8gubPGQu6tjoF
-        9hc7F25cBOLVuuROvme/pg4mnY+K5aRaL2cvsrbfvFq3w1+6F5lY/B2+IpR+yf8DjmyQoBILAAA=
+        J1mZLaf43qGQt9kFkPju3d/3o8mn9w8OJjv59r29B9Pt/ezTyXZ2bzrZnmZ7k7375/ce7px/+vt+
+        pC+21ysezQ1daeuymmYYHt64ypt2bb4gnFd53RZ5Q18xneTDy6Kh5sXy4nWbtdzR6/V0muezfCZv
+        UjNLhLUQ8vxg99ODT8/3tndmk/3t/cnDh9uT/Wyyne+CiucP75/PHtqXz+tq2ebL2dnLk2p5Xlys
+        a0YQaHxPmqQGHzx29p57o3sGGKdLixGen9NJvTs0qrs3ov11GUEeTFlvHuXBV7eYTXmocXFJTc5e
+        HpeGZ77I23nFRH16TbNQTLuvrCdlMaU3ZjOiYK9/avFDnJIOMnlz96V+QtPzkY/XL3F/2F9/iR2Z
+        NwTLesVqypOqsivPD3Nw78FvcVx/xGTfyDx0kCEmk0+K1b1viMX2/OH/MIf2NVgsxPVHLPaNzEMH
+        GY/F9m5mMfnl+zq8jybZ9C1NoIJ6WVUlBrfRytLET/IVtfRp9MMcf58PI6PA5xE0f85Y0LXVKbC/
+        2Llw4yIQr9Yld/I9+zV1MOl8VCwn1Xo5e5G1/ebVuh3+0r3IxOLv8BWh9Ev+H48r//wSCwAA
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:14 GMT']
-      ETag: [W/"4901f66a-9876-4e4e-99b3-400fedb92be5"]
+      Date: ['Wed, 13 Jul 2016 23:07:39 GMT']
+      ETag: [W/"b6588b0e-327c-4a6b-a3cb-ca2b25f390f6"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2810,14 +2810,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [5813e364-4518-11e6-b8f3-a0b3ccf7272a]
+      x-ms-client-request-id: [98b3a0a2-494e-11e6-8f7a-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -2827,20 +2827,20 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o/2HO9T1p9n2w4MHn27v5/v59sOHk3vb+zs75/mMup/k93/fj/TF
-        9nrFo7mhK21dVtMMw8MbV3nTrs0XhPMqr9sib+grppN8eFk01LxYXrxus5Y7er2eTvN8ls/kTWpm
-        ibAWQt7bf7i/+2CabU/yT+9v7z+4f297cv/+zvbOw3v3P73/4NP92c4D+/J5XS3bfDk7e3lSLc+L
-        i3XNCAKN70mT1OCDx87ec290zwDjdGkxwvNzOql3h0Z190a0vy4jyIMp682jPPjqFrMpDzUuLqnJ
-        2cvj0vDMF3k7r5ioT69pFopp95X1pCym9MZsRhTs9U8tfohT0kEmb+6+1E9oej7y8fol7g/76y+x
-        I/OGYFmvWE15UlV25flhDu49+C2O64+Y7BuZhw4yxGTySbG69w2x2J4//B/m0L4Gi4W4/ojFvpF5
-        6CDjsdjezSwmv3xfh/fRJJu+pQlUUC+rqsTgNlpZmvhJvqKWPo1+mOPv82FkFPg8gubPGQu6tjoF
-        9hc7F25cBOLVuuROvme/pg4mnY+K5aRaL2cvsrbfvFq3w1+6F5lY/B2+IpR+yf8DjmyQoBILAAA=
+        J1mZLaf43qGQt9kFkPju3d/3o8mn9w8OJjv59r29B9Pt/ezTyXZ2bzrZnmZ7k7375/ce7px/+vt+
+        pC+21ysezQ1daeuymmYYHt64ypt2bb4gnFd53RZ5Q18xneTDy6Kh5sXy4nWbtdzR6/V0muezfCZv
+        UjNLhLUQ8vxg99ODT8/3tndmk/3t/cnDh9uT/Wyyne+CiucP75/PHtqXz+tq2ebL2dnLk2p5Xlys
+        a0YQaHxPmqQGHzx29p57o3sGGKdLixGen9NJvTs0qrs3ov11GUEeTFlvHuXBV7eYTXmocXFJTc5e
+        HpeGZ77I23nFRH16TbNQTLuvrCdlMaU3ZjOiYK9/avFDnJIOMnlz96V+QtPzkY/XL3F/2F9/iR2Z
+        NwTLesVqypOqsivPD3Nw78FvcVx/xGTfyDx0kCEmk0+K1b1viMX2/OH/MIf2NVgsxPVHLPaNzEMH
+        GY/F9m5mMfnl+zq8jybZ9C1NoIJ6WVUlBrfRytLET/IVtfRp9MMcf58PI6PA5xE0f85Y0LXVKbC/
+        2Llw4yIQr9Yld/I9+zV1MOl8VCwn1Xo5e5G1/ebVuh3+0r3IxOLv8BWh9Ev+H48r//wSCwAA
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:14 GMT']
-      ETag: [W/"4901f66a-9876-4e4e-99b3-400fedb92be5"]
+      Date: ['Wed, 13 Jul 2016 23:07:40 GMT']
+      ETag: [W/"b6588b0e-327c-4a6b-a3cb-ca2b25f390f6"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2849,41 +2849,41 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9u
-      dGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJuYW1lIjogIkxvYWRCYWxhbmNlckZyb250RW5kIiwg
-      InByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJwcml2YXRl
-      SVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVibGljSVBBZGRyZXNzIjogeyJpZCI6
-      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
-      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3B1YmxpY0lQQWRk
-      cmVzc2VzL1B1YmxpY0lQbGIxIn19LCAiZXRhZyI6ICJXL1wiNDkwMWY2NmEtOTg3Ni00ZTRlLTk5
-      YjMtNDAwZmVkYjkyYmU1XCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00
-      ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNy
-      b3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMv
-      TG9hZEJhbGFuY2VyRnJvbnRFbmQifSwgeyJuYW1lIjogImlwY29uZmlnMSIsICJwcm9wZXJ0aWVz
-      IjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlv
-      bk1ldGhvZCI6ICJEeW5hbWljIiwgInB1YmxpY0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlw
-      dGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBz
-      L2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9wdWJs
-      aWNpcDMifX0sICJldGFnIjogIlcvXCI0OTAxZjY2YS05ODc2LTRlNGUtOTliMy00MDBmZWRiOTJi
-      ZTVcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjky
-      NzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3Jr
-      L2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9ucy9pcGNvbmZpZzEifV0s
-      ICJyZXNvdXJjZUd1aWQiOiAiMzQ5NDE3Y2EtYmU2NS00NzUzLWI1NTAtMDkzNTY1NzY0ZDA3Iiwg
-      Im91dGJvdW5kTmF0UnVsZXMiOiBbXSwgImxvYWRCYWxhbmNpbmdSdWxlcyI6IFtdLCAicHJvdmlz
-      aW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImluYm91bmROYXRSdWxlcyI6IFtdLCAiaW5ib3Vu
-      ZE5hdFBvb2xzIjogW10sICJiYWNrZW5kQWRkcmVzc1Bvb2xzIjogW3sibmFtZSI6ICJsYjFiZXBv
-      b2wiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn0sICJl
-      dGFnIjogIlcvXCI0OTAxZjY2YS05ODc2LTRlNGUtOTliMy00MDBmZWRiOTJiZTVcIiIsICJpZCI6
-      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
-      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNl
-      cnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMvbGIxYmVwb29sIn1dfSwgImV0YWciOiAiVy9cIjQ5
-      MDFmNjZhLTk4NzYtNGU0ZS05OWIzLTQwMGZlZGI5MmJlNVwiIiwgImlkIjogIi9zdWJzY3JpcHRp
+      eyJldGFnIjogIlcvXCJiNjU4OGIwZS0zMjdjLTRhNmItYTNjYi1jYTJiMjVmMzkwZjZcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9udGVu
+      ZElQQ29uZmlndXJhdGlvbnMiOiBbeyJldGFnIjogIlcvXCJiNjU4OGIwZS0zMjdjLTRhNmItYTNj
+      Yi1jYTJiMjVmMzkwZjZcIiIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1Ymxp
+      Y0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
+      YzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQu
+      TmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9QdWJsaWNJUGxiMSJ9fSwgImlkIjogIi9zdWJzY3Jp
+      cHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vw
+      cy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJv
+      bnRlbmRJUENvbmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNlckZyb250RW5kIiwgIm5hbWUiOiAiTG9h
+      ZEJhbGFuY2VyRnJvbnRFbmQifSwgeyJldGFnIjogIlcvXCJiNjU4OGIwZS0zMjdjLTRhNmItYTNj
+      Yi1jYTJiMjVmMzkwZjZcIiIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1Ymxp
+      Y0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
+      YzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQu
+      TmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9wdWJsaWNpcDMifX0sICJpZCI6ICIvc3Vic2NyaXB0
+      aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMv
+      bGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250
+      ZW5kSVBDb25maWd1cmF0aW9ucy9pcGNvbmZpZzEiLCAibmFtZSI6ICJpcGNvbmZpZzEifV0sICJv
+      dXRib3VuZE5hdFJ1bGVzIjogW10sICJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAi
+      aW5ib3VuZE5hdFJ1bGVzIjogW10sICJiYWNrZW5kQWRkcmVzc1Bvb2xzIjogW3siZXRhZyI6ICJX
+      L1wiYjY1ODhiMGUtMzI3Yy00YTZiLWEzY2ItY2EyYjI1ZjM5MGY2XCIiLCAibmFtZSI6ICJsYjFi
+      ZXBvb2wiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5
+      MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29y
+      ay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVzc1Bvb2xzL2xiMWJlcG9vbCIsICJwcm9w
+      ZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQifX1dLCAiaW5ib3VuZE5h
+      dFBvb2xzIjogW10sICJyZXNvdXJjZUd1aWQiOiAiZjgxNjg2ZjItMGRiNC00Yjk5LWI0YWItZTE0
+      ZGRhZjk1ZmQ5IiwgImxvYWRCYWxhbmNpbmdSdWxlcyI6IFtdfSwgImlkIjogIi9zdWJzY3JpcHRp
       b25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9s
       YnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEifQ==
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Length: ['1762']
       Content-Type: [application/json; charset=utf-8]
@@ -2891,7 +2891,7 @@ interactions:
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [584abf80-4518-11e6-9cdc-a0b3ccf7272a]
+      x-ms-client-request-id: [98e9c66c-494e-11e6-aacc-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -2901,20 +2901,20 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o/3dB58+2H94sD3Z2bm3vT/J9rYP9g92th88mObnn97b3c92Jr/v
-        R/pie73i0dzQlbYuq2mG4eGNq7xp1+YLwnmV122RN/QV00k+vCwaal4sL163WcsdvV5Pp3k+y2fy
-        JjWzRFgLIe/tP6QhTLPtSf7p/e39B/fvbU/u39/Z3nl47/6n9x98uj/beWBfPq+rZZsvZ2cvT6rl
-        eXGxrhlBoPE9aZIafPDY2Xvuje4ZYJwuLUZ4fk4n9e7QqO7eiPbXZQR5MGW9eZQHX91iNuWhxsUl
-        NTl7eVwanvkib+cVE/XpNc1CMe2+sp6UxZTemM2Igr3+qcUPcUo6yOTN3Zf6CU3PRz5ev8T9YX/9
-        JXZk3hAs6xWrKU+qyq48P8zBvQe/xXH9EZN9I/PQQYaYTD4pVvduZjH55fs6vI8m2fQtTaCCellV
-        JQa3UQXSxE/yFbX0afTDHH+fDyOjwOcRNH/OWNC11Smwv9i5cOMiEK/WJXfyPfs1dTDpfFQsJ9V6
-        OXuRtf3m1bod/tK9yMTi7/AVofRL/h8+PSY3rwgAAA==
+        J1mZLaf43qGQt9kFkPju3d/3o+mnDyefTu8fbGcHn+5v7++cH2xPpjvT7f1sej558On++YNZ/vt+
+        pC+21ysezQ1daeuymmYYHt64ypt2bb4gnFd53RZ5Q18xneTDy6Kh5sXy4nWbtdzR6/V0muezfCZv
+        UjNLhLUQ8vxg99ODT8/3tndmE8J/8vDh9mQ/m2znu6Di+cP757OH9uXzulq2+XJ29vKkWp4XF+ua
+        EQQa35MmqcEHj529597ongHG6dJihOfndFLvDo3q7o1of11GkAdT1ptHefDVLWZTHmpcXFKTs5fH
+        peGZL/J2XjFRn17TLBTT7ivrSVlM6Y3ZjCjY659a/BCnpINM3tx9qZ/Q9Hzk4/VL3B/2119iR+YN
+        wbJesZrypKrsyvPDHNx78Fsc1x8x2TcyDx1kiMnkk2J172YWk1++r8P7aJJN39IEKqiXVVVicBtV
+        IE38JF9RS59GP8zx9/kwMgp8HkHz54wFXVudAvuLnQs3LgLxal1yJ9+zX1MHk85HxXJSrZezF1nb
+        b16t2+Ev3YtMLP4OXxFKv+T/AV38wA2vCAAA
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/754b77ed-cb64-4940-97c4-9820be515a83?api-version=2016-03-30']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/5352ee66-85b3-48fb-ab06-f49d0f97543f?api-version=2016-03-30']
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:14 GMT']
+      Date: ['Wed, 13 Jul 2016 23:07:40 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2927,14 +2927,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [58ee186c-4518-11e6-af3e-a0b3ccf7272a]
+      x-ms-client-request-id: [998eaf08-494e-11e6-9266-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -2944,20 +2944,20 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o/3dB58+2H94sD3Z2bm3vT/J9rYP9g92th88mObnn97b3c92Jr/v
-        R/pie73i0dzQlbYuq2mG4eGNq7xp1+YLwnmV122RN/QV00k+vCwaal4sL163WcsdvV5Pp3k+y2fy
-        JjWzRFgLIe/tP6QhTLPtSf7p/e39B/fvbU/u39/Z3nl47/6n9x98uj/beWBfPq+rZZsvZ2cvT6rl
-        eXGxrhlBoPE9aZIafPDY2Xvuje4ZYJwuLUZ4fk4n9e7QqO7eiPbXZQR5MGW9eZQHX91iNuWhxsUl
-        NTl7eVwanvkib+cVE/XpNc1CMe2+sp6UxZTemM2Igr3+qcUPcUo6yOTN3Zf6CU3PRz5ev8T9YX/9
-        JXZk3hAs6xWrKU+qyq48P8zBvQe/xXH9EZN9I/PQQYaYTD4pVvduZjH55fs6vI8m2fQtTaCCellV
-        JQa3UQXSxE/yFbX0afTDHH+fDyOjwOcRNH/OWNC11Smwv9i5cOMiEK/WJXfyPfs1dTDpfFQsJ9V6
-        OXuRtf3m1bod/tK9yMTi7/AVofRL/h8+PSY3rwgAAA==
+        J1mZLaf43qGQt9kFkPju3d/3o+mnDyefTu8fbGcHn+5v7++cH2xPpjvT7f1sej558On++YNZ/vt+
+        pC+21ysezQ1daeuymmYYHt64ypt2bb4gnFd53RZ5Q18xneTDy6Kh5sXy4nWbtdzR6/V0muezfCZv
+        UjNLhLUQ8vxg99ODT8/3tndmE8J/8vDh9mQ/m2znu6Di+cP757OH9uXzulq2+XJ29vKkWp4XF+ua
+        EQQa35MmqcEHj529597ongHG6dJihOfndFLvDo3q7o1of11GkAdT1ptHefDVLWZTHmpcXFKTs5fH
+        peGZL/J2XjFRn17TLBTT7ivrSVlM6Y3ZjCjY659a/BCnpINM3tx9qZ/Q9Hzk4/VL3B/2119iR+YN
+        wbJesZrypKrsyvPDHNx78Fsc1x8x2TcyDx1kiMnkk2J172YWk1++r8P7aJJN39IEKqiXVVVicBtV
+        IE38JF9RS59GP8zx9/kwMgp8HkHz54wFXVudAvuLnQs3LgLxal1yJ9+zX1MHk85HxXJSrZezF1nb
+        b16t2+Ev3YtMLP4OXxFKv+T/AV38wA2vCAAA
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:15 GMT']
-      ETag: [W/"41767498-b003-4ba2-8480-77cef6314a0b"]
+      Date: ['Wed, 13 Jul 2016 23:07:41 GMT']
+      ETag: [W/"c69b6c58-a864-40f8-bc0c-4acfb764f7de"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2969,14 +2969,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [59362a18-4518-11e6-b679-a0b3ccf7272a]
+      x-ms-client-request-id: [99d5221c-494e-11e6-834c-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -2986,20 +2986,20 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o/3dB58+2H94sD3Z2bm3vT/J9rYP9g92th88mObnn97b3c92Jr/v
-        R/pie73i0dzQlbYuq2mG4eGNq7xp1+YLwnmV122RN/QV00k+vCwaal4sL163WcsdvV5Pp3k+y2fy
-        JjWzRFgLIe/tP6QhTLPtSf7p/e39B/fvbU/u39/Z3nl47/6n9x98uj/beWBfPq+rZZsvZ2cvT6rl
-        eXGxrhlBoPE9aZIafPDY2Xvuje4ZYJwuLUZ4fk4n9e7QqO7eiPbXZQR5MGW9eZQHX91iNuWhxsUl
-        NTl7eVwanvkib+cVE/XpNc1CMe2+sp6UxZTemM2Igr3+qcUPcUo6yOTN3Zf6CU3PRz5ev8T9YX/9
-        JXZk3hAs6xWrKU+qyq48P8zBvQe/xXH9EZN9I/PQQYaYTD4pVvduZjH55fs6vI8m2fQtTaCCellV
-        JQa3UQXSxE/yFbX0afTDHH+fDyOjwOcRNH/OWNC11Smwv9i5cOMiEK/WJXfyPfs1dTDpfFQsJ9V6
-        OXuRtf3m1bod/tK9yMTi7/AVofRL/h8+PSY3rwgAAA==
+        J1mZLaf43qGQt9kFkPju3d/3o+mnDyefTu8fbGcHn+5v7++cH2xPpjvT7f1sej558On++YNZ/vt+
+        pC+21ysezQ1daeuymmYYHt64ypt2bb4gnFd53RZ5Q18xneTDy6Kh5sXy4nWbtdzR6/V0muezfCZv
+        UjNLhLUQ8vxg99ODT8/3tndmE8J/8vDh9mQ/m2znu6Di+cP757OH9uXzulq2+XJ29vKkWp4XF+ua
+        EQQa35MmqcEHj529597ongHG6dJihOfndFLvDo3q7o1of11GkAdT1ptHefDVLWZTHmpcXFKTs5fH
+        peGZL/J2XjFRn17TLBTT7ivrSVlM6Y3ZjCjY659a/BCnpINM3tx9qZ/Q9Hzk4/VL3B/2119iR+YN
+        wbJesZrypKrsyvPDHNx78Fsc1x8x2TcyDx1kiMnkk2J172YWk1++r8P7aJJN39IEKqiXVVVicBtV
+        IE38JF9RS59GP8zx9/kwMgp8HkHz54wFXVudAvuLnQs3LgLxal1yJ9+zX1MHk85HxXJSrZezF1nb
+        b16t2+Ev3YtMLP4OXxFKv+T/AV38wA2vCAAA
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:16 GMT']
-      ETag: [W/"41767498-b003-4ba2-8480-77cef6314a0b"]
+      Date: ['Wed, 13 Jul 2016 23:07:41 GMT']
+      ETag: [W/"c69b6c58-a864-40f8-bc0c-4acfb764f7de"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3008,42 +3008,42 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9u
-      dGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJuYW1lIjogIkxvYWRCYWxhbmNlckZyb250RW5kIiwg
-      InByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJwcml2YXRl
-      SVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVibGljSVBBZGRyZXNzIjogeyJpZCI6
-      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
-      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3B1YmxpY0lQQWRk
-      cmVzc2VzL1B1YmxpY0lQbGIxIn19LCAiZXRhZyI6ICJXL1wiNDE3Njc0OTgtYjAwMy00YmEyLTg0
-      ODAtNzdjZWY2MzE0YTBiXCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00
-      ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNy
-      b3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMv
-      TG9hZEJhbGFuY2VyRnJvbnRFbmQifSwgeyJuYW1lIjogImlwY29uZmlnMSIsICJwcm9wZXJ0aWVz
-      IjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlv
-      bk1ldGhvZCI6ICJEeW5hbWljIiwgInB1YmxpY0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlw
-      dGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBz
-      L2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9wdWJs
-      aWNpcDMifX0sICJldGFnIjogIlcvXCI0MTc2NzQ5OC1iMDAzLTRiYTItODQ4MC03N2NlZjYzMTRh
-      MGJcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjky
-      NzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3Jr
-      L2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9ucy9pcGNvbmZpZzEifV0s
-      ICJyZXNvdXJjZUd1aWQiOiAiMzQ5NDE3Y2EtYmU2NS00NzUzLWI1NTAtMDkzNTY1NzY0ZDA3Iiwg
-      Im91dGJvdW5kTmF0UnVsZXMiOiBbXSwgImxvYWRCYWxhbmNpbmdSdWxlcyI6IFtdLCAicHJvdmlz
-      aW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImluYm91bmROYXRSdWxlcyI6IFtdLCAiaW5ib3Vu
-      ZE5hdFBvb2xzIjogW10sICJiYWNrZW5kQWRkcmVzc1Bvb2xzIjogW3sibmFtZSI6ICJsYjFiZXBv
-      b2wiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn0sICJl
-      dGFnIjogIlcvXCI0MTc2NzQ5OC1iMDAzLTRiYTItODQ4MC03N2NlZjYzMTRhMGJcIiIsICJpZCI6
-      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
-      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNl
-      cnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMvbGIxYmVwb29sIn0sIHsibmFtZSI6ICJiYXAxIn1d
-      fSwgImV0YWciOiAiVy9cIjQxNzY3NDk4LWIwMDMtNGJhMi04NDgwLTc3Y2VmNjMxNGEwYlwiIiwg
+      eyJldGFnIjogIlcvXCJjNjliNmM1OC1hODY0LTQwZjgtYmMwYy00YWNmYjc2NGY3ZGVcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9udGVu
+      ZElQQ29uZmlndXJhdGlvbnMiOiBbeyJldGFnIjogIlcvXCJjNjliNmM1OC1hODY0LTQwZjgtYmMw
+      Yy00YWNmYjc2NGY3ZGVcIiIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1Ymxp
+      Y0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
+      YzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQu
+      TmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9QdWJsaWNJUGxiMSJ9fSwgImlkIjogIi9zdWJzY3Jp
+      cHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vw
+      cy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJv
+      bnRlbmRJUENvbmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNlckZyb250RW5kIiwgIm5hbWUiOiAiTG9h
+      ZEJhbGFuY2VyRnJvbnRFbmQifSwgeyJldGFnIjogIlcvXCJjNjliNmM1OC1hODY0LTQwZjgtYmMw
+      Yy00YWNmYjc2NGY3ZGVcIiIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1Ymxp
+      Y0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
+      YzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQu
+      TmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9wdWJsaWNpcDMifX0sICJpZCI6ICIvc3Vic2NyaXB0
+      aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMv
+      bGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250
+      ZW5kSVBDb25maWd1cmF0aW9ucy9pcGNvbmZpZzEiLCAibmFtZSI6ICJpcGNvbmZpZzEifV0sICJv
+      dXRib3VuZE5hdFJ1bGVzIjogW10sICJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAi
+      aW5ib3VuZE5hdFJ1bGVzIjogW10sICJiYWNrZW5kQWRkcmVzc1Bvb2xzIjogW3siZXRhZyI6ICJX
+      L1wiYzY5YjZjNTgtYTg2NC00MGY4LWJjMGMtNGFjZmI3NjRmN2RlXCIiLCAibmFtZSI6ICJsYjFi
+      ZXBvb2wiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5
+      MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29y
+      ay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVzc1Bvb2xzL2xiMWJlcG9vbCIsICJwcm9w
+      ZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQifX0sIHsibmFtZSI6ICJi
+      YXAxIn1dLCAiaW5ib3VuZE5hdFBvb2xzIjogW10sICJyZXNvdXJjZUd1aWQiOiAiZjgxNjg2ZjIt
+      MGRiNC00Yjk5LWI0YWItZTE0ZGRhZjk1ZmQ5IiwgImxvYWRCYWxhbmNpbmdSdWxlcyI6IFtdfSwg
       ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5
       MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJh
       bGFuY2Vycy9sYjEifQ==
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Length: ['1780']
       Content-Type: [application/json; charset=utf-8]
@@ -3051,7 +3051,7 @@ interactions:
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [5968f952-4518-11e6-85a9-a0b3ccf7272a]
+      x-ms-client-request-id: [9a077464-494e-11e6-b0bc-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -3061,40 +3061,40 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o/175/fPD+7d2/50cn+yvZ8/3N3Ostnu9uT+wWRysHPv4N6n+7/v
-        R/pie73i0dzQlbYuq2mG4eGNq7xp1+YLwnmV122RN/QV00k+vCwaal4sL163WcsdvV5Pp3k+y2fy
-        JjWzRFgLIe/tP9zffTDNtif5p/e39x/cv0eo39/Z3nl47/6n9x98uj/beWBfPq+rZZsvZ2cvT6rl
-        eXGxrhlBoPE9aZIafPDY2Xvuje4ZYJwuLUZ4fk4n9e7QqO7eiPbXZQR5MGW9eZQHX91iNuWhxsUl
-        NTl7eVwanvkib+cVE/XpNc1CMe2+sp6UxZTemM2Igr3+qcUPcUo6yOTN3Zf6CU3PRz5ev8T9YX/9
-        JXZk3hAs6xWrKU+qyq48P8zBvQe/xXH9EZN9I/PQQYaYTD4pVvduZjH55fs6vI8m2fQtTaCCellV
-        JQa3UQXSxE/yFbX0afTDHH+fDyOjwOcRNH/OWNC11SmgXyxkD5Il8yRbhdLz/zoK9zD8fxVx5RfL
-        6G5IBOLVuuROvme/pg4mnY+K5aRaL2cvsrbfvFq3w1+6F5lO/B2+IpR+yf8DaneJMAwKAAA=
+        J1mZLaf43qGQt9kFkPju3d/3oyn1e75zsL89fbh/b3v/3s5k+2Ann2zfv7+3/yCbzfY+nez9vh/p
+        i+31ikdzQ1fauqymGYaHN67ypl2bLwjnVV63Rd7QV0wn+fCyaKh5sbx43WYtd/R6PZ3m+SyfyZvU
+        zBJhLYQ8P9j99ODT873tndlkf3t/8vDh9mQ/m2znu6Di+cP757OH9uXzulq2+XJ29vKkWp4XF+ua
+        EQQa35MmqcEHj529597ongHG6dJihOfndFLvDo3q7o1of11GkAdT1ptHefDVLWZTHmpcXFKTs5fH
+        peGZL/J2XjFRn17TLBTT7ivrSVlM6Y3ZjCjY659a/BCnpINM3tx9qZ/Q9Hzk4/VL3B/2119iR+YN
+        wbJesZrypKrsyvPDHNx78Fsc1x8x2TcyDx1kiMnkk2J172YWk1++r8P7aJJN39IEKqiXVVVicBtV
+        IE38JF9RS59GP8zx9/kwMgp8HkHz54wFXVudAvrFQvYgWTJPslUoPf+vo3APw/9XEVd+sYzuhkQg
+        Xq1L7uR79mvqYNL5qFhOqvVy9iJr+82rdTv8pXuR6cTf4StC6Zf8P1EpWMkMCgAA
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/59fbcffd-9bc5-4534-8384-a14ecf7c1851?api-version=2016-03-30']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/b339dc7a-d735-4c15-9a1b-ba1357c363a2?api-version=2016-03-30']
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:17 GMT']
+      Date: ['Wed, 13 Jul 2016 23:07:42 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [5a0c58a2-4518-11e6-8a8f-a0b3ccf7272a]
+      x-ms-client-request-id: [9aae3aca-494e-11e6-83bf-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -3104,20 +3104,20 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o/175/fPD+7d2/50cn+yvZ8/3N3Ostnu9uT+wWRysHPv4N6n+7/v
-        R/pie73i0dzQlbYuq2mG4eGNq7xp1+YLwnmV122RN/QV00k+vCwaal4sL163WcsdvV5Pp3k+y2fy
-        JjWzRFgLIe/tP9zffTDNtif5p/e39x/cv0eo39/Z3nl47/6n9x98uj/beWBfPq+rZZsvZ2cvT6rl
-        eXGxrhlBoPE9aZIafPDY2Xvuje4ZYJwuLUZ4fk4n9e7QqO7eiPbXZQR5MGW9eZQHX91iNuWhxsUl
-        NTl7eVwanvkib+cVE/XpNc1CMe2+sp6UxZTemM2Igr3+qcUPcUo6yOTN3Zf6CU3PRz5ev8T9YX/9
-        JXZk3hAs6xWrKU+qyq48P8zBvQe/xXH9EZN9I/PQQYaYTD4pVvduZjH55fs6vI8m2fQtTaCCellV
-        JQa3UQXSxE/yFbX0afTDHH+fDyOjwOcRNH/OWNC11SmgXyxkD5Il8yRbhdLz/zoK9zD8fxVx5RfL
-        6G5IBOLVuuROvme/pg4mnY+K5aRaL2cvsrbfvFq3w1+6F5lO/B2+IpR+yf8DaneJMAwKAAA=
+        J1mZLaf43qGQt9kFkPju3d/3oyn1e75zsL89fbh/b3v/3s5k+2Ann2zfv7+3/yCbzfY+nez9vh/p
+        i+31ikdzQ1fauqymGYaHN67ypl2bLwjnVV63Rd7QV0wn+fCyaKh5sbx43WYtd/R6PZ3m+SyfyZvU
+        zBJhLYQ8P9j99ODT873tndlkf3t/8vDh9mQ/m2znu6Di+cP757OH9uXzulq2+XJ29vKkWp4XF+ua
+        EQQa35MmqcEHj529597ongHG6dJihOfndFLvDo3q7o1of11GkAdT1ptHefDVLWZTHmpcXFKTs5fH
+        peGZL/J2XjFRn17TLBTT7ivrSVlM6Y3ZjCjY659a/BCnpINM3tx9qZ/Q9Hzk4/VL3B/2119iR+YN
+        wbJesZrypKrsyvPDHNx78Fsc1x8x2TcyDx1kiMnkk2J172YWk1++r8P7aJJN39IEKqiXVVVicBtV
+        IE38JF9RS59GP8zx9/kwMgp8HkHz54wFXVudAvrFQvYgWTJPslUoPf+vo3APw/9XEVd+sYzuhkQg
+        Xq1L7uR79mvqYNL5qFhOqvVy9iJr+82rdTv8pXuR6cTf4StC6Zf8P1EpWMkMCgAA
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:17 GMT']
-      ETag: [W/"43f5f833-6b5b-4e91-aad1-b58bb8038364"]
+      Date: ['Wed, 13 Jul 2016 23:07:43 GMT']
+      ETag: [W/"cf64f084-c943-430b-80eb-55247add26b2"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -3126,47 +3126,47 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9u
-      dGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJuYW1lIjogIkxvYWRCYWxhbmNlckZyb250RW5kIiwg
-      InByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJwcml2YXRl
-      SVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVibGljSVBBZGRyZXNzIjogeyJpZCI6
-      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
-      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3B1YmxpY0lQQWRk
-      cmVzc2VzL1B1YmxpY0lQbGIxIn19LCAiZXRhZyI6ICJXL1wiNDNmNWY4MzMtNmI1Yi00ZTkxLWFh
-      ZDEtYjU4YmI4MDM4MzY0XCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00
-      ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNy
-      b3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMv
-      TG9hZEJhbGFuY2VyRnJvbnRFbmQifSwgeyJuYW1lIjogImlwY29uZmlnMSIsICJwcm9wZXJ0aWVz
-      IjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlv
-      bk1ldGhvZCI6ICJEeW5hbWljIiwgInB1YmxpY0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlw
-      dGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBz
-      L2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9wdWJs
-      aWNpcDMifX0sICJldGFnIjogIlcvXCI0M2Y1ZjgzMy02YjViLTRlOTEtYWFkMS1iNThiYjgwMzgz
-      NjRcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjky
-      NzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3Jr
-      L2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9ucy9pcGNvbmZpZzEifV0s
-      ICJyZXNvdXJjZUd1aWQiOiAiMzQ5NDE3Y2EtYmU2NS00NzUzLWI1NTAtMDkzNTY1NzY0ZDA3Iiwg
-      Im91dGJvdW5kTmF0UnVsZXMiOiBbXSwgImxvYWRCYWxhbmNpbmdSdWxlcyI6IFtdLCAicHJvdmlz
-      aW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImluYm91bmROYXRSdWxlcyI6IFtdLCAiaW5ib3Vu
-      ZE5hdFBvb2xzIjogW10sICJiYWNrZW5kQWRkcmVzc1Bvb2xzIjogW3sibmFtZSI6ICJsYjFiZXBv
-      b2wiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn0sICJl
-      dGFnIjogIlcvXCI0M2Y1ZjgzMy02YjViLTRlOTEtYWFkMS1iNThiYjgwMzgzNjRcIiIsICJpZCI6
-      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
-      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNl
-      cnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMvbGIxYmVwb29sIn0sIHsibmFtZSI6ICJiYXAxIiwg
-      InByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCJ9LCAiZXRhZyI6
-      ICJXL1wiNDNmNWY4MzMtNmI1Yi00ZTkxLWFhZDEtYjU4YmI4MDM4MzY0XCIiLCAiaWQiOiAiL3N1
-      YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNl
-      R3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xi
-      MS9iYWNrZW5kQWRkcmVzc1Bvb2xzL2JhcDEifSwgeyJuYW1lIjogImJhcDIifV19LCAiZXRhZyI6
-      ICJXL1wiNDNmNWY4MzMtNmI1Yi00ZTkxLWFhZDEtYjU4YmI4MDM4MzY0XCIiLCAiaWQiOiAiL3N1
+      eyJldGFnIjogIlcvXCJjZjY0ZjA4NC1jOTQzLTQzMGItODBlYi01NTI0N2FkZDI2YjJcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9udGVu
+      ZElQQ29uZmlndXJhdGlvbnMiOiBbeyJldGFnIjogIlcvXCJjZjY0ZjA4NC1jOTQzLTQzMGItODBl
+      Yi01NTI0N2FkZDI2YjJcIiIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1Ymxp
+      Y0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
+      YzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQu
+      TmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9QdWJsaWNJUGxiMSJ9fSwgImlkIjogIi9zdWJzY3Jp
+      cHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vw
+      cy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJv
+      bnRlbmRJUENvbmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNlckZyb250RW5kIiwgIm5hbWUiOiAiTG9h
+      ZEJhbGFuY2VyRnJvbnRFbmQifSwgeyJldGFnIjogIlcvXCJjZjY0ZjA4NC1jOTQzLTQzMGItODBl
+      Yi01NTI0N2FkZDI2YjJcIiIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1Ymxp
+      Y0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
+      YzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQu
+      TmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9wdWJsaWNpcDMifX0sICJpZCI6ICIvc3Vic2NyaXB0
+      aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMv
+      bGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250
+      ZW5kSVBDb25maWd1cmF0aW9ucy9pcGNvbmZpZzEiLCAibmFtZSI6ICJpcGNvbmZpZzEifV0sICJv
+      dXRib3VuZE5hdFJ1bGVzIjogW10sICJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAi
+      aW5ib3VuZE5hdFJ1bGVzIjogW10sICJiYWNrZW5kQWRkcmVzc1Bvb2xzIjogW3siZXRhZyI6ICJX
+      L1wiY2Y2NGYwODQtYzk0My00MzBiLTgwZWItNTUyNDdhZGQyNmIyXCIiLCAibmFtZSI6ICJsYjFi
+      ZXBvb2wiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5
+      MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29y
+      ay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVzc1Bvb2xzL2xiMWJlcG9vbCIsICJwcm9w
+      ZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQifX0sIHsiZXRhZyI6ICJX
+      L1wiY2Y2NGYwODQtYzk0My00MzBiLTgwZWItNTUyNDdhZGQyNmIyXCIiLCAibmFtZSI6ICJiYXAx
+      IiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYw
+      OTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9h
+      ZEJhbGFuY2Vycy9sYjEvYmFja2VuZEFkZHJlc3NQb29scy9iYXAxIiwgInByb3BlcnRpZXMiOiB7
+      InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCJ9fSwgeyJuYW1lIjogImJhcDIifV0sICJp
+      bmJvdW5kTmF0UG9vbHMiOiBbXSwgInJlc291cmNlR3VpZCI6ICJmODE2ODZmMi0wZGI0LTRiOTkt
+      YjRhYi1lMTRkZGFmOTVmZDkiLCAibG9hZEJhbGFuY2luZ1J1bGVzIjogW119LCAiaWQiOiAiL3N1
       YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNl
       R3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xi
       MSJ9
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Length: ['2055']
       Content-Type: [application/json; charset=utf-8]
@@ -3174,7 +3174,7 @@ interactions:
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [5a4052b4-4518-11e6-9648-a0b3ccf7272a]
+      x-ms-client-request-id: [9aeab6be-494e-11e6-9095-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -3184,1418 +3184,21 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o+nOg2n+YOfe9t6De9n2/gQ9Tx7m25P96cMH5w8f7O/vTn7fj/TF
-        9nrFo7mhK21dVtMMw8MbV3nTrs0XhPMqr9sib+grppN8eFk01LxYXrxus5Y7er2eTvN8ls/kTWpm
-        ibAWQt7bf7i/+2CabU/yT+9v7z+4f297cv/+zvbOw3v3P73/4NP92c4D+/J5XS3bfDk7e3lSLc+L
-        i3XNCAKN70mT1OCDx87ec290zwDjdGkxwvNzOql3h0Z190a0vy4jyIMp682jPPjqFrMpDzUuLqnJ
-        2cvj0vDMF3k7r5ioT69pFopp95X1pCym9MZsRhTs9U8tfohT0kEmb+6+1E9oej7y8fol7g/76y+x
-        I/OGYFmvWE15UlV25flhDu49+C2O64+YjAb54fPQQYaYTD4pVvduZjH55fs6vI8m2fQtTaCCellV
-        JQa3UQXSxE/yFbX0afTDHH+fDyOjwOcRNH/OWNC11SmgXyxkD5Il8yRbhdLz/zoK9zD8/xRx94K+
-        /99I3BDD/1cRV36xWsQNiUC8Wpfcyffs19TBpPNRsZxU6+XsRdb2m1frdvhL9yLTib/DV4TSL/l/
-        AMRh561pCwAA
+        J1mZLaf43qGQt9kFkPju3d/3o9nup/sP873J9u75/v72/s79Per54d727GD304c7uwf37s/Of9+P
+        9MX2esWjuaErbV1W0wzDwxtXedOuzReE8yqv2yJv6Cumk3x4WTTUvFhevG6zljt6vZ5O83yWz+RN
+        amaJsBZCnhOeB5+e723vzCaE/+Thw+3JfjbZzndBxfOH989nD+3L53W1bPPl7OzlSbU8Ly7WNSMI
+        NL4nTVKDDx47e8+90T0DjNOlxQjPz+mk3h0a1d0b0f66jCAPpqw3j/Lgq1vMpjzUuLikJmcvj0vD
+        M1/k7bxioj69plkopt1X1pOymNIbsxlRsNc/tfghTkkHmby5+1I/oen5yMfrl7g/7K+/xI7MG4Jl
+        vWI15UlV2ZXnhzm49+C3OK4/YrJvZB46yBCTySfF6t7NLCa/fF+H99Ekm76lCVRQL6uqxOA2qkCa
+        +Em+opY+jX6Y4+/zYWQU+DyC5s8ZC7q2OgX0i4XsQbJknmSrUHr+X0fhHob/nyLuXtD3/xuJG2L4
+        /yriyi9Wi7ghEYhX65I7+Z79mjqYdD4qlpNqvZy9yNp+82rdDn/pXmQ68Xf4ilD6Jf8PSnyRsWkL
+        AAA=
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/22d8ea78-7193-43a7-8068-29dd027e6163?api-version=2016-03-30']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/1960c78e-f507-49a3-b175-8cf39f5ea0fa?api-version=2016-03-30']
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:17 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [5ae3bfae-4518-11e6-8d2f-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o+nOg2n+YOfe9t6De9n2/gQ9Tx7m25P96cMH5w8f7O/vTn7fj/TF
-        9nrFo7mhK21dVtMMw8MbV3nTrs0XhPMqr9sib+grppN8eFk01LxYXrxus5Y7er2eTvN8ls/kTWpm
-        ibAWQt7bf7i/+2CabU/yT+9v7z+4f297cv/+zvbOw3v3P73/4NP92c4D+/J5XS3bfDk7e3lSLc+L
-        i3XNCAKN70mT1OCDx87ec290zwDjdGkxwvNzOql3h0Z190a0vy4jyIMp682jPPjqFrMpDzUuLqnJ
-        2cvj0vDMF3k7r5ioT69pFopp95X1pCym9MZsRhTs9U8tfohT0kEmb+6+1E9oej7y8fol7g/76y+x
-        I/OGYFmvWE15UlV25flhDu49+C2O64+YjAb54fPQQYaYTD4pVvduZjH55fs6vI8m2fQtTaCCellV
-        JQa3UQXSxE/yFbX0afTDHH+fDyOjwOcRNH/OWNC11SmgXyxkD5Il8yRbhdLz/zoK9zD8/xRx94K+
-        /99I3BDD/1cRV36xWsQNiUC8Wpfcyffs19TBpPNRsZxU6+XsRdb2m1frdvhL9yLTib/DV4TSL/l/
-        AMRh561pCwAA
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:19 GMT']
-      ETag: [W/"c07ce703-273a-4bda-ab9e-b4c97f97441b"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9u
-      dGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJuYW1lIjogIkxvYWRCYWxhbmNlckZyb250RW5kIiwg
-      InByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJwcml2YXRl
-      SVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVibGljSVBBZGRyZXNzIjogeyJpZCI6
-      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
-      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3B1YmxpY0lQQWRk
-      cmVzc2VzL1B1YmxpY0lQbGIxIn19LCAiZXRhZyI6ICJXL1wiYzA3Y2U3MDMtMjczYS00YmRhLWFi
-      OWUtYjRjOTdmOTc0NDFiXCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00
-      ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNy
-      b3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMv
-      TG9hZEJhbGFuY2VyRnJvbnRFbmQifSwgeyJuYW1lIjogImlwY29uZmlnMSIsICJwcm9wZXJ0aWVz
-      IjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlv
-      bk1ldGhvZCI6ICJEeW5hbWljIiwgInB1YmxpY0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlw
-      dGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBz
-      L2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9wdWJs
-      aWNpcDMifX0sICJldGFnIjogIlcvXCJjMDdjZTcwMy0yNzNhLTRiZGEtYWI5ZS1iNGM5N2Y5NzQ0
-      MWJcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjky
-      NzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3Jr
-      L2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9ucy9pcGNvbmZpZzEifV0s
-      ICJyZXNvdXJjZUd1aWQiOiAiMzQ5NDE3Y2EtYmU2NS00NzUzLWI1NTAtMDkzNTY1NzY0ZDA3Iiwg
-      Im91dGJvdW5kTmF0UnVsZXMiOiBbXSwgImxvYWRCYWxhbmNpbmdSdWxlcyI6IFtdLCAicHJvdmlz
-      aW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImluYm91bmROYXRSdWxlcyI6IFtdLCAiaW5ib3Vu
-      ZE5hdFBvb2xzIjogW10sICJiYWNrZW5kQWRkcmVzc1Bvb2xzIjogW3sibmFtZSI6ICJsYjFiZXBv
-      b2wiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn0sICJl
-      dGFnIjogIlcvXCJjMDdjZTcwMy0yNzNhLTRiZGEtYWI5ZS1iNGM5N2Y5NzQ0MWJcIiIsICJpZCI6
-      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
-      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNl
-      cnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMvbGIxYmVwb29sIn0sIHsibmFtZSI6ICJiYXAxIiwg
-      InByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCJ9LCAiZXRhZyI6
-      ICJXL1wiYzA3Y2U3MDMtMjczYS00YmRhLWFiOWUtYjRjOTdmOTc0NDFiXCIiLCAiaWQiOiAiL3N1
-      YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNl
-      R3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xi
-      MS9iYWNrZW5kQWRkcmVzc1Bvb2xzL2JhcDEifSwgeyJuYW1lIjogImJhcDIiLCAicHJvcGVydGll
-      cyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn0sICJldGFnIjogIlcvXCJjMDdj
-      ZTcwMy0yNzNhLTRiZGEtYWI5ZS1iNGM5N2Y5NzQ0MWJcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9u
-      cy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJz
-      cmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2JhY2tlbmRB
-      ZGRyZXNzUG9vbHMvYmFwMiJ9LCB7Im5hbWUiOiAiYmFwMyJ9XX0sICJldGFnIjogIlcvXCJjMDdj
-      ZTcwMy0yNzNhLTRiZGEtYWI5ZS1iNGM5N2Y5NzQ0MWJcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9u
-      cy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJz
-      cmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxIn0=
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Length: ['2330']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [5b1c651e-4518-11e6-aaf0-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o0+nO9ns/v7D7b37GfV88HBnO7t3L9u+92DvXj7N9mYPJ/d/34/0
-        xfZ6xaO5oSttXVbTDMPDG1d5067NF4TzKq/bIm/oK6aTfHhZNNS8WF68brOWO3q9nk7zfJbP5E1q
-        ZomwFkLe23+4v/tgmm1P8k/vb+8/uH9ve3L//s72zsN79z+9/+DT/dnOA/vyeV0t23w5O3t5Ui3P
-        i4t1zQgCje9Jk9Tgg8fO3nNvdM8A43RpMcLzczqpd4dGdfdGtL8uI8iDKevNozz46hazKQ81Li6p
-        ydnL49LwzBd5O6+YqE+vaRaKafeV9aQspvTGbEYU7PVPLX6IU9JBJm/uvtRPaHo+8vH6Je4P++sv
-        sSPzhmBZr1hNeVJVduX5YQ7uPfgtjuuPmOwbmYcOMsRk8kmxunczi8kv39fhfTTJpm9pAhXUy6oq
-        MbiNKpAmfpKvqKVPox/m+Pt8GBkFPo+g+XPGgq6tTgH9YiF7kCyZJ9kqlJ7/11G4h+H/p4i7F/T9
-        /0bihhj+f4q494K+/99I3BDD/1cRV36xKtoNiUC8Wpfcyffs19TBpPNRsZxU6+XsRdb2m1frdvhL
-        9yLTib/DV4TSL/l/AFmsrAjGDAAA
-    headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/50f0c370-b351-4cdf-b7d2-549af5e835fb?api-version=2016-03-30']
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:19 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [5bc15fba-4518-11e6-9d98-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o0+nO9ns/v7D7b37GfV88HBnO7t3L9u+92DvXj7N9mYPJ/d/34/0
-        xfZ6xaO5oSttXVbTDMPDG1d5067NF4TzKq/bIm/oK6aTfHhZNNS8WF68brOWO3q9nk7zfJbP5E1q
-        ZomwFkLe23+4v/tgmm1P8k/vb+8/uH9ve3L//s72zsN79z+9/+DT/dnOA/vyeV0t23w5O3t5Ui3P
-        i4t1zQgCje9Jk9Tgg8fO3nNvdM8A43RpMcLzczqpd4dGdfdGtL8uI8iDKevNozz46hazKQ81Li6p
-        ydnL49LwzBd5O6+YqE+vaRaKafeV9aQspvTGbEYU7PVPLX6IU9JBJm/uvtRPaHo+8vH6Je4P++sv
-        sSPzhmBZr1hNeVJVduX5YQ7uPfgtjuuPmOwbmYcOMsRk8kmxunczi8kv39fhfTTJpm9pAhXUy6oq
-        MbiNKpAmfpKvqKVPox/m+Pt8GBkFPo+g+XPGgq6tTgH9YiF7kCyZJ9kqlJ7/11G4h+H/p4i7F/T9
-        /0bihhj+f4q494K+/99I3BDD/1cRV36xKtoNiUC8Wpfcyffs19TBpPNRsZxU6+XsRdb2m1frdvhL
-        9yLTib/DV4TSL/l/AFmsrAjGDAAA
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:20 GMT']
-      ETag: [W/"6c0ad549-25a0-4890-a33a-3723eca2d9b5"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [5bfed338-4518-11e6-98fc-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o0+nO9ns/v7D7b37GfV88HBnO7t3L9u+92DvXj7N9mYPJ/d/34/0
-        xfZ6xaO5oSttXVbTDMPDG1d5067NF4TzKq/bIm/oK6aTfHhZNNS8WF68brOWO3q9nk7zfJbP5E1q
-        ZomwFkLe23+4v/tgmm1P8k/vb+8/uH9ve3L//s72zsN79z+9/+DT/dnOA/vyeV0t23w5O3t5Ui3P
-        i4t1zQgCje9Jk9Tgg8fO3nNvdM8A43RpMcLzczqpd4dGdfdGtL8uI8iDKevNozz46hazKQ81Li6p
-        ydnL49LwzBd5O6+YqE+vaRaKafeV9aQspvTGbEYU7PVPLX6IU9JBJm/uvtRPaHo+8vH6Je4P++sv
-        sSPzhmBZr1hNeVJVduX5YQ7uPfgtjuuPmOwbmYcOMsRk8kmxunczi8kv39fhfTTJpm9pAhXUy6oq
-        MbiNKpAmfpKvqKVPox/m+Pt8GBkFPo+g+XPGgq6tTgH9YiF7kCyZJ9kqlJ7/11G4h+H/p4i7F/T9
-        /0bihhj+f4q494K+/99I3BDD/1cRV36xKtoNiUC8Wpfcyffs19TBpPNRsZxU6+XsRdb2m1frdvhL
-        9yLTib/DV4TSL/l/AFmsrAjGDAAA
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:20 GMT']
-      ETag: [W/"6c0ad549-25a0-4890-a33a-3723eca2d9b5"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [5c3d38ca-4518-11e6-ac76-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o0+nO9ns/v7D7b37GfV88HBnO7t3L9u+92DvXj7N9mYPJ/d/34/0
-        xfZ6xaO5oSttXVbTDMPDG1d5067NF4TzKq/bIm/oK6aTfHhZNNS8WF68brOWO3q9nk7zfJbP5E1q
-        ZomwFkLe23+4v/tgmm1P8k/vb+8/uH9ve3L//s72zsN79z+9/+DT/dnOA/vyeV0t23w5O3t5Ui3P
-        i4t1zQgCje9Jk9Tgg8fO3nNvdM8A43RpMcLzczqpd4dGdfdGtL8uI8iDKevNozz46hazKQ81Li6p
-        ydnL49LwzBd5O6+YqE+vaRaKafeV9aQspvTGbEYU7PVPLX6IU9JBJm/uvtRPaHo+8vH6Je4P++sv
-        sSPzhmBZr1hNeVJVduX5YQ7uPfgtjuuPmOwbmYcOMsRk8kmxunczi8kv39fhfTTJpm9pAhXUy6oq
-        MbiNKpAmfpKvqKVPox/m+Pt8GBkFPo+g+XPGgq6tTgH9YiF7kCyZJ9kqlJ7/11G4h+H/p4i7F/T9
-        /0bihhj+f4q494K+/99I3BDD/1cRV36xKtoNiUC8Wpfcyffs19TBpPNRsZxU6+XsRdb2m1frdvhL
-        9yLTib/DV4TSL/l/AFmsrAjGDAAA
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:20 GMT']
-      ETag: [W/"6c0ad549-25a0-4890-a33a-3723eca2d9b5"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9u
-      dGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJuYW1lIjogIkxvYWRCYWxhbmNlckZyb250RW5kIiwg
-      InByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJwcml2YXRl
-      SVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVibGljSVBBZGRyZXNzIjogeyJpZCI6
-      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
-      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3B1YmxpY0lQQWRk
-      cmVzc2VzL1B1YmxpY0lQbGIxIn19LCAiZXRhZyI6ICJXL1wiNmMwYWQ1NDktMjVhMC00ODkwLWEz
-      M2EtMzcyM2VjYTJkOWI1XCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00
-      ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNy
-      b3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMv
-      TG9hZEJhbGFuY2VyRnJvbnRFbmQifSwgeyJuYW1lIjogImlwY29uZmlnMSIsICJwcm9wZXJ0aWVz
-      IjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlv
-      bk1ldGhvZCI6ICJEeW5hbWljIiwgInB1YmxpY0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlw
-      dGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBz
-      L2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9wdWJs
-      aWNpcDMifX0sICJldGFnIjogIlcvXCI2YzBhZDU0OS0yNWEwLTQ4OTAtYTMzYS0zNzIzZWNhMmQ5
-      YjVcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjky
-      NzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3Jr
-      L2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9ucy9pcGNvbmZpZzEifV0s
-      ICJyZXNvdXJjZUd1aWQiOiAiMzQ5NDE3Y2EtYmU2NS00NzUzLWI1NTAtMDkzNTY1NzY0ZDA3Iiwg
-      Im91dGJvdW5kTmF0UnVsZXMiOiBbXSwgImxvYWRCYWxhbmNpbmdSdWxlcyI6IFtdLCAicHJvdmlz
-      aW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImluYm91bmROYXRSdWxlcyI6IFtdLCAiaW5ib3Vu
-      ZE5hdFBvb2xzIjogW10sICJiYWNrZW5kQWRkcmVzc1Bvb2xzIjogW3sibmFtZSI6ICJsYjFiZXBv
-      b2wiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn0sICJl
-      dGFnIjogIlcvXCI2YzBhZDU0OS0yNWEwLTQ4OTAtYTMzYS0zNzIzZWNhMmQ5YjVcIiIsICJpZCI6
-      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
-      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNl
-      cnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMvbGIxYmVwb29sIn0sIHsibmFtZSI6ICJiYXAxIiwg
-      InByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCJ9LCAiZXRhZyI6
-      ICJXL1wiNmMwYWQ1NDktMjVhMC00ODkwLWEzM2EtMzcyM2VjYTJkOWI1XCIiLCAiaWQiOiAiL3N1
-      YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNl
-      R3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xi
-      MS9iYWNrZW5kQWRkcmVzc1Bvb2xzL2JhcDEifSwgeyJuYW1lIjogImJhcDIiLCAicHJvcGVydGll
-      cyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn0sICJldGFnIjogIlcvXCI2YzBh
-      ZDU0OS0yNWEwLTQ4OTAtYTMzYS0zNzIzZWNhMmQ5YjVcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9u
-      cy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJz
-      cmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2JhY2tlbmRB
-      ZGRyZXNzUG9vbHMvYmFwMiJ9XX0sICJldGFnIjogIlcvXCI2YzBhZDU0OS0yNWEwLTQ4OTAtYTMz
-      YS0zNzIzZWNhMmQ5YjVcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRk
-      ZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jv
-      c29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxIn0=
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Length: ['2312']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [5c71157a-4518-11e6-812c-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o1n+6e4D6mV7+iC7v72/f29v++HuwXR79zz7dOfhLDvYmez/vh/p
-        i+31ikdzQ1fauqymGYaHN67ypl2bLwjnVV63Rd7QV0wn+fCyaKh5sbx43WYtd/R6PZ3m+SyfyZvU
-        zBJhLYS8t/9wf/fBNNue5J8S/g/u39ue3L+/s73z8N79T+8/+HR/tvPAvnxeV8s2X87OXp5Uy/Pi
-        Yl0zgkDje9IkNfjgsbP33BvdM8A4XVqM8PycTurdoVHdvRHtr8sI8mDKevMoD766xWzKQ42LS2py
-        9vK4NDzzRd7OKybq02uahWLafWU9KYspvTGbEQV7/VOLH+KUdJDJm7sv9ROano98vH6J+8P++kvs
-        yLwhWNYrVlOeVJVdeX6Yg3sPfovj+iMm+0bmoYMMMZl8Uqzu3cxi8sv3dXgfTbLpW5pABfWyqkoM
-        bqMKpImf5Ctq6dPohzn+Ph9GRoHPI2j+nLGga6tTQL9YyB4kS+ZJtgql5/91FO5h+P8p4u4Fff+/
-        kbghhv+vIq78YrWIGxKBeLUuuZPv2a+pg0nno2I5qdbL2Yus7Tev1u3wl+5FphN/h68IpV/y/wBs
-        1mQFaQsAAA==
-    headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/1d428061-8280-4f61-a276-224d7c10178f?api-version=2016-03-30']
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:21 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [5d161048-4518-11e6-ae6d-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o1n+6e4D6mV7+iC7v72/f29v++HuwXR79zz7dOfhLDvYmez/vh/p
-        i+31ikdzQ1fauqymGYaHN67ypl2bLwjnVV63Rd7QV0wn+fCyaKh5sbx43WYtd/R6PZ3m+SyfyZvU
-        zBJhLYS8t/9wf/fBNNue5J8S/g/u39ue3L+/s73z8N79T+8/+HR/tvPAvnxeV8s2X87OXp5Uy/Pi
-        Yl0zgkDje9IkNfjgsbP33BvdM8A4XVqM8PycTurdoVHdvRHtr8sI8mDKevMoD766xWzKQ42LS2py
-        9vK4NDzzRd7OKybq02uahWLafWU9KYspvTGbEQV7/VOLH+KUdJDJm7sv9ROano98vH6J+8P++kvs
-        yLwhWNYrVlOeVJVdeX6Yg3sPfovj+iMm+0bmoYMMMZl8Uqzu3cxi8sv3dXgfTbLpW5pABfWyqkoM
-        bqMKpImf5Ctq6dPohzn+Ph9GRoHPI2j+nLGga6tTQL9YyB4kS+ZJtgql5/91FO5h+P8p4u4Fff+/
-        kbghhv+vIq78YrWIGxKBeLUuuZPv2a+pg0nno2I5qdbL2Yus7Tev1u3wl+5FphN/h68IpV/y/wBs
-        1mQFaQsAAA==
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:22 GMT']
-      ETag: [W/"de617b92-c7a5-4432-918c-1fa609da80b4"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [5d52d586-4518-11e6-b583-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o1n+6e4D6mV7+iC7v72/f29v++HuwXR79zz7dOfhLDvYmez/vh/p
-        i+31ikdzQ1fauqymGYaHN67ypl2bLwjnVV63Rd7QV0wn+fCyaKh5sbx43WYtd/R6PZ3m+SyfyZvU
-        zBJhLYS8t/9wf/fBNNue5J8S/g/u39ue3L+/s73z8N79T+8/+HR/tvPAvnxeV8s2X87OXp5Uy/Pi
-        Yl0zgkDje9IkNfjgsbP33BvdM8A4XVqM8PycTurdoVHdvRHtr8sI8mDKevMoD766xWzKQ42LS2py
-        9vK4NDzzRd7OKybq02uahWLafWU9KYspvTGbEQV7/VOLH+KUdJDJm7sv9ROano98vH6J+8P++kvs
-        yLwhWNYrVlOeVJVdeX6Yg3sPfovj+iMm+0bmoYMMMZl8Uqzu3cxi8sv3dXgfTbLpW5pABfWyqkoM
-        bqMKpImf5Ctq6dPohzn+Ph9GRoHPI2j+nLGga6tTQL9YyB4kS+ZJtgql5/91FO5h+P8p4u4Fff+/
-        kbghhv+vIq78YrWIGxKBeLUuuZPv2a+pg0nno2I5qdbL2Yus7Tev1u3wl+5FphN/h68IpV/y/wBs
-        1mQFaQsAAA==
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:23 GMT']
-      ETag: [W/"de617b92-c7a5-4432-918c-1fa609da80b4"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW3sibmFtZSI6
-      ICJwcm9iZTEiLCAicHJvcGVydGllcyI6IHsicG9ydCI6IDEsICJwcm90b2NvbCI6ICJodHRwIiwg
-      InJlcXVlc3RQYXRoIjogIi90ZXN0MSJ9fV0sICJmcm9udGVuZElQQ29uZmlndXJhdGlvbnMiOiBb
-      eyJuYW1lIjogIkxvYWRCYWxhbmNlckZyb250RW5kIiwgInByb3BlcnRpZXMiOiB7InByb3Zpc2lv
-      bmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJwcml2YXRlSVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5
-      bmFtaWMiLCAicHVibGljSVBBZGRyZXNzIjogeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3
-      MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlk
-      ZXJzL01pY3Jvc29mdC5OZXR3b3JrL3B1YmxpY0lQQWRkcmVzc2VzL1B1YmxpY0lQbGIxIn19LCAi
-      ZXRhZyI6ICJXL1wiZGU2MTdiOTItYzdhNS00NDMyLTkxOGMtMWZhNjA5ZGE4MGI0XCIiLCAiaWQi
-      OiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jl
-      c291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5j
-      ZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMvTG9hZEJhbGFuY2VyRnJvbnRFbmQifSwg
-      eyJuYW1lIjogImlwY29uZmlnMSIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6
-      ICJTdWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1
-      YmxpY0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRh
-      LWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3Nv
-      ZnQuTmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9wdWJsaWNpcDMifX0sICJldGFnIjogIlcvXCJk
-      ZTYxN2I5Mi1jN2E1LTQ0MzItOTE4Yy0xZmE2MDlkYTgwYjRcIiIsICJpZCI6ICIvc3Vic2NyaXB0
-      aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMv
-      bGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250
-      ZW5kSVBDb25maWd1cmF0aW9ucy9pcGNvbmZpZzEifV0sICJyZXNvdXJjZUd1aWQiOiAiMzQ5NDE3
-      Y2EtYmU2NS00NzUzLWI1NTAtMDkzNTY1NzY0ZDA3IiwgIm91dGJvdW5kTmF0UnVsZXMiOiBbXSwg
-      ImxvYWRCYWxhbmNpbmdSdWxlcyI6IFtdLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVk
-      IiwgImluYm91bmROYXRSdWxlcyI6IFtdLCAiaW5ib3VuZE5hdFBvb2xzIjogW10sICJiYWNrZW5k
-      QWRkcmVzc1Bvb2xzIjogW3sibmFtZSI6ICJsYjFiZXBvb2wiLCAicHJvcGVydGllcyI6IHsicHJv
-      dmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn0sICJldGFnIjogIlcvXCJkZTYxN2I5Mi1jN2E1
-      LTQ0MzItOTE4Yy0xZmE2MDlkYTgwYjRcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3
-      MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlk
-      ZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9v
-      bHMvbGIxYmVwb29sIn0sIHsibmFtZSI6ICJiYXAxIiwgInByb3BlcnRpZXMiOiB7InByb3Zpc2lv
-      bmluZ1N0YXRlIjogIlN1Y2NlZWRlZCJ9LCAiZXRhZyI6ICJXL1wiZGU2MTdiOTItYzdhNS00NDMy
-      LTkxOGMtMWZhNjA5ZGE4MGI0XCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJm
-      MC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9N
-      aWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVzc1Bvb2xzL2Jh
-      cDEifSwgeyJuYW1lIjogImJhcDIiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUi
-      OiAiU3VjY2VlZGVkIn0sICJldGFnIjogIlcvXCJkZTYxN2I5Mi1jN2E1LTQ0MzItOTE4Yy0xZmE2
-      MDlkYTgwYjRcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVj
-      My1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5O
-      ZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMvYmFwMiJ9XX0sICJl
-      dGFnIjogIlcvXCJkZTYxN2I5Mi1jN2E1LTQ0MzItOTE4Yy0xZmE2MDlkYTgwYjRcIiIsICJpZCI6
-      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
-      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNl
-      cnMvbGIxIn0=
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Length: ['2402']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [5d8c563a-4518-11e6-9e52-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o70H+/n0wXR/e29/dr69//Bgd3uyd39/+8HD/eze/QcPZvd27v2+
-        H+mL7fWKR3NDV9q6rKYZhoc3rvKmXZsvCOdVXrdF3tBXTCf58LJoqHmxvHjdZi139Ho9neb5LJ/J
-        m9TMEmEthLy3/3B/98E0257kn97f3n9w/9725P79ne2dh/fuf3r/waf7s50H9uXzulq2+XJ29vKk
-        Wp4XF+uaEQQa35MmqcEHj529597ongHG6dJihOfndFLvDo3q7o1of11GkAdT1ptHefDVLWZTHmpc
-        XFKTs5fHpeGZL/J2XjFRn17TLBTT7ivrSVlM6Y3ZjCjY659a/BCnpINM3tx9qZ/Q9Hzk4/VL3B/2
-        119iR+YNwbJesZrypKrsyvPDHNx78Fsc1x8x2TcyDx1kiMnkk2J172YWk1++r8P7aJJN39IEKqiX
-        VVVicBtVIE38JF9RS59GP8zx9/kwMgp8HkHz54wFXVudAvrFQvYgWTJPslUoPf+vo3APw/9PEXcv
-        6Pv/jcQNMfx/FXHlF6tF3JAIxKt1yZ18z35NHUzkI/kgPifcKmSon9NZodaEtfwI0fo5mwoPijRu
-        qykpOGrz7bZddb+u6pa+2g0/rfNftCYP/GXWzunLj+629EcwOmpTkFGvL7PybPk6Jzs+A56798M2
-        y/Viktdfnr8EedBgz32t7GF/sYxQLCfVejl7kbV9JqnW7fCX7kWWDv4OX1EHv+T/ASXbFttfDQAA
-    headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/706ffe1e-6668-4622-bca3-5f1ea315fcb1?api-version=2016-03-30']
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:23 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [5e321592-4518-11e6-b25f-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o70H+/n0wXR/e29/dr69//Bgd3uyd39/+8HD/eze/QcPZvd27v2+
-        H+mL7fWKR3NDV9q6rKYZhoc3rvKmXZsvCOdVXrdF3tBXTCf58LJoqHmxvHjdZi139Ho9neb5LJ/J
-        m9TMEmEthLy3/3B/98E0257kn97f3n9w/9725P79ne2dh/fuf3r/waf7s50H9uXzulq2+XJ29vKk
-        Wp4XF+uaEQQa35MmqcEHj529597ongHG6dJihOfndFLvDo3q7o1of11GkAdT1ptHefDVLWZTHmpc
-        XFKTs5fHpeGZL/J2XjFRn17TLBTT7ivrSVlM6Y3ZjCjY659a/BCnpINM3tx9qZ/Q9Hzk4/VL3B/2
-        119iR+YNwbJesZrypKrsyvPDHNx78Fsc1x8x2TcyDx1kiMnkk2J172YWk1++r8P7aJJN39IEKqiX
-        VVVicBtVIE38JF9RS59GP8zx9/kwMgp8HkHz54wFXVudAvrFQvYgWTJPslUoPf+vo3APw/9PEXcv
-        6Pv/jcQNMfx/FXHlF6tF3JAIxKt1yZ18z35NHUzkI/kgPifcKmSon9NZodaEtfwI0fo5mwoPijRu
-        qykpOGrz7bZddb+u6pa+2g0/rfNftCYP/GXWzunLj+629EcwOmpTkFGvL7PybPk6Jzs+A56798M2
-        y/Viktdfnr8EedBgz32t7GF/sYxQLCfVejl7kbV9JqnW7fCX7kWWDv4OX1EHv+T/ASXbFttfDQAA
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:24 GMT']
-      ETag: [W/"274ec7c4-24df-4981-b254-794a3577d303"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW3sibmFtZSI6
-      ICJwcm9iZTEiLCAicHJvcGVydGllcyI6IHsicG9ydCI6IDEsICJwcm90b2NvbCI6ICJIdHRwIiwg
-      Im51bWJlck9mUHJvYmVzIjogMiwgInByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJy
-      ZXF1ZXN0UGF0aCI6ICIvdGVzdDEiLCAiaW50ZXJ2YWxJblNlY29uZHMiOiAxNX0sICJldGFnIjog
-      IlcvXCIyNzRlYzdjNC0yNGRmLTQ5ODEtYjI1NC03OTRhMzU3N2QzMDNcIiIsICJpZCI6ICIvc3Vi
-      c2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VH
-      cm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIx
-      L3Byb2Jlcy9wcm9iZTEifSwgeyJuYW1lIjogInByb2JlMiIsICJwcm9wZXJ0aWVzIjogeyJwb3J0
-      IjogMiwgInByb3RvY29sIjogImh0dHAiLCAicmVxdWVzdFBhdGgiOiAiL3Rlc3QyIn19XSwgImZy
-      b250ZW5kSVBDb25maWd1cmF0aW9ucyI6IFt7Im5hbWUiOiAiTG9hZEJhbGFuY2VyRnJvbnRFbmQi
-      LCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgInByaXZh
-      dGVJUEFsbG9jYXRpb25NZXRob2QiOiAiRHluYW1pYyIsICJwdWJsaWNJUEFkZHJlc3MiOiB7Imlk
-      IjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9y
-      ZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvcHVibGljSVBB
-      ZGRyZXNzZXMvUHVibGljSVBsYjEifX0sICJldGFnIjogIlcvXCIyNzRlYzdjNC0yNGRmLTQ5ODEt
-      YjI1NC03OTRhMzU3N2QzMDNcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYw
-      LTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01p
-      Y3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9u
-      cy9Mb2FkQmFsYW5jZXJGcm9udEVuZCJ9LCB7Im5hbWUiOiAiaXBjb25maWcxIiwgInByb3BlcnRp
-      ZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJwcml2YXRlSVBBbGxvY2F0
-      aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVibGljSVBBZGRyZXNzIjogeyJpZCI6ICIvc3Vic2Ny
-      aXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91
-      cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3B1YmxpY0lQQWRkcmVzc2VzL3B1
-      YmxpY2lwMyJ9fSwgImV0YWciOiAiVy9cIjI3NGVjN2M0LTI0ZGYtNDk4MS1iMjU0LTc5NGEzNTc3
-      ZDMwM1wiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNi
-      OTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdv
-      cmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJvbnRlbmRJUENvbmZpZ3VyYXRpb25zL2lwY29uZmlnMSJ9
-      XSwgInJlc291cmNlR3VpZCI6ICIzNDk0MTdjYS1iZTY1LTQ3NTMtYjU1MC0wOTM1NjU3NjRkMDci
-      LCAib3V0Ym91bmROYXRSdWxlcyI6IFtdLCAibG9hZEJhbGFuY2luZ1J1bGVzIjogW10sICJwcm92
-      aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAiaW5ib3VuZE5hdFJ1bGVzIjogW10sICJpbmJv
-      dW5kTmF0UG9vbHMiOiBbXSwgImJhY2tlbmRBZGRyZXNzUG9vbHMiOiBbeyJuYW1lIjogImxiMWJl
-      cG9vbCIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQifSwg
-      ImV0YWciOiAiVy9cIjI3NGVjN2M0LTI0ZGYtNDk4MS1iMjU0LTc5NGEzNTc3ZDMwM1wiIiwgImlk
-      IjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9y
-      ZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFu
-      Y2Vycy9sYjEvYmFja2VuZEFkZHJlc3NQb29scy9sYjFiZXBvb2wifSwgeyJuYW1lIjogImJhcDEi
-      LCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn0sICJldGFn
-      IjogIlcvXCIyNzRlYzdjNC0yNGRmLTQ5ODEtYjI1NC03OTRhMzU3N2QzMDNcIiIsICJpZCI6ICIv
-      c3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3Vy
-      Y2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMv
-      bGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMvYmFwMSJ9LCB7Im5hbWUiOiAiYmFwMiIsICJwcm9wZXJ0
-      aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQifSwgImV0YWciOiAiVy9cIjI3
-      NGVjN2M0LTI0ZGYtNDk4MS1iMjU0LTc5NGEzNTc3ZDMwM1wiIiwgImlkIjogIi9zdWJzY3JpcHRp
-      b25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9s
-      YnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvYmFja2Vu
-      ZEFkZHJlc3NQb29scy9iYXAyIn1dfSwgImV0YWciOiAiVy9cIjI3NGVjN2M0LTI0ZGYtNDk4MS1i
-      MjU0LTc5NGEzNTc3ZDMwM1wiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAt
-      NGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWlj
-      cm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEifQ==
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Length: ['2770']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [5e60e61c-4518-11e6-9909-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o91suj/bf/Dp9iy/n23vT2bT7cn5Xr798PzT3Z0sPzjYn+79vh/p
-        i+31ikdzQ1fauqymGYaHN67ypl2bLwjnVV63Rd7QV0wn+fCyaKh5sbx43WYtd/R6PZ3m+SyfyZvU
-        zBJhLYS8t/9wf/fBNNue5J/e395/cP/e9uT+/Z3tnYf37n96/8Gn+7OdB/bl87patvlydvbypFqe
-        FxfrmhEEGt+TJqnBB4+dvefe6J4BxunSYoTn53RS7w6N6u6NaH9dRpAHU9abR3nw1S1mUx5qXFxS
-        k7OXx6XhmS/ydl4xUZ9e0ywU0+4r60lZTOmN2Ywo2OufWvwQp6SDTN7cfamf0PR85OP1S9wf9tdf
-        YkfmDcGyXrGa8qSq7Mrzwxzce/BbHNcfMdk3Mg8dZIjJ5JNide9mFpNfvq/D+2iSTd/SBCqol1VV
-        YnAbVSBN/CRfUUufRj/M8ff5MDIKfB5B8+eMBV1bnQL6xUL2IFkyT7JVKD3/r6NwD8P/TxF3L+j7
-        /43EDTH8fxVx5RerRdyQCMSrdcmdfM9+TR1M5CP5ID4n3CpkqJ/TWaHWhLX8CNH6OZsKD4o0bqsp
-        KThq8+22XXW/ruqWvtoNP63zX7QmD/xl1s7py4/utvRHMDpqU5BRry+z8mz5Oic7PgOeu/fDNsv1
-        YpLXX56/BHnQYM99rexBv9h3vGGGEx4y+f9rJjxE6/9TE74Xfhqb8GB01Oabm3D5xUp+sZxU6+Xs
-        Rdb2tUK1boe/dC+yOuTv8BV18Ev+HztNx1ZQDwAA
-    headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/28936b6b-207c-489b-805e-580a83b50df8?api-version=2016-03-30']
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:24 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [5f053828-4518-11e6-9d39-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o91suj/bf/Dp9iy/n23vT2bT7cn5Xr798PzT3Z0sPzjYn+79vh/p
-        i+31ikdzQ1fauqymGYaHN67ypl2bLwjnVV63Rd7QV0wn+fCyaKh5sbx43WYtd/R6PZ3m+SyfyZvU
-        zBJhLYS8t/9wf/fBNNue5J/e395/cP/e9uT+/Z3tnYf37n96/8Gn+7OdB/bl87patvlydvbypFqe
-        FxfrmhEEGt+TJqnBB4+dvefe6J4BxunSYoTn53RS7w6N6u6NaH9dRpAHU9abR3nw1S1mUx5qXFxS
-        k7OXx6XhmS/ydl4xUZ9e0ywU0+4r60lZTOmN2Ywo2OufWvwQp6SDTN7cfamf0PR85OP1S9wf9tdf
-        YkfmDcGyXrGa8qSq7Mrzwxzce/BbHNcfMdk3Mg8dZIjJ5JNide9mFpNfvq/D+2iSTd/SBCqol1VV
-        YnAbVSBN/CRfUUufRj/M8ff5MDIKfB5B8+eMBV1bnQL6xUL2IFkyT7JVKD3/r6NwD8P/TxF3L+j7
-        /43EDTH8fxVx5RerRdyQCMSrdcmdfM9+TR1M5CP5ID4n3CpkqJ/TWaHWhLX8CNH6OZsKD4o0bqsp
-        KThq8+22XXW/ruqWvtoNP63zX7QmD/xl1s7py4/utvRHMDpqU5BRry+z8mz5Oic7PgOeu/fDNsv1
-        YpLXX56/BHnQYM99rexBv9h3vGGGEx4y+f9rJjxE6/9TE74Xfhqb8GB01Oabm3D5xUp+sZxU6+Xs
-        Rdb2tUK1boe/dC+yOuTv8BV18Ev+HztNx1ZQDwAA
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:25 GMT']
-      ETag: [W/"1ac4d476-de5a-4bdc-bf2e-9f610ae884c2"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW3sibmFtZSI6
-      ICJwcm9iZTEiLCAicHJvcGVydGllcyI6IHsicG9ydCI6IDEsICJwcm90b2NvbCI6ICJIdHRwIiwg
-      Im51bWJlck9mUHJvYmVzIjogMiwgInByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJy
-      ZXF1ZXN0UGF0aCI6ICIvdGVzdDEiLCAiaW50ZXJ2YWxJblNlY29uZHMiOiAxNX0sICJldGFnIjog
-      IlcvXCIxYWM0ZDQ3Ni1kZTVhLTRiZGMtYmYyZS05ZjYxMGFlODg0YzJcIiIsICJpZCI6ICIvc3Vi
-      c2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VH
-      cm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIx
-      L3Byb2Jlcy9wcm9iZTEifSwgeyJuYW1lIjogInByb2JlMiIsICJwcm9wZXJ0aWVzIjogeyJwb3J0
-      IjogMiwgInByb3RvY29sIjogIkh0dHAiLCAibnVtYmVyT2ZQcm9iZXMiOiAyLCAicHJvdmlzaW9u
-      aW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgInJlcXVlc3RQYXRoIjogIi90ZXN0MiIsICJpbnRlcnZh
-      bEluU2Vjb25kcyI6IDE1fSwgImV0YWciOiAiVy9cIjFhYzRkNDc2LWRlNWEtNGJkYy1iZjJlLTlm
-      NjEwYWU4ODRjMlwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1h
-      ZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0
-      Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvcHJvYmVzL3Byb2JlMiJ9LCB7Im5hbWUiOiAicHJv
-      YmUzIiwgInByb3BlcnRpZXMiOiB7InBvcnQiOiAzLCAicHJvdG9jb2wiOiAiaHR0cCIsICJyZXF1
-      ZXN0UGF0aCI6ICIvdGVzdDMifX1dLCAiZnJvbnRlbmRJUENvbmZpZ3VyYXRpb25zIjogW3sibmFt
-      ZSI6ICJMb2FkQmFsYW5jZXJGcm9udEVuZCIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdT
-      dGF0ZSI6ICJTdWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWlj
-      IiwgInB1YmxpY0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJm
-      MC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9N
-      aWNyb3NvZnQuTmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9QdWJsaWNJUGxiMSJ9fSwgImV0YWci
-      OiAiVy9cIjFhYzRkNDc2LWRlNWEtNGJkYy1iZjJlLTlmNjEwYWU4ODRjMlwiIiwgImlkIjogIi9z
-      dWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJj
-      ZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9s
-      YjEvZnJvbnRlbmRJUENvbmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNlckZyb250RW5kIn0sIHsibmFt
-      ZSI6ICJpcGNvbmZpZzEiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3Vj
-      Y2VlZGVkIiwgInByaXZhdGVJUEFsbG9jYXRpb25NZXRob2QiOiAiRHluYW1pYyIsICJwdWJsaWNJ
-      UEFkZHJlc3MiOiB7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMz
-      LWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5l
-      dHdvcmsvcHVibGljSVBBZGRyZXNzZXMvcHVibGljaXAzIn19LCAiZXRhZyI6ICJXL1wiMWFjNGQ0
-      NzYtZGU1YS00YmRjLWJmMmUtOWY2MTBhZTg4NGMyXCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMv
-      MGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3Jn
-      L3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQ
-      Q29uZmlndXJhdGlvbnMvaXBjb25maWcxIn1dLCAicmVzb3VyY2VHdWlkIjogIjM0OTQxN2NhLWJl
-      NjUtNDc1My1iNTUwLTA5MzU2NTc2NGQwNyIsICJvdXRib3VuZE5hdFJ1bGVzIjogW10sICJsb2Fk
-      QmFsYW5jaW5nUnVsZXMiOiBbXSwgInByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJp
-      bmJvdW5kTmF0UnVsZXMiOiBbXSwgImluYm91bmROYXRQb29scyI6IFtdLCAiYmFja2VuZEFkZHJl
-      c3NQb29scyI6IFt7Im5hbWUiOiAibGIxYmVwb29sIiwgInByb3BlcnRpZXMiOiB7InByb3Zpc2lv
-      bmluZ1N0YXRlIjogIlN1Y2NlZWRlZCJ9LCAiZXRhZyI6ICJXL1wiMWFjNGQ0NzYtZGU1YS00YmRj
-      LWJmMmUtOWY2MTBhZTg4NGMyXCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJm
-      MC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9N
-      aWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVzc1Bvb2xzL2xi
-      MWJlcG9vbCJ9LCB7Im5hbWUiOiAiYmFwMSIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdT
-      dGF0ZSI6ICJTdWNjZWVkZWQifSwgImV0YWciOiAiVy9cIjFhYzRkNDc2LWRlNWEtNGJkYy1iZjJl
-      LTlmNjEwYWU4ODRjMlwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRk
-      YS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9z
-      b2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvYmFja2VuZEFkZHJlc3NQb29scy9iYXAxIn0s
-      IHsibmFtZSI6ICJiYXAyIiwgInByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1
-      Y2NlZWRlZCJ9LCAiZXRhZyI6ICJXL1wiMWFjNGQ0NzYtZGU1YS00YmRjLWJmMmUtOWY2MTBhZTg4
-      NGMyXCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5
-      MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29y
-      ay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVzc1Bvb2xzL2JhcDIifV19LCAiZXRhZyI6
-      ICJXL1wiMWFjNGQ0NzYtZGU1YS00YmRjLWJmMmUtOWY2MTBhZTg4NGMyXCIiLCAiaWQiOiAiL3N1
-      YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNl
-      R3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xi
-      MSJ9
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Length: ['3138']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [5f317fe2-4518-11e6-b4b8-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o/P7n04e3H9wb3uS7862988fHmxP9vKH2+eT/fODfG9yb3dv5/f9
-        SF9sr1c8mhu60tZlNc0wPLxxlTft2nxBOK/yui3yhr5iOsmHl0VDzYvlxes2a7mj1+vpNM9n+Uze
-        pGaWCGsh5L39h/u7D6YZ4f/p/e39B/dpJPfv72zvPLx3/9P7Dz7dn+08sC+f19WyzZezs5cn1fK8
-        uFjXjCDQ+J40SQ0+eOzsPfdG9wwwTpcWIzw/p5N6d2hUd29E++sygjyYst48yoOvbjGb8lDj4pKa
-        nL08Lg3PfJG384qJ+vSaZqGYdl9ZT8piSm/MZkTBXv/U4oc4JR1k8ubuS/2EpucjH69f4v6wv/4S
-        OzJvCJb1itWUJ1VlV54f5uDeg9/iuP6Iyb6ReeggQ0wmnxSrezezmPzyfR3eR5Ns+pYmUEG9rKoS
-        g9uoAmniJ/mKWvo0+mGOv8+HkVHg8wiaP2cs6NrqFNAvFrIHyZJ5kq1C6fl/HYV7GP5/irh7Qd//
-        byRuiOH/q4grv1gt4oZEIF6tS+7ke/Zr6mAiH8kH8TnhViFD/ZzOCrUmrOVHiNbP2VR4UKRxW01J
-        wVGbb7ftqvt1Vbf01W74aZ3/ojV54C+zdk5ffnS3pT+C0VGbgox6fZmVZ8vXOdnxGfDcvR+2Wa4X
-        k7z+8vwlyIMGe+5rZQ/6xb7jDTOc8JDJ/18z4SFa/5+a8L3w09iEB6OjNj/MCb/n9/3/ngkP0fr/
-        1ITfCz+NTXgwOmrzzU24/GJVfbGcVOvl7EXW9s1AtW6Hv3Qvsv3j7/AVdfBL/h9y7coYQREAAA==
-    headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/0385e3c2-365c-42b8-8fb9-3eaef09115fe?api-version=2016-03-30']
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:25 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [5fd54048-4518-11e6-8cd5-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o/P7n04e3H9wb3uS7862988fHmxP9vKH2+eT/fODfG9yb3dv5/f9
-        SF9sr1c8mhu60tZlNc0wPLxxlTft2nxBOK/yui3yhr5iOsmHl0VDzYvlxes2a7mj1+vpNM9n+Uze
-        pGaWCGsh5L39h/u7D6YZ4f/p/e39B/dpJPfv72zvPLx3/9P7Dz7dn+08sC+f19WyzZezs5cn1fK8
-        uFjXjCDQ+J40SQ0+eOzsPfdG9wwwTpcWIzw/p5N6d2hUd29E++sygjyYst48yoOvbjGb8lDj4pKa
-        nL08Lg3PfJG384qJ+vSaZqGYdl9ZT8piSm/MZkTBXv/U4oc4JR1k8ubuS/2EpucjH69f4v6wv/4S
-        OzJvCJb1itWUJ1VlV54f5uDeg9/iuP6Iyb6ReeggQ0wmnxSrezezmPzyfR3eR5Ns+pYmUEG9rKoS
-        g9uoAmniJ/mKWvo0+mGOv8+HkVHg8wiaP2cs6NrqFNAvFrIHyZJ5kq1C6fl/HYV7GP5/irh7Qd//
-        byRuiOH/q4grv1gt4oZEIF6tS+7ke/Zr6mAiH8kH8TnhViFD/ZzOCrUmrOVHiNbP2VR4UKRxW01J
-        wVGbb7ftqvt1Vbf01W74aZ3/ojV54C+zdk5ffnS3pT+C0VGbgox6fZmVZ8vXOdnxGfDcvR+2Wa4X
-        k7z+8vwlyIMGe+5rZQ/6xb7jDTOc8JDJ/18z4SFa/5+a8L3w09iEB6OjNj/MCb/n9/3/ngkP0fr/
-        1ITfCz+NTXgwOmrzzU24/GJVfbGcVOvl7EXW9s1AtW6Hv3Qvsv3j7/AVdfBL/h9y7coYQREAAA==
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:26 GMT']
-      ETag: [W/"f56b7573-be1d-4f98-b2e9-fb4f8e2b3120"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [600f09da-4518-11e6-a18b-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o/P7n04e3H9wb3uS7862988fHmxP9vKH2+eT/fODfG9yb3dv5/f9
-        SF9sr1c8mhu60tZlNc0wPLxxlTft2nxBOK/yui3yhr5iOsmHl0VDzYvlxes2a7mj1+vpNM9n+Uze
-        pGaWCGsh5L39h/u7D6YZ4f/p/e39B/dpJPfv72zvPLx3/9P7Dz7dn+08sC+f19WyzZezs5cn1fK8
-        uFjXjCDQ+J40SQ0+eOzsPfdG9wwwTpcWIzw/p5N6d2hUd29E++sygjyYst48yoOvbjGb8lDj4pKa
-        nL08Lg3PfJG384qJ+vSaZqGYdl9ZT8piSm/MZkTBXv/U4oc4JR1k8ubuS/2EpucjH69f4v6wv/4S
-        OzJvCJb1itWUJ1VlV54f5uDeg9/iuP6Iyb6ReeggQ0wmnxSrezezmPzyfR3eR5Ns+pYmUEG9rKoS
-        g9uoAmniJ/mKWvo0+mGOv8+HkVHg8wiaP2cs6NrqFNAvFrIHyZJ5kq1C6fl/HYV7GP5/irh7Qd//
-        byRuiOH/q4grv1gt4oZEIF6tS+7ke/Zr6mAiH8kH8TnhViFD/ZzOCrUmrOVHiNbP2VR4UKRxW01J
-        wVGbb7ftqvt1Vbf01W74aZ3/ojV54C+zdk5ffnS3pT+C0VGbgox6fZmVZ8vXOdnxGfDcvR+2Wa4X
-        k7z+8vwlyIMGe+5rZQ/6xb7jDTOc8JDJ/18z4SFa/5+a8L3w09iEB6OjNj/MCb/n9/3/ngkP0fr/
-        1ITfCz+NTXgwOmrzzU24/GJVfbGcVOvl7EXW9s1AtW6Hv3Qvsv3j7/AVdfBL/h9y7coYQREAAA==
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:27 GMT']
-      ETag: [W/"f56b7573-be1d-4f98-b2e9-fb4f8e2b3120"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW3sibmFtZSI6
-      ICJwcm9iZTEiLCAicHJvcGVydGllcyI6IHsicG9ydCI6IDEsICJwcm90b2NvbCI6ICJIdHRwIiwg
-      Im51bWJlck9mUHJvYmVzIjogNSwgInByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJy
-      ZXF1ZXN0UGF0aCI6ICIvdGVzdDEiLCAiaW50ZXJ2YWxJblNlY29uZHMiOiAyMH0sICJldGFnIjog
-      IlcvXCJmNTZiNzU3My1iZTFkLTRmOTgtYjJlOS1mYjRmOGUyYjMxMjBcIiIsICJpZCI6ICIvc3Vi
-      c2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VH
-      cm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIx
-      L3Byb2Jlcy9wcm9iZTEifSwgeyJuYW1lIjogInByb2JlMiIsICJwcm9wZXJ0aWVzIjogeyJwb3J0
-      IjogMiwgInByb3RvY29sIjogIkh0dHAiLCAibnVtYmVyT2ZQcm9iZXMiOiAyLCAicHJvdmlzaW9u
-      aW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgInJlcXVlc3RQYXRoIjogIi90ZXN0MiIsICJpbnRlcnZh
-      bEluU2Vjb25kcyI6IDE1fSwgImV0YWciOiAiVy9cImY1NmI3NTczLWJlMWQtNGY5OC1iMmU5LWZi
-      NGY4ZTJiMzEyMFwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1h
-      ZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0
-      Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvcHJvYmVzL3Byb2JlMiJ9LCB7Im5hbWUiOiAicHJv
-      YmUzIiwgInByb3BlcnRpZXMiOiB7InBvcnQiOiAzLCAicHJvdG9jb2wiOiAiSHR0cCIsICJudW1i
-      ZXJPZlByb2JlcyI6IDIsICJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAicmVxdWVz
-      dFBhdGgiOiAiL3Rlc3QzIiwgImludGVydmFsSW5TZWNvbmRzIjogMTV9LCAiZXRhZyI6ICJXL1wi
-      ZjU2Yjc1NzMtYmUxZC00Zjk4LWIyZTktZmI0ZjhlMmIzMTIwXCIiLCAiaWQiOiAiL3N1YnNjcmlw
-      dGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBz
-      L2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9wcm9i
-      ZXMvcHJvYmUzIn1dLCAiZnJvbnRlbmRJUENvbmZpZ3VyYXRpb25zIjogW3sibmFtZSI6ICJMb2Fk
-      QmFsYW5jZXJGcm9udEVuZCIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
-      dWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1Ymxp
-      Y0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
-      YzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQu
-      TmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9QdWJsaWNJUGxiMSJ9fSwgImV0YWciOiAiVy9cImY1
-      NmI3NTczLWJlMWQtNGY5OC1iMmU5LWZiNGY4ZTJiMzEyMFwiIiwgImlkIjogIi9zdWJzY3JpcHRp
-      b25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9s
-      YnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJvbnRl
-      bmRJUENvbmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNlckZyb250RW5kIn0sIHsibmFtZSI6ICJpcGNv
-      bmZpZzEiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwg
-      InByaXZhdGVJUEFsbG9jYXRpb25NZXRob2QiOiAiRHluYW1pYyIsICJwdWJsaWNJUEFkZHJlc3Mi
-      OiB7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYw
-      OTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvcHVi
-      bGljSVBBZGRyZXNzZXMvcHVibGljaXAzIn19LCAiZXRhZyI6ICJXL1wiZjU2Yjc1NzMtYmUxZC00
-      Zjk4LWIyZTktZmI0ZjhlMmIzMTIwXCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEt
-      MWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVy
-      cy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJh
-      dGlvbnMvaXBjb25maWcxIn1dLCAicmVzb3VyY2VHdWlkIjogIjM0OTQxN2NhLWJlNjUtNDc1My1i
-      NTUwLTA5MzU2NTc2NGQwNyIsICJvdXRib3VuZE5hdFJ1bGVzIjogW10sICJsb2FkQmFsYW5jaW5n
-      UnVsZXMiOiBbXSwgInByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJpbmJvdW5kTmF0
-      UnVsZXMiOiBbXSwgImluYm91bmROYXRQb29scyI6IFtdLCAiYmFja2VuZEFkZHJlc3NQb29scyI6
-      IFt7Im5hbWUiOiAibGIxYmVwb29sIiwgInByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRl
-      IjogIlN1Y2NlZWRlZCJ9LCAiZXRhZyI6ICJXL1wiZjU2Yjc1NzMtYmUxZC00Zjk4LWIyZTktZmI0
-      ZjhlMmIzMTIwXCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
-      YzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQu
-      TmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVzc1Bvb2xzL2xiMWJlcG9vbCJ9
-      LCB7Im5hbWUiOiAiYmFwMSIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
-      dWNjZWVkZWQifSwgImV0YWciOiAiVy9cImY1NmI3NTczLWJlMWQtNGY5OC1iMmU5LWZiNGY4ZTJi
-      MzEyMFwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNi
-      OTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdv
-      cmsvbG9hZEJhbGFuY2Vycy9sYjEvYmFja2VuZEFkZHJlc3NQb29scy9iYXAxIn0sIHsibmFtZSI6
-      ICJiYXAyIiwgInByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCJ9
-      LCAiZXRhZyI6ICJXL1wiZjU2Yjc1NzMtYmUxZC00Zjk4LWIyZTktZmI0ZjhlMmIzMTIwXCIiLCAi
-      aWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkw
-      L3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFs
-      YW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVzc1Bvb2xzL2JhcDIifV19LCAiZXRhZyI6ICJXL1wiZjU2
-      Yjc1NzMtYmUxZC00Zjk4LWIyZTktZmI0ZjhlMmIzMTIwXCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlv
-      bnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xi
-      c3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMSJ9
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Length: ['3414']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [6035266e-4518-11e6-8b23-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o52d6b396f3Z9qf7e/e29w8e3NvODib3tu8/mEx2Jvd3dvLp+e/7
-        kb7YXq94NDd0pa3LappheHjjKm/atfmCcF7ldVvkDX3FdJIPL4uGmhfLi9dt1nJHr9fTaZ7P8pm8
-        Sc0sEdZCyHv7D/d3H0yz7Un+6f3t/Qf3721P7t/f2d55eO/+p/cffLo/23lgXz6vq2WbL2dnL0+q
-        5Xlxsa4ZQaDxPWmSGnzw2Nl77o3uGWCcLi1GeH5OJ/Xu0Kju3oj212UEeTBlvXmUB1/dYjblocbF
-        JTU5e3lcGp75Im/nFRP16TXNQjHtvrKelMWU3pjNiIK9/qnFD3FKOsjkzd2X+glNz0c+Xr/E/WF/
-        /SV2ZN4QLOsVqylPqsquPD/Mwb0Hv8Vx/RGTfSPz0EGGmEw+KVb3bmYx+eX7OryPJtn0LU2ggnpZ
-        VSUGt1EF0sRP8hW19Gn0wxx/nw8jo8DnETR/zljQtdUpoF8sZA+SJfMkW4XS8/86Cvcw/P8UcfeC
-        vv/fSNwQw/9XEVd+sVrEDYlAvFqX3Mn37NfUwUQ+kg/ic8KtQob6OZ0Vak1Yy48QrZ+zqfCgSOO2
-        mpKCozbfbttV9+uqbumr3fDTOv9Fa/LAX2btnL786G5LfwSjozYFGfX6MivPlq9zsuMz4Lm3E7ZZ
-        rheTvP7y/CXIgwb33dfKHvSLfccbZjjhIZP/v2bCQ7T+PzXhe+GnsQkPRkdtYhO+ez9s05vwPff1
-        +0z4Pb/v//dMeIjW/6cm/F74aWzCg9FRm29uwuUXq+qL5aRaL2cvsrZvBqp1O/yle5HtH3+Hr6iD
-        X/L/AH4tD1tBEQAA
-    headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/7f8b5dd2-60d8-40b8-a71c-012b24f47cce?api-version=2016-03-30']
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:27 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [60d8a7c0-4518-11e6-add6-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o52d6b396f3Z9qf7e/e29w8e3NvODib3tu8/mEx2Jvd3dvLp+e/7
-        kb7YXq94NDd0pa3LappheHjjKm/atfmCcF7ldVvkDX3FdJIPL4uGmhfLi9dt1nJHr9fTaZ7P8pm8
-        Sc0sEdZCyHv7D/d3H0yz7Un+6f3t/Qf3721P7t/f2d55eO/+p/cffLo/23lgXz6vq2WbL2dnL0+q
-        5Xlxsa4ZQaDxPWmSGnzw2Nl77o3uGWCcLi1GeH5OJ/Xu0Kju3oj212UEeTBlvXmUB1/dYjblocbF
-        JTU5e3lcGp75Im/nFRP16TXNQjHtvrKelMWU3pjNiIK9/qnFD3FKOsjkzd2X+glNz0c+Xr/E/WF/
-        /SV2ZN4QLOsVqylPqsquPD/Mwb0Hv8Vx/RGTfSPz0EGGmEw+KVb3bmYx+eX7OryPJtn0LU2ggnpZ
-        VSUGt1EF0sRP8hW19Gn0wxx/nw8jo8DnETR/zljQtdUpoF8sZA+SJfMkW4XS8/86Cvcw/P8UcfeC
-        vv/fSNwQw/9XEVd+sVrEDYlAvFqX3Mn37NfUwUQ+kg/ic8KtQob6OZ0Vak1Yy48QrZ+zqfCgSOO2
-        mpKCozbfbttV9+uqbumr3fDTOv9Fa/LAX2btnL786G5LfwSjozYFGfX6MivPlq9zsuMz4Lm3E7ZZ
-        rheTvP7y/CXIgwb33dfKHvSLfccbZjjhIZP/v2bCQ7T+PzXhe+GnsQkPRkdtYhO+ez9s05vwPff1
-        +0z4Pb/v//dMeIjW/6cm/F74aWzCg9FRm29uwuUXq+qL5aRaL2cvsrZvBqp1O/yle5HtH3+Hr6iD
-        X/L/AH4tD1tBEQAA
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:28 GMT']
-      ETag: [W/"00c34c5d-6423-4873-a8b3-57bb0b500ecf"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW3sibmFtZSI6
-      ICJwcm9iZTEiLCAicHJvcGVydGllcyI6IHsicG9ydCI6IDEsICJwcm90b2NvbCI6ICJIdHRwIiwg
-      Im51bWJlck9mUHJvYmVzIjogNSwgInByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJy
-      ZXF1ZXN0UGF0aCI6ICIvdGVzdDEiLCAiaW50ZXJ2YWxJblNlY29uZHMiOiAyMH0sICJldGFnIjog
-      IlcvXCIwMGMzNGM1ZC02NDIzLTQ4NzMtYThiMy01N2JiMGI1MDBlY2ZcIiIsICJpZCI6ICIvc3Vi
-      c2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VH
-      cm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIx
-      L3Byb2Jlcy9wcm9iZTEifSwgeyJuYW1lIjogInByb2JlMiIsICJwcm9wZXJ0aWVzIjogeyJwb3J0
-      IjogMiwgIm51bWJlck9mUHJvYmVzIjogMiwgInByb3RvY29sIjogInRjcCIsICJpbnRlcnZhbElu
-      U2Vjb25kcyI6IDE1LCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn0sICJldGFnIjog
-      IlcvXCIwMGMzNGM1ZC02NDIzLTQ4NzMtYThiMy01N2JiMGI1MDBlY2ZcIiIsICJpZCI6ICIvc3Vi
-      c2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VH
-      cm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIx
-      L3Byb2Jlcy9wcm9iZTIifSwgeyJuYW1lIjogInByb2JlMyIsICJwcm9wZXJ0aWVzIjogeyJwb3J0
-      IjogMywgInByb3RvY29sIjogIkh0dHAiLCAibnVtYmVyT2ZQcm9iZXMiOiAyLCAicHJvdmlzaW9u
-      aW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgInJlcXVlc3RQYXRoIjogIi90ZXN0MyIsICJpbnRlcnZh
-      bEluU2Vjb25kcyI6IDE1fSwgImV0YWciOiAiVy9cIjAwYzM0YzVkLTY0MjMtNDg3My1hOGIzLTU3
-      YmIwYjUwMGVjZlwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1h
-      ZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0
-      Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvcHJvYmVzL3Byb2JlMyJ9XSwgImZyb250ZW5kSVBD
-      b25maWd1cmF0aW9ucyI6IFt7Im5hbWUiOiAiTG9hZEJhbGFuY2VyRnJvbnRFbmQiLCAicHJvcGVy
-      dGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgInByaXZhdGVJUEFsbG9j
-      YXRpb25NZXRob2QiOiAiRHluYW1pYyIsICJwdWJsaWNJUEFkZHJlc3MiOiB7ImlkIjogIi9zdWJz
-      Y3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdy
-      b3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvcHVibGljSVBBZGRyZXNzZXMv
-      UHVibGljSVBsYjEifX0sICJldGFnIjogIlcvXCIwMGMzNGM1ZC02NDIzLTQ4NzMtYThiMy01N2Ji
-      MGI1MDBlY2ZcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVj
-      My1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5O
-      ZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9ucy9Mb2FkQmFs
-      YW5jZXJGcm9udEVuZCJ9LCB7Im5hbWUiOiAiaXBjb25maWcxIiwgInByb3BlcnRpZXMiOiB7InBy
-      b3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJwcml2YXRlSVBBbGxvY2F0aW9uTWV0aG9k
-      IjogIkR5bmFtaWMiLCAicHVibGljSVBBZGRyZXNzIjogeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8w
-      YjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcv
-      cHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3B1YmxpY0lQQWRkcmVzc2VzL3B1YmxpY2lwMyJ9
-      fSwgImV0YWciOiAiVy9cIjAwYzM0YzVkLTY0MjMtNDg3My1hOGIzLTU3YmIwYjUwMGVjZlwiIiwg
-      ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5
-      MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJh
-      bGFuY2Vycy9sYjEvZnJvbnRlbmRJUENvbmZpZ3VyYXRpb25zL2lwY29uZmlnMSJ9XSwgInJlc291
-      cmNlR3VpZCI6ICIzNDk0MTdjYS1iZTY1LTQ3NTMtYjU1MC0wOTM1NjU3NjRkMDciLCAib3V0Ym91
-      bmROYXRSdWxlcyI6IFtdLCAibG9hZEJhbGFuY2luZ1J1bGVzIjogW10sICJwcm92aXNpb25pbmdT
-      dGF0ZSI6ICJTdWNjZWVkZWQiLCAiaW5ib3VuZE5hdFJ1bGVzIjogW10sICJpbmJvdW5kTmF0UG9v
-      bHMiOiBbXSwgImJhY2tlbmRBZGRyZXNzUG9vbHMiOiBbeyJuYW1lIjogImxiMWJlcG9vbCIsICJw
-      cm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQifSwgImV0YWciOiAi
-      Vy9cIjAwYzM0YzVkLTY0MjMtNDg3My1hOGIzLTU3YmIwYjUwMGVjZlwiIiwgImlkIjogIi9zdWJz
-      Y3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdy
-      b3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEv
-      YmFja2VuZEFkZHJlc3NQb29scy9sYjFiZXBvb2wifSwgeyJuYW1lIjogImJhcDEiLCAicHJvcGVy
-      dGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn0sICJldGFnIjogIlcvXCIw
-      MGMzNGM1ZC02NDIzLTQ4NzMtYThiMy01N2JiMGI1MDBlY2ZcIiIsICJpZCI6ICIvc3Vic2NyaXB0
-      aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMv
-      bGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2JhY2tl
-      bmRBZGRyZXNzUG9vbHMvYmFwMSJ9LCB7Im5hbWUiOiAiYmFwMiIsICJwcm9wZXJ0aWVzIjogeyJw
-      cm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQifSwgImV0YWciOiAiVy9cIjAwYzM0YzVkLTY0
-      MjMtNDg3My1hOGIzLTU3YmIwYjUwMGVjZlwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2
-      NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92
-      aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvYmFja2VuZEFkZHJlc3NQ
-      b29scy9iYXAyIn1dfSwgImV0YWciOiAiVy9cIjAwYzM0YzVkLTY0MjMtNDg3My1hOGIzLTU3YmIw
-      YjUwMGVjZlwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMz
-      LWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5l
-      dHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEifQ==
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Length: ['3388']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [6106fbb6-4518-11e6-99a6-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o2zycDJ7sD/ZfrA7fbC9f28y2c5m97Ltg4cHeXZ+vrOzv7f7+36k
-        L7bXKx7NDV1p67KaZhge3rjKm3ZtviCcV3ndFnlDXzGd5MPLoqHmxfLidZu13NHr9XSa57N8Jm9S
-        M0uEtRDy3v7D/d0H02x7kn96f3v/wf1725P793e2dx7eu//p/Qef7s92HtiXz+tq2ebL2dnLk2p5
-        Xlysa0YQaHxPmqQGHzx29p57o3sGGKdLixGen9NJvTs0qrs3ov11GUEeTFlvHuXBV7eYTXmocXFJ
-        Tc5eHpeGZ77I23nFRH16TbNQTLuvrCdlMaU3ZjOiYK9/avFDnJIOMnlz96V+QtPzkY/XL3F/2F9/
-        iR2ZNwTLesVqypOqsivPD3Nw78FvcVx/xGTfyDx0kCEmk0+K1b2bWUx++b4O76NJNn1LE6igXlZV
-        icFtVIE08ZN8RS19Gv0wx9/nw8go8HkEzZ8zFnRtdQroFwvZg2TJPMlWofT8v47CPQz/P0XcvaDv
-        /zcSN8Tw/1XElV+sFnFDIhCv1iV38j37NXUwkY/kg/iccKuQoX5OZ4VaE9byI0Tr52wqPCjSuK2m
-        pOCozbfbdtX9uqpb+mo3/LTOf9GaPPCXWTunLz+629IfweioTUFGvb7MyrPl65zs+Ax47u2EbZbr
-        xSSvvzx/CfKgwX33tbIH/WLf8YYZTnjI5P+vmfAQrf8XTvib6cB874WfxuZy937YpjeXe+7r95nL
-        ez5G/++ZyxCt/xfO5bDw3gs/jQlvMDpq881NuPxitXixnFTr5exF1vY1fLVuh790L7Jp4+/wFXXw
-        S/4f5mHrGhwRAAA=
-    headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/bcafe680-db3e-48ac-9bf9-fc6aebcf5141?api-version=2016-03-30']
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:29 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [61aeec46-4518-11e6-8fb4-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o2zycDJ7sD/ZfrA7fbC9f28y2c5m97Ltg4cHeXZ+vrOzv7f7+36k
-        L7bXKx7NDV1p67KaZhge3rjKm3ZtviCcV3ndFnlDXzGd5MPLoqHmxfLidZu13NHr9XSa57N8Jm9S
-        M0uEtRDy3v7D/d0H02x7kn96f3v/wf1725P793e2dx7eu//p/Qef7s92HtiXz+tq2ebL2dnLk2p5
-        Xlysa0YQaHxPmqQGHzx29p57o3sGGKdLixGen9NJvTs0qrs3ov11GUEeTFlvHuXBV7eYTXmocXFJ
-        Tc5eHpeGZ77I23nFRH16TbNQTLuvrCdlMaU3ZjOiYK9/avFDnJIOMnlz96V+QtPzkY/XL3F/2F9/
-        iR2ZNwTLesVqypOqsivPD3Nw78FvcVx/xGTfyDx0kCEmk0+K1b2bWUx++b4O76NJNn1LE6igXlZV
-        icFtVIE08ZN8RS19Gv0wx9/nw8go8HkEzZ8zFnRtdQroFwvZg2TJPMlWofT8v47CPQz/P0XcvaDv
-        /zcSN8Tw/1XElV+sFnFDIhCv1iV38j37NXUwkY/kg/iccKuQoX5OZ4VaE9byI0Tr52wqPCjSuK2m
-        pOCozbfbdtX9uqpb+mo3/LTOf9GaPPCXWTunLz+629IfweioTUFGvb7MyrPl65zs+Ax47u2EbZbr
-        xSSvvzx/CfKgwX33tbIH/WLf8YYZTnjI5P+vmfAQrf8XTvib6cB874WfxuZy937YpjeXe+7r95nL
-        ez5G/++ZyxCt/xfO5bDw3gs/jQlvMDpq881NuPxitXixnFTr5exF1vY1fLVuh790L7Jp4+/wFXXw
-        S/4f5mHrGhwRAAA=
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:30 GMT']
-      ETag: [W/"ab9bd74b-71c7-43bb-ad3a-898eaff00421"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [61deccb4-4518-11e6-93f9-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o2zycDJ7sD/ZfrA7fbC9f28y2c5m97Ltg4cHeXZ+vrOzv7f7+36k
-        L7bXKx7NDV1p67KaZhge3rjKm3ZtviCcV3ndFnlDXzGd5MPLoqHmxfLidZu13NHr9XSa57N8Jm9S
-        M0uEtRDy3v7D/d0H02x7kn96f3v/wf1725P793e2dx7eu//p/Qef7s92HtiXz+tq2ebL2dnLk2p5
-        Xlysa0YQaHxPmqQGHzx29p57o3sGGKdLixGen9NJvTs0qrs3ov11GUEeTFlvHuXBV7eYTXmocXFJ
-        Tc5eHpeGZ77I23nFRH16TbNQTLuvrCdlMaU3ZjOiYK9/avFDnJIOMnlz96V+QtPzkY/XL3F/2F9/
-        iR2ZNwTLesVqypOqsivPD3Nw78FvcVx/xGTfyDx0kCEmk0+K1b2bWUx++b4O76NJNn1LE6igXlZV
-        icFtVIE08ZN8RS19Gv0wx9/nw8go8HkEzZ8zFnRtdQroFwvZg2TJPMlWofT8v47CPQz/P0XcvaDv
-        /zcSN8Tw/1XElV+sFnFDIhCv1iV38j37NXUwkY/kg/iccKuQoX5OZ4VaE9byI0Tr52wqPCjSuK2m
-        pOCozbfbdtX9uqpb+mo3/LTOf9GaPPCXWTunLz+629IfweioTUFGvb7MyrPl65zs+Ax47u2EbZbr
-        xSSvvzx/CfKgwX33tbIH/WLf8YYZTnjI5P+vmfAQrf8XTvib6cB874WfxuZy937YpjeXe+7r95nL
-        ez5G/++ZyxCt/xfO5bDw3gs/jQlvMDpq881NuPxitXixnFTr5exF1vY1fLVuh790L7Jp4+/wFXXw
-        S/4f5mHrGhwRAAA=
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:30 GMT']
-      ETag: [W/"ab9bd74b-71c7-43bb-ad3a-898eaff00421"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [62102934-4518-11e6-9399-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o2zycDJ7sD/ZfrA7fbC9f28y2c5m97Ltg4cHeXZ+vrOzv7f7+36k
-        L7bXKx7NDV1p67KaZhge3rjKm3ZtviCcV3ndFnlDXzGd5MPLoqHmxfLidZu13NHr9XSa57N8Jm9S
-        M0uEtRDy3v7D/d0H02x7kn96f3v/wf1725P793e2dx7eu//p/Qef7s92HtiXz+tq2ebL2dnLk2p5
-        Xlysa0YQaHxPmqQGHzx29p57o3sGGKdLixGen9NJvTs0qrs3ov11GUEeTFlvHuXBV7eYTXmocXFJ
-        Tc5eHpeGZ77I23nFRH16TbNQTLuvrCdlMaU3ZjOiYK9/avFDnJIOMnlz96V+QtPzkY/XL3F/2F9/
-        iR2ZNwTLesVqypOqsivPD3Nw78FvcVx/xGTfyDx0kCEmk0+K1b2bWUx++b4O76NJNn1LE6igXlZV
-        icFtVIE08ZN8RS19Gv0wx9/nw8go8HkEzZ8zFnRtdQroFwvZg2TJPMlWofT8v47CPQz/P0XcvaDv
-        /zcSN8Tw/1XElV+sFnFDIhCv1iV38j37NXUwkY/kg/iccKuQoX5OZ4VaE9byI0Tr52wqPCjSuK2m
-        pOCozbfbdtX9uqpb+mo3/LTOf9GaPPCXWTunLz+629IfweioTUFGvb7MyrPl65zs+Ax47u2EbZbr
-        xSSvvzx/CfKgwX33tbIH/WLf8YYZTnjI5P+vmfAQrf8XTvib6cB874WfxuZy937YpjeXe+7r95nL
-        ez5G/++ZyxCt/xfO5bDw3gs/jQlvMDpq881NuPxitXixnFTr5exF1vY1fLVuh790L7Jp4+/wFXXw
-        S/4f5mHrGhwRAAA=
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:30 GMT']
-      ETag: [W/"ab9bd74b-71c7-43bb-ad3a-898eaff00421"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW3sibmFtZSI6
-      ICJwcm9iZTEiLCAicHJvcGVydGllcyI6IHsicG9ydCI6IDEsICJwcm90b2NvbCI6ICJIdHRwIiwg
-      Im51bWJlck9mUHJvYmVzIjogNSwgInByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJy
-      ZXF1ZXN0UGF0aCI6ICIvdGVzdDEiLCAiaW50ZXJ2YWxJblNlY29uZHMiOiAyMH0sICJldGFnIjog
-      IlcvXCJhYjliZDc0Yi03MWM3LTQzYmItYWQzYS04OThlYWZmMDA0MjFcIiIsICJpZCI6ICIvc3Vi
-      c2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VH
-      cm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIx
-      L3Byb2Jlcy9wcm9iZTEifSwgeyJuYW1lIjogInByb2JlMiIsICJwcm9wZXJ0aWVzIjogeyJwb3J0
-      IjogMiwgIm51bWJlck9mUHJvYmVzIjogMiwgInByb3RvY29sIjogIlRjcCIsICJpbnRlcnZhbElu
-      U2Vjb25kcyI6IDE1LCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn0sICJldGFnIjog
-      IlcvXCJhYjliZDc0Yi03MWM3LTQzYmItYWQzYS04OThlYWZmMDA0MjFcIiIsICJpZCI6ICIvc3Vi
-      c2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VH
-      cm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIx
-      L3Byb2Jlcy9wcm9iZTIifV0sICJmcm9udGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJuYW1lIjog
-      IkxvYWRCYWxhbmNlckZyb250RW5kIiwgInByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRl
-      IjogIlN1Y2NlZWRlZCIsICJwcml2YXRlSVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAi
-      cHVibGljSVBBZGRyZXNzIjogeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRk
-      ZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jv
-      c29mdC5OZXR3b3JrL3B1YmxpY0lQQWRkcmVzc2VzL1B1YmxpY0lQbGIxIn19LCAiZXRhZyI6ICJX
-      L1wiYWI5YmQ3NGItNzFjNy00M2JiLWFkM2EtODk4ZWFmZjAwNDIxXCIiLCAiaWQiOiAiL3N1YnNj
-      cmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3Jv
-      dXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9m
-      cm9udGVuZElQQ29uZmlndXJhdGlvbnMvTG9hZEJhbGFuY2VyRnJvbnRFbmQifSwgeyJuYW1lIjog
-      ImlwY29uZmlnMSIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVk
-      ZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1YmxpY0lQQWRk
-      cmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5
-      MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29y
-      ay9wdWJsaWNJUEFkZHJlc3Nlcy9wdWJsaWNpcDMifX0sICJldGFnIjogIlcvXCJhYjliZDc0Yi03
-      MWM3LTQzYmItYWQzYS04OThlYWZmMDA0MjFcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFm
-      NjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJv
-      dmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25m
-      aWd1cmF0aW9ucy9pcGNvbmZpZzEifV0sICJyZXNvdXJjZUd1aWQiOiAiMzQ5NDE3Y2EtYmU2NS00
-      NzUzLWI1NTAtMDkzNTY1NzY0ZDA3IiwgIm91dGJvdW5kTmF0UnVsZXMiOiBbXSwgImxvYWRCYWxh
-      bmNpbmdSdWxlcyI6IFtdLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImluYm91
-      bmROYXRSdWxlcyI6IFtdLCAiaW5ib3VuZE5hdFBvb2xzIjogW10sICJiYWNrZW5kQWRkcmVzc1Bv
-      b2xzIjogW3sibmFtZSI6ICJsYjFiZXBvb2wiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5n
-      U3RhdGUiOiAiU3VjY2VlZGVkIn0sICJldGFnIjogIlcvXCJhYjliZDc0Yi03MWM3LTQzYmItYWQz
-      YS04OThlYWZmMDA0MjFcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRk
-      ZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jv
-      c29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMvbGIxYmVw
-      b29sIn0sIHsibmFtZSI6ICJiYXAxIiwgInByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRl
-      IjogIlN1Y2NlZWRlZCJ9LCAiZXRhZyI6ICJXL1wiYWI5YmQ3NGItNzFjNy00M2JiLWFkM2EtODk4
-      ZWFmZjAwNDIxXCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
-      YzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQu
-      TmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVzc1Bvb2xzL2JhcDEifSwgeyJu
-      YW1lIjogImJhcDIiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2Vl
-      ZGVkIn0sICJldGFnIjogIlcvXCJhYjliZDc0Yi03MWM3LTQzYmItYWQzYS04OThlYWZmMDA0MjFc
-      IiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJm
-      MDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xv
-      YWRCYWxhbmNlcnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMvYmFwMiJ9XX0sICJldGFnIjogIlcv
-      XCJhYjliZDc0Yi03MWM3LTQzYmItYWQzYS04OThlYWZmMDA0MjFcIiIsICJpZCI6ICIvc3Vic2Ny
-      aXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91
-      cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxIn0=
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Length: ['3020']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [622f0480-4518-11e6-a069-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o0/3Zp/ufZrtbD/M9x5s7+8cfLo9OT+4t31+f7LzYDo73zn/9OD3
-        /UhfbK9XPJobutLWZTXNMDy8cZU37dp8QTiv8rot8oa+YjrJh5dFQ82L5cXrNmu5o9fr6TTPZ/lM
-        3qRmlghrIeS9/Yf7uw+m2fYk//T+9v6D+/e2J/fv72zvPLx3/9P7Dz7dn+08sC+f19WyzZezs5cn
-        1fK8uFjXjCDQ+J40SQ0+eOzsPfdG9wwwTpcWIzw/p5N6d2hUd29E++sygjyYst48yoOvbjGb8lDj
-        4pKanL08Lg3PfJG384qJ+vSaZqGYdl9ZT8piSm/MZkTBXv/U4oc4JR1k8ubuS/2EpucjH69f4v6w
-        v/4SOzJvCJb1itWUJ1VlV54f5uDeg9/iuP6Iyb6ReeggQ0wmnxSrezezmPzyfR3eR5Ns+pYmUEG9
-        rKoSg9uoAmniJ/mKWvo0+mGOv8+HkVHg8wiaP2cs6NrqFNAvFrIHyZJ5kq1C6fl/HYV7GP5/irh7
-        Qd//byRuiOH/q4grv1gt4oZEIF6tS+7ke/Zr6mAiH8kH8TnhViFD/ZzOCrUmrOVHiNbP2VR4UKRx
-        W01JwVGbb7ftqvt1Vbf01W74aZ3/ojV54C+zdk5ffnS3pT+C0VGbgox6fZmVZ8vXOdnxGfDc2wnb
-        LNeLSV5/ef4S5EGD++5rZQ/6xb7jDTOc8JDJ/18z4SFa/y+c8DfTgfneCz+NzeXu/bBNby733Ndu
-        LuUXK9TFclKtl7MXWdsX+GrdDn/pXmRNx9/hK+rgl/w/FSFOVSsPAAA=
-    headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/bfb6df31-9417-4485-87b7-b7ba113f641e?api-version=2016-03-30']
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:31 GMT']
+      Date: ['Wed, 13 Jul 2016 23:07:44 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4608,14 +3211,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [62d3cf8c-4518-11e6-87f3-a0b3ccf7272a]
+      x-ms-client-request-id: [9b905d9c-494e-11e6-896a-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -4625,68 +3228,21 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o0/3Zp/ufZrtbD/M9x5s7+8cfLo9OT+4t31+f7LzYDo73zn/9OD3
-        /UhfbK9XPJobutLWZTXNMDy8cZU37dp8QTiv8rot8oa+YjrJh5dFQ82L5cXrNmu5o9fr6TTPZ/lM
-        3qRmlghrIeS9/Yf7uw+m2fYk//T+9v6D+/e2J/fv72zvPLx3/9P7Dz7dn+08sC+f19WyzZezs5cn
-        1fK8uFjXjCDQ+J40SQ0+eOzsPfdG9wwwTpcWIzw/p5N6d2hUd29E++sygjyYst48yoOvbjGb8lDj
-        4pKanL08Lg3PfJG384qJ+vSaZqGYdl9ZT8piSm/MZkTBXv/U4oc4JR1k8ubuS/2EpucjH69f4v6w
-        v/4SOzJvCJb1itWUJ1VlV54f5uDeg9/iuP6Iyb6ReeggQ0wmnxSrezezmPzyfR3eR5Ns+pYmUEG9
-        rKoSg9uoAmniJ/mKWvo0+mGOv8+HkVHg8wiaP2cs6NrqFNAvFrIHyZJ5kq1C6fl/HYV7GP5/irh7
-        Qd//byRuiOH/q4grv1gt4oZEIF6tS+7ke/Zr6mAiH8kH8TnhViFD/ZzOCrUmrOVHiNbP2VR4UKRx
-        W01JwVGbb7ftqvt1Vbf01W74aZ3/ojV54C+zdk5ffnS3pT+C0VGbgox6fZmVZ8vXOdnxGfDc2wnb
-        LNeLSV5/ef4S5EGD++5rZQ/6xb7jDTOc8JDJ/18z4SFa/y+c8DfTgfneCz+NzeXu/bBNby733Ndu
-        LuUXK9TFclKtl7MXWdsX+GrdDn/pXmRNx9/hK+rgl/w/FSFOVSsPAAA=
+        J1mZLaf43qGQt9kFkPju3d/3o9nup/sP873J9u75/v72/s79Per54d727GD304c7uwf37s/Of9+P
+        9MX2esWjuaErbV1W0wzDwxtXedOuzReE8yqv2yJv6Cumk3x4WTTUvFhevG6zljt6vZ5O83yWz+RN
+        amaJsBZCnhOeB5+e723vzCaE/+Thw+3JfjbZzndBxfOH989nD+3L53W1bPPl7OzlSbU8Ly7WNSMI
+        NL4nTVKDDx47e8+90T0DjNOlxQjPz+mk3h0a1d0b0f66jCAPpqw3j/Lgq1vMpjzUuLikJmcvj0vD
+        M1/k7bxioj69plkopt1X1pOymNIbsxlRsNc/tfghTkkHmby5+1I/oen5yMfrl7g/7K+/xI7MG4Jl
+        vWI15UlV2ZXnhzm49+C3OK4/YrJvZB46yBCTySfF6t7NLCa/fF+H99Ekm76lCVRQL6uqxOA2qkCa
+        +Em+opY+jX6Y4+/zYWQU+DyC5s8ZC7q2OgX0i4XsQbJknmSrUHr+X0fhHob/nyLuXtD3/xuJG2L4
+        /yriyi9Wi7ghEYhX65I7+Z79mjqYdD4qlpNqvZy9yNp+82rdDn/pXmQ68Xf4ilD6Jf8PSnyRsWkL
+        AAA=
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:32 GMT']
-      ETag: [W/"62d626a0-9e27-4086-bf83-f5b07cdf0f68"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [63032c38-4518-11e6-8b85-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o0/3Zp/ufZrtbD/M9x5s7+8cfLo9OT+4t31+f7LzYDo73zn/9OD3
-        /UhfbK9XPJobutLWZTXNMDy8cZU37dp8QTiv8rot8oa+YjrJh5dFQ82L5cXrNmu5o9fr6TTPZ/lM
-        3qRmlghrIeS9/Yf7uw+m2fYk//T+9v6D+/e2J/fv72zvPLx3/9P7Dz7dn+08sC+f19WyzZezs5cn
-        1fK8uFjXjCDQ+J40SQ0+eOzsPfdG9wwwTpcWIzw/p5N6d2hUd29E++sygjyYst48yoOvbjGb8lDj
-        4pKanL08Lg3PfJG384qJ+vSaZqGYdl9ZT8piSm/MZkTBXv/U4oc4JR1k8ubuS/2EpucjH69f4v6w
-        v/4SOzJvCJb1itWUJ1VlV54f5uDeg9/iuP6Iyb6ReeggQ0wmnxSrezezmPzyfR3eR5Ns+pYmUEG9
-        rKoSg9uoAmniJ/mKWvo0+mGOv8+HkVHg8wiaP2cs6NrqFNAvFrIHyZJ5kq1C6fl/HYV7GP5/irh7
-        Qd//byRuiOH/q4grv1gt4oZEIF6tS+7ke/Zr6mAiH8kH8TnhViFD/ZzOCrUmrOVHiNbP2VR4UKRx
-        W01JwVGbb7ftqvt1Vbf01W74aZ3/ojV54C+zdk5ffnS3pT+C0VGbgox6fZmVZ8vXOdnxGfDc2wnb
-        LNeLSV5/ef4S5EGD++5rZQ/6xb7jDTOc8JDJ/18z4SFa/y+c8DfTgfneCz+NzeXu/bBNby733Ndu
-        LuUXK9TFclKtl7MXWdsX+GrdDn/pXmRNx9/hK+rgl/w/FSFOVSsPAAA=
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:32 GMT']
-      ETag: [W/"62d626a0-9e27-4086-bf83-f5b07cdf0f68"]
+      Date: ['Wed, 13 Jul 2016 23:07:44 GMT']
+      ETag: [W/"d1649e2b-1f44-4052-ae92-d816901835df"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -4695,1022 +3251,59 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW3sibmFtZSI6
-      ICJwcm9iZTEiLCAicHJvcGVydGllcyI6IHsicG9ydCI6IDEsICJwcm90b2NvbCI6ICJIdHRwIiwg
-      Im51bWJlck9mUHJvYmVzIjogNSwgInByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJy
-      ZXF1ZXN0UGF0aCI6ICIvdGVzdDEiLCAiaW50ZXJ2YWxJblNlY29uZHMiOiAyMH0sICJldGFnIjog
-      IlcvXCI2MmQ2MjZhMC05ZTI3LTQwODYtYmY4My1mNWIwN2NkZjBmNjhcIiIsICJpZCI6ICIvc3Vi
-      c2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VH
-      cm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIx
-      L3Byb2Jlcy9wcm9iZTEifSwgeyJuYW1lIjogInByb2JlMiIsICJwcm9wZXJ0aWVzIjogeyJwb3J0
-      IjogMiwgIm51bWJlck9mUHJvYmVzIjogMiwgInByb3RvY29sIjogIlRjcCIsICJpbnRlcnZhbElu
-      U2Vjb25kcyI6IDE1LCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn0sICJldGFnIjog
-      IlcvXCI2MmQ2MjZhMC05ZTI3LTQwODYtYmY4My1mNWIwN2NkZjBmNjhcIiIsICJpZCI6ICIvc3Vi
-      c2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VH
-      cm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIx
-      L3Byb2Jlcy9wcm9iZTIifV0sICJmcm9udGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJuYW1lIjog
-      IkxvYWRCYWxhbmNlckZyb250RW5kIiwgInByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRl
-      IjogIlN1Y2NlZWRlZCIsICJwcml2YXRlSVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAi
-      cHVibGljSVBBZGRyZXNzIjogeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRk
-      ZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jv
-      c29mdC5OZXR3b3JrL3B1YmxpY0lQQWRkcmVzc2VzL1B1YmxpY0lQbGIxIn19LCAiZXRhZyI6ICJX
-      L1wiNjJkNjI2YTAtOWUyNy00MDg2LWJmODMtZjViMDdjZGYwZjY4XCIiLCAiaWQiOiAiL3N1YnNj
-      cmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3Jv
-      dXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9m
-      cm9udGVuZElQQ29uZmlndXJhdGlvbnMvTG9hZEJhbGFuY2VyRnJvbnRFbmQifSwgeyJuYW1lIjog
-      ImlwY29uZmlnMSIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVk
-      ZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1YmxpY0lQQWRk
-      cmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5
-      MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29y
-      ay9wdWJsaWNJUEFkZHJlc3Nlcy9wdWJsaWNpcDMifX0sICJldGFnIjogIlcvXCI2MmQ2MjZhMC05
-      ZTI3LTQwODYtYmY4My1mNWIwN2NkZjBmNjhcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFm
-      NjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJv
-      dmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25m
-      aWd1cmF0aW9ucy9pcGNvbmZpZzEifV0sICJyZXNvdXJjZUd1aWQiOiAiMzQ5NDE3Y2EtYmU2NS00
-      NzUzLWI1NTAtMDkzNTY1NzY0ZDA3IiwgIm91dGJvdW5kTmF0UnVsZXMiOiBbXSwgImxvYWRCYWxh
-      bmNpbmdSdWxlcyI6IFt7Im5hbWUiOiAicnVsZTEiLCAicHJvcGVydGllcyI6IHsiYmFja2VuZEFk
-      ZHJlc3NQb29sIjogeyJuYW1lIjogImJhcDEiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5n
-      U3RhdGUiOiAiU3VjY2VlZGVkIn0sICJldGFnIjogIlcvXCI2MmQ2MjZhMC05ZTI3LTQwODYtYmY4
-      My1mNWIwN2NkZjBmNjhcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRk
-      ZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jv
-      c29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMvYmFwMSJ9
-      LCAiZnJvbnRlbmRJUENvbmZpZ3VyYXRpb24iOiB7Im5hbWUiOiAiTG9hZEJhbGFuY2VyRnJvbnRF
-      bmQiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgInBy
-      aXZhdGVJUEFsbG9jYXRpb25NZXRob2QiOiAiRHluYW1pYyIsICJwdWJsaWNJUEFkZHJlc3MiOiB7
-      ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5
-      MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvcHVibGlj
-      SVBBZGRyZXNzZXMvUHVibGljSVBsYjEifX0sICJldGFnIjogIlcvXCI2MmQ2MjZhMC05ZTI3LTQw
-      ODYtYmY4My1mNWIwN2NkZjBmNjhcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0x
-      YmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJz
-      L01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0
-      aW9ucy9Mb2FkQmFsYW5jZXJGcm9udEVuZCJ9LCAicHJvdG9jb2wiOiAidGNwIiwgImZyb250ZW5k
-      UG9ydCI6IDQwLCAibG9hZERpc3RyaWJ1dGlvbiI6ICJkZWZhdWx0IiwgImVuYWJsZUZsb2F0aW5n
-      SVAiOiBmYWxzZSwgImJhY2tlbmRQb3J0IjogNDB9fV0sICJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
-      dWNjZWVkZWQiLCAiaW5ib3VuZE5hdFJ1bGVzIjogW10sICJpbmJvdW5kTmF0UG9vbHMiOiBbXSwg
-      ImJhY2tlbmRBZGRyZXNzUG9vbHMiOiBbeyJuYW1lIjogImxiMWJlcG9vbCIsICJwcm9wZXJ0aWVz
-      IjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQifSwgImV0YWciOiAiVy9cIjYyZDYy
-      NmEwLTllMjctNDA4Ni1iZjgzLWY1YjA3Y2RmMGY2OFwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25z
-      LzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNy
-      Zy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvYmFja2VuZEFk
-      ZHJlc3NQb29scy9sYjFiZXBvb2wifSwgeyJuYW1lIjogImJhcDEiLCAicHJvcGVydGllcyI6IHsi
-      cHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn0sICJldGFnIjogIlcvXCI2MmQ2MjZhMC05
-      ZTI3LTQwODYtYmY4My1mNWIwN2NkZjBmNjhcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFm
-      NjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJv
-      dmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2JhY2tlbmRBZGRyZXNz
-      UG9vbHMvYmFwMSJ9LCB7Im5hbWUiOiAiYmFwMiIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25p
-      bmdTdGF0ZSI6ICJTdWNjZWVkZWQifSwgImV0YWciOiAiVy9cIjYyZDYyNmEwLTllMjctNDA4Ni1i
-      ZjgzLWY1YjA3Y2RmMGY2OFwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAt
-      NGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWlj
-      cm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvYmFja2VuZEFkZHJlc3NQb29scy9iYXAy
-      In1dfSwgImV0YWciOiAiVy9cIjYyZDYyNmEwLTllMjctNDA4Ni1iZjgzLWY1YjA3Y2RmMGY2OFwi
-      IiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYw
-      OTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9h
-      ZEJhbGFuY2Vycy9sYjEifQ==
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Length: ['4006']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [632eedb0-4518-11e6-aeb3-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o93pwaef5g93trMH+afb+w/v72wf7Dy4v53f2915+ODB7vn5vd3f
-        9yN9sb1e8Whu6Epbl9U0w/DwxlXetGvzBeG8yuu2yBv6iukkH14WDTUvlhev26zljl6vp9M8n+Uz
-        eZOaWSKshZD39h/u7z6YZtuT/NP72/sP7t/bntynQew8vHf/0/sPPt2f7TywL5/X1bLNl7OzlyfV
-        8ry4WNeMIND4njRJDT547Ow990b3DDBOlxYjPD+nk3p3aFR3b0T76zKCPJiy3jzKg69uMZvyUOPi
-        kpqcvTwuDc98kbfzion69JpmoZh2X1lPymJKb8xmRMFe/9TihzglHWTy5u5L/YSm5yMfr18SjsLN
-        JZHp1bpkQlpOlKczLnrrhzgyhyC+p9F4nxiU79b0bzhMGqj/5/fdH/ZzRwlvgFbgitWUWVk1ljw/
-        twMflLI4rj8SrW9kHjrIELfJJ8XqXsBxlq+8X/WX7+vwPppk07c0gQrqZVWVGJwVN2+Ulg9p4if5
-        ilr6NPphjr/Ph5FR4PMImj9nLOja6hTQLxayB8mSeZKtQun5fx2Fexj+nBHXg0KNHfbUmtUxtbYs
-        LU8AHs/PLXndJwblnw0LQhO259Pq53bMAywVYvhzxlKurSOu/GJ1pxsSgeBJIxCWz7ze7ATInOr7
-        eH5uZ8B9YgagXOdj+HM2Ax4UajzgatArAVBq+XNK0gE0B+IOH3MnunjseF9WdUvj2d8Jv1bhGfg2
-        X2aTMn9G6LVE27OX1OQ8K5s8bFXMyvxNscirdXu2/KJYrluepP2wFY2/raZkRomob6arzrRQF7On
-        RdPWxWSNgaLV0/w8W5dtp6Vi7Ik7tf1/1dz1MWSFFCphVQJ47K/6i1UM1O2ESblRGXCrUNZ+TodP
-        rQlr+RGi9f8SFUCNLSd+u227rLgSWdgNP63zX7SmPMvLrJ3Tlx/dJR5vg9FRm4Ikrb7MyrPl65zi
-        lhnw3OuI1HK9mOT1l+cvQR40uO++1vmnX+w73jDDCQ/N2/9rJjxE6/+FE95XPTrfe+GnsbncvR+2
-        6c3lnvvazaX8YoW6WE6q9XL2ImvZUtJb37PfkQYd/tK9yCqFv8NX1MEv+X8ARfFr5REVAAA=
-    headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/ec355d1f-0e7b-4a64-827b-f0f066ab1925?api-version=2016-03-30']
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:33 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [63d2bacc-4518-11e6-bb94-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o93pwaef5g93trMH+afb+w/v72wf7Dy4v53f2915+ODB7vn5vd3f
-        9yN9sb1e8Whu6Epbl9U0w/DwxlXetGvzBeG8yuu2yBv6iukkH14WDTUvlhev26zljl6vp9M8n+Uz
-        eZOaWSKshZD39h/u7z6YZtuT/NP72/sP7t/bntynQew8vHf/0/sPPt2f7TywL5/X1bLNl7OzlyfV
-        8ry4WNeMIND4njRJDT547Ow990b3DDBOlxYjPD+nk3p3aFR3b0T76zKCPJiy3jzKg69uMZvyUOPi
-        kpqcvTwuDc98kbfzion69JpmoZh2X1lPymJKb8xmRMFe/9TihzglHWTy5u5L/YSm5yMfr18SjsLN
-        JZHp1bpkQlpOlKczLnrrhzgyhyC+p9F4nxiU79b0bzhMGqj/5/fdH/ZzRwlvgFbgitWUWVk1ljw/
-        twMflLI4rj8SrW9kHjrIELfJJ8XqXsBxlq+8X/WX7+vwPppk07c0gQrqZVWVGJwVN2+Ulg9p4if5
-        ilr6NPphjr/Ph5FR4PMImj9nLOja6hTQLxayB8mSeZKtQun5fx2Fexj+nBHXg0KNHfbUmtUxtbYs
-        LU8AHs/PLXndJwblnw0LQhO259Pq53bMAywVYvhzxlKurSOu/GJ1pxsSgeBJIxCWz7ze7ATInOr7
-        eH5uZ8B9YgagXOdj+HM2Ax4UajzgatArAVBq+XNK0gE0B+IOH3MnunjseF9WdUvj2d8Jv1bhGfg2
-        X2aTMn9G6LVE27OX1OQ8K5s8bFXMyvxNscirdXu2/KJYrluepP2wFY2/raZkRomob6arzrRQF7On
-        RdPWxWSNgaLV0/w8W5dtp6Vi7Ik7tf1/1dz1MWSFFCphVQJ47K/6i1UM1O2ESblRGXCrUNZ+TodP
-        rQlr+RGi9f8SFUCNLSd+u227rLgSWdgNP63zX7SmPMvLrJ3Tlx/dJR5vg9FRm4Ikrb7MyrPl65zi
-        lhnw3OuI1HK9mOT1l+cvQR40uO++1vmnX+w73jDDCQ/N2/9rJjxE6/+FE95XPTrfe+GnsbncvR+2
-        6c3lnvvazaX8YoW6WE6q9XL2ImvZUtJb37PfkQYd/tK9yCqFv8NX1MEv+X8ARfFr5REVAAA=
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:33 GMT']
-      ETag: [W/"1c866e90-a7e6-4950-8075-e3109771ff31"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW3sibmFtZSI6
-      ICJwcm9iZTEiLCAicHJvcGVydGllcyI6IHsicG9ydCI6IDEsICJwcm90b2NvbCI6ICJIdHRwIiwg
-      Im51bWJlck9mUHJvYmVzIjogNSwgInByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJy
-      ZXF1ZXN0UGF0aCI6ICIvdGVzdDEiLCAiaW50ZXJ2YWxJblNlY29uZHMiOiAyMH0sICJldGFnIjog
-      IlcvXCIxYzg2NmU5MC1hN2U2LTQ5NTAtODA3NS1lMzEwOTc3MWZmMzFcIiIsICJpZCI6ICIvc3Vi
-      c2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VH
-      cm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIx
-      L3Byb2Jlcy9wcm9iZTEifSwgeyJuYW1lIjogInByb2JlMiIsICJwcm9wZXJ0aWVzIjogeyJwb3J0
-      IjogMiwgIm51bWJlck9mUHJvYmVzIjogMiwgInByb3RvY29sIjogIlRjcCIsICJpbnRlcnZhbElu
-      U2Vjb25kcyI6IDE1LCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn0sICJldGFnIjog
-      IlcvXCIxYzg2NmU5MC1hN2U2LTQ5NTAtODA3NS1lMzEwOTc3MWZmMzFcIiIsICJpZCI6ICIvc3Vi
-      c2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VH
-      cm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIx
-      L3Byb2Jlcy9wcm9iZTIifV0sICJmcm9udGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJuYW1lIjog
-      IkxvYWRCYWxhbmNlckZyb250RW5kIiwgInByb3BlcnRpZXMiOiB7ImxvYWRCYWxhbmNpbmdSdWxl
-      cyI6IFt7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3
-      MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsv
-      bG9hZEJhbGFuY2Vycy9sYjEvbG9hZEJhbGFuY2luZ1J1bGVzL3J1bGUxIn1dLCAicHJvdmlzaW9u
-      aW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgInByaXZhdGVJUEFsbG9jYXRpb25NZXRob2QiOiAiRHlu
-      YW1pYyIsICJwdWJsaWNJUEFkZHJlc3MiOiB7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcx
-      LTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRl
-      cnMvTWljcm9zb2Z0Lk5ldHdvcmsvcHVibGljSVBBZGRyZXNzZXMvUHVibGljSVBsYjEifX0sICJl
-      dGFnIjogIlcvXCIxYzg2NmU5MC1hN2U2LTQ5NTAtODA3NS1lMzEwOTc3MWZmMzFcIiIsICJpZCI6
-      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
-      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNl
-      cnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9ucy9Mb2FkQmFsYW5jZXJGcm9udEVuZCJ9LCB7
-      Im5hbWUiOiAiaXBjb25maWcxIiwgInByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjog
-      IlN1Y2NlZWRlZCIsICJwcml2YXRlSVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVi
-      bGljSVBBZGRyZXNzIjogeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEt
-      YWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29m
-      dC5OZXR3b3JrL3B1YmxpY0lQQWRkcmVzc2VzL3B1YmxpY2lwMyJ9fSwgImV0YWciOiAiVy9cIjFj
-      ODY2ZTkwLWE3ZTYtNDk1MC04MDc1LWUzMTA5NzcxZmYzMVwiIiwgImlkIjogIi9zdWJzY3JpcHRp
-      b25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9s
-      YnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJvbnRl
-      bmRJUENvbmZpZ3VyYXRpb25zL2lwY29uZmlnMSJ9XSwgInJlc291cmNlR3VpZCI6ICIzNDk0MTdj
-      YS1iZTY1LTQ3NTMtYjU1MC0wOTM1NjU3NjRkMDciLCAib3V0Ym91bmROYXRSdWxlcyI6IFtdLCAi
-      bG9hZEJhbGFuY2luZ1J1bGVzIjogW3sibmFtZSI6ICJydWxlMSIsICJwcm9wZXJ0aWVzIjogeyJi
-      YWNrZW5kQWRkcmVzc1Bvb2wiOiB7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAt
-      NGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWlj
-      cm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvYmFja2VuZEFkZHJlc3NQb29scy9iYXAx
-      In0sICJmcm9udGVuZElQQ29uZmlndXJhdGlvbiI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIx
-      ZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3By
-      b3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29u
-      ZmlndXJhdGlvbnMvTG9hZEJhbGFuY2VyRnJvbnRFbmQifSwgInByb3RvY29sIjogIlRjcCIsICJm
-      cm9udGVuZFBvcnQiOiA0MCwgImxvYWREaXN0cmlidXRpb24iOiAiRGVmYXVsdCIsICJlbmFibGVG
-      bG9hdGluZ0lQIjogZmFsc2UsICJpZGxlVGltZW91dEluTWludXRlcyI6IDQsICJwcm92aXNpb25p
-      bmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAiYmFja2VuZFBvcnQiOiA0MH0sICJldGFnIjogIlcvXCIx
-      Yzg2NmU5MC1hN2U2LTQ5NTAtODA3NS1lMzEwOTc3MWZmMzFcIiIsICJpZCI6ICIvc3Vic2NyaXB0
-      aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMv
-      bGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2xvYWRC
-      YWxhbmNpbmdSdWxlcy9ydWxlMSJ9LCB7Im5hbWUiOiAicnVsZTIiLCAicHJvcGVydGllcyI6IHsi
-      YmFja2VuZEFkZHJlc3NQb29sIjogeyJuYW1lIjogImJhcDEiLCAicHJvcGVydGllcyI6IHsicHJv
-      dmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImxvYWRCYWxhbmNpbmdSdWxlcyI6IFt7Imlk
-      IjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9y
-      ZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFu
-      Y2Vycy9sYjEvbG9hZEJhbGFuY2luZ1J1bGVzL3J1bGUxIn1dfSwgImV0YWciOiAiVy9cIjFjODY2
-      ZTkwLWE3ZTYtNDk1MC04MDc1LWUzMTA5NzcxZmYzMVwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25z
-      LzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNy
-      Zy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvYmFja2VuZEFk
-      ZHJlc3NQb29scy9iYXAxIn0sICJmcm9udGVuZElQQ29uZmlndXJhdGlvbiI6IHsibmFtZSI6ICJM
-      b2FkQmFsYW5jZXJGcm9udEVuZCIsICJwcm9wZXJ0aWVzIjogeyJsb2FkQmFsYW5jaW5nUnVsZXMi
-      OiBbeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJm
-      MDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xv
-      YWRCYWxhbmNlcnMvbGIxL2xvYWRCYWxhbmNpbmdSdWxlcy9ydWxlMSJ9XSwgInByb3Zpc2lvbmlu
-      Z1N0YXRlIjogIlN1Y2NlZWRlZCIsICJwcml2YXRlSVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFt
-      aWMiLCAicHVibGljSVBBZGRyZXNzIjogeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0x
-      YmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJz
-      L01pY3Jvc29mdC5OZXR3b3JrL3B1YmxpY0lQQWRkcmVzc2VzL1B1YmxpY0lQbGIxIn19LCAiZXRh
-      ZyI6ICJXL1wiMWM4NjZlOTAtYTdlNi00OTUwLTgwNzUtZTMxMDk3NzFmZjMxXCIiLCAiaWQiOiAi
-      L3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291
-      cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJz
-      L2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMvTG9hZEJhbGFuY2VyRnJvbnRFbmQifSwgInBy
-      b3RvY29sIjogInRjcCIsICJmcm9udGVuZFBvcnQiOiA2MCwgImxvYWREaXN0cmlidXRpb24iOiAi
-      ZGVmYXVsdCIsICJlbmFibGVGbG9hdGluZ0lQIjogZmFsc2UsICJiYWNrZW5kUG9ydCI6IDYwfX1d
-      LCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImluYm91bmROYXRSdWxlcyI6IFtd
-      LCAiaW5ib3VuZE5hdFBvb2xzIjogW10sICJiYWNrZW5kQWRkcmVzc1Bvb2xzIjogW3sibmFtZSI6
-      ICJsYjFiZXBvb2wiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2Vl
-      ZGVkIn0sICJldGFnIjogIlcvXCIxYzg2NmU5MC1hN2U2LTQ5NTAtODA3NS1lMzEwOTc3MWZmMzFc
-      IiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJm
-      MDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xv
-      YWRCYWxhbmNlcnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMvbGIxYmVwb29sIn0sIHsibmFtZSI6
-      ICJiYXAxIiwgInByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIs
-      ICJsb2FkQmFsYW5jaW5nUnVsZXMiOiBbeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0x
-      YmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJz
-      L01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2xvYWRCYWxhbmNpbmdSdWxlcy9y
-      dWxlMSJ9XX0sICJldGFnIjogIlcvXCIxYzg2NmU5MC1hN2U2LTQ5NTAtODA3NS1lMzEwOTc3MWZm
-      MzFcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjky
-      NzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3Jr
-      L2xvYWRCYWxhbmNlcnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMvYmFwMSJ9LCB7Im5hbWUiOiAi
-      YmFwMiIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQifSwg
-      ImV0YWciOiAiVy9cIjFjODY2ZTkwLWE3ZTYtNDk1MC04MDc1LWUzMTA5NzcxZmYzMVwiIiwgImlk
-      IjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9y
-      ZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFu
-      Y2Vycy9sYjEvYmFja2VuZEFkZHJlc3NQb29scy9iYXAyIn1dfSwgImV0YWciOiAiVy9cIjFjODY2
-      ZTkwLWE3ZTYtNDk1MC04MDc1LWUzMTA5NzcxZmYzMVwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25z
-      LzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNy
-      Zy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEifQ==
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Length: ['5521']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [63f8a76e-4518-11e6-aa01-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o+n+bLK7m9/bnjzcPd/ezw/2tw8+zWfbB/d397J8Zz8jxH7fj/TF
-        9nrFo7mhK21dVtMMw8MbV3nTrs0XhPMqr9sib+grppN8eFk01LxYXrxus5Y7er2eTvN8ls/kTWpm
-        ibAWQt7bf7i/+2CabU/yT+9v7z+4TyO5f39ne+fhvfuf3n/w6f5s54F9+byulm2+nJ29PKmW58XF
-        umYEgcb3pElq8MFjZ++5N7pngHG6tBjh+Tmd1LtDo7p7I9pflxHkwZT15lEefHWL2ZSHGheX1OTs
-        5XFpeOaLvJ1XTNSn1zQLxbT7ynpSFlN6YzYjCvb6pxY/xCnpIJM3d1/qJzQ9H/l4/ZJwFG4uiUyv
-        1iUT0nKiPJ1x0Vs/xJE5BPE9jcb7xKB8t6Z/w2F2B/r/lVHsdUfh//l994f93A3TG6BVG8VqygKp
-        eleen9uBD+qKOK4/UhDfyDx0kCFuk0+K1b2A4yxfeb/qL9/X4X00yaZvaQIV1MuqKjE4qzS8UVo+
-        pImf5Ctq6dPohzn+Ph9GRoHPI2j+nLGga6tTQL9YyB4kS+ZJtgql5/91FO5h+HNGXA8KNXbYU2tW
-        x9TasrQ8AXg8P7fkdZ8YlNmC/MgOml9oaJ5g7Pkz/nM75gHBCDH8ORMM19YRV36xFsANiUDwpBEI
-        Ky1eb3YCMKeh4P+czoD7xAyAuS7E8OdsBjwo1HjAYaJXAqDU8ueUpANoDsSAPuZOdPHY8b6s6pbG
-        s78Tfq3CM/BtvswmZf6M0GuJtmcvqcl5VjZ52KqYlfmbYpFX6/Zs+UWxXLc8SfthKxp/W03JGSCi
-        vpmuOtNCXcyeFk1bF5M1BopWT/PzbF22nZaKsSfu1Pb/VXPXx5AVUmhKVAngsb+6qfPGEwh9qNR+
-        TkfpPiHWcEIfYvgjoScsb03SATQ/WOg/7Yi1MujAtz8S+q8zd30Mbyv08ov1BqjbCZNyowfArUID
-        +3M6fGpNWMuPEK3/l6gAamw58dtt22XFlcjCbvhpnf+iNSW6X2btnL786C7xeBuMjtoUJGn1ZVae
-        LV/nlHKZAc+9jkgt14tJXn95/hLkQYP77mudf/rFvuMNM5zwULn+v2bCQ7T+XzjhfdWj870Xfhqb
-        y937YZveXO65r91cyi9WqIvlpFovZy+yli0lvfU9+x1p0OEv3YusUvg7fEUd/JL/BxkIDceSGgAA
-    headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/c0438380-f430-40c6-aaaa-6a10f44f758c?api-version=2016-03-30']
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:34 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [649c29c6-4518-11e6-a8b8-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o+n+bLK7m9/bnjzcPd/ezw/2tw8+zWfbB/d397J8Zz8jxH7fj/TF
-        9nrFo7mhK21dVtMMw8MbV3nTrs0XhPMqr9sib+grppN8eFk01LxYXrxus5Y7er2eTvN8ls/kTWpm
-        ibAWQt7bf7i/+2CabU/yT+9v7z+4TyO5f39ne+fhvfuf3n/w6f5s54F9+byulm2+nJ29PKmW58XF
-        umYEgcb3pElq8MFjZ++5N7pngHG6tBjh+Tmd1LtDo7p7I9pflxHkwZT15lEefHWL2ZSHGheX1OTs
-        5XFpeOaLvJ1XTNSn1zQLxbT7ynpSFlN6YzYjCvb6pxY/xCnpIJM3d1/qJzQ9H/l4/ZJwFG4uiUyv
-        1iUT0nKiPJ1x0Vs/xJE5BPE9jcb7xKB8t6Z/w2F2B/r/lVHsdUfh//l994f93A3TG6BVG8VqygKp
-        eleen9uBD+qKOK4/UhDfyDx0kCFuk0+K1b2A4yxfeb/qL9/X4X00yaZvaQIV1MuqKjE4qzS8UVo+
-        pImf5Ctq6dPohzn+Ph9GRoHPI2j+nLGga6tTQL9YyB4kS+ZJtgql5/91FO5h+HNGXA8KNXbYU2tW
-        x9TasrQ8AXg8P7fkdZ8YlNmC/MgOml9oaJ5g7Pkz/nM75gHBCDH8ORMM19YRV36xFsANiUDwpBEI
-        Ky1eb3YCMKeh4P+czoD7xAyAuS7E8OdsBjwo1HjAYaJXAqDU8ueUpANoDsSAPuZOdPHY8b6s6pbG
-        s78Tfq3CM/BtvswmZf6M0GuJtmcvqcl5VjZ52KqYlfmbYpFX6/Zs+UWxXLc8SfthKxp/W03JGSCi
-        vpmuOtNCXcyeFk1bF5M1BopWT/PzbF22nZaKsSfu1Pb/VXPXx5AVUmhKVAngsb+6qfPGEwh9qNR+
-        TkfpPiHWcEIfYvgjoScsb03SATQ/WOg/7Yi1MujAtz8S+q8zd30Mbyv08ov1BqjbCZNyowfArUID
-        +3M6fGpNWMuPEK3/l6gAamw58dtt22XFlcjCbvhpnf+iNSW6X2btnL786C7xeBuMjtoUJGn1ZVae
-        LV/nlHKZAc+9jkgt14tJXn95/hLkQYP77mudf/rFvuMNM5zwULn+v2bCQ7T+XzjhfdWj870Xfhqb
-        y937YZveXO65r91cyi9WqIvlpFovZy+yli0lvfU9+x1p0OEv3YusUvg7fEUd/JL/BxkIDceSGgAA
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:34 GMT']
-      ETag: [W/"c4db11e3-b91f-4e84-86ed-8512ae04a1f6"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [64c9fc88-4518-11e6-bb11-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o+n+bLK7m9/bnjzcPd/ezw/2tw8+zWfbB/d397J8Zz8jxH7fj/TF
-        9nrFo7mhK21dVtMMw8MbV3nTrs0XhPMqr9sib+grppN8eFk01LxYXrxus5Y7er2eTvN8ls/kTWpm
-        ibAWQt7bf7i/+2CabU/yT+9v7z+4TyO5f39ne+fhvfuf3n/w6f5s54F9+byulm2+nJ29PKmW58XF
-        umYEgcb3pElq8MFjZ++5N7pngHG6tBjh+Tmd1LtDo7p7I9pflxHkwZT15lEefHWL2ZSHGheX1OTs
-        5XFpeOaLvJ1XTNSn1zQLxbT7ynpSFlN6YzYjCvb6pxY/xCnpIJM3d1/qJzQ9H/l4/ZJwFG4uiUyv
-        1iUT0nKiPJ1x0Vs/xJE5BPE9jcb7xKB8t6Z/w2F2B/r/lVHsdUfh//l994f93A3TG6BVG8VqygKp
-        eleen9uBD+qKOK4/UhDfyDx0kCFuk0+K1b2A4yxfeb/qL9/X4X00yaZvaQIV1MuqKjE4qzS8UVo+
-        pImf5Ctq6dPohzn+Ph9GRoHPI2j+nLGga6tTQL9YyB4kS+ZJtgql5/91FO5h+HNGXA8KNXbYU2tW
-        x9TasrQ8AXg8P7fkdZ8YlNmC/MgOml9oaJ5g7Pkz/nM75gHBCDH8ORMM19YRV36xFsANiUDwpBEI
-        Ky1eb3YCMKeh4P+czoD7xAyAuS7E8OdsBjwo1HjAYaJXAqDU8ueUpANoDsSAPuZOdPHY8b6s6pbG
-        s78Tfq3CM/BtvswmZf6M0GuJtmcvqcl5VjZ52KqYlfmbYpFX6/Zs+UWxXLc8SfthKxp/W03JGSCi
-        vpmuOtNCXcyeFk1bF5M1BopWT/PzbF22nZaKsSfu1Pb/VXPXx5AVUmhKVAngsb+6qfPGEwh9qNR+
-        TkfpPiHWcEIfYvgjoScsb03SATQ/WOg/7Yi1MujAtz8S+q8zd30Mbyv08ov1BqjbCZNyowfArUID
-        +3M6fGpNWMuPEK3/l6gAamw58dtt22XFlcjCbvhpnf+iNSW6X2btnL786C7xeBuMjtoUJGn1ZVae
-        LV/nlHKZAc+9jkgt14tJXn95/hLkQYP77mudf/rFvuMNM5zwULn+v2bCQ7T+XzjhfdWj870Xfhqb
-        y937YZveXO65r91cyi9WqIvlpFovZy+yli0lvfU9+x1p0OEv3YusUvg7fEUd/JL/BxkIDceSGgAA
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:35 GMT']
-      ETag: [W/"c4db11e3-b91f-4e84-86ed-8512ae04a1f6"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW3sibmFtZSI6
-      ICJwcm9iZTEiLCAicHJvcGVydGllcyI6IHsicG9ydCI6IDEsICJwcm90b2NvbCI6ICJIdHRwIiwg
-      Im51bWJlck9mUHJvYmVzIjogNSwgInByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJy
-      ZXF1ZXN0UGF0aCI6ICIvdGVzdDEiLCAiaW50ZXJ2YWxJblNlY29uZHMiOiAyMH0sICJldGFnIjog
-      IlcvXCJjNGRiMTFlMy1iOTFmLTRlODQtODZlZC04NTEyYWUwNGExZjZcIiIsICJpZCI6ICIvc3Vi
-      c2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VH
-      cm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIx
-      L3Byb2Jlcy9wcm9iZTEifSwgeyJuYW1lIjogInByb2JlMiIsICJwcm9wZXJ0aWVzIjogeyJwb3J0
-      IjogMiwgIm51bWJlck9mUHJvYmVzIjogMiwgInByb3RvY29sIjogIlRjcCIsICJpbnRlcnZhbElu
-      U2Vjb25kcyI6IDE1LCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn0sICJldGFnIjog
-      IlcvXCJjNGRiMTFlMy1iOTFmLTRlODQtODZlZC04NTEyYWUwNGExZjZcIiIsICJpZCI6ICIvc3Vi
-      c2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VH
-      cm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIx
-      L3Byb2Jlcy9wcm9iZTIifV0sICJmcm9udGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJuYW1lIjog
-      IkxvYWRCYWxhbmNlckZyb250RW5kIiwgInByb3BlcnRpZXMiOiB7ImxvYWRCYWxhbmNpbmdSdWxl
-      cyI6IFt7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3
-      MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsv
-      bG9hZEJhbGFuY2Vycy9sYjEvbG9hZEJhbGFuY2luZ1J1bGVzL3J1bGUxIn0sIHsiaWQiOiAiL3N1
-      YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNl
-      R3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xi
-      MS9sb2FkQmFsYW5jaW5nUnVsZXMvcnVsZTIifV0sICJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNj
-      ZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1YmxpY0lQ
-      QWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMt
-      Y2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0
-      d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9QdWJsaWNJUGxiMSJ9fSwgImV0YWciOiAiVy9cImM0ZGIx
-      MWUzLWI5MWYtNGU4NC04NmVkLTg1MTJhZTA0YTFmNlwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25z
-      LzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNy
-      Zy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJvbnRlbmRJ
-      UENvbmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNlckZyb250RW5kIn0sIHsibmFtZSI6ICJpcGNvbmZp
-      ZzEiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgInBy
-      aXZhdGVJUEFsbG9jYXRpb25NZXRob2QiOiAiRHluYW1pYyIsICJwdWJsaWNJUEFkZHJlc3MiOiB7
-      ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5
-      MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvcHVibGlj
-      SVBBZGRyZXNzZXMvcHVibGljaXAzIn19LCAiZXRhZyI6ICJXL1wiYzRkYjExZTMtYjkxZi00ZTg0
-      LTg2ZWQtODUxMmFlMDRhMWY2XCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJm
-      MC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9N
-      aWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlv
-      bnMvaXBjb25maWcxIn1dLCAicmVzb3VyY2VHdWlkIjogIjM0OTQxN2NhLWJlNjUtNDc1My1iNTUw
-      LTA5MzU2NTc2NGQwNyIsICJvdXRib3VuZE5hdFJ1bGVzIjogW10sICJsb2FkQmFsYW5jaW5nUnVs
-      ZXMiOiBbeyJuYW1lIjogInJ1bGUxIiwgInByb3BlcnRpZXMiOiB7ImJhY2tlbmRBZGRyZXNzUG9v
-      bCI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5Mjcy
-      ZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9s
-      b2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVzc1Bvb2xzL2JhcDEifSwgImZyb250ZW5kSVBD
-      b25maWd1cmF0aW9uIjogeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEt
-      YWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29m
-      dC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9ucy9Mb2Fk
-      QmFsYW5jZXJGcm9udEVuZCJ9LCAicHJvdG9jb2wiOiAidWRwIiwgImZyb250ZW5kUG9ydCI6IDQw
-      LCAibG9hZERpc3RyaWJ1dGlvbiI6ICJzb3VyY2VpcCIsICJlbmFibGVGbG9hdGluZ0lQIjogdHJ1
-      ZSwgImlkbGVUaW1lb3V0SW5NaW51dGVzIjogMjAsICJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNj
-      ZWVkZWQiLCAiYmFja2VuZFBvcnQiOiA0MH0sICJldGFnIjogIlcvXCJjNGRiMTFlMy1iOTFmLTRl
-      ODQtODZlZC04NTEyYWUwNGExZjZcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0x
-      YmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJz
-      L01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2xvYWRCYWxhbmNpbmdSdWxlcy9y
-      dWxlMSJ9LCB7Im5hbWUiOiAicnVsZTIiLCAicHJvcGVydGllcyI6IHsiYmFja2VuZEFkZHJlc3NQ
-      b29sIjogeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjky
-      NzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3Jr
-      L2xvYWRCYWxhbmNlcnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMvYmFwMSJ9LCAiZnJvbnRlbmRJ
-      UENvbmZpZ3VyYXRpb24iOiB7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRk
-      YS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9z
-      b2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJvbnRlbmRJUENvbmZpZ3VyYXRpb25zL0xv
-      YWRCYWxhbmNlckZyb250RW5kIn0sICJwcm90b2NvbCI6ICJUY3AiLCAiZnJvbnRlbmRQb3J0Ijog
-      NjAsICJsb2FkRGlzdHJpYnV0aW9uIjogIkRlZmF1bHQiLCAiZW5hYmxlRmxvYXRpbmdJUCI6IGZh
-      bHNlLCAiaWRsZVRpbWVvdXRJbk1pbnV0ZXMiOiA0LCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3Vj
-      Y2VlZGVkIiwgImJhY2tlbmRQb3J0IjogNjB9LCAiZXRhZyI6ICJXL1wiYzRkYjExZTMtYjkxZi00
-      ZTg0LTg2ZWQtODUxMmFlMDRhMWY2XCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEt
-      MWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVy
-      cy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9sb2FkQmFsYW5jaW5nUnVsZXMv
-      cnVsZTIifV0sICJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAiaW5ib3VuZE5hdFJ1
-      bGVzIjogW10sICJpbmJvdW5kTmF0UG9vbHMiOiBbXSwgImJhY2tlbmRBZGRyZXNzUG9vbHMiOiBb
-      eyJuYW1lIjogImxiMWJlcG9vbCIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6
-      ICJTdWNjZWVkZWQifSwgImV0YWciOiAiVy9cImM0ZGIxMWUzLWI5MWYtNGU4NC04NmVkLTg1MTJh
-      ZTA0YTFmNlwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMz
-      LWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5l
-      dHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvYmFja2VuZEFkZHJlc3NQb29scy9sYjFiZXBvb2wifSwg
-      eyJuYW1lIjogImJhcDEiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3Vj
-      Y2VlZGVkIiwgImxvYWRCYWxhbmNpbmdSdWxlcyI6IFt7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBi
-      MWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9w
-      cm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvbG9hZEJhbGFuY2lu
-      Z1J1bGVzL3J1bGUxIn0sIHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRh
-      LWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3Nv
-      ZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9sb2FkQmFsYW5jaW5nUnVsZXMvcnVsZTIifV19
-      LCAiZXRhZyI6ICJXL1wiYzRkYjExZTMtYjkxZi00ZTg0LTg2ZWQtODUxMmFlMDRhMWY2XCIiLCAi
-      aWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkw
-      L3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFs
-      YW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVzc1Bvb2xzL2JhcDEifSwgeyJuYW1lIjogImJhcDIiLCAi
-      cHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn0sICJldGFnIjog
-      IlcvXCJjNGRiMTFlMy1iOTFmLTRlODQtODZlZC04NTEyYWUwNGExZjZcIiIsICJpZCI6ICIvc3Vi
-      c2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VH
-      cm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIx
-      L2JhY2tlbmRBZGRyZXNzUG9vbHMvYmFwMiJ9XX0sICJldGFnIjogIlcvXCJjNGRiMTFlMy1iOTFm
-      LTRlODQtODZlZC04NTEyYWUwNGExZjZcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3
-      MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlk
-      ZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxIn0=
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Length: ['5285']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [64f0a000-4518-11e6-860b-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o/Pdyc7DT/O97d3dg0+39x/m97YPPj3Ptnfu72X3H0z38oP7+7/v
-        R/pie73i0dzQlbYuq2mG4eGNq7xp1+YLwnmV122RN/QV00k+vCwaal4sL163WcsdvV5Pp3k+y2fy
-        JjWzRFgLIe/tP9zffTDNtif5p/e39x/cv7c9uX9/Z3vn4b37n95/8On+bOeBffm8rpZtvpydvTyp
-        lufFxbpmBIHG96RJavDBY2fvuTe6Z4BxurQY4fk5ndS7Q6O6eyPaX5cR5MGU9eZRHnx1i9mUhxoX
-        l9Tk7OVxaXjmi7ydV0zUp9c0C8W0+8p6UhZTemM2Iwr2+qcWP8Qp6SCTN3df6ic0PR/5eP2ScBRu
-        LolMr9YlE9JyojydcdFbP8SROQTxPY3G+8SgfLemf8Nhdgf6/5VR7HVH4f/5ffeH/dwN0xugVRvF
-        asoCqXpXnp/bgQ/qijiuP1IQ38g8dJAhbpNPitW9gOMsX3m/6i/f1+F9NMmmb2kCFdTLqioxOKs0
-        vFFaPqSJn+QraunT6Ic5/j4fRkaBzyNo/pyxoGurU0C/WMgeJEvmSbYKpef/dRTuYfhzRlwPCjV2
-        2FNrVsfU2rK0PAF4PD+35HWfGJTZgvzIDppfaGieYOz5M/5zO+YBwQgx/DkTDNfWEVd+sRbADYlA
-        8KQRCCstXm92AjCnoeD/nM6A+8QMgLkuxPDnbAY8KNR4wGGiVwKg1PLnlKQDaA7EgD7mTnTx2PG+
-        rOqWxrO/E36twjPwbb7MJmX+jNBribZnL6lJW6/zsFExK/M3xSKv1u3Z8otiuW55jvY6sGj8bTUl
-        Z4CI+tVs1ZkW6mL2tGjaupisMVC0es1EpF7DpoqyJ+/U+P9Vk9fHkDVSaEtUC+Cxv7q588YTSH2o
-        1X5OR+k+Id5wUh9i+COpJyxvTdIBND9Y6j/tyKIy6MC3Eak/z8rmdmK/H7ai8VupfzO9jdQ/zc+z
-        ddl2WirGnkhR2/9XzV0fw9sKvfxi3QHqdsKk3OgCcKvQwv6cDp9aE9byI0Tr/yUqgBpbTvx223ZZ
-        cSWysBt+Wue/aE2Z7pdZO6cvP7pLPN4Go6M2BUlafZmVZ8vXOeVcZsCza/yW68Ukr788fwnyoMF9
-        97XOP/1i3/GGGU54qFz/XzPhIVr/L5zwvurR+d4LP43N5e79sE1vLvfc124u5Rcr1MVyUq2XsxdZ
-        y5aS3vqe/Y406PCX7kVWKfwdvqIOfsn/A3cZFhyTGgAA
-    headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/0a8821b8-57aa-4aa1-aee6-d6aca72c1229?api-version=2016-03-30']
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:35 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [659513d2-4518-11e6-9245-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o/Pdyc7DT/O97d3dg0+39x/m97YPPj3Ptnfu72X3H0z38oP7+7/v
-        R/pie73i0dzQlbYuq2mG4eGNq7xp1+YLwnmV122RN/QV00k+vCwaal4sL163WcsdvV5Pp3k+y2fy
-        JjWzRFgLIe/tP9zffTDNtif5p/e39x/cv7c9uX9/Z3vn4b37n95/8On+bOeBffm8rpZtvpydvTyp
-        lufFxbpmBIHG96RJavDBY2fvuTe6Z4BxurQY4fk5ndS7Q6O6eyPaX5cR5MGU9eZRHnx1i9mUhxoX
-        l9Tk7OVxaXjmi7ydV0zUp9c0C8W0+8p6UhZTemM2Iwr2+qcWP8Qp6SCTN3df6ic0PR/5eP2ScBRu
-        LolMr9YlE9JyojydcdFbP8SROQTxPY3G+8SgfLemf8Nhdgf6/5VR7HVH4f/5ffeH/dwN0xugVRvF
-        asoCqXpXnp/bgQ/qijiuP1IQ38g8dJAhbpNPitW9gOMsX3m/6i/f1+F9NMmmb2kCFdTLqioxOKs0
-        vFFaPqSJn+QraunT6Ic5/j4fRkaBzyNo/pyxoGurU0C/WMgeJEvmSbYKpef/dRTuYfhzRlwPCjV2
-        2FNrVsfU2rK0PAF4PD+35HWfGJTZgvzIDppfaGieYOz5M/5zO+YBwQgx/DkTDNfWEVd+sRbADYlA
-        8KQRCCstXm92AjCnoeD/nM6A+8QMgLkuxPDnbAY8KNR4wGGiVwKg1PLnlKQDaA7EgD7mTnTx2PG+
-        rOqWxrO/E36twjPwbb7MJmX+jNBribZnL6lJW6/zsFExK/M3xSKv1u3Z8otiuW55jvY6sGj8bTUl
-        Z4CI+tVs1ZkW6mL2tGjaupisMVC0es1EpF7DpoqyJ+/U+P9Vk9fHkDVSaEtUC+Cxv7q588YTSH2o
-        1X5OR+k+Id5wUh9i+COpJyxvTdIBND9Y6j/tyKIy6MC3Eak/z8rmdmK/H7ai8VupfzO9jdQ/zc+z
-        ddl2WirGnkhR2/9XzV0fw9sKvfxi3QHqdsKk3OgCcKvQwv6cDp9aE9byI0Tr/yUqgBpbTvx223ZZ
-        cSWysBt+Wue/aE2Z7pdZO6cvP7pLPN4Go6M2BUlafZmVZ8vXOeVcZsCza/yW68Ukr788fwnyoMF9
-        97XOP/1i3/GGGU54qFz/XzPhIVr/L5zwvurR+d4LP43N5e79sE1vLvfc124u5Rcr1MVyUq2XsxdZ
-        y5aS3vqe/Y406PCX7kVWKfwdvqIOfsn/A3cZFhyTGgAA
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:37 GMT']
-      ETag: [W/"f1b096e2-1186-49e3-86fa-052a57c2e854"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW3sibmFtZSI6
-      ICJwcm9iZTEiLCAicHJvcGVydGllcyI6IHsicG9ydCI6IDEsICJwcm90b2NvbCI6ICJIdHRwIiwg
-      Im51bWJlck9mUHJvYmVzIjogNSwgInByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJy
-      ZXF1ZXN0UGF0aCI6ICIvdGVzdDEiLCAiaW50ZXJ2YWxJblNlY29uZHMiOiAyMH0sICJldGFnIjog
-      IlcvXCJmMWIwOTZlMi0xMTg2LTQ5ZTMtODZmYS0wNTJhNTdjMmU4NTRcIiIsICJpZCI6ICIvc3Vi
-      c2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VH
-      cm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIx
-      L3Byb2Jlcy9wcm9iZTEifSwgeyJuYW1lIjogInByb2JlMiIsICJwcm9wZXJ0aWVzIjogeyJwb3J0
-      IjogMiwgIm51bWJlck9mUHJvYmVzIjogMiwgInByb3RvY29sIjogIlRjcCIsICJpbnRlcnZhbElu
-      U2Vjb25kcyI6IDE1LCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn0sICJldGFnIjog
-      IlcvXCJmMWIwOTZlMi0xMTg2LTQ5ZTMtODZmYS0wNTJhNTdjMmU4NTRcIiIsICJpZCI6ICIvc3Vi
-      c2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VH
-      cm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIx
-      L3Byb2Jlcy9wcm9iZTIifV0sICJmcm9udGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJuYW1lIjog
-      IkxvYWRCYWxhbmNlckZyb250RW5kIiwgInByb3BlcnRpZXMiOiB7ImxvYWRCYWxhbmNpbmdSdWxl
-      cyI6IFt7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3
-      MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsv
-      bG9hZEJhbGFuY2Vycy9sYjEvbG9hZEJhbGFuY2luZ1J1bGVzL3J1bGUxIn0sIHsiaWQiOiAiL3N1
-      YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNl
-      R3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xi
-      MS9sb2FkQmFsYW5jaW5nUnVsZXMvcnVsZTIifV0sICJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNj
-      ZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1YmxpY0lQ
-      QWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMt
-      Y2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0
-      d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9QdWJsaWNJUGxiMSJ9fSwgImV0YWciOiAiVy9cImYxYjA5
-      NmUyLTExODYtNDllMy04NmZhLTA1MmE1N2MyZTg1NFwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25z
-      LzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNy
-      Zy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJvbnRlbmRJ
-      UENvbmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNlckZyb250RW5kIn0sIHsibmFtZSI6ICJpcGNvbmZp
-      ZzEiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgInBy
-      aXZhdGVJUEFsbG9jYXRpb25NZXRob2QiOiAiRHluYW1pYyIsICJwdWJsaWNJUEFkZHJlc3MiOiB7
-      ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5
-      MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvcHVibGlj
-      SVBBZGRyZXNzZXMvcHVibGljaXAzIn19LCAiZXRhZyI6ICJXL1wiZjFiMDk2ZTItMTE4Ni00OWUz
-      LTg2ZmEtMDUyYTU3YzJlODU0XCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJm
-      MC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9N
-      aWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlv
-      bnMvaXBjb25maWcxIn1dLCAicmVzb3VyY2VHdWlkIjogIjM0OTQxN2NhLWJlNjUtNDc1My1iNTUw
-      LTA5MzU2NTc2NGQwNyIsICJvdXRib3VuZE5hdFJ1bGVzIjogW10sICJsb2FkQmFsYW5jaW5nUnVs
-      ZXMiOiBbeyJuYW1lIjogInJ1bGUxIiwgInByb3BlcnRpZXMiOiB7ImJhY2tlbmRBZGRyZXNzUG9v
-      bCI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5Mjcy
-      ZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9s
-      b2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVzc1Bvb2xzL2JhcDEifSwgImZyb250ZW5kSVBD
-      b25maWd1cmF0aW9uIjogeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEt
-      YWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29m
-      dC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9ucy9Mb2Fk
-      QmFsYW5jZXJGcm9udEVuZCJ9LCAicHJvdG9jb2wiOiAiVWRwIiwgImZyb250ZW5kUG9ydCI6IDQw
-      LCAibG9hZERpc3RyaWJ1dGlvbiI6ICJTb3VyY2VJUCIsICJlbmFibGVGbG9hdGluZ0lQIjogdHJ1
-      ZSwgImlkbGVUaW1lb3V0SW5NaW51dGVzIjogMjAsICJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNj
-      ZWVkZWQiLCAiYmFja2VuZFBvcnQiOiA0MH0sICJldGFnIjogIlcvXCJmMWIwOTZlMi0xMTg2LTQ5
-      ZTMtODZmYS0wNTJhNTdjMmU4NTRcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0x
-      YmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJz
-      L01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2xvYWRCYWxhbmNpbmdSdWxlcy9y
-      dWxlMSJ9LCB7Im5hbWUiOiAicnVsZTIiLCAicHJvcGVydGllcyI6IHsiYmFja2VuZEFkZHJlc3NQ
-      b29sIjogeyJuYW1lIjogImJhcDIiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUi
-      OiAiU3VjY2VlZGVkIn0sICJldGFnIjogIlcvXCJmMWIwOTZlMi0xMTg2LTQ5ZTMtODZmYS0wNTJh
-      NTdjMmU4NTRcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVj
-      My1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5O
-      ZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMvYmFwMiJ9LCAiZnJv
-      bnRlbmRJUENvbmZpZ3VyYXRpb24iOiB7Im5hbWUiOiAiaXBjb25maWcxIiwgInByb3BlcnRpZXMi
-      OiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJwcml2YXRlSVBBbGxvY2F0aW9u
-      TWV0aG9kIjogIkR5bmFtaWMiLCAicHVibGljSVBBZGRyZXNzIjogeyJpZCI6ICIvc3Vic2NyaXB0
-      aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMv
-      bGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3B1YmxpY0lQQWRkcmVzc2VzL3B1Ymxp
-      Y2lwMyJ9fSwgImV0YWciOiAiVy9cImYxYjA5NmUyLTExODYtNDllMy04NmZhLTA1MmE1N2MyZTg1
-      NFwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3
-      MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsv
-      bG9hZEJhbGFuY2Vycy9sYjEvZnJvbnRlbmRJUENvbmZpZ3VyYXRpb25zL2lwY29uZmlnMSJ9LCAi
-      cHJvdG9jb2wiOiAiVGNwIiwgImZyb250ZW5kUG9ydCI6IDYwLCAibG9hZERpc3RyaWJ1dGlvbiI6
-      ICJzb3VyY2VpcHByb3RvY29sIiwgImVuYWJsZUZsb2F0aW5nSVAiOiBmYWxzZSwgImlkbGVUaW1l
-      b3V0SW5NaW51dGVzIjogNCwgInByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJiYWNr
-      ZW5kUG9ydCI6IDYwfSwgImV0YWciOiAiVy9cImYxYjA5NmUyLTExODYtNDllMy04NmZhLTA1MmE1
-      N2MyZTg1NFwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMz
-      LWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5l
-      dHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvbG9hZEJhbGFuY2luZ1J1bGVzL3J1bGUyIn1dLCAicHJv
-      dmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImluYm91bmROYXRSdWxlcyI6IFtdLCAiaW5i
-      b3VuZE5hdFBvb2xzIjogW10sICJiYWNrZW5kQWRkcmVzc1Bvb2xzIjogW3sibmFtZSI6ICJsYjFi
-      ZXBvb2wiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn0s
-      ICJldGFnIjogIlcvXCJmMWIwOTZlMi0xMTg2LTQ5ZTMtODZmYS0wNTJhNTdjMmU4NTRcIiIsICJp
-      ZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAv
-      cmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxh
-      bmNlcnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMvbGIxYmVwb29sIn0sIHsibmFtZSI6ICJiYXAx
-      IiwgInByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJsb2Fk
-      QmFsYW5jaW5nUnVsZXMiOiBbeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRk
-      ZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jv
-      c29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2xvYWRCYWxhbmNpbmdSdWxlcy9ydWxlMSJ9
-      LCB7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYw
-      OTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9h
-      ZEJhbGFuY2Vycy9sYjEvbG9hZEJhbGFuY2luZ1J1bGVzL3J1bGUyIn1dfSwgImV0YWciOiAiVy9c
-      ImYxYjA5NmUyLTExODYtNDllMy04NmZhLTA1MmE1N2MyZTg1NFwiIiwgImlkIjogIi9zdWJzY3Jp
-      cHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vw
-      cy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvYmFj
-      a2VuZEFkZHJlc3NQb29scy9iYXAxIn0sIHsibmFtZSI6ICJiYXAyIiwgInByb3BlcnRpZXMiOiB7
-      InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCJ9LCAiZXRhZyI6ICJXL1wiZjFiMDk2ZTIt
-      MTE4Ni00OWUzLTg2ZmEtMDUyYTU3YzJlODU0XCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIx
-      ZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3By
-      b3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVz
-      c1Bvb2xzL2JhcDIifV19LCAiZXRhZyI6ICJXL1wiZjFiMDk2ZTItMTE4Ni00OWUzLTg2ZmEtMDUy
-      YTU3YzJlODU0XCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
+      eyJldGFnIjogIlcvXCJkMTY0OWUyYi0xZjQ0LTQwNTItYWU5Mi1kODE2OTAxODM1ZGZcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9udGVu
+      ZElQQ29uZmlndXJhdGlvbnMiOiBbeyJldGFnIjogIlcvXCJkMTY0OWUyYi0xZjQ0LTQwNTItYWU5
+      Mi1kODE2OTAxODM1ZGZcIiIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1Ymxp
+      Y0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
       YzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQu
-      TmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMSJ9
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Length: ['5727']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [65bfa642-4518-11e6-9a75-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o4N72f1P8wf3t6fZHvW8u0c9Tz+dbU/u70/3sofns+nu3u/7kb7Y
-        Xq94NDd0pa3LappheHjjKm/atfmCcF7ldVvkDX3FdJIPL4uGmhfLi9dt1nJHr9fTaZ7P8pm8Sc0s
-        EdZCyHv7D/d3H0yz7Un+6f3t/Qf37xHq93e2dx7eu//p/Qef7s92HtiXz+tq2ebL2dnLk2p5Xlys
-        a0YQaHxPmqQGHzx29p57o3sGGKdLixGen9NJvTs0qrs3ov11GUEeTFlvHuXBV7eYTXmocXFJTc5e
-        HpeGZ77I23nFRH16TbNQTLuvrCdlMaU3ZjOiYK9/avFDnJIOMnlz96V+QtPzkY/XLwlH4eaSyPRq
-        XTIhLSfK0xkXvfVDHJlDEN/TaLxPDMp3a/o3HCYN1P/z++4P+7mjhDdAK3DFasqsrBpLnp/bgQ9K
-        WRzXH4kWDfLD56GDDHGbfFKs7gUc59gJz/+PBGsvGCYN1P8zKljyy/eVIB9NsulbYlsl4MuqKgNa
-        eFSw0kfoTPIVtfQ54+eWOpFR4PMImj9ngufa6hTQLxayB8mSeZKtQp3x/zoK9zD8OSOuB4UaO+yp
-        NcsKtbYsLU8AHs/PLXndJwZlFu9v2G7ShO35tPq5HfMAS4UY/oilvi553ScGZWapD7YYfbg0SEsK
-        jwiW7dBtqCj+30iYEMP/l/DdgFtJrwRAqeXPKUkH0ByIMX3MncLCY8f7sqpbGs/+Tvi1qoyBb/Nl
-        NinzZ4ReS7Q9e0lN2nqdh42KWZm/KRZ5tW7Pll8Uy3XLc7TXgUXjb6spOQ9E1K9mq860UBezp0XT
-        1sVkjYGi1WsmIvUaNlWUPS1Hjf9fNXl9DFkPh7ZHtQAe+6ubO288gdSHuvzndJTuE+INJ/Uhhj+S
-        esLy1iQdQNOPeX10HbvgsYNUYf60I4DKlQPfRkT9PCub28n6ftiKBm1F/c30fUT9pXkzfEVR9wSK
-        Xvp/1cz1MWSRD30DK+fer/qLdQao2wnTdKMDwK1C+/pzOnxqTVjLjxCt/5coAGosjEVtvt22XZ5c
-        iVDshp/W+S9aUx79ZdbO6cuP7hKzt8HoqE1BIldfZuXZ8nVOMjoDnl3Tt1wvJnn95TlxN1GJGtx3
-        X+v80y/2HW+Y4YSHqvX/NRMeovX/wgnv6yCd773w09hc7t4P2/Tmcs997eZSfrFCXSwn1Xo5e5G1
-        bCfpre/Z70iVDn/pXmSVwt/hK+rgl/w/S7iUcfEaAAA=
-    headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/f39c7af3-8334-47f8-b108-4b210a4cb52d?api-version=2016-03-30']
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:37 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [6662f386-4518-11e6-8823-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o4N72f1P8wf3t6fZHvW8u0c9Tz+dbU/u70/3sofns+nu3u/7kb7Y
-        Xq94NDd0pa3LappheHjjKm/atfmCcF7ldVvkDX3FdJIPL4uGmhfLi9dt1nJHr9fTaZ7P8pm8Sc0s
-        EdZCyHv7D/d3H0yz7Un+6f3t/Qf37xHq93e2dx7eu//p/Qef7s92HtiXz+tq2ebL2dnLk2p5Xlys
-        a0YQaHxPmqQGHzx29p57o3sGGKdLixGen9NJvTs0qrs3ov11GUEeTFlvHuXBV7eYTXmocXFJTc5e
-        HpeGZ77I23nFRH16TbNQTLuvrCdlMaU3ZjOiYK9/avFDnJIOMnlz96V+QtPzkY/XLwlH4eaSyPRq
-        XTIhLSfK0xkXvfVDHJlDEN/TaLxPDMp3a/o3HCYN1P/z++4P+7mjhDdAK3DFasqsrBpLnp/bgQ9K
-        WRzXH4kWDfLD56GDDHGbfFKs7gUc59gJz/+PBGsvGCYN1P8zKljyy/eVIB9NsulbYlsl4MuqKgNa
-        eFSw0kfoTPIVtfQ54+eWOpFR4PMImj9ngufa6hTQLxayB8mSeZKtQp3x/zoK9zD8OSOuB4UaO+yp
-        NcsKtbYsLU8AHs/PLXndJwZlFu9v2G7ShO35tPq5HfMAS4UY/oilvi553ScGZWapD7YYfbg0SEsK
-        jwiW7dBtqCj+30iYEMP/l/DdgFtJrwRAqeXPKUkH0ByIMX3MncLCY8f7sqpbGs/+Tvi1qoyBb/Nl
-        NinzZ4ReS7Q9e0lN2nqdh42KWZm/KRZ5tW7Pll8Uy3XLc7TXgUXjb6spOQ9E1K9mq860UBezp0XT
-        1sVkjYGi1WsmIvUaNlWUPS1Hjf9fNXl9DFkPh7ZHtQAe+6ubO288gdSHuvzndJTuE+INJ/Uhhj+S
-        esLy1iQdQNOPeX10HbvgsYNUYf60I4DKlQPfRkT9PCub28n6ftiKBm1F/c30fUT9pXkzfEVR9wSK
-        Xvp/1cz1MWSRD30DK+fer/qLdQao2wnTdKMDwK1C+/pzOnxqTVjLjxCt/5coAGosjEVtvt22XZ5c
-        iVDshp/W+S9aUx79ZdbO6cuP7hKzt8HoqE1BIldfZuXZ8nVOMjoDnl3Tt1wvJnn95TlxN1GJGtx3
-        X+v80y/2HW+Y4YSHqvX/NRMeovX/wgnv6yCd773w09hc7t4P2/Tmcs997eZSfrFCXSwn1Xo5e5G1
-        bCfpre/Z70iVDn/pXmSVwt/hK+rgl/w/S7iUcfEaAAA=
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:37 GMT']
-      ETag: [W/"83a56e75-ca20-412a-ac6d-b54c2a9fdc12"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [66944e54-4518-11e6-b405-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o4N72f1P8wf3t6fZHvW8u0c9Tz+dbU/u70/3sofns+nu3u/7kb7Y
-        Xq94NDd0pa3LappheHjjKm/atfmCcF7ldVvkDX3FdJIPL4uGmhfLi9dt1nJHr9fTaZ7P8pm8Sc0s
-        EdZCyHv7D/d3H0yz7Un+6f3t/Qf37xHq93e2dx7eu//p/Qef7s92HtiXz+tq2ebL2dnLk2p5Xlys
-        a0YQaHxPmqQGHzx29p57o3sGGKdLixGen9NJvTs0qrs3ov11GUEeTFlvHuXBV7eYTXmocXFJTc5e
-        HpeGZ77I23nFRH16TbNQTLuvrCdlMaU3ZjOiYK9/avFDnJIOMnlz96V+QtPzkY/XLwlH4eaSyPRq
-        XTIhLSfK0xkXvfVDHJlDEN/TaLxPDMp3a/o3HCYN1P/z++4P+7mjhDdAK3DFasqsrBpLnp/bgQ9K
-        WRzXH4kWDfLD56GDDHGbfFKs7gUc59gJz/+PBGsvGCYN1P8zKljyy/eVIB9NsulbYlsl4MuqKgNa
-        eFSw0kfoTPIVtfQ54+eWOpFR4PMImj9ngufa6hTQLxayB8mSeZKtQp3x/zoK9zD8OSOuB4UaO+yp
-        NcsKtbYsLU8AHs/PLXndJwZlFu9v2G7ShO35tPq5HfMAS4UY/oilvi553ScGZWapD7YYfbg0SEsK
-        jwiW7dBtqCj+30iYEMP/l/DdgFtJrwRAqeXPKUkH0ByIMX3MncLCY8f7sqpbGs/+Tvi1qoyBb/Nl
-        NinzZ4ReS7Q9e0lN2nqdh42KWZm/KRZ5tW7Pll8Uy3XLc7TXgUXjb6spOQ9E1K9mq860UBezp0XT
-        1sVkjYGi1WsmIvUaNlWUPS1Hjf9fNXl9DFkPh7ZHtQAe+6ubO288gdSHuvzndJTuE+INJ/Uhhj+S
-        esLy1iQdQNOPeX10HbvgsYNUYf60I4DKlQPfRkT9PCub28n6ftiKBm1F/c30fUT9pXkzfEVR9wSK
-        Xvp/1cz1MWSRD30DK+fer/qLdQao2wnTdKMDwK1C+/pzOnxqTVjLjxCt/5coAGosjEVtvt22XZ5c
-        iVDshp/W+S9aUx79ZdbO6cuP7hKzt8HoqE1BIldfZuXZ8nVOMjoDnl3Tt1wvJnn95TlxN1GJGtx3
-        X+v80y/2HW+Y4YSHqvX/NRMeovX/wgnv6yCd773w09hc7t4P2/Tmcs997eZSfrFCXSwn1Xo5e5G1
-        bCfpre/Z70iVDn/pXmSVwt/hK+rgl/w/S7iUcfEaAAA=
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:37 GMT']
-      ETag: [W/"83a56e75-ca20-412a-ac6d-b54c2a9fdc12"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [66bcb4e2-4518-11e6-829c-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o4N72f1P8wf3t6fZHvW8u0c9Tz+dbU/u70/3sofns+nu3u/7kb7Y
-        Xq94NDd0pa3LappheHjjKm/atfmCcF7ldVvkDX3FdJIPL4uGmhfLi9dt1nJHr9fTaZ7P8pm8Sc0s
-        EdZCyHv7D/d3H0yz7Un+6f3t/Qf37xHq93e2dx7eu//p/Qef7s92HtiXz+tq2ebL2dnLk2p5Xlys
-        a0YQaHxPmqQGHzx29p57o3sGGKdLixGen9NJvTs0qrs3ov11GUEeTFlvHuXBV7eYTXmocXFJTc5e
-        HpeGZ77I23nFRH16TbNQTLuvrCdlMaU3ZjOiYK9/avFDnJIOMnlz96V+QtPzkY/XLwlH4eaSyPRq
-        XTIhLSfK0xkXvfVDHJlDEN/TaLxPDMp3a/o3HCYN1P/z++4P+7mjhDdAK3DFasqsrBpLnp/bgQ9K
-        WRzXH4kWDfLD56GDDHGbfFKs7gUc59gJz/+PBGsvGCYN1P8zKljyy/eVIB9NsulbYlsl4MuqKgNa
-        eFSw0kfoTPIVtfQ54+eWOpFR4PMImj9ngufa6hTQLxayB8mSeZKtQp3x/zoK9zD8OSOuB4UaO+yp
-        NcsKtbYsLU8AHs/PLXndJwZlFu9v2G7ShO35tPq5HfMAS4UY/oilvi553ScGZWapD7YYfbg0SEsK
-        jwiW7dBtqCj+30iYEMP/l/DdgFtJrwRAqeXPKUkH0ByIMX3MncLCY8f7sqpbGs/+Tvi1qoyBb/Nl
-        NinzZ4ReS7Q9e0lN2nqdh42KWZm/KRZ5tW7Pll8Uy3XLc7TXgUXjb6spOQ9E1K9mq860UBezp0XT
-        1sVkjYGi1WsmIvUaNlWUPS1Hjf9fNXl9DFkPh7ZHtQAe+6ubO288gdSHuvzndJTuE+INJ/Uhhj+S
-        esLy1iQdQNOPeX10HbvgsYNUYf60I4DKlQPfRkT9PCub28n6ftiKBm1F/c30fUT9pXkzfEVR9wSK
-        Xvp/1cz1MWSRD30DK+fer/qLdQao2wnTdKMDwK1C+/pzOnxqTVjLjxCt/5coAGosjEVtvt22XZ5c
-        iVDshp/W+S9aUx79ZdbO6cuP7hKzt8HoqE1BIldfZuXZ8nVOMjoDnl3Tt1wvJnn95TlxN1GJGtx3
-        X+v80y/2HW+Y4YSHqvX/NRMeovX/wgnv6yCd773w09hc7t4P2/Tmcs997eZSfrFCXSwn1Xo5e5G1
-        bCfpre/Z70iVDn/pXmSVwt/hK+rgl/w/S7iUcfEaAAA=
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:38 GMT']
-      ETag: [W/"83a56e75-ca20-412a-ac6d-b54c2a9fdc12"]
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW3sibmFtZSI6
-      ICJwcm9iZTEiLCAicHJvcGVydGllcyI6IHsicG9ydCI6IDEsICJwcm90b2NvbCI6ICJIdHRwIiwg
-      Im51bWJlck9mUHJvYmVzIjogNSwgInByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJy
-      ZXF1ZXN0UGF0aCI6ICIvdGVzdDEiLCAiaW50ZXJ2YWxJblNlY29uZHMiOiAyMH0sICJldGFnIjog
-      IlcvXCI4M2E1NmU3NS1jYTIwLTQxMmEtYWM2ZC1iNTRjMmE5ZmRjMTJcIiIsICJpZCI6ICIvc3Vi
-      c2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VH
-      cm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIx
-      L3Byb2Jlcy9wcm9iZTEifSwgeyJuYW1lIjogInByb2JlMiIsICJwcm9wZXJ0aWVzIjogeyJwb3J0
-      IjogMiwgIm51bWJlck9mUHJvYmVzIjogMiwgInByb3RvY29sIjogIlRjcCIsICJpbnRlcnZhbElu
-      U2Vjb25kcyI6IDE1LCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn0sICJldGFnIjog
-      IlcvXCI4M2E1NmU3NS1jYTIwLTQxMmEtYWM2ZC1iNTRjMmE5ZmRjMTJcIiIsICJpZCI6ICIvc3Vi
-      c2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VH
-      cm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIx
-      L3Byb2Jlcy9wcm9iZTIifV0sICJmcm9udGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJuYW1lIjog
-      IkxvYWRCYWxhbmNlckZyb250RW5kIiwgInByb3BlcnRpZXMiOiB7ImxvYWRCYWxhbmNpbmdSdWxl
-      cyI6IFt7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3
-      MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsv
-      bG9hZEJhbGFuY2Vycy9sYjEvbG9hZEJhbGFuY2luZ1J1bGVzL3J1bGUxIn1dLCAicHJvdmlzaW9u
-      aW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgInByaXZhdGVJUEFsbG9jYXRpb25NZXRob2QiOiAiRHlu
-      YW1pYyIsICJwdWJsaWNJUEFkZHJlc3MiOiB7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcx
-      LTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRl
-      cnMvTWljcm9zb2Z0Lk5ldHdvcmsvcHVibGljSVBBZGRyZXNzZXMvUHVibGljSVBsYjEifX0sICJl
-      dGFnIjogIlcvXCI4M2E1NmU3NS1jYTIwLTQxMmEtYWM2ZC1iNTRjMmE5ZmRjMTJcIiIsICJpZCI6
-      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
-      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNl
-      cnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9ucy9Mb2FkQmFsYW5jZXJGcm9udEVuZCJ9LCB7
-      Im5hbWUiOiAiaXBjb25maWcxIiwgInByb3BlcnRpZXMiOiB7ImxvYWRCYWxhbmNpbmdSdWxlcyI6
-      IFt7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYw
-      OTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9h
-      ZEJhbGFuY2Vycy9sYjEvbG9hZEJhbGFuY2luZ1J1bGVzL3J1bGUyIn1dLCAicHJvdmlzaW9uaW5n
-      U3RhdGUiOiAiU3VjY2VlZGVkIiwgInByaXZhdGVJUEFsbG9jYXRpb25NZXRob2QiOiAiRHluYW1p
-      YyIsICJwdWJsaWNJUEFkZHJlc3MiOiB7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFi
-      ZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMv
-      TWljcm9zb2Z0Lk5ldHdvcmsvcHVibGljSVBBZGRyZXNzZXMvcHVibGljaXAzIn19LCAiZXRhZyI6
-      ICJXL1wiODNhNTZlNzUtY2EyMC00MTJhLWFjNmQtYjU0YzJhOWZkYzEyXCIiLCAiaWQiOiAiL3N1
-      YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNl
-      R3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xi
-      MS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMvaXBjb25maWcxIn1dLCAicmVzb3VyY2VHdWlkIjog
-      IjM0OTQxN2NhLWJlNjUtNDc1My1iNTUwLTA5MzU2NTc2NGQwNyIsICJvdXRib3VuZE5hdFJ1bGVz
-      IjogW10sICJsb2FkQmFsYW5jaW5nUnVsZXMiOiBbeyJuYW1lIjogInJ1bGUyIiwgInByb3BlcnRp
-      ZXMiOiB7ImJhY2tlbmRBZGRyZXNzUG9vbCI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0
-      NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3Zp
-      ZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVzc1Bv
-      b2xzL2JhcDIifSwgImZyb250ZW5kSVBDb25maWd1cmF0aW9uIjogeyJpZCI6ICIvc3Vic2NyaXB0
+      TmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9QdWJsaWNJUGxiMSJ9fSwgImlkIjogIi9zdWJzY3Jp
+      cHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vw
+      cy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJv
+      bnRlbmRJUENvbmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNlckZyb250RW5kIiwgIm5hbWUiOiAiTG9h
+      ZEJhbGFuY2VyRnJvbnRFbmQifSwgeyJldGFnIjogIlcvXCJkMTY0OWUyYi0xZjQ0LTQwNTItYWU5
+      Mi1kODE2OTAxODM1ZGZcIiIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1Ymxp
+      Y0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
+      YzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQu
+      TmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9wdWJsaWNpcDMifX0sICJpZCI6ICIvc3Vic2NyaXB0
       aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMv
       bGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250
-      ZW5kSVBDb25maWd1cmF0aW9ucy9pcGNvbmZpZzEifSwgInByb3RvY29sIjogIlRjcCIsICJmcm9u
-      dGVuZFBvcnQiOiA2MCwgImxvYWREaXN0cmlidXRpb24iOiAiU291cmNlSVBQcm90b2NvbCIsICJl
-      bmFibGVGbG9hdGluZ0lQIjogZmFsc2UsICJpZGxlVGltZW91dEluTWludXRlcyI6IDQsICJwcm92
-      aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAiYmFja2VuZFBvcnQiOiA2MH0sICJldGFnIjog
-      IlcvXCI4M2E1NmU3NS1jYTIwLTQxMmEtYWM2ZC1iNTRjMmE5ZmRjMTJcIiIsICJpZCI6ICIvc3Vi
-      c2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VH
-      cm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIx
-      L2xvYWRCYWxhbmNpbmdSdWxlcy9ydWxlMiJ9XSwgInByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2Nl
-      ZWRlZCIsICJpbmJvdW5kTmF0UnVsZXMiOiBbXSwgImluYm91bmROYXRQb29scyI6IFtdLCAiYmFj
-      a2VuZEFkZHJlc3NQb29scyI6IFt7Im5hbWUiOiAibGIxYmVwb29sIiwgInByb3BlcnRpZXMiOiB7
-      InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCJ9LCAiZXRhZyI6ICJXL1wiODNhNTZlNzUt
-      Y2EyMC00MTJhLWFjNmQtYjU0YzJhOWZkYzEyXCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIx
-      ZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3By
-      b3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVz
-      c1Bvb2xzL2xiMWJlcG9vbCJ9LCB7Im5hbWUiOiAiYmFwMSIsICJwcm9wZXJ0aWVzIjogeyJwcm92
-      aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAibG9hZEJhbGFuY2luZ1J1bGVzIjogW3siaWQi
-      OiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jl
-      c291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5j
-      ZXJzL2xiMS9sb2FkQmFsYW5jaW5nUnVsZXMvcnVsZTEifV19LCAiZXRhZyI6ICJXL1wiODNhNTZl
-      NzUtY2EyMC00MTJhLWFjNmQtYjU0YzJhOWZkYzEyXCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMv
-      MGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3Jn
-      L3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRk
-      cmVzc1Bvb2xzL2JhcDEifSwgeyJuYW1lIjogImJhcDIiLCAicHJvcGVydGllcyI6IHsicHJvdmlz
-      aW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImxvYWRCYWxhbmNpbmdSdWxlcyI6IFt7ImlkIjog
-      Ii9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNv
-      dXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vy
-      cy9sYjEvbG9hZEJhbGFuY2luZ1J1bGVzL3J1bGUyIn1dfSwgImV0YWciOiAiVy9cIjgzYTU2ZTc1
-      LWNhMjAtNDEyYS1hYzZkLWI1NGMyYTlmZGMxMlwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBi
-      MWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9w
-      cm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvYmFja2VuZEFkZHJl
-      c3NQb29scy9iYXAyIn1dfSwgImV0YWciOiAiVy9cIjgzYTU2ZTc1LWNhMjAtNDEyYS1hYzZkLWI1
-      NGMyYTlmZGMxMlwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1h
-      ZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0
-      Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEifQ==
+      ZW5kSVBDb25maWd1cmF0aW9ucy9pcGNvbmZpZzEiLCAibmFtZSI6ICJpcGNvbmZpZzEifV0sICJv
+      dXRib3VuZE5hdFJ1bGVzIjogW10sICJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAi
+      aW5ib3VuZE5hdFJ1bGVzIjogW10sICJiYWNrZW5kQWRkcmVzc1Bvb2xzIjogW3siZXRhZyI6ICJX
+      L1wiZDE2NDllMmItMWY0NC00MDUyLWFlOTItZDgxNjkwMTgzNWRmXCIiLCAibmFtZSI6ICJsYjFi
+      ZXBvb2wiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5
+      MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29y
+      ay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVzc1Bvb2xzL2xiMWJlcG9vbCIsICJwcm9w
+      ZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQifX0sIHsiZXRhZyI6ICJX
+      L1wiZDE2NDllMmItMWY0NC00MDUyLWFlOTItZDgxNjkwMTgzNWRmXCIiLCAibmFtZSI6ICJiYXAx
+      IiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYw
+      OTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9h
+      ZEJhbGFuY2Vycy9sYjEvYmFja2VuZEFkZHJlc3NQb29scy9iYXAxIiwgInByb3BlcnRpZXMiOiB7
+      InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCJ9fSwgeyJldGFnIjogIlcvXCJkMTY0OWUy
+      Yi0xZjQ0LTQwNTItYWU5Mi1kODE2OTAxODM1ZGZcIiIsICJuYW1lIjogImJhcDIiLCAiaWQiOiAi
+      L3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291
+      cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJz
+      L2xiMS9iYWNrZW5kQWRkcmVzc1Bvb2xzL2JhcDIiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9u
+      aW5nU3RhdGUiOiAiU3VjY2VlZGVkIn19LCB7Im5hbWUiOiAiYmFwMyJ9XSwgImluYm91bmROYXRQ
+      b29scyI6IFtdLCAicmVzb3VyY2VHdWlkIjogImY4MTY4NmYyLTBkYjQtNGI5OS1iNGFiLWUxNGRk
+      YWY5NWZkOSIsICJsb2FkQmFsYW5jaW5nUnVsZXMiOiBbXX0sICJpZCI6ICIvc3Vic2NyaXB0aW9u
+      cy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJz
+      cmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxIn0=
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
-      Content-Length: ['4531']
+      Content-Length: ['2330']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [66e02f22-4518-11e6-8085-a0b3ccf7272a]
+      x-ms-client-request-id: [9bc0f412-494e-11e6-af5c-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -5720,47 +3313,41 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3owcH+/f2d/Z3tj+9P9vf3t95+HB7sndvsj0737+fffrpw/0HD+79
-        vh/pi+31ikdzQ1fauqymGYaHN67ypl2bLwjnVV63Rd7QV0wn+fCyaKh5sbx43WYtd/R6PZ3m+Syf
-        yZvUzBJhLYS8t/9wf/fBNNue5J/e395/cP/e9uT+/Z3tnYf37n96/8Gn+7OdB/bl87patvlydvby
-        pFqeFxfrmhEEGt+TJqnBB4+dvefe6J4BxunSYoTn53RS7w6N6u6NaH9dRpAHU9abR3nw1S1mUx5q
-        XFxSk7OXx6XhmS/ydl4xUZ9e0ywU0+4r60lZTOmN2Ywo2OufWvwQp6SDTN7cfamf0PR85OP1S9wf
-        9tdfYkfmDcGyXrGa8qSq7Mrzwxzce/BbHNcfMdk3Mg8dZIjJ5JNidS9ksXAMbvqISK/WJZPRKjt5
-        OqOit36I43II4nvwl/vEoHy3pn/3gmHSQP0/v+/+sJ/rL99Xgnw0yaZviW2VgC+rqgxo4VHBSh+h
-        M8lX1NLnjJ9b6kRGgc8jaP6cCZ5rq1NAv1jIHiRL5km2CnXG/+so3MPw/1PE3Qv6/n8jcUMMf86I
-        60Ghxg57as2KiFpbfSFPAB7Pzy153ScG5W9Gd/bh0iAtKTwiWLaTbvV9PP8vJYyP4f9L+G7AwaJX
-        AqDU8ueUpANo+n6gj67TUnjsIF9WdUuD+HQn/Fr1xMC3+TKblPkzwqklgp69pCbnWdnkYatiVuZv
-        ikVerduz5RfFct3yzOyHrWjQbTUl20mUfDNddeaCupg9LZq2LiZrjA6tXjPlzl6+NG+Gryjqnoqj
-        l/5fNXN9DFUJ+0iqCsBjf9VfrFqgbidM042qgFuF5vPndPjUmrCWHyFa/y9RANRYGIvafLttuzy5
-        EqHYDT+t81+0pizLy6yd05cf3SVmb4PRUZuCRK6+zMqz5eucZHQGPPc6srVcLyZ5/eU5cTdRiRrc
-        d1/r/NMv9h1vmOGEh6r1/zUTHqL1/8IJ7+sgne+98NPYXO7eD9v05nLPfe3mUn6xQl0sJ9V6OXuR
-        tWwn6a3v2e9IlQ5/6V5klcLf4Svq4Jf8PzxEmAUPFQAA
+        J1mZLaf43qGQt9kFkPju3d/3o093qY/Jpw+3H2a7n1LP5/e2Hz7cO9/+NM93708f5p+e7zz4fT/S
+        F9vrFY/mhq60dVlNMwwPb1zlTbs2XxDOq7xui7yhr5hO8uFl0VDzYnnxus1a7uj1ejrN81k+kzep
+        mSXCWgh5frD76cGn53vbO7PJ/vb+5OHD7cl+NtnOd0HF84f3z2cP7cvndbVs8+Xs7OVJtTwvLtY1
+        Iwg0vidNUoMPHjt7z73RPQOM06XFCM/P6aTeHRrV3RvR/rqMIA+mrDeP8uCrW8ymPNS4uKQmZy+P
+        S8MzX+TtvGKiPr2mWSim3VfWk7KY0huzGVGw1z+1+CFOSQeZvLn7Uj+h6fnIx+uXuD/sr7/Ejswb
+        gmW9YjXlSVXZleeHObj34Lc4rj9ism9kHjrIEJPJJ8Xq3s0sJr98X4f30SSbvqUJVFAvq6rE4Daq
+        QJr4Sb6ilj6Nfpjj7/NhZBT4PILmzxkLurY6BfSLhexBsmSeZKtQev5fR+Eehv+fIu5e0Pf/G4kb
+        Yvj/KeLeC/r+fyNxQwz/X0Vc+cWqaDckAvFqXXIn37NfUweTzkfFclKtl7MXWdtvXq3b4S/di0wn
+        /g5fEUq/5P8BbcAjUsYMAAA=
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/efd38b43-cd00-4cc2-85cd-5721ede05fd2?api-version=2016-03-30']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/6502b559-6d26-43f3-a8db-5de08e194961?api-version=2016-03-30']
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:39 GMT']
+      Date: ['Wed, 13 Jul 2016 23:07:45 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [678394f6-4518-11e6-a968-a0b3ccf7272a]
+      x-ms-client-request-id: [9c6bfaec-494e-11e6-8bc4-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -5770,27 +3357,107 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3owcH+/f2d/Z3tj+9P9vf3t95+HB7sndvsj0737+fffrpw/0HD+79
-        vh/pi+31ikdzQ1fauqymGYaHN67ypl2bLwjnVV63Rd7QV0wn+fCyaKh5sbx43WYtd/R6PZ3m+Syf
-        yZvUzBJhLYS8t/9wf/fBNNue5J/e395/cP/e9uT+/Z3tnYf37n96/8Gn+7OdB/bl87patvlydvby
-        pFqeFxfrmhEEGt+TJqnBB4+dvefe6J4BxunSYoTn53RS7w6N6u6NaH9dRpAHU9abR3nw1S1mUx5q
-        XFxSk7OXx6XhmS/ydl4xUZ9e0ywU0+4r60lZTOmN2Ywo2OufWvwQp6SDTN7cfamf0PR85OP1S9wf
-        9tdfYkfmDcGyXrGa8qSq7Mrzwxzce/BbHNcfMdk3Mg8dZIjJ5JNidS9ksXAMbvqISK/WJZPRKjt5
-        OqOit36I43II4nvwl/vEoHy3pn/3gmHSQP0/v+/+sJ/rL99Xgnw0yaZviW2VgC+rqgxo4VHBSh+h
-        M8lX1NLnjJ9b6kRGgc8jaP6cCZ5rq1NAv1jIHiRL5km2CnXG/+so3MPw/1PE3Qv6/n8jcUMMf86I
-        60Ghxg57as2KiFpbfSFPAB7Pzy153ScG5W9Gd/bh0iAtKTwiWLaTbvV9PP8vJYyP4f9L+G7AwaJX
-        AqDU8ueUpANo+n6gj67TUnjsIF9WdUuD+HQn/Fr1xMC3+TKblPkzwqklgp69pCbnWdnkYatiVuZv
-        ikVerduz5RfFct3yzOyHrWjQbTUl20mUfDNddeaCupg9LZq2LiZrjA6tXjPlzl6+NG+Gryjqnoqj
-        l/5fNXN9DFUJ+0iqCsBjf9VfrFqgbidM042qgFuF5vPndPjUmrCWHyFa/y9RANRYGIvafLttuzy5
-        EqHYDT+t81+0pizLy6yd05cf3SVmb4PRUZuCRK6+zMqz5eucZHQGPPc6srVcLyZ5/eU5cTdRiRrc
-        d1/r/NMv9h1vmOGEh6r1/zUTHqL1/8IJ7+sgne+98NPYXO7eD9v05nLPfe3mUn6xQl0sJ9V6OXuR
-        tWwn6a3v2e9IlQ5/6V5klcLf4Svq4Jf8PzxEmAUPFQAA
+        J1mZLaf43qGQt9kFkPju3d/3o093qY/Jpw+3H2a7n1LP5/e2Hz7cO9/+NM93708f5p+e7zz4fT/S
+        F9vrFY/mhq60dVlNMwwPb1zlTbs2XxDOq7xui7yhr5hO8uFl0VDzYnnxus1a7uj1ejrN81k+kzep
+        mSXCWgh5frD76cGn53vbO7PJ/vb+5OHD7cl+NtnOd0HF84f3z2cP7cvndbVs8+Xs7OVJtTwvLtY1
+        Iwg0vidNUoMPHjt7z73RPQOM06XFCM/P6aTeHRrV3RvR/rqMIA+mrDeP8uCrW8ymPNS4uKQmZy+P
+        S8MzX+TtvGKiPr2mWSim3VfWk7KY0huzGVGw1z+1+CFOSQeZvLn7Uj+h6fnIx+uXuD/sr7/Ejswb
+        gmW9YjXlSVXZleeHObj34Lc4rj9ism9kHjrIEJPJJ8Xq3s0sJr98X4f30SSbvqUJVFAvq6rE4Daq
+        QJr4Sb6ilj6Nfpjj7/NhZBT4PILmzxkLurY6BfSLhexBsmSeZKtQev5fR+Eehv+fIu5e0Pf/G4kb
+        Yvj/KeLeC/r+fyNxQwz/X0Vc+cWqaDckAvFqXXIn37NfUweTzkfFclKtl7MXWdtvXq3b4S/di0wn
+        /g5fEUq/5P8BbcAjUsYMAAA=
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:40 GMT']
-      ETag: [W/"78434040-65d4-4099-b23b-df45a6694773"]
+      Date: ['Wed, 13 Jul 2016 23:07:46 GMT']
+      ETag: [W/"61cb9b69-9a16-4df3-992f-6ee15c9e6f07"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9cad1200-494e-11e6-8eae-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o093qY/Jpw+3H2a7n1LP5/e2Hz7cO9/+NM93708f5p+e7zz4fT/S
+        F9vrFY/mhq60dVlNMwwPb1zlTbs2XxDOq7xui7yhr5hO8uFl0VDzYnnxus1a7uj1ejrN81k+kzep
+        mSXCWgh5frD76cGn53vbO7PJ/vb+5OHD7cl+NtnOd0HF84f3z2cP7cvndbVs8+Xs7OVJtTwvLtY1
+        Iwg0vidNUoMPHjt7z73RPQOM06XFCM/P6aTeHRrV3RvR/rqMIA+mrDeP8uCrW8ymPNS4uKQmZy+P
+        S8MzX+TtvGKiPr2mWSim3VfWk7KY0huzGVGw1z+1+CFOSQeZvLn7Uj+h6fnIx+uXuD/sr7/Ejswb
+        gmW9YjXlSVXZleeHObj34Lc4rj9ism9kHjrIEJPJJ8Xq3s0sJr98X4f30SSbvqUJVFAvq6rE4Daq
+        QJr4Sb6ilj6Nfpjj7/NhZBT4PILmzxkLurY6BfSLhexBsmSeZKtQev5fR+Eehv+fIu5e0Pf/G4kb
+        Yvj/KeLeC/r+fyNxQwz/X0Vc+cWqaDckAvFqXXIn37NfUweTzkfFclKtl7MXWdtvXq3b4S/di0wn
+        /g5fEUq/5P8BbcAjUsYMAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:07:46 GMT']
+      ETag: [W/"61cb9b69-9a16-4df3-992f-6ee15c9e6f07"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9cef02b4-494e-11e6-8d5c-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o093qY/Jpw+3H2a7n1LP5/e2Hz7cO9/+NM93708f5p+e7zz4fT/S
+        F9vrFY/mhq60dVlNMwwPb1zlTbs2XxDOq7xui7yhr5hO8uFl0VDzYnnxus1a7uj1ejrN81k+kzep
+        mSXCWgh5frD76cGn53vbO7PJ/vb+5OHD7cl+NtnOd0HF84f3z2cP7cvndbVs8+Xs7OVJtTwvLtY1
+        Iwg0vidNUoMPHjt7z73RPQOM06XFCM/P6aTeHRrV3RvR/rqMIA+mrDeP8uCrW8ymPNS4uKQmZy+P
+        S8MzX+TtvGKiPr2mWSim3VfWk7KY0huzGVGw1z+1+CFOSQeZvLn7Uj+h6fnIx+uXuD/sr7/Ejswb
+        gmW9YjXlSVXZleeHObj34Lc4rj9ism9kHjrIEJPJJ8Xq3s0sJr98X4f30SSbvqUJVFAvq6rE4Daq
+        QJr4Sb6ilj6Nfpjj7/NhZBT4PILmzxkLurY6BfSLhexBsmSeZKtQev5fR+Eehv+fIu5e0Pf/G4kb
+        Yvj/KeLeC/r+fyNxQwz/X0Vc+cWqaDckAvFqXXIn37NfUweTzkfFclKtl7MXWdtvXq3b4S/di0wn
+        /g5fEUq/5P8BbcAjUsYMAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:07:47 GMT']
+      ETag: [W/"61cb9b69-9a16-4df3-992f-6ee15c9e6f07"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -5799,78 +3466,59 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW3sibmFtZSI6
-      ICJwcm9iZTEiLCAicHJvcGVydGllcyI6IHsicG9ydCI6IDEsICJwcm90b2NvbCI6ICJIdHRwIiwg
-      Im51bWJlck9mUHJvYmVzIjogNSwgInByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJy
-      ZXF1ZXN0UGF0aCI6ICIvdGVzdDEiLCAiaW50ZXJ2YWxJblNlY29uZHMiOiAyMH0sICJldGFnIjog
-      IlcvXCI3ODQzNDA0MC02NWQ0LTQwOTktYjIzYi1kZjQ1YTY2OTQ3NzNcIiIsICJpZCI6ICIvc3Vi
-      c2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VH
-      cm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIx
-      L3Byb2Jlcy9wcm9iZTEifSwgeyJuYW1lIjogInByb2JlMiIsICJwcm9wZXJ0aWVzIjogeyJwb3J0
-      IjogMiwgIm51bWJlck9mUHJvYmVzIjogMiwgInByb3RvY29sIjogIlRjcCIsICJpbnRlcnZhbElu
-      U2Vjb25kcyI6IDE1LCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn0sICJldGFnIjog
-      IlcvXCI3ODQzNDA0MC02NWQ0LTQwOTktYjIzYi1kZjQ1YTY2OTQ3NzNcIiIsICJpZCI6ICIvc3Vi
-      c2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VH
-      cm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIx
-      L3Byb2Jlcy9wcm9iZTIifV0sICJmcm9udGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJuYW1lIjog
-      IkxvYWRCYWxhbmNlckZyb250RW5kIiwgInByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRl
-      IjogIlN1Y2NlZWRlZCIsICJwcml2YXRlSVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAi
-      cHVibGljSVBBZGRyZXNzIjogeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRk
+      eyJldGFnIjogIlcvXCI2MWNiOWI2OS05YTE2LTRkZjMtOTkyZi02ZWUxNWM5ZTZmMDdcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW10sICJmcm9udGVu
+      ZElQQ29uZmlndXJhdGlvbnMiOiBbeyJldGFnIjogIlcvXCI2MWNiOWI2OS05YTE2LTRkZjMtOTky
+      Zi02ZWUxNWM5ZTZmMDdcIiIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1Ymxp
+      Y0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
+      YzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQu
+      TmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9QdWJsaWNJUGxiMSJ9fSwgImlkIjogIi9zdWJzY3Jp
+      cHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vw
+      cy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJv
+      bnRlbmRJUENvbmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNlckZyb250RW5kIiwgIm5hbWUiOiAiTG9h
+      ZEJhbGFuY2VyRnJvbnRFbmQifSwgeyJldGFnIjogIlcvXCI2MWNiOWI2OS05YTE2LTRkZjMtOTky
+      Zi02ZWUxNWM5ZTZmMDdcIiIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1Ymxp
+      Y0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
+      YzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQu
+      TmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9wdWJsaWNpcDMifX0sICJpZCI6ICIvc3Vic2NyaXB0
+      aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMv
+      bGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250
+      ZW5kSVBDb25maWd1cmF0aW9ucy9pcGNvbmZpZzEiLCAibmFtZSI6ICJpcGNvbmZpZzEifV0sICJv
+      dXRib3VuZE5hdFJ1bGVzIjogW10sICJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAi
+      aW5ib3VuZE5hdFJ1bGVzIjogW10sICJiYWNrZW5kQWRkcmVzc1Bvb2xzIjogW3siZXRhZyI6ICJX
+      L1wiNjFjYjliNjktOWExNi00ZGYzLTk5MmYtNmVlMTVjOWU2ZjA3XCIiLCAibmFtZSI6ICJsYjFi
+      ZXBvb2wiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5
+      MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29y
+      ay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVzc1Bvb2xzL2xiMWJlcG9vbCIsICJwcm9w
+      ZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQifX0sIHsiZXRhZyI6ICJX
+      L1wiNjFjYjliNjktOWExNi00ZGYzLTk5MmYtNmVlMTVjOWU2ZjA3XCIiLCAibmFtZSI6ICJiYXAx
+      IiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYw
+      OTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9h
+      ZEJhbGFuY2Vycy9sYjEvYmFja2VuZEFkZHJlc3NQb29scy9iYXAxIiwgInByb3BlcnRpZXMiOiB7
+      InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCJ9fSwgeyJldGFnIjogIlcvXCI2MWNiOWI2
+      OS05YTE2LTRkZjMtOTkyZi02ZWUxNWM5ZTZmMDdcIiIsICJuYW1lIjogImJhcDIiLCAiaWQiOiAi
+      L3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291
+      cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJz
+      L2xiMS9iYWNrZW5kQWRkcmVzc1Bvb2xzL2JhcDIiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9u
+      aW5nU3RhdGUiOiAiU3VjY2VlZGVkIn19XSwgImluYm91bmROYXRQb29scyI6IFtdLCAicmVzb3Vy
+      Y2VHdWlkIjogImY4MTY4NmYyLTBkYjQtNGI5OS1iNGFiLWUxNGRkYWY5NWZkOSIsICJsb2FkQmFs
+      YW5jaW5nUnVsZXMiOiBbXX0sICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRk
       ZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jv
-      c29mdC5OZXR3b3JrL3B1YmxpY0lQQWRkcmVzc2VzL1B1YmxpY0lQbGIxIn19LCAiZXRhZyI6ICJX
-      L1wiNzg0MzQwNDAtNjVkNC00MDk5LWIyM2ItZGY0NWE2Njk0NzczXCIiLCAiaWQiOiAiL3N1YnNj
-      cmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3Jv
-      dXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9m
-      cm9udGVuZElQQ29uZmlndXJhdGlvbnMvTG9hZEJhbGFuY2VyRnJvbnRFbmQifSwgeyJuYW1lIjog
-      ImlwY29uZmlnMSIsICJwcm9wZXJ0aWVzIjogeyJsb2FkQmFsYW5jaW5nUnVsZXMiOiBbeyJpZCI6
-      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
-      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNl
-      cnMvbGIxL2xvYWRCYWxhbmNpbmdSdWxlcy9ydWxlMiJ9XSwgInByb3Zpc2lvbmluZ1N0YXRlIjog
-      IlN1Y2NlZWRlZCIsICJwcml2YXRlSVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVi
-      bGljSVBBZGRyZXNzIjogeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEt
-      YWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29m
-      dC5OZXR3b3JrL3B1YmxpY0lQQWRkcmVzc2VzL3B1YmxpY2lwMyJ9fSwgImV0YWciOiAiVy9cIjc4
-      NDM0MDQwLTY1ZDQtNDA5OS1iMjNiLWRmNDVhNjY5NDc3M1wiIiwgImlkIjogIi9zdWJzY3JpcHRp
-      b25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9s
-      YnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJvbnRl
-      bmRJUENvbmZpZ3VyYXRpb25zL2lwY29uZmlnMSJ9XSwgInJlc291cmNlR3VpZCI6ICIzNDk0MTdj
-      YS1iZTY1LTQ3NTMtYjU1MC0wOTM1NjU3NjRkMDciLCAib3V0Ym91bmROYXRSdWxlcyI6IFtdLCAi
-      bG9hZEJhbGFuY2luZ1J1bGVzIjogW10sICJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQi
-      LCAiaW5ib3VuZE5hdFJ1bGVzIjogW10sICJpbmJvdW5kTmF0UG9vbHMiOiBbXSwgImJhY2tlbmRB
-      ZGRyZXNzUG9vbHMiOiBbeyJuYW1lIjogImxiMWJlcG9vbCIsICJwcm9wZXJ0aWVzIjogeyJwcm92
-      aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQifSwgImV0YWciOiAiVy9cIjc4NDM0MDQwLTY1ZDQt
-      NDA5OS1iMjNiLWRmNDVhNjY5NDc3M1wiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcx
-      LTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRl
-      cnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvYmFja2VuZEFkZHJlc3NQb29s
-      cy9sYjFiZXBvb2wifSwgeyJuYW1lIjogImJhcDEiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9u
-      aW5nU3RhdGUiOiAiU3VjY2VlZGVkIn0sICJldGFnIjogIlcvXCI3ODQzNDA0MC02NWQ0LTQwOTkt
-      YjIzYi1kZjQ1YTY2OTQ3NzNcIiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYw
-      LTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01p
-      Y3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMvYmFw
-      MSJ9LCB7Im5hbWUiOiAiYmFwMiIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6
-      ICJTdWNjZWVkZWQiLCAibG9hZEJhbGFuY2luZ1J1bGVzIjogW3siaWQiOiAiL3N1YnNjcmlwdGlv
-      bnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xi
-      c3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9sb2FkQmFs
-      YW5jaW5nUnVsZXMvcnVsZTIifV19LCAiZXRhZyI6ICJXL1wiNzg0MzQwNDAtNjVkNC00MDk5LWIy
-      M2ItZGY0NWE2Njk0NzczXCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00
-      ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNy
-      b3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVzc1Bvb2xzL2JhcDIi
-      fV19LCAiZXRhZyI6ICJXL1wiNzg0MzQwNDAtNjVkNC00MDk5LWIyM2ItZGY0NWE2Njk0NzczXCIi
-      LCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5
-      NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2Fk
-      QmFsYW5jZXJzL2xiMSJ9
+      c29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxIn0=
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
-      Content-Length: ['3378']
+      Content-Length: ['2312']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [67a9dd50-4518-11e6-bcff-a0b3ccf7272a]
+      x-ms-client-request-id: [9dbe63be-494e-11e6-82a2-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -5880,23 +3528,21 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o4cH9/J8uruz/WDv4fn2fnYw2X64lz3Yzvb39vO9nfOH+XT/9/1I
-        X2yvVzyaG7rS1mU1zTA8vHGVN+3afEE4r/K6LfKGvmI6yYeXRUPNi+XF6zZruaPX6+k0z2f5TN6k
-        ZpYIayHkvf2H+7sPptn2JP/0/vb+g/v3tif37+9s7zy8d//T+w8+3Z/tPLAvn9fVss2Xs7OXJ9Xy
-        vLhY14wg0PieNEkNPnjs7D33RvcMME6XFiM8P6eTendoVHdvRPvrMoI8mLLePMqDr24xm/JQ4+KS
-        mpy9PC4Nz3yRt/OKifr0mmahmHZfWU/KYkpvzGZEwV7/1OKHOCUdZPLm7kv9hKbnIx+vX+L+sL/+
-        EjsybwiW9YrVlCdVZVeeH+bg3oPf4rj+iMm+kXnoIENMJp8Uq3s3s5j88n0d3keTbPqWJlBBvayq
-        EoPbqAJp4if5ilr6NPphjr/Ph5FR4PMImj9nLOja6hTQLxayB8mSeZKtQun5fx2Fexj+f4q4e0Hf
-        /28kbojh/6uIK79YLeKGRCBerUvu5Hv2a+pgIh/JB/E54VYhQ/2czgq1JqzlR4jWz9lUeFCkcVtN
-        ScFRm2+37ar7dVW39NVu+Gmd/6I1eeAvs3ZOX350t6U/gtFRm4KMen2ZlWfL1znZ8Rnw3NsJ2yzX
-        i0lef3n+EuRBg/vua2UP+sW+4w0znPCQyf9fM+EhWv8vnPA304H53gs/jc3l7v2wTW8u99zXbi7l
-        FyvUxXJSrZezF1nbF/hq3Q5/6V5kTcff4Svq4Jf8P6gv+cUrDwAA
+        J1mZLaf43qGQt9kFkPju3d/3o3v3J3v39vZm21n26d72/uTT/e2Hnz7It3d39vLs4cP72XQ2+30/
+        0hfb6xWP5oautHVZTTMMD29c5U27Nl8Qzqu8bou8oa+YTvLhZdFQ82J58brNWu7o9Xo6zfNZPpM3
+        qZklwloIeX6w++nBp+d72zuzyT7h//Dh9mQ/m2znu6Di+cP757OH9uXzulq2+XJ29vKkWp4XF+ua
+        EQQa35MmqcEHj529597ongHG6dJihOfndFLvDo3q7o1of11GkAdT1ptHefDVLWZTHmpcXFKTs5fH
+        peGZL/J2XjFRn17TLBTT7ivrSVlM6Y3ZjCjY659a/BCnpINM3tx9qZ/Q9Hzk4/VL3B/2119iR+YN
+        wbJesZrypKrsyvPDHNx78Fsc1x8x2TcyDx1kiMnkk2J172YWk1++r8P7aJJN39IEKqiXVVVicBtV
+        IE38JF9RS59GP8zx9/kwMgp8HkHz54wFXVudAvrFQvYgWTJPslUoPf+vo3APw/9PEXcv6Pv/jcQN
+        Mfx/FXHlF6tF3JAIxKt1yZ18z35NHUw6HxXLSbVezl5kbb95tW6Hv3QvMp34O3xFKP2S/wc9hWgC
+        aQsAAA==
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/951be439-7464-4bae-8f58-b9bdecc742e8?api-version=2016-03-30']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/693b1c6f-65c1-4d44-be80-6fad0d79aa3b?api-version=2016-03-30']
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:40 GMT']
+      Date: ['Wed, 13 Jul 2016 23:07:48 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -5909,14 +3555,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY3OTg2Nzk5LCJuYmYiOjE0Njc5ODY3OTksImV4cCI6MTQ2Nzk5MDY5OSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.WhpdVHf17ZAH3ZsjRrZ9PvsA7QY0MWi5PbrE6Kh8onuhxaKC8ij24DB_PtEULD3veI9Z7SeX1-y7E2lOZDZ5B3Cj9QDvxUsK2cOP6o2zD9k04-gB-iZV_-w26SI825-IMPw1QRcc2KE67RklEdBEqIVvSni2_13IXcjiUm9snQXvVIb1ODWx_LrjfMrhyH37W9k_ceqp8ZrMADbGOft4xVfRF8ALedrAgCoKc86ooztAFuXaN3VA4RXqtN6_q1VFazgTQLfWO9HKdpwBVDd5pnPF06Gw-NuQ098YeIxID4NwvbD7NQ_qhbtcIwkEgSCrZK0IjW2SFY4BdJUnoXQ5YQ]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
           msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [684f2122-4518-11e6-a743-a0b3ccf7272a]
+      x-ms-client-request-id: [9e6379e8-494e-11e6-9ef3-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
   response:
@@ -5926,23 +3572,2377 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
         h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
-        J1mZLaf43qGQt9kFkPju3d/3o4cH9/J8uruz/WDv4fn2fnYw2X64lz3Yzvb39vO9nfOH+XT/9/1I
-        X2yvVzyaG7rS1mU1zTA8vHGVN+3afEE4r/K6LfKGvmI6yYeXRUPNi+XF6zZruaPX6+k0z2f5TN6k
-        ZpYIayHkvf2H+7sPptn2JP/0/vb+g/v3tif37+9s7zy8d//T+w8+3Z/tPLAvn9fVss2Xs7OXJ9Xy
-        vLhY14wg0PieNEkNPnjs7D33RvcMME6XFiM8P6eTendoVHdvRPvrMoI8mLLePMqDr24xm/JQ4+KS
-        mpy9PC4Nz3yRt/OKifr0mmahmHZfWU/KYkpvzGZEwV7/1OKHOCUdZPLm7kv9hKbnIx+vX+L+sL/+
-        EjsybwiW9YrVlCdVZVeeH+bg3oPf4rj+iMm+kXnoIENMJp8Uq3s3s5j88n0d3keTbPqWJlBBvayq
-        EoPbqAJp4if5ilr6NPphjr/Ph5FR4PMImj9nLOja6hTQLxayB8mSeZKtQun5fx2Fexj+f4q4e0Hf
-        /28kbojh/6uIK79YLeKGRCBerUvu5Hv2a+pgIh/JB/E54VYhQ/2czgq1JqzlR4jWz9lUeFCkcVtN
-        ScFRm2+37ar7dVW39NVu+Gmd/6I1eeAvs3ZOX350t6U/gtFRm4KMen2ZlWfL1znZ8Rnw3NsJ2yzX
-        i0lef3n+EuRBg/vua2UP+sW+4w0znPCQyf9fM+EhWv8vnPA304H53gs/jc3l7v2wTW8u99zXbi7l
-        FyvUxXJSrZezF1nbF/hq3Q5/6V5kTcff4Svq4Jf8P6gv+cUrDwAA
+        J1mZLaf43qGQt9kFkPju3d/3o3v3J3v39vZm21n26d72/uTT/e2Hnz7It3d39vLs4cP72XQ2+30/
+        0hfb6xWP5oautHVZTTMMD29c5U27Nl8Qzqu8bou8oa+YTvLhZdFQ82J58brNWu7o9Xo6zfNZPpM3
+        qZklwloIeX6w++nBp+d72zuzyT7h//Dh9mQ/m2znu6Di+cP757OH9uXzulq2+XJ29vKkWp4XF+ua
+        EQQa35MmqcEHj529597ongHG6dJihOfndFLvDo3q7o1of11GkAdT1ptHefDVLWZTHmpcXFKTs5fH
+        peGZL/J2XjFRn17TLBTT7ivrSVlM6Y3ZjCjY659a/BCnpINM3tx9qZ/Q9Hzk4/VL3B/2119iR+YN
+        wbJesZrypKrsyvPDHNx78Fsc1x8x2TcyDx1kiMnkk2J172YWk1++r8P7aJJN39IEKqiXVVVicBtV
+        IE38JF9RS59GP8zx9/kwMgp8HkHz54wFXVudAvrFQvYgWTJPslUoPf+vo3APw/9PEXcv6Pv/jcQN
+        Mfx/FXHlF6tF3JAIxKt1yZ18z35NHUw6HxXLSbVezl5kbb95tW6Hv3QvMp34O3xFKP2S/wc9hWgC
+        aQsAAA==
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Fri, 08 Jul 2016 14:29:41 GMT']
-      ETag: [W/"983eec10-729f-4a8b-92a7-a424e20f9ec4"]
+      Date: ['Wed, 13 Jul 2016 23:07:50 GMT']
+      ETag: [W/"35b2322d-aa62-4b64-967e-102ea995acdd"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9f444e5a-494e-11e6-866a-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o3v3J3v39vZm21n26d72/uTT/e2Hnz7It3d39vLs4cP72XQ2+30/
+        0hfb6xWP5oautHVZTTMMD29c5U27Nl8Qzqu8bou8oa+YTvLhZdFQ82J58brNWu7o9Xo6zfNZPpM3
+        qZklwloIeX6w++nBp+d72zuzyT7h//Dh9mQ/m2znu6Di+cP757OH9uXzulq2+XJ29vKkWp4XF+ua
+        EQQa35MmqcEHj529597ongHG6dJihOfndFLvDo3q7o1of11GkAdT1ptHefDVLWZTHmpcXFKTs5fH
+        peGZL/J2XjFRn17TLBTT7ivrSVlM6Y3ZjCjY659a/BCnpINM3tx9qZ/Q9Hzk4/VL3B/2119iR+YN
+        wbJesZrypKrsyvPDHNx78Fsc1x8x2TcyDx1kiMnkk2J172YWk1++r8P7aJJN39IEKqiXVVVicBtV
+        IE38JF9RS59GP8zx9/kwMgp8HkHz54wFXVudAvrFQvYgWTJPslUoPf+vo3APw/9PEXcv6Pv/jcQN
+        Mfx/FXHlF6tF3JAIxKt1yZ18z35NHUw6HxXLSbVezl5kbb95tW6Hv3QvMp34O3xFKP2S/wc9hWgC
+        aQsAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:07:50 GMT']
+      ETag: [W/"35b2322d-aa62-4b64-967e-102ea995acdd"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJldGFnIjogIlcvXCIzNWIyMzIyZC1hYTYyLTRiNjQtOTY3ZS0xMDJlYTk5NWFjZGRcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW3sicHJvcGVydGll
+      cyI6IHsicHJvdG9jb2wiOiAiaHR0cCIsICJyZXF1ZXN0UGF0aCI6ICIvdGVzdDEiLCAicG9ydCI6
+      IDF9LCAibmFtZSI6ICJwcm9iZTEifV0sICJmcm9udGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJl
+      dGFnIjogIlcvXCIzNWIyMzIyZC1hYTYyLTRiNjQtOTY3ZS0xMDJlYTk5NWFjZGRcIiIsICJwcm9w
+      ZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxs
+      b2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1YmxpY0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1
+      YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNl
+      R3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9wdWJsaWNJUEFkZHJlc3Nl
+      cy9QdWJsaWNJUGxiMSJ9fSwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRk
+      YS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9z
+      b2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJvbnRlbmRJUENvbmZpZ3VyYXRpb25zL0xv
+      YWRCYWxhbmNlckZyb250RW5kIiwgIm5hbWUiOiAiTG9hZEJhbGFuY2VyRnJvbnRFbmQifSwgeyJl
+      dGFnIjogIlcvXCIzNWIyMzIyZC1hYTYyLTRiNjQtOTY3ZS0xMDJlYTk5NWFjZGRcIiIsICJwcm9w
+      ZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxs
+      b2NhdGlvbk1ldGhvZCI6ICJEeW5hbWljIiwgInB1YmxpY0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1
+      YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNl
+      R3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9wdWJsaWNJUEFkZHJlc3Nl
+      cy9wdWJsaWNpcDMifX0sICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEt
+      YWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29m
+      dC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9ucy9pcGNv
+      bmZpZzEiLCAibmFtZSI6ICJpcGNvbmZpZzEifV0sICJvdXRib3VuZE5hdFJ1bGVzIjogW10sICJw
+      cm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAiaW5ib3VuZE5hdFJ1bGVzIjogW10sICJi
+      YWNrZW5kQWRkcmVzc1Bvb2xzIjogW3siZXRhZyI6ICJXL1wiMzViMjMyMmQtYWE2Mi00YjY0LTk2
+      N2UtMTAyZWE5OTVhY2RkXCIiLCAibmFtZSI6ICJsYjFiZXBvb2wiLCAiaWQiOiAiL3N1YnNjcmlw
+      dGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBz
+      L2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNr
+      ZW5kQWRkcmVzc1Bvb2xzL2xiMWJlcG9vbCIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdT
+      dGF0ZSI6ICJTdWNjZWVkZWQifX0sIHsiZXRhZyI6ICJXL1wiMzViMjMyMmQtYWE2Mi00YjY0LTk2
+      N2UtMTAyZWE5OTVhY2RkXCIiLCAibmFtZSI6ICJiYXAxIiwgImlkIjogIi9zdWJzY3JpcHRpb25z
+      LzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNy
+      Zy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvYmFja2VuZEFk
+      ZHJlc3NQb29scy9iYXAxIiwgInByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1
+      Y2NlZWRlZCJ9fSwgeyJldGFnIjogIlcvXCIzNWIyMzIyZC1hYTYyLTRiNjQtOTY3ZS0xMDJlYTk5
+      NWFjZGRcIiIsICJuYW1lIjogImJhcDIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEt
+      MWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVy
+      cy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVzc1Bvb2xz
+      L2JhcDIiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn19
+      XSwgImluYm91bmROYXRQb29scyI6IFtdLCAicmVzb3VyY2VHdWlkIjogImY4MTY4NmYyLTBkYjQt
+      NGI5OS1iNGFiLWUxNGRkYWY5NWZkOSIsICJsb2FkQmFsYW5jaW5nUnVsZXMiOiBbXX0sICJpZCI6
+      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
+      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNl
+      cnMvbGIxIn0=
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Length: ['2402']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9f77f92c-494e-11e6-9c75-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o8nDyb3pwwf3th88yPLt/Xxvuv1w9/759t7e/fP84OFBdn/y8Pf9
+        SF9sr1c8mhu60tZlNc0wPLxxlTft2nxBOK/yui3yhr5iOsmHl0VDzYvlxes2a7mj1+vpNM9n+Uze
+        pGaWCGsh5PnB7qcHn57vbe/MJvvb+5OHD7cn+9lkO98FFc8f3j+fPbQvn9fVss2Xs7OXJ9XyvLhY
+        14wg0PieNEkNPnjs7D33RvcMME6XFiM8P6eTendoVHdvRPvrMoI8mLLePMqDr24xm/JQ4+KSmpy9
+        PC4Nz3yRt/OKifr0mmahmHZfWU/KYkpvzGZEwV7/1OKHOCUdZPLm7kv9hKbnIx+vX+L+sL/+Ejsy
+        bwiW9YrVlCdVZVeeH+bg3oPf4rj+iMm+kXnoIENMJp8Uq3s3s5j88n0d3keTbPqWJlBBvayqEoPb
+        qAJp4if5ilr6NPphjr/Ph5FR4PMImj9nLOja6hTQLxayB8mSeZKtQun5fx2Fexj+f4q4e0Hf/28k
+        bojh/6uIK79YLeKGRCBerUvu5Hv2a+pgIh/JB/E54VYhQ/2czgq1JqzlR4jWz9lUeFCkcVtNScFR
+        m2+37ar7dVW39NVu+Gmd/6I1eeAvs3ZOX350t6U/gtFRm4KMen2ZlWfL1znZ8Rnw3L0ftlmuF5O8
+        /vL8JciDBnvua2UP+4tlhGI5qdbL2Yus7TNJtW6Hv3QvsnTwd/iKOvgl/w/ujo1qXw0AAA==
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/666a3b68-8f11-4121-ac00-eb861994283e?api-version=2016-03-30']
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:08:20 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1194']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b168815c-494e-11e6-b1f5-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o8nDyb3pwwf3th88yPLt/Xxvuv1w9/759t7e/fP84OFBdn/y8Pf9
+        SF9sr1c8mhu60tZlNc0wPLxxlTft2nxBOK/yui3yhr5iOsmHl0VDzYvlxes2a7mj1+vpNM9n+Uze
+        pGaWCGsh5PnB7qcHn57vbe/MJvvb+5OHD7cn+9lkO98FFc8f3j+fPbQvn9fVss2Xs7OXJ9XyvLhY
+        14wg0PieNEkNPnjs7D33RvcMME6XFiM8P6eTendoVHdvRPvrMoI8mLLePMqDr24xm/JQ4+KSmpy9
+        PC4Nz3yRt/OKifr0mmahmHZfWU/KYkpvzGZEwV7/1OKHOCUdZPLm7kv9hKbnIx+vX+L+sL/+Ejsy
+        bwiW9YrVlCdVZVeeH+bg3oPf4rj+iMm+kXnoIENMJp8Uq3s3s5j88n0d3keTbPqWJlBBvayqEoPb
+        qAJp4if5ilr6NPphjr/Ph5FR4PMImj9nLOja6hTQLxayB8mSeZKtQun5fx2Fexj+f4q4e0Hf/28k
+        bojh/6uIK79YLeKGRCBerUvu5Hv2a+pgIh/JB/E54VYhQ/2czgq1JqzlR4jWz9lUeFCkcVtNScFR
+        m2+37ar7dVW39NVu+Gmd/6I1eeAvs3ZOX350t6U/gtFRm4KMen2ZlWfL1znZ8Rnw3L0ftlmuF5O8
+        /vL8JciDBnvua2UP+4tlhGI5qdbL2Yus7TNJtW6Hv3QvsnTwd/iKOvgl/w/ujo1qXw0AAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:08:22 GMT']
+      ETag: [W/"b9b3c973-77ae-4e2c-915f-225fe898a5b9"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJldGFnIjogIlcvXCJiOWIzYzk3My03N2FlLTRlMmMtOTE1Zi0yMjVmZTg5OGE1YjlcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW3siZXRhZyI6ICJX
+      L1wiYjliM2M5NzMtNzdhZS00ZTJjLTkxNWYtMjI1ZmU4OThhNWI5XCIiLCAibmFtZSI6ICJwcm9i
+      ZTEiLCAicHJvcGVydGllcyI6IHsibnVtYmVyT2ZQcm9iZXMiOiAyLCAicHJvdG9jb2wiOiAiSHR0
+      cCIsICJyZXF1ZXN0UGF0aCI6ICIvdGVzdDEiLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2Vl
+      ZGVkIiwgInBvcnQiOiAxLCAiaW50ZXJ2YWxJblNlY29uZHMiOiAxNX0sICJpZCI6ICIvc3Vic2Ny
+      aXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91
+      cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL3By
+      b2Jlcy9wcm9iZTEifSwgeyJwcm9wZXJ0aWVzIjogeyJwcm90b2NvbCI6ICJodHRwIiwgInJlcXVl
+      c3RQYXRoIjogIi90ZXN0MiIsICJwb3J0IjogMn0sICJuYW1lIjogInByb2JlMiJ9XSwgImZyb250
+      ZW5kSVBDb25maWd1cmF0aW9ucyI6IFt7ImV0YWciOiAiVy9cImI5YjNjOTczLTc3YWUtNGUyYy05
+      MTVmLTIyNWZlODk4YTViOVwiIiwgInByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjog
+      IlN1Y2NlZWRlZCIsICJwcml2YXRlSVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVi
+      bGljSVBBZGRyZXNzIjogeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEt
+      YWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29m
+      dC5OZXR3b3JrL3B1YmxpY0lQQWRkcmVzc2VzL1B1YmxpY0lQbGIxIn19LCAiaWQiOiAiL3N1YnNj
+      cmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3Jv
+      dXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9m
+      cm9udGVuZElQQ29uZmlndXJhdGlvbnMvTG9hZEJhbGFuY2VyRnJvbnRFbmQiLCAibmFtZSI6ICJM
+      b2FkQmFsYW5jZXJGcm9udEVuZCJ9LCB7ImV0YWciOiAiVy9cImI5YjNjOTczLTc3YWUtNGUyYy05
+      MTVmLTIyNWZlODk4YTViOVwiIiwgInByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjog
+      IlN1Y2NlZWRlZCIsICJwcml2YXRlSVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVi
+      bGljSVBBZGRyZXNzIjogeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEt
+      YWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29m
+      dC5OZXR3b3JrL3B1YmxpY0lQQWRkcmVzc2VzL3B1YmxpY2lwMyJ9fSwgImlkIjogIi9zdWJzY3Jp
+      cHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vw
+      cy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJv
+      bnRlbmRJUENvbmZpZ3VyYXRpb25zL2lwY29uZmlnMSIsICJuYW1lIjogImlwY29uZmlnMSJ9XSwg
+      Im91dGJvdW5kTmF0UnVsZXMiOiBbXSwgInByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIs
+      ICJpbmJvdW5kTmF0UnVsZXMiOiBbXSwgImJhY2tlbmRBZGRyZXNzUG9vbHMiOiBbeyJldGFnIjog
+      IlcvXCJiOWIzYzk3My03N2FlLTRlMmMtOTE1Zi0yMjVmZTg5OGE1YjlcIiIsICJuYW1lIjogImxi
+      MWJlcG9vbCIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1j
+      YjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3
+      b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMvbGIxYmVwb29sIiwgInBy
+      b3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCJ9fSwgeyJldGFnIjog
+      IlcvXCJiOWIzYzk3My03N2FlLTRlMmMtOTE1Zi0yMjVmZTg5OGE1YjlcIiIsICJuYW1lIjogImJh
+      cDEiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5Mjcy
+      ZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9s
+      b2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVzc1Bvb2xzL2JhcDEiLCAicHJvcGVydGllcyI6
+      IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn19LCB7ImV0YWciOiAiVy9cImI5YjNj
+      OTczLTc3YWUtNGUyYy05MTVmLTIyNWZlODk4YTViOVwiIiwgIm5hbWUiOiAiYmFwMiIsICJpZCI6
+      ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVz
+      b3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNl
+      cnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMvYmFwMiIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNp
+      b25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQifX1dLCAiaW5ib3VuZE5hdFBvb2xzIjogW10sICJyZXNv
+      dXJjZUd1aWQiOiAiZjgxNjg2ZjItMGRiNC00Yjk5LWI0YWItZTE0ZGRhZjk1ZmQ5IiwgImxvYWRC
+      YWxhbmNpbmdSdWxlcyI6IFtdfSwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAt
+      NGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWlj
+      cm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEifQ==
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Length: ['2770']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b22a2c0c-494e-11e6-8fac-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o+nk/t7s0/vn27OHe7vb+3s797cfPvx0ur0/OZhluw/Ozx+c3/t9
+        P9IX2+sVj+aGrrR1WU0zDA9vXOVNuzZfEM6rvG6LvKGvmE7y4WXRUPNiefG6zVru6PV6Os3zWT6T
+        N6mZJcJaCHl+sPvpwafne9s7s8k+Yf3w4fZkP5ts57ug4vnD++ezh/bl87patvlydvbypFqeFxfr
+        mhEEGt+TJqnBB4+dvefe6J4BxunSYoTn53RS7w6N6u6NaH9dRpAHU9abR3nw1S1mUx5qXFxSk7OX
+        x6XhmS/ydl4xUZ9e0ywU0+4r60lZTOmN2Ywo2OufWvwQp6SDTN7cfamf0PR85OP1S9wf9tdfYkfm
+        DcGyXrGa8qSq7Mrzwxzce/BbHNcfMdk3Mg8dZIjJ5JNide9mFpNfvq/D+2iSTd/SBCqol1VVYnAb
+        VSBN/CRfUUufRj/M8ff5MDIKfB5B8+eMBV1bnQL6xUL2IFkyT7JVKD3/r6NwD8P/TxF3L+j7/43E
+        DTH8fxVx5RerRdyQCMSrdcmdfM9+TR1M5CP5ID4n3CpkqJ/TWaHWhLX8CNH6OZsKD4o0bqspKThq
+        8+22XXW/ruqWvtoNP63zX7QmD/xl1s7py4/utvRHMDpqU5BRry+z8mz5Oic7PgOeu/fDNsv1YpLX
+        X56/BHnQYM99rexBv9h3vGGGEx4y+f9rJjxE6/9TE74Xfhqb8GB01Oabm3D5xUp+sZxU6+XsRdb2
+        tUK1boe/dC+yOuTv8BV18Ev+H0LhkyFQDwAA
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/72609949-f848-4a01-93ab-33d7cd842b7d?api-version=2016-03-30']
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:08:22 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b2d216e4-494e-11e6-8575-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o+nk/t7s0/vn27OHe7vb+3s797cfPvx0ur0/OZhluw/Ozx+c3/t9
+        P9IX2+sVj+aGrrR1WU0zDA9vXOVNuzZfEM6rvG6LvKGvmE7y4WXRUPNiefG6zVru6PV6Os3zWT6T
+        N6mZJcJaCHl+sPvpwafne9s7s8k+Yf3w4fZkP5ts57ug4vnD++ezh/bl87patvlydvbypFqeFxfr
+        mhEEGt+TJqnBB4+dvefe6J4BxunSYoTn53RS7w6N6u6NaH9dRpAHU9abR3nw1S1mUx5qXFxSk7OX
+        x6XhmS/ydl4xUZ9e0ywU0+4r60lZTOmN2Ywo2OufWvwQp6SDTN7cfamf0PR85OP1S9wf9tdfYkfm
+        DcGyXrGa8qSq7Mrzwxzce/BbHNcfMdk3Mg8dZIjJ5JNide9mFpNfvq/D+2iSTd/SBCqol1VVYnAb
+        VSBN/CRfUUufRj/M8ff5MDIKfB5B8+eMBV1bnQL6xUL2IFkyT7JVKD3/r6NwD8P/TxF3L+j7/43E
+        DTH8fxVx5RerRdyQCMSrdcmdfM9+TR1M5CP5ID4n3CpkqJ/TWaHWhLX8CNH6OZsKD4o0bqspKThq
+        8+22XXW/ruqWvtoNP63zX7QmD/xl1s7py4/utvRHMDpqU5BRry+z8mz5Oic7PgOeu/fDNsv1YpLX
+        X56/BHnQYM99rexBv9h3vGGGEx4y+f9rJjxE6/9TE74Xfhqb8GB01Oabm3D5xUp+sZxU6+XsRdb2
+        tUK1boe/dC+yOuTv8BV18Ev+H0LhkyFQDwAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:08:24 GMT']
+      ETag: [W/"cb52d65f-d921-4205-996c-4b8da17ff7f3"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJldGFnIjogIlcvXCJjYjUyZDY1Zi1kOTIxLTQyMDUtOTk2Yy00YjhkYTE3ZmY3ZjNcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW3siZXRhZyI6ICJX
+      L1wiY2I1MmQ2NWYtZDkyMS00MjA1LTk5NmMtNGI4ZGExN2ZmN2YzXCIiLCAibmFtZSI6ICJwcm9i
+      ZTEiLCAicHJvcGVydGllcyI6IHsibnVtYmVyT2ZQcm9iZXMiOiAyLCAicHJvdG9jb2wiOiAiSHR0
+      cCIsICJyZXF1ZXN0UGF0aCI6ICIvdGVzdDEiLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2Vl
+      ZGVkIiwgInBvcnQiOiAxLCAiaW50ZXJ2YWxJblNlY29uZHMiOiAxNX0sICJpZCI6ICIvc3Vic2Ny
+      aXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91
+      cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL3By
+      b2Jlcy9wcm9iZTEifSwgeyJldGFnIjogIlcvXCJjYjUyZDY1Zi1kOTIxLTQyMDUtOTk2Yy00Yjhk
+      YTE3ZmY3ZjNcIiIsICJuYW1lIjogInByb2JlMiIsICJwcm9wZXJ0aWVzIjogeyJudW1iZXJPZlBy
+      b2JlcyI6IDIsICJwcm90b2NvbCI6ICJIdHRwIiwgInJlcXVlc3RQYXRoIjogIi90ZXN0MiIsICJw
+      cm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAicG9ydCI6IDIsICJpbnRlcnZhbEluU2Vj
+      b25kcyI6IDE1fSwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMz
+      LWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5l
+      dHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvcHJvYmVzL3Byb2JlMiJ9LCB7InByb3BlcnRpZXMiOiB7
+      InByb3RvY29sIjogImh0dHAiLCAicmVxdWVzdFBhdGgiOiAiL3Rlc3QzIiwgInBvcnQiOiAzfSwg
+      Im5hbWUiOiAicHJvYmUzIn1dLCAiZnJvbnRlbmRJUENvbmZpZ3VyYXRpb25zIjogW3siZXRhZyI6
+      ICJXL1wiY2I1MmQ2NWYtZDkyMS00MjA1LTk5NmMtNGI4ZGExN2ZmN2YzXCIiLCAicHJvcGVydGll
+      cyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgInByaXZhdGVJUEFsbG9jYXRp
+      b25NZXRob2QiOiAiRHluYW1pYyIsICJwdWJsaWNJUEFkZHJlc3MiOiB7ImlkIjogIi9zdWJzY3Jp
+      cHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vw
+      cy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvcHVibGljSVBBZGRyZXNzZXMvUHVi
+      bGljSVBsYjEifX0sICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVj
+      My1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5O
+      ZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9ucy9Mb2FkQmFs
+      YW5jZXJGcm9udEVuZCIsICJuYW1lIjogIkxvYWRCYWxhbmNlckZyb250RW5kIn0sIHsiZXRhZyI6
+      ICJXL1wiY2I1MmQ2NWYtZDkyMS00MjA1LTk5NmMtNGI4ZGExN2ZmN2YzXCIiLCAicHJvcGVydGll
+      cyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgInByaXZhdGVJUEFsbG9jYXRp
+      b25NZXRob2QiOiAiRHluYW1pYyIsICJwdWJsaWNJUEFkZHJlc3MiOiB7ImlkIjogIi9zdWJzY3Jp
+      cHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vw
+      cy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvcHVibGljSVBBZGRyZXNzZXMvcHVi
+      bGljaXAzIn19LCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMt
+      Y2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0
+      d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMvaXBjb25maWcx
+      IiwgIm5hbWUiOiAiaXBjb25maWcxIn1dLCAib3V0Ym91bmROYXRSdWxlcyI6IFtdLCAicHJvdmlz
+      aW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImluYm91bmROYXRSdWxlcyI6IFtdLCAiYmFja2Vu
+      ZEFkZHJlc3NQb29scyI6IFt7ImV0YWciOiAiVy9cImNiNTJkNjVmLWQ5MjEtNDIwNS05OTZjLTRi
+      OGRhMTdmZjdmM1wiIiwgIm5hbWUiOiAibGIxYmVwb29sIiwgImlkIjogIi9zdWJzY3JpcHRpb25z
+      LzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNy
+      Zy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvYmFja2VuZEFk
+      ZHJlc3NQb29scy9sYjFiZXBvb2wiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUi
+      OiAiU3VjY2VlZGVkIn19LCB7ImV0YWciOiAiVy9cImNiNTJkNjVmLWQ5MjEtNDIwNS05OTZjLTRi
+      OGRhMTdmZjdmM1wiIiwgIm5hbWUiOiAiYmFwMSIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFm
+      NjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJv
+      dmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2JhY2tlbmRBZGRyZXNz
+      UG9vbHMvYmFwMSIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVk
+      ZWQifX0sIHsiZXRhZyI6ICJXL1wiY2I1MmQ2NWYtZDkyMS00MjA1LTk5NmMtNGI4ZGExN2ZmN2Yz
+      XCIiLCAibmFtZSI6ICJiYXAyIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAt
+      NGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWlj
+      cm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvYmFja2VuZEFkZHJlc3NQb29scy9iYXAy
+      IiwgInByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCJ9fV0sICJp
+      bmJvdW5kTmF0UG9vbHMiOiBbXSwgInJlc291cmNlR3VpZCI6ICJmODE2ODZmMi0wZGI0LTRiOTkt
+      YjRhYi1lMTRkZGFmOTVmZDkiLCAibG9hZEJhbGFuY2luZ1J1bGVzIjogW119LCAiaWQiOiAiL3N1
+      YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNl
+      R3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xi
+      MSJ9
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Length: ['3138']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b2f7f4ec-494e-11e6-a567-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o8nO3sOHu7s729l0d5d6zmfbk+z+dPvg3s5s78E0v5fnu7/vR/pi
+        e73i0dzQlbYuq2mG4eGNq7xp1+YLwnmV122RN/QV00k+vCwaal4sL163WcsdvV5Pp3lOSMmb1MwS
+        YS2EPD/Y/fTg0/O97Z3ZZH97f/Lw4fZkP5ts57ug4vnD++ezh/bl87patvlydvbypFqeFxfrmhEE
+        Gt+TJqnBB4+dvefe6J4BxunSYoTn53RS7w6N6u6NaH9dRpAHU9abR3nw1S1mUx5qXFxSk7OXx6Xh
+        mS/ydl4xUZ9e0ywU0+4r60lZTOmN2Ywo2OufWvwQp6SDTN7cfamf0PR85OP1S9wf9tdfYkfmDcGy
+        XrGa8qSq7Mrzwxzce/BbHNcfMdk3Mg8dZIjJ5JNide9mFpNfvq/D+2iSTd/SBCqol1VVYnAbVSBN
+        /CRfUUufRj/M8ff5MDIKfB5B8+eMBV1bnQL6xUL2IFkyT7JVKD3/r6NwD8P/TxF3L+j7/43EDTH8
+        fxVx5RerRdyQCMSrdcmdfM9+TR1M5CP5ID4n3CpkqJ/TWaHWhLX8CNH6OZsKD4o0bqspKThq8+22
+        XXW/ruqWvtoNP63zX7QmD/xl1s7py4/utvRHMDpqU5BRry+z8mz5Oic7PgOeu/fDNsv1YpLXX56/
+        BHnQYM99rexBv9h3vGGGEx4y+f9rJjxE6/9TE74Xfhqb8GB01OaHOeH3/L7/3zPhIVr/n5rwe+Gn
+        sQkPRkdtvrkJl1+sqi+Wk2q9nL3I2r4ZqNbt8JfuRbZ//B2+og5+yf8D9qArcUERAAA=
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/dea320f4-2130-4691-90e1-e53633de6628?api-version=2016-03-30']
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:08:24 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1193']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b39f4e3a-494e-11e6-9099-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o8nO3sOHu7s729l0d5d6zmfbk+z+dPvg3s5s78E0v5fnu7/vR/pi
+        e73i0dzQlbYuq2mG4eGNq7xp1+YLwnmV122RN/QV00k+vCwaal4sL163WcsdvV5Pp3lOSMmb1MwS
+        YS2EPD/Y/fTg0/O97Z3ZZH97f/Lw4fZkP5ts57ug4vnD++ezh/bl87patvlydvbypFqeFxfrmhEE
+        Gt+TJqnBB4+dvefe6J4BxunSYoTn53RS7w6N6u6NaH9dRpAHU9abR3nw1S1mUx5qXFxSk7OXx6Xh
+        mS/ydl4xUZ9e0ywU0+4r60lZTOmN2Ywo2OufWvwQp6SDTN7cfamf0PR85OP1S9wf9tdfYkfmDcGy
+        XrGa8qSq7Mrzwxzce/BbHNcfMdk3Mg8dZIjJ5JNide9mFpNfvq/D+2iSTd/SBCqol1VVYnAbVSBN
+        /CRfUUufRj/M8ff5MDIKfB5B8+eMBV1bnQL6xUL2IFkyT7JVKD3/r6NwD8P/TxF3L+j7/43EDTH8
+        fxVx5RerRdyQCMSrdcmdfM9+TR1M5CP5ID4n3CpkqJ/TWaHWhLX8CNH6OZsKD4o0bqspKThq8+22
+        XXW/ruqWvtoNP63zX7QmD/xl1s7py4/utvRHMDpqU5BRry+z8mz5Oic7PgOeu/fDNsv1YpLXX56/
+        BHnQYM99rexBv9h3vGGGEx4y+f9rJjxE6/9TE74Xfhqb8GB01OaHOeH3/L7/3zPhIVr/n5rwe+Gn
+        sQkPRkdtvrkJl1+sqi+Wk2q9nL3I2r4ZqNbt8JfuRbZ//B2+og5+yf8D9qArcUERAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:08:25 GMT']
+      ETag: [W/"b0299110-ac11-4ded-ba5c-830d27ce3ee1"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b3d4e668-494e-11e6-9deb-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o8nO3sOHu7s729l0d5d6zmfbk+z+dPvg3s5s78E0v5fnu7/vR/pi
+        e73i0dzQlbYuq2mG4eGNq7xp1+YLwnmV122RN/QV00k+vCwaal4sL163WcsdvV5Pp3lOSMmb1MwS
+        YS2EPD/Y/fTg0/O97Z3ZZH97f/Lw4fZkP5ts57ug4vnD++ezh/bl87patvlydvbypFqeFxfrmhEE
+        Gt+TJqnBB4+dvefe6J4BxunSYoTn53RS7w6N6u6NaH9dRpAHU9abR3nw1S1mUx5qXFxSk7OXx6Xh
+        mS/ydl4xUZ9e0ywU0+4r60lZTOmN2Ywo2OufWvwQp6SDTN7cfamf0PR85OP1S9wf9tdfYkfmDcGy
+        XrGa8qSq7Mrzwxzce/BbHNcfMdk3Mg8dZIjJ5JNide9mFpNfvq/D+2iSTd/SBCqol1VVYnAbVSBN
+        /CRfUUufRj/M8ff5MDIKfB5B8+eMBV1bnQL6xUL2IFkyT7JVKD3/r6NwD8P/TxF3L+j7/43EDTH8
+        fxVx5RerRdyQCMSrdcmdfM9+TR1M5CP5ID4n3CpkqJ/TWaHWhLX8CNH6OZsKD4o0bqspKThq8+22
+        XXW/ruqWvtoNP63zX7QmD/xl1s7py4/utvRHMDpqU5BRry+z8mz5Oic7PgOeu/fDNsv1YpLXX56/
+        BHnQYM99rexBv9h3vGGGEx4y+f9rJjxE6/9TE74Xfhqb8GB01OaHOeH3/L7/3zPhIVr/n5rwe+Gn
+        sQkPRkdtvrkJl1+sqi+Wk2q9nL3I2r4ZqNbt8JfuRbZ//B2+og5+yf8D9qArcUERAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:08:26 GMT']
+      ETag: [W/"b0299110-ac11-4ded-ba5c-830d27ce3ee1"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJldGFnIjogIlcvXCJiMDI5OTExMC1hYzExLTRkZWQtYmE1Yy04MzBkMjdjZTNlZTFcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW3siZXRhZyI6ICJX
+      L1wiYjAyOTkxMTAtYWMxMS00ZGVkLWJhNWMtODMwZDI3Y2UzZWUxXCIiLCAibmFtZSI6ICJwcm9i
+      ZTEiLCAicHJvcGVydGllcyI6IHsibnVtYmVyT2ZQcm9iZXMiOiA1LCAicHJvdG9jb2wiOiAiSHR0
+      cCIsICJyZXF1ZXN0UGF0aCI6ICIvdGVzdDEiLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2Vl
+      ZGVkIiwgInBvcnQiOiAxLCAiaW50ZXJ2YWxJblNlY29uZHMiOiAyMH0sICJpZCI6ICIvc3Vic2Ny
+      aXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91
+      cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL3By
+      b2Jlcy9wcm9iZTEifSwgeyJldGFnIjogIlcvXCJiMDI5OTExMC1hYzExLTRkZWQtYmE1Yy04MzBk
+      MjdjZTNlZTFcIiIsICJuYW1lIjogInByb2JlMiIsICJwcm9wZXJ0aWVzIjogeyJudW1iZXJPZlBy
+      b2JlcyI6IDIsICJwcm90b2NvbCI6ICJIdHRwIiwgInJlcXVlc3RQYXRoIjogIi90ZXN0MiIsICJw
+      cm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAicG9ydCI6IDIsICJpbnRlcnZhbEluU2Vj
+      b25kcyI6IDE1fSwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMz
+      LWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5l
+      dHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvcHJvYmVzL3Byb2JlMiJ9LCB7ImV0YWciOiAiVy9cImIw
+      Mjk5MTEwLWFjMTEtNGRlZC1iYTVjLTgzMGQyN2NlM2VlMVwiIiwgIm5hbWUiOiAicHJvYmUzIiwg
+      InByb3BlcnRpZXMiOiB7Im51bWJlck9mUHJvYmVzIjogMiwgInByb3RvY29sIjogIkh0dHAiLCAi
+      cmVxdWVzdFBhdGgiOiAiL3Rlc3QzIiwgInByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIs
+      ICJwb3J0IjogMywgImludGVydmFsSW5TZWNvbmRzIjogMTV9LCAiaWQiOiAiL3N1YnNjcmlwdGlv
+      bnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xi
+      c3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9wcm9iZXMv
+      cHJvYmUzIn1dLCAiZnJvbnRlbmRJUENvbmZpZ3VyYXRpb25zIjogW3siZXRhZyI6ICJXL1wiYjAy
+      OTkxMTAtYWMxMS00ZGVkLWJhNWMtODMwZDI3Y2UzZWUxXCIiLCAicHJvcGVydGllcyI6IHsicHJv
+      dmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgInByaXZhdGVJUEFsbG9jYXRpb25NZXRob2Qi
+      OiAiRHluYW1pYyIsICJwdWJsaWNJUEFkZHJlc3MiOiB7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBi
+      MWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9w
+      cm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvcHVibGljSVBBZGRyZXNzZXMvUHVibGljSVBsYjEi
+      fX0sICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJm
+      MDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xv
+      YWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9ucy9Mb2FkQmFsYW5jZXJGcm9u
+      dEVuZCIsICJuYW1lIjogIkxvYWRCYWxhbmNlckZyb250RW5kIn0sIHsiZXRhZyI6ICJXL1wiYjAy
+      OTkxMTAtYWMxMS00ZGVkLWJhNWMtODMwZDI3Y2UzZWUxXCIiLCAicHJvcGVydGllcyI6IHsicHJv
+      dmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgInByaXZhdGVJUEFsbG9jYXRpb25NZXRob2Qi
+      OiAiRHluYW1pYyIsICJwdWJsaWNJUEFkZHJlc3MiOiB7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBi
+      MWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9w
+      cm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvcHVibGljSVBBZGRyZXNzZXMvcHVibGljaXAzIn19
+      LCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5
+      NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2Fk
+      QmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMvaXBjb25maWcxIiwgIm5hbWUi
+      OiAiaXBjb25maWcxIn1dLCAib3V0Ym91bmROYXRSdWxlcyI6IFtdLCAicHJvdmlzaW9uaW5nU3Rh
+      dGUiOiAiU3VjY2VlZGVkIiwgImluYm91bmROYXRSdWxlcyI6IFtdLCAiYmFja2VuZEFkZHJlc3NQ
+      b29scyI6IFt7ImV0YWciOiAiVy9cImIwMjk5MTEwLWFjMTEtNGRlZC1iYTVjLTgzMGQyN2NlM2Vl
+      MVwiIiwgIm5hbWUiOiAibGIxYmVwb29sIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcx
+      LTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRl
+      cnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvYmFja2VuZEFkZHJlc3NQb29s
+      cy9sYjFiZXBvb2wiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2Vl
+      ZGVkIn19LCB7ImV0YWciOiAiVy9cImIwMjk5MTEwLWFjMTEtNGRlZC1iYTVjLTgzMGQyN2NlM2Vl
+      MVwiIiwgIm5hbWUiOiAiYmFwMSIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYw
+      LTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01p
+      Y3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMvYmFw
+      MSIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQifX0sIHsi
+      ZXRhZyI6ICJXL1wiYjAyOTkxMTAtYWMxMS00ZGVkLWJhNWMtODMwZDI3Y2UzZWUxXCIiLCAibmFt
+      ZSI6ICJiYXAyIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMz
+      LWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5l
+      dHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvYmFja2VuZEFkZHJlc3NQb29scy9iYXAyIiwgInByb3Bl
+      cnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCJ9fV0sICJpbmJvdW5kTmF0
+      UG9vbHMiOiBbXSwgInJlc291cmNlR3VpZCI6ICJmODE2ODZmMi0wZGI0LTRiOTktYjRhYi1lMTRk
+      ZGFmOTVmZDkiLCAibG9hZEJhbGFuY2luZ1J1bGVzIjogW119LCAiaWQiOiAiL3N1YnNjcmlwdGlv
+      bnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xi
+      c3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMSJ9
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Length: ['3414']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b499ee06-494e-11e6-91ab-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o/NsNj2Yzu5v7+0/nG3vT2YH25MHk2x7snM+2Tu4P723u3vv9/1I
+        X2yvVzyaG7rS1mU1zTA8vHGVN+3afEE4r/K6LfKGvmI6yYeXRUPNi+XF6zZruaPX6+k0z2f5TN6k
+        ZpYIayHk+cHupwefnu9t78wm+4T/w4fbk/1ssp3vgornD++fzx7al8/ratnmy9nZy5NqeV5crGtG
+        EGh8T5qkBh88dvaee6N7BhinS4sRnp/TSb07NKq7N6L9dRlBHkxZbx7lwVe3mE15qHFxSU3OXh6X
+        hme+yNt5xUR9ek2zUEy7r6wnZTGlN2YzomCvf2rxQ5ySDjJ5c/elfkLT85GP1y9xf9hff4kdmTcE
+        y3rFasqTqrIrzw9zcO/Bb3Fcf8Rk38g8dJAhJpNPitW9m1lMfvm+Du+jSTZ9SxOooF5WVYnBbVSB
+        NPGTfEUtfRr9MMff58PIKPB5BM2fMxZ0bXUK6BcL2YNkyTzJVqH0/L+Owj0M/z9F3L2g7/83EjfE
+        8P9VxJVfrBZxQyIQr9Yld/I9+zV1MJGP5IP4nHCrkKF+TmeFWhPW8iNE6+dsKjwo0ritpqTgqM23
+        23bV/bqqW/pqN/y0zn/Rmjzwl1k7py8/utvSH8HoqE1BRr2+zMqz5euc7PgMeO7thG2W68Ukr788
+        fwnyoMF997WyB/1i3/GGGU54yOT/r5nwEK3/T034XvhpbMKD0VGb2ITv3g/b9CZ8z339PhN+z+/7
+        /z0THqL1/6kJvxd+GpvwYHTU5pubcPnFqvpiOanWy9mLrO2bgWrdDn/pXmT7x9/hK+rgl/w/GZ64
+        oEERAAA=
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/ffda9a8f-3119-4b23-b8fa-8e545af8a1e2?api-version=2016-03-30']
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:08:26 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1194']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b5420ad0-494e-11e6-8114-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o/NsNj2Yzu5v7+0/nG3vT2YH25MHk2x7snM+2Tu4P723u3vv9/1I
+        X2yvVzyaG7rS1mU1zTA8vHGVN+3afEE4r/K6LfKGvmI6yYeXRUPNi+XF6zZruaPX6+k0z2f5TN6k
+        ZpYIayHk+cHupwefnu9t78wm+4T/w4fbk/1ssp3vgornD++fzx7al8/ratnmy9nZy5NqeV5crGtG
+        EGh8T5qkBh88dvaee6N7BhinS4sRnp/TSb07NKq7N6L9dRlBHkxZbx7lwVe3mE15qHFxSU3OXh6X
+        hme+yNt5xUR9ek2zUEy7r6wnZTGlN2YzomCvf2rxQ5ySDjJ5c/elfkLT85GP1y9xf9hff4kdmTcE
+        y3rFasqTqrIrzw9zcO/Bb3Fcf8Rk38g8dJAhJpNPitW9m1lMfvm+Du+jSTZ9SxOooF5WVYnBbVSB
+        NPGTfEUtfRr9MMff58PIKPB5BM2fMxZ0bXUK6BcL2YNkyTzJVqH0/L+Owj0M/z9F3L2g7/83EjfE
+        8P9VxJVfrBZxQyIQr9Yld/I9+zV1MJGP5IP4nHCrkKF+TmeFWhPW8iNE6+dsKjwo0ritpqTgqM23
+        23bV/bqqW/pqN/y0zn/Rmjzwl1k7py8/utvSH8HoqE1BRr2+zMqz5euc7PgMeO7thG2W68Ukr788
+        fwnyoMF997WyB/1i3/GGGU54yOT/r5nwEK3/T034XvhpbMKD0VGb2ITv3g/b9CZ8z339PhN+z+/7
+        /z0THqL1/6kJvxd+GpvwYHTU5pubcPnFqvpiOanWy9mLrO2bgWrdDn/pXmT7x9/hK+rgl/w/GZ64
+        oEERAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:08:27 GMT']
+      ETag: [W/"fadc8cd5-249d-4bd8-b7ba-b0fb285c3113"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJldGFnIjogIlcvXCJmYWRjOGNkNS0yNDlkLTRiZDgtYjdiYS1iMGZiMjg1YzMxMTNcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW3siZXRhZyI6ICJX
+      L1wiZmFkYzhjZDUtMjQ5ZC00YmQ4LWI3YmEtYjBmYjI4NWMzMTEzXCIiLCAibmFtZSI6ICJwcm9i
+      ZTEiLCAicHJvcGVydGllcyI6IHsibnVtYmVyT2ZQcm9iZXMiOiA1LCAicHJvdG9jb2wiOiAiSHR0
+      cCIsICJyZXF1ZXN0UGF0aCI6ICIvdGVzdDEiLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2Vl
+      ZGVkIiwgInBvcnQiOiAxLCAiaW50ZXJ2YWxJblNlY29uZHMiOiAyMH0sICJpZCI6ICIvc3Vic2Ny
+      aXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91
+      cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL3By
+      b2Jlcy9wcm9iZTEifSwgeyJldGFnIjogIlcvXCJmYWRjOGNkNS0yNDlkLTRiZDgtYjdiYS1iMGZi
+      Mjg1YzMxMTNcIiIsICJuYW1lIjogInByb2JlMiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFm
+      NjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJv
+      dmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL3Byb2Jlcy9wcm9iZTIi
+      LCAicHJvcGVydGllcyI6IHsicHJvdG9jb2wiOiAidGNwIiwgInBvcnQiOiAyLCAicHJvdmlzaW9u
+      aW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgIm51bWJlck9mUHJvYmVzIjogMiwgImludGVydmFsSW5T
+      ZWNvbmRzIjogMTV9fSwgeyJldGFnIjogIlcvXCJmYWRjOGNkNS0yNDlkLTRiZDgtYjdiYS1iMGZi
+      Mjg1YzMxMTNcIiIsICJuYW1lIjogInByb2JlMyIsICJwcm9wZXJ0aWVzIjogeyJudW1iZXJPZlBy
+      b2JlcyI6IDIsICJwcm90b2NvbCI6ICJIdHRwIiwgInJlcXVlc3RQYXRoIjogIi90ZXN0MyIsICJw
+      cm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAicG9ydCI6IDMsICJpbnRlcnZhbEluU2Vj
+      b25kcyI6IDE1fSwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMz
+      LWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5l
+      dHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvcHJvYmVzL3Byb2JlMyJ9XSwgImZyb250ZW5kSVBDb25m
+      aWd1cmF0aW9ucyI6IFt7ImV0YWciOiAiVy9cImZhZGM4Y2Q1LTI0OWQtNGJkOC1iN2JhLWIwZmIy
+      ODVjMzExM1wiIiwgInByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRl
+      ZCIsICJwcml2YXRlSVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVibGljSVBBZGRy
+      ZXNzIjogeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjky
+      NzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3Jr
+      L3B1YmxpY0lQQWRkcmVzc2VzL1B1YmxpY0lQbGIxIn19LCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMv
+      MGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3Jn
+      L3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQ
+      Q29uZmlndXJhdGlvbnMvTG9hZEJhbGFuY2VyRnJvbnRFbmQiLCAibmFtZSI6ICJMb2FkQmFsYW5j
+      ZXJGcm9udEVuZCJ9LCB7ImV0YWciOiAiVy9cImZhZGM4Y2Q1LTI0OWQtNGJkOC1iN2JhLWIwZmIy
+      ODVjMzExM1wiIiwgInByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRl
+      ZCIsICJwcml2YXRlSVBBbGxvY2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVibGljSVBBZGRy
+      ZXNzIjogeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjky
+      NzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3Jr
+      L3B1YmxpY0lQQWRkcmVzc2VzL3B1YmxpY2lwMyJ9fSwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBi
+      MWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9w
+      cm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJvbnRlbmRJUENv
+      bmZpZ3VyYXRpb25zL2lwY29uZmlnMSIsICJuYW1lIjogImlwY29uZmlnMSJ9XSwgIm91dGJvdW5k
+      TmF0UnVsZXMiOiBbXSwgInByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJpbmJvdW5k
+      TmF0UnVsZXMiOiBbXSwgImJhY2tlbmRBZGRyZXNzUG9vbHMiOiBbeyJldGFnIjogIlcvXCJmYWRj
+      OGNkNS0yNDlkLTRiZDgtYjdiYS1iMGZiMjg1YzMxMTNcIiIsICJuYW1lIjogImxiMWJlcG9vbCIs
+      ICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1
+      OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRC
+      YWxhbmNlcnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMvbGIxYmVwb29sIiwgInByb3BlcnRpZXMi
+      OiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCJ9fSwgeyJldGFnIjogIlcvXCJmYWRj
+      OGNkNS0yNDlkLTRiZDgtYjdiYS1iMGZiMjg1YzMxMTNcIiIsICJuYW1lIjogImJhcDEiLCAiaWQi
+      OiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jl
+      c291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5j
+      ZXJzL2xiMS9iYWNrZW5kQWRkcmVzc1Bvb2xzL2JhcDEiLCAicHJvcGVydGllcyI6IHsicHJvdmlz
+      aW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn19LCB7ImV0YWciOiAiVy9cImZhZGM4Y2Q1LTI0OWQt
+      NGJkOC1iN2JhLWIwZmIyODVjMzExM1wiIiwgIm5hbWUiOiAiYmFwMiIsICJpZCI6ICIvc3Vic2Ny
+      aXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91
+      cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Jh
+      Y2tlbmRBZGRyZXNzUG9vbHMvYmFwMiIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0
+      ZSI6ICJTdWNjZWVkZWQifX1dLCAiaW5ib3VuZE5hdFBvb2xzIjogW10sICJyZXNvdXJjZUd1aWQi
+      OiAiZjgxNjg2ZjItMGRiNC00Yjk5LWI0YWItZTE0ZGRhZjk1ZmQ5IiwgImxvYWRCYWxhbmNpbmdS
+      dWxlcyI6IFtdfSwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMz
+      LWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5l
+      dHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEifQ==
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Length: ['3388']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b567739e-494e-11e6-9314-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o/v3d+7fn80ebN/buXewvX9wf7p98PDg0+29nf17B5NPZ5ODvcnv
+        +5G+2F6veDQ3dKWty2qaYXh44ypv2rX5gnBe5XVb5A19xXSSDy+LhpoXy4vXbdZyR6/X02mez/KZ
+        vEnNLBHWQsjzg91PDz4939vemU32t/cnDx9uT/azyXa+CyqeP7x/PntoXz6vq2WbL2dnL0+q5Xlx
+        sa4ZQaDxPWmSGnzw2Nl77o3uGWCcLi1GeH5OJ/Xu0Kju3oj212UEeTBlvXmUB1/dYjblocbFJTU5
+        e3lcGp75Im/nFRP16TXNQjHtvrKelMWU3pjNiIK9/qnFD3FKOsjkzd2X+glNz0c+Xr/E/WF//SV2
+        ZN4QLOsVqylPqsquPD/Mwb0Hv8Vx/RGTfSPz0EGGmEw+KVb3bmYx+eX7OryPJtn0LU2ggnpZVSUG
+        t1EF0sRP8hW19Gn0wxx/nw8jo8DnETR/zljQtdUpoF8sZA+SJfMkW4XS8/86Cvcw/P8UcfeCvv/f
+        SNwQw/9XEVd+sVrEDYlAvFqX3Mn37NfUwUQ+kg/ic8KtQob6OZ0Vak1Yy48QrZ+zqfCgSOO2mpKC
+        ozbfbttV9+uqbumr3fDTOv9Fa/LAX2btnL786G5LfwSjozYFGfX6MivPlq9zsuMz4Lm3E7ZZrheT
+        vP7y/CXIgwb33dfKHvSLfccbZjjhIZP/v2bCQ7T+Xzjhb6YD870Xfhqby937YZveXO65r99nLu/5
+        GP2/Zy5DtP5fOJfDwnsv/DQmvMHoqM03N+Hyi9XixXJSrZezF1nb1/DVuh3+0r3Ipo2/w1fUwS/5
+        fwCOFTnrHBEAAA==
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/7a12a07d-6974-49a3-911b-835bf72a9e15?api-version=2016-03-30']
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:08:28 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1193']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b616bd90-494e-11e6-9de4-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o/v3d+7fn80ebN/buXewvX9wf7p98PDg0+29nf17B5NPZ5ODvcnv
+        +5G+2F6veDQ3dKWty2qaYXh44ypv2rX5gnBe5XVb5A19xXSSDy+LhpoXy4vXbdZyR6/X02mez/KZ
+        vEnNLBHWQsjzg91PDz4939vemU32t/cnDx9uT/azyXa+CyqeP7x/PntoXz6vq2WbL2dnL0+q5Xlx
+        sa4ZQaDxPWmSGnzw2Nl77o3uGWCcLi1GeH5OJ/Xu0Kju3oj212UEeTBlvXmUB1/dYjblocbFJTU5
+        e3lcGp75Im/nFRP16TXNQjHtvrKelMWU3pjNiIK9/qnFD3FKOsjkzd2X+glNz0c+Xr/E/WF//SV2
+        ZN4QLOsVqylPqsquPD/Mwb0Hv8Vx/RGTfSPz0EGGmEw+KVb3bmYx+eX7OryPJtn0LU2ggnpZVSUG
+        t1EF0sRP8hW19Gn0wxx/nw8jo8DnETR/zljQtdUpoF8sZA+SJfMkW4XS8/86Cvcw/P8UcfeCvv/f
+        SNwQw/9XEVd+sVrEDYlAvFqX3Mn37NfUwUQ+kg/ic8KtQob6OZ0Vak1Yy48QrZ+zqfCgSOO2mpKC
+        ozbfbttV9+uqbumr3fDTOv9Fa/LAX2btnL786G5LfwSjozYFGfX6MivPlq9zsuMz4Lm3E7ZZrheT
+        vP7y/CXIgwb33dfKHvSLfccbZjjhIZP/v2bCQ7T+Xzjhb6YD870Xfhqby937YZveXO65r99nLu/5
+        GP2/Zy5DtP5fOJfDwnsv/DQmvMHoqM03N+Hyi9XixXJSrZezF1nb1/DVuh3+0r3Ipo2/w1fUwS/5
+        fwCOFTnrHBEAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:08:29 GMT']
+      ETag: [W/"55055dd7-3038-485c-8986-20438b6db82b"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b6483662-494e-11e6-aa29-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o/v3d+7fn80ebN/buXewvX9wf7p98PDg0+29nf17B5NPZ5ODvcnv
+        +5G+2F6veDQ3dKWty2qaYXh44ypv2rX5gnBe5XVb5A19xXSSDy+LhpoXy4vXbdZyR6/X02mez/KZ
+        vEnNLBHWQsjzg91PDz4939vemU32t/cnDx9uT/azyXa+CyqeP7x/PntoXz6vq2WbL2dnL0+q5Xlx
+        sa4ZQaDxPWmSGnzw2Nl77o3uGWCcLi1GeH5OJ/Xu0Kju3oj212UEeTBlvXmUB1/dYjblocbFJTU5
+        e3lcGp75Im/nFRP16TXNQjHtvrKelMWU3pjNiIK9/qnFD3FKOsjkzd2X+glNz0c+Xr/E/WF//SV2
+        ZN4QLOsVqylPqsquPD/Mwb0Hv8Vx/RGTfSPz0EGGmEw+KVb3bmYx+eX7OryPJtn0LU2ggnpZVSUG
+        t1EF0sRP8hW19Gn0wxx/nw8jo8DnETR/zljQtdUpoF8sZA+SJfMkW4XS8/86Cvcw/P8UcfeCvv/f
+        SNwQw/9XEVd+sVrEDYlAvFqX3Mn37NfUwUQ+kg/ic8KtQob6OZ0Vak1Yy48QrZ+zqfCgSOO2mpKC
+        ozbfbttV9+uqbumr3fDTOv9Fa/LAX2btnL786G5LfwSjozYFGfX6MivPlq9zsuMz4Lm3E7ZZrheT
+        vP7y/CXIgwb33dfKHvSLfccbZjjhIZP/v2bCQ7T+Xzjhb6YD870Xfhqby937YZveXO65r99nLu/5
+        GP2/Zy5DtP5fOJfDwnsv/DQmvMHoqM03N+Hyi9XixXJSrZezF1nb1/DVuh3+0r3Ipo2/w1fUwS/5
+        fwCOFTnrHBEAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:08:29 GMT']
+      ETag: [W/"55055dd7-3038-485c-8986-20438b6db82b"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b67b3608-494e-11e6-a2e8-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o/v3d+7fn80ebN/buXewvX9wf7p98PDg0+29nf17B5NPZ5ODvcnv
+        +5G+2F6veDQ3dKWty2qaYXh44ypv2rX5gnBe5XVb5A19xXSSDy+LhpoXy4vXbdZyR6/X02mez/KZ
+        vEnNLBHWQsjzg91PDz4939vemU32t/cnDx9uT/azyXa+CyqeP7x/PntoXz6vq2WbL2dnL0+q5Xlx
+        sa4ZQaDxPWmSGnzw2Nl77o3uGWCcLi1GeH5OJ/Xu0Kju3oj212UEeTBlvXmUB1/dYjblocbFJTU5
+        e3lcGp75Im/nFRP16TXNQjHtvrKelMWU3pjNiIK9/qnFD3FKOsjkzd2X+glNz0c+Xr/E/WF//SV2
+        ZN4QLOsVqylPqsquPD/Mwb0Hv8Vx/RGTfSPz0EGGmEw+KVb3bmYx+eX7OryPJtn0LU2ggnpZVSUG
+        t1EF0sRP8hW19Gn0wxx/nw8jo8DnETR/zljQtdUpoF8sZA+SJfMkW4XS8/86Cvcw/P8UcfeCvv/f
+        SNwQw/9XEVd+sVrEDYlAvFqX3Mn37NfUwUQ+kg/ic8KtQob6OZ0Vak1Yy48QrZ+zqfCgSOO2mpKC
+        ozbfbttV9+uqbumr3fDTOv9Fa/LAX2btnL786G5LfwSjozYFGfX6MivPlq9zsuMz4Lm3E7ZZrheT
+        vP7y/CXIgwb33dfKHvSLfccbZjjhIZP/v2bCQ7T+Xzjhb6YD870Xfhqby937YZveXO65r99nLu/5
+        GP2/Zy5DtP5fOJfDwnsv/DQmvMHoqM03N+Hyi9XixXJSrZezF1nb1/DVuh3+0r3Ipo2/w1fUwS/5
+        fwCOFTnrHBEAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:08:30 GMT']
+      ETag: [W/"55055dd7-3038-485c-8986-20438b6db82b"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJldGFnIjogIlcvXCI1NTA1NWRkNy0zMDM4LTQ4NWMtODk4Ni0yMDQzOGI2ZGI4MmJcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW3siZXRhZyI6ICJX
+      L1wiNTUwNTVkZDctMzAzOC00ODVjLTg5ODYtMjA0MzhiNmRiODJiXCIiLCAibmFtZSI6ICJwcm9i
+      ZTEiLCAicHJvcGVydGllcyI6IHsibnVtYmVyT2ZQcm9iZXMiOiA1LCAicHJvdG9jb2wiOiAiSHR0
+      cCIsICJyZXF1ZXN0UGF0aCI6ICIvdGVzdDEiLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2Vl
+      ZGVkIiwgInBvcnQiOiAxLCAiaW50ZXJ2YWxJblNlY29uZHMiOiAyMH0sICJpZCI6ICIvc3Vic2Ny
+      aXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91
+      cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL3By
+      b2Jlcy9wcm9iZTEifSwgeyJldGFnIjogIlcvXCI1NTA1NWRkNy0zMDM4LTQ4NWMtODk4Ni0yMDQz
+      OGI2ZGI4MmJcIiIsICJuYW1lIjogInByb2JlMiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFm
+      NjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJv
+      dmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL3Byb2Jlcy9wcm9iZTIi
+      LCAicHJvcGVydGllcyI6IHsicHJvdG9jb2wiOiAiVGNwIiwgInBvcnQiOiAyLCAicHJvdmlzaW9u
+      aW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgIm51bWJlck9mUHJvYmVzIjogMiwgImludGVydmFsSW5T
+      ZWNvbmRzIjogMTV9fV0sICJmcm9udGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJldGFnIjogIlcv
+      XCI1NTA1NWRkNy0zMDM4LTQ4NWMtODk4Ni0yMDQzOGI2ZGI4MmJcIiIsICJwcm9wZXJ0aWVzIjog
+      eyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1l
+      dGhvZCI6ICJEeW5hbWljIiwgInB1YmxpY0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlv
+      bnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xi
+      c3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9QdWJsaWNJ
+      UGxiMSJ9fSwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNi
+      OTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdv
+      cmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJvbnRlbmRJUENvbmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNl
+      ckZyb250RW5kIiwgIm5hbWUiOiAiTG9hZEJhbGFuY2VyRnJvbnRFbmQifSwgeyJldGFnIjogIlcv
+      XCI1NTA1NWRkNy0zMDM4LTQ4NWMtODk4Ni0yMDQzOGI2ZGI4MmJcIiIsICJwcm9wZXJ0aWVzIjog
+      eyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1l
+      dGhvZCI6ICJEeW5hbWljIiwgInB1YmxpY0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlv
+      bnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xi
+      c3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9wdWJsaWNp
+      cDMifX0sICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjky
+      NzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3Jr
+      L2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9ucy9pcGNvbmZpZzEiLCAi
+      bmFtZSI6ICJpcGNvbmZpZzEifV0sICJvdXRib3VuZE5hdFJ1bGVzIjogW10sICJwcm92aXNpb25p
+      bmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAiaW5ib3VuZE5hdFJ1bGVzIjogW10sICJiYWNrZW5kQWRk
+      cmVzc1Bvb2xzIjogW3siZXRhZyI6ICJXL1wiNTUwNTVkZDctMzAzOC00ODVjLTg5ODYtMjA0Mzhi
+      NmRiODJiXCIiLCAibmFtZSI6ICJsYjFiZXBvb2wiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIx
+      ZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3By
+      b3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVz
+      c1Bvb2xzL2xiMWJlcG9vbCIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQifX0sIHsiZXRhZyI6ICJXL1wiNTUwNTVkZDctMzAzOC00ODVjLTg5ODYtMjA0Mzhi
+      NmRiODJiXCIiLCAibmFtZSI6ICJiYXAxIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcx
+      LTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRl
+      cnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvYmFja2VuZEFkZHJlc3NQb29s
+      cy9iYXAxIiwgInByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCJ9
+      fSwgeyJldGFnIjogIlcvXCI1NTA1NWRkNy0zMDM4LTQ4NWMtODk4Ni0yMDQzOGI2ZGI4MmJcIiIs
+      ICJuYW1lIjogImJhcDIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRh
+      LWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3Nv
+      ZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVzc1Bvb2xzL2JhcDIiLCAi
+      cHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn19XSwgImluYm91
+      bmROYXRQb29scyI6IFtdLCAicmVzb3VyY2VHdWlkIjogImY4MTY4NmYyLTBkYjQtNGI5OS1iNGFi
+      LWUxNGRkYWY5NWZkOSIsICJsb2FkQmFsYW5jaW5nUnVsZXMiOiBbXX0sICJpZCI6ICIvc3Vic2Ny
+      aXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91
+      cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxIn0=
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Length: ['3020']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b69af882-494e-11e6-85ec-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o9n+wfnB7oPJ9k5+fm97P9s72M4e7O1v7+89fHh/On24e757/vt+
+        pC+21ysezQ1daeuymmYYHt64ypt2bb4gnFd53RZ5Q18xneTDy6Kh5sXy4nWbtdzR6/V0muezfCZv
+        UjNLhLUQkpD/9ODT873tndmEsJ48fLg92c8m2/kuqHj+8P757KF9+byulm2+nJ29PKmW58XFumYE
+        gcb3pElq8MFjZ++5N7pngHG6tBjh+Tmd1LtDo7p7I9pflxHkwZT15lEefHWL2ZSHGheX1OTs5XFp
+        eOaLvJ1XTNSn1zQLxbT7ynpSFlN6YzYjCvb6pxY/xCnpIJM3d1/qJzQ9H/l4/RL3h/31l9iReUOw
+        rFespjypKrvy/DAH9x78Fsf1R0z2jcxDBxliMvmkWN27mcXkl+/r8D6aZNO3NIEK6mVVlRjcRhVI
+        Ez/JV9TSp9EPc/x9PoyMAp9H0Pw5Y0HXVqeAfrGQPUiWzJNsFUrP/+so3MPw/1PE3Qv6/n8jcUMM
+        /19FXPnFahE3JALxal1yJ9+zX1MHE/lIPojPCbcKGerndFaoNWEtP0K0fs6mwoMijdtqSgqO2ny7
+        bVfdr6u6pa92w0/r/BetyQN/mbVz+vKjuy39EYyO2hRk1OvLrDxbvs7Jjs+A595O2Ga5Xkzy+svz
+        lyAPGtx3Xyt70C/2HW+Y4YSHTP7/mgkP0fp/4YS/mQ7M9174aWwud++HbXpzuee+dnMpv1ihLpaT
+        ar2cvcjavsBX63b4S/ciazr+Dl9RB7/k/wH6xixBKw8AAA==
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/9b96ddad-64f4-4fcb-8e89-4d646682a1a8?api-version=2016-03-30']
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:08:30 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1192']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b741979a-494e-11e6-bfd8-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o9n+wfnB7oPJ9k5+fm97P9s72M4e7O1v7+89fHh/On24e757/vt+
+        pC+21ysezQ1daeuymmYYHt64ypt2bb4gnFd53RZ5Q18xneTDy6Kh5sXy4nWbtdzR6/V0muezfCZv
+        UjNLhLUQkpD/9ODT873tndmEsJ48fLg92c8m2/kuqHj+8P757KF9+byulm2+nJ29PKmW58XFumYE
+        gcb3pElq8MFjZ++5N7pngHG6tBjh+Tmd1LtDo7p7I9pflxHkwZT15lEefHWL2ZSHGheX1OTs5XFp
+        eOaLvJ1XTNSn1zQLxbT7ynpSFlN6YzYjCvb6pxY/xCnpIJM3d1/qJzQ9H/l4/RL3h/31l9iReUOw
+        rFespjypKrvy/DAH9x78Fsf1R0z2jcxDBxliMvmkWN27mcXkl+/r8D6aZNO3NIEK6mVVlRjcRhVI
+        Ez/JV9TSp9EPc/x9PoyMAp9H0Pw5Y0HXVqeAfrGQPUiWzJNsFUrP/+so3MPw/1PE3Qv6/n8jcUMM
+        /19FXPnFahE3JALxal1yJ9+zX1MHE/lIPojPCbcKGerndFaoNWEtP0K0fs6mwoMijdtqSgqO2ny7
+        bVfdr6u6pa92w0/r/BetyQN/mbVz+vKjuy39EYyO2hRk1OvLrDxbvs7Jjs+A595O2Ga5Xkzy+svz
+        lyAPGtx3Xyt70C/2HW+Y4YSHTP7/mgkP0fp/4YS/mQ7M9174aWwud++HbXpzuee+dnMpv1ihLpaT
+        ar2cvcjavsBX63b4S/ciazr+Dl9RB7/k/wH6xixBKw8AAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:08:31 GMT']
+      ETag: [W/"d48f817b-0ef3-4a28-a724-42995cc91f1f"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b7735e86-494e-11e6-96ba-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o9n+wfnB7oPJ9k5+fm97P9s72M4e7O1v7+89fHh/On24e757/vt+
+        pC+21ysezQ1daeuymmYYHt64ypt2bb4gnFd53RZ5Q18xneTDy6Kh5sXy4nWbtdzR6/V0muezfCZv
+        UjNLhLUQkpD/9ODT873tndmEsJ48fLg92c8m2/kuqHj+8P757KF9+byulm2+nJ29PKmW58XFumYE
+        gcb3pElq8MFjZ++5N7pngHG6tBjh+Tmd1LtDo7p7I9pflxHkwZT15lEefHWL2ZSHGheX1OTs5XFp
+        eOaLvJ1XTNSn1zQLxbT7ynpSFlN6YzYjCvb6pxY/xCnpIJM3d1/qJzQ9H/l4/RL3h/31l9iReUOw
+        rFespjypKrvy/DAH9x78Fsf1R0z2jcxDBxliMvmkWN27mcXkl+/r8D6aZNO3NIEK6mVVlRjcRhVI
+        Ez/JV9TSp9EPc/x9PoyMAp9H0Pw5Y0HXVqeAfrGQPUiWzJNsFUrP/+so3MPw/1PE3Qv6/n8jcUMM
+        /19FXPnFahE3JALxal1yJ9+zX1MHE/lIPojPCbcKGerndFaoNWEtP0K0fs6mwoMijdtqSgqO2ny7
+        bVfdr6u6pa92w0/r/BetyQN/mbVz+vKjuy39EYyO2hRk1OvLrDxbvs7Jjs+A595O2Ga5Xkzy+svz
+        lyAPGtx3Xyt70C/2HW+Y4YSHTP7/mgkP0fp/4YS/mQ7M9174aWwud++HbXpzuee+dnMpv1ihLpaT
+        ar2cvcjavsBX63b4S/ciazr+Dl9RB7/k/wH6xixBKw8AAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:08:32 GMT']
+      ETag: [W/"d48f817b-0ef3-4a28-a724-42995cc91f1f"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJldGFnIjogIlcvXCJkNDhmODE3Yi0wZWYzLTRhMjgtYTcyNC00Mjk5NWNjOTFmMWZcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW3siZXRhZyI6ICJX
+      L1wiZDQ4ZjgxN2ItMGVmMy00YTI4LWE3MjQtNDI5OTVjYzkxZjFmXCIiLCAibmFtZSI6ICJwcm9i
+      ZTEiLCAicHJvcGVydGllcyI6IHsibnVtYmVyT2ZQcm9iZXMiOiA1LCAicHJvdG9jb2wiOiAiSHR0
+      cCIsICJyZXF1ZXN0UGF0aCI6ICIvdGVzdDEiLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2Vl
+      ZGVkIiwgInBvcnQiOiAxLCAiaW50ZXJ2YWxJblNlY29uZHMiOiAyMH0sICJpZCI6ICIvc3Vic2Ny
+      aXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91
+      cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL3By
+      b2Jlcy9wcm9iZTEifSwgeyJldGFnIjogIlcvXCJkNDhmODE3Yi0wZWYzLTRhMjgtYTcyNC00Mjk5
+      NWNjOTFmMWZcIiIsICJuYW1lIjogInByb2JlMiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFm
+      NjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJv
+      dmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL3Byb2Jlcy9wcm9iZTIi
+      LCAicHJvcGVydGllcyI6IHsicHJvdG9jb2wiOiAiVGNwIiwgInBvcnQiOiAyLCAicHJvdmlzaW9u
+      aW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgIm51bWJlck9mUHJvYmVzIjogMiwgImludGVydmFsSW5T
+      ZWNvbmRzIjogMTV9fV0sICJmcm9udGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJldGFnIjogIlcv
+      XCJkNDhmODE3Yi0wZWYzLTRhMjgtYTcyNC00Mjk5NWNjOTFmMWZcIiIsICJwcm9wZXJ0aWVzIjog
+      eyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1l
+      dGhvZCI6ICJEeW5hbWljIiwgInB1YmxpY0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlv
+      bnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xi
+      c3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9QdWJsaWNJ
+      UGxiMSJ9fSwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNi
+      OTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdv
+      cmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJvbnRlbmRJUENvbmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNl
+      ckZyb250RW5kIiwgIm5hbWUiOiAiTG9hZEJhbGFuY2VyRnJvbnRFbmQifSwgeyJldGFnIjogIlcv
+      XCJkNDhmODE3Yi0wZWYzLTRhMjgtYTcyNC00Mjk5NWNjOTFmMWZcIiIsICJwcm9wZXJ0aWVzIjog
+      eyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1l
+      dGhvZCI6ICJEeW5hbWljIiwgInB1YmxpY0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlv
+      bnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xi
+      c3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9wdWJsaWNp
+      cDMifX0sICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjky
+      NzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3Jr
+      L2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9ucy9pcGNvbmZpZzEiLCAi
+      bmFtZSI6ICJpcGNvbmZpZzEifV0sICJvdXRib3VuZE5hdFJ1bGVzIjogW10sICJwcm92aXNpb25p
+      bmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAiaW5ib3VuZE5hdFJ1bGVzIjogW10sICJiYWNrZW5kQWRk
+      cmVzc1Bvb2xzIjogW3siZXRhZyI6ICJXL1wiZDQ4ZjgxN2ItMGVmMy00YTI4LWE3MjQtNDI5OTVj
+      YzkxZjFmXCIiLCAibmFtZSI6ICJsYjFiZXBvb2wiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIx
+      ZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3By
+      b3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVz
+      c1Bvb2xzL2xiMWJlcG9vbCIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJT
+      dWNjZWVkZWQifX0sIHsiZXRhZyI6ICJXL1wiZDQ4ZjgxN2ItMGVmMy00YTI4LWE3MjQtNDI5OTVj
+      YzkxZjFmXCIiLCAibmFtZSI6ICJiYXAxIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcx
+      LTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRl
+      cnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvYmFja2VuZEFkZHJlc3NQb29s
+      cy9iYXAxIiwgInByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCJ9
+      fSwgeyJldGFnIjogIlcvXCJkNDhmODE3Yi0wZWYzLTRhMjgtYTcyNC00Mjk5NWNjOTFmMWZcIiIs
+      ICJuYW1lIjogImJhcDIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRh
+      LWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3Nv
+      ZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVzc1Bvb2xzL2JhcDIiLCAi
+      cHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn19XSwgImluYm91
+      bmROYXRQb29scyI6IFtdLCAicmVzb3VyY2VHdWlkIjogImY4MTY4NmYyLTBkYjQtNGI5OS1iNGFi
+      LWUxNGRkYWY5NWZkOSIsICJsb2FkQmFsYW5jaW5nUnVsZXMiOiBbeyJwcm9wZXJ0aWVzIjogeyJi
+      YWNrZW5kQWRkcmVzc1Bvb2wiOiB7ImV0YWciOiAiVy9cImQ0OGY4MTdiLTBlZjMtNGEyOC1hNzI0
+      LTQyOTk1Y2M5MWYxZlwiIiwgIm5hbWUiOiAiYmFwMSIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8w
+      YjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcv
+      cHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2JhY2tlbmRBZGRy
+      ZXNzUG9vbHMvYmFwMSIsICJwcm9wZXJ0aWVzIjogeyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNj
+      ZWVkZWQifX0sICJlbmFibGVGbG9hdGluZ0lQIjogZmFsc2UsICJmcm9udGVuZFBvcnQiOiA0MCwg
+      InByb3RvY29sIjogInRjcCIsICJmcm9udGVuZElQQ29uZmlndXJhdGlvbiI6IHsiZXRhZyI6ICJX
+      L1wiZDQ4ZjgxN2ItMGVmMy00YTI4LWE3MjQtNDI5OTVjYzkxZjFmXCIiLCAicHJvcGVydGllcyI6
+      IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgInByaXZhdGVJUEFsbG9jYXRpb25N
+      ZXRob2QiOiAiRHluYW1pYyIsICJwdWJsaWNJUEFkZHJlc3MiOiB7ImlkIjogIi9zdWJzY3JpcHRp
+      b25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9s
+      YnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvcHVibGljSVBBZGRyZXNzZXMvUHVibGlj
+      SVBsYjEifX0sICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1j
+      YjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3
+      b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9ucy9Mb2FkQmFsYW5j
+      ZXJGcm9udEVuZCIsICJuYW1lIjogIkxvYWRCYWxhbmNlckZyb250RW5kIn0sICJsb2FkRGlzdHJp
+      YnV0aW9uIjogImRlZmF1bHQiLCAiYmFja2VuZFBvcnQiOiA0MH0sICJuYW1lIjogInJ1bGUxIn1d
+      fSwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYw
+      OTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9h
+      ZEJhbGFuY2Vycy9sYjEifQ==
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Length: ['4006']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b831024c-494e-11e6-8c98-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o09nO/cnD/cPtvf2H1LPk/18+2DyMN++l012DrJsOtnJJr/vR/pi
+        e73i0dzQlbYuq2mG4eGNq7xp1+YLwnmV122RN/QV00k+vCwaal4sL163WcsdvV5Pp3k+y2fyJjWz
+        RFgLIc8Pdj89+PR8b3tnNtkn/B8+3J7sZ5PtfBdUPH94/3z20L58XlfLNl/Ozl6eVMvz4mJdM4JA
+        43vSJDX44LGz99wb3TPAOF1ajPD8nE7q3aFR3b0R7a/LCPJgynrzKA++usVsykONi0tqcvbyuDQ8
+        80Xezism6tNrmoVi2n1lPSmLKb0xmxEFe/1Tix/ilHSQyZu7L/UTmp6PfLx+STgKN5dEplfrkglp
+        OVGezrjorR/iyByC+J5G431iUL5b07/hMGmg/p/fd3/Yzx0lvAFagStWU2Zl1Vjy/NwOfFDK4rj+
+        SLS+kXnoIEPcJp8Uq3sBx1m+8n7VX76vw/tokk3f0gQqqJdVVWJwVty8UVo+pImf5Ctq6dPohzn+
+        Ph9GRoHPI2j+nLGga6tTQL9YyB4kS+ZJtgql5/91FO5h+HNGXA8KNXbYU2tWx9TasrQ8AXg8P7fk
+        dZ8YlH82LAhN2J5Pq5/bMQ+wVIjhzxlLubaOuPKL1Z1uSASCJ41AWD7zerMTIHOq7+P5uZ0B94kZ
+        gHKdj+HP2Qx4UKjxgKtBrwRAqeXPKUkH0ByIO3zMnejiseN9WdUtjWd/J/xahWfg23yZTcr8GaHX
+        Em3PXlKT86xs8rBVMSvzN8Uir9bt2fKLYrlueZL2w1Y0/raakhklor6ZrjrTQl3MnhZNWxeTNQaK
+        Vk/z82xdtp2WirEn7tT2/1Vz18eQFVKohFUJ4LG/6i9WMVC3EyblRmXArUJZ+zkdPrUmrOVHiNb/
+        S1QANbac+O227bLiSmRhN/y0zn/RmvIsL7N2Tl9+dJd4vA1GR20KkrT6MivPlq9ziltmwHOvI1LL
+        9WKS11+evwR50OC++1rnn36x73jDDCc8NG//r5nwEK3/F054X/XofO+Fn8bmcvd+2KY3l3vuazeX
+        8osV6mI5qdbL2YusZUtJb33PfkcadPhL9yKrFP4OX1EHv+T/AR+uou4RFQAA
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/1aeaae45-e945-4520-a4bd-584c5cf1b6be?api-version=2016-03-30']
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:08:32 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1191']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b8d7248a-494e-11e6-b1d7-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o09nO/cnD/cPtvf2H1LPk/18+2DyMN++l012DrJsOtnJJr/vR/pi
+        e73i0dzQlbYuq2mG4eGNq7xp1+YLwnmV122RN/QV00k+vCwaal4sL163WcsdvV5Pp3k+y2fyJjWz
+        RFgLIc8Pdj89+PR8b3tnNtkn/B8+3J7sZ5PtfBdUPH94/3z20L58XlfLNl/Ozl6eVMvz4mJdM4JA
+        43vSJDX44LGz99wb3TPAOF1ajPD8nE7q3aFR3b0R7a/LCPJgynrzKA++usVsykONi0tqcvbyuDQ8
+        80Xezism6tNrmoVi2n1lPSmLKb0xmxEFe/1Tix/ilHSQyZu7L/UTmp6PfLx+STgKN5dEplfrkglp
+        OVGezrjorR/iyByC+J5G431iUL5b07/hMGmg/p/fd3/Yzx0lvAFagStWU2Zl1Vjy/NwOfFDK4rj+
+        SLS+kXnoIEPcJp8Uq3sBx1m+8n7VX76vw/tokk3f0gQqqJdVVWJwVty8UVo+pImf5Ctq6dPohzn+
+        Ph9GRoHPI2j+nLGga6tTQL9YyB4kS+ZJtgql5/91FO5h+HNGXA8KNXbYU2tWx9TasrQ8AXg8P7fk
+        dZ8YlH82LAhN2J5Pq5/bMQ+wVIjhzxlLubaOuPKL1Z1uSASCJ41AWD7zerMTIHOq7+P5uZ0B94kZ
+        gHKdj+HP2Qx4UKjxgKtBrwRAqeXPKUkH0ByIO3zMnejiseN9WdUtjWd/J/xahWfg23yZTcr8GaHX
+        Em3PXlKT86xs8rBVMSvzN8Uir9bt2fKLYrlueZL2w1Y0/raakhklor6ZrjrTQl3MnhZNWxeTNQaK
+        Vk/z82xdtp2WirEn7tT2/1Vz18eQFVKohFUJ4LG/6i9WMVC3EyblRmXArUJZ+zkdPrUmrOVHiNb/
+        S1QANbac+O227bLiSmRhN/y0zn/RmvIsL7N2Tl9+dJd4vA1GR20KkrT6MivPlq9ziltmwHOvI1LL
+        9WKS11+evwR50OC++1rnn36x73jDDCc8NG//r5nwEK3/F054X/XofO+Fn8bmcvd+2KY3l3vuazeX
+        8osV6mI5qdbL2YusZUtJb33PfkcadPhL9yKrFP4OX1EHv+T/AR+uou4RFQAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:08:33 GMT']
+      ETag: [W/"6d05b948-2490-4b4e-8b9e-3ab08aacb0ab"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJldGFnIjogIlcvXCI2ZDA1Yjk0OC0yNDkwLTRiNGUtOGI5ZS0zYWIwOGFhY2IwYWJcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW3siZXRhZyI6ICJX
+      L1wiNmQwNWI5NDgtMjQ5MC00YjRlLThiOWUtM2FiMDhhYWNiMGFiXCIiLCAibmFtZSI6ICJwcm9i
+      ZTEiLCAicHJvcGVydGllcyI6IHsibnVtYmVyT2ZQcm9iZXMiOiA1LCAicHJvdG9jb2wiOiAiSHR0
+      cCIsICJyZXF1ZXN0UGF0aCI6ICIvdGVzdDEiLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2Vl
+      ZGVkIiwgInBvcnQiOiAxLCAiaW50ZXJ2YWxJblNlY29uZHMiOiAyMH0sICJpZCI6ICIvc3Vic2Ny
+      aXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91
+      cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL3By
+      b2Jlcy9wcm9iZTEifSwgeyJldGFnIjogIlcvXCI2ZDA1Yjk0OC0yNDkwLTRiNGUtOGI5ZS0zYWIw
+      OGFhY2IwYWJcIiIsICJuYW1lIjogInByb2JlMiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFm
+      NjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJv
+      dmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL3Byb2Jlcy9wcm9iZTIi
+      LCAicHJvcGVydGllcyI6IHsicHJvdG9jb2wiOiAiVGNwIiwgInBvcnQiOiAyLCAicHJvdmlzaW9u
+      aW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgIm51bWJlck9mUHJvYmVzIjogMiwgImludGVydmFsSW5T
+      ZWNvbmRzIjogMTV9fV0sICJmcm9udGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJldGFnIjogIlcv
+      XCI2ZDA1Yjk0OC0yNDkwLTRiNGUtOGI5ZS0zYWIwOGFhY2IwYWJcIiIsICJwcm9wZXJ0aWVzIjog
+      eyJsb2FkQmFsYW5jaW5nUnVsZXMiOiBbeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0x
+      YmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJz
+      L01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2xvYWRCYWxhbmNpbmdSdWxlcy9y
+      dWxlMSJ9XSwgInByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJwcml2YXRlSVBBbGxv
+      Y2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVibGljSVBBZGRyZXNzIjogeyJpZCI6ICIvc3Vi
+      c2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VH
+      cm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3B1YmxpY0lQQWRkcmVzc2Vz
+      L1B1YmxpY0lQbGIxIn19LCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRh
+      LWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3Nv
+      ZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMvTG9h
+      ZEJhbGFuY2VyRnJvbnRFbmQiLCAibmFtZSI6ICJMb2FkQmFsYW5jZXJGcm9udEVuZCJ9LCB7ImV0
+      YWciOiAiVy9cIjZkMDViOTQ4LTI0OTAtNGI0ZS04YjllLTNhYjA4YWFjYjBhYlwiIiwgInByb3Bl
+      cnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJwcml2YXRlSVBBbGxv
+      Y2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVibGljSVBBZGRyZXNzIjogeyJpZCI6ICIvc3Vi
+      c2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VH
+      cm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3B1YmxpY0lQQWRkcmVzc2Vz
+      L3B1YmxpY2lwMyJ9fSwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1h
+      ZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0
+      Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJvbnRlbmRJUENvbmZpZ3VyYXRpb25zL2lwY29u
+      ZmlnMSIsICJuYW1lIjogImlwY29uZmlnMSJ9XSwgIm91dGJvdW5kTmF0UnVsZXMiOiBbXSwgInBy
+      b3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJpbmJvdW5kTmF0UnVsZXMiOiBbXSwgImJh
+      Y2tlbmRBZGRyZXNzUG9vbHMiOiBbeyJldGFnIjogIlcvXCI2ZDA1Yjk0OC0yNDkwLTRiNGUtOGI5
+      ZS0zYWIwOGFhY2IwYWJcIiIsICJuYW1lIjogImxiMWJlcG9vbCIsICJpZCI6ICIvc3Vic2NyaXB0
+      aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMv
+      bGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2JhY2tl
+      bmRBZGRyZXNzUG9vbHMvbGIxYmVwb29sIiwgInByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0
+      YXRlIjogIlN1Y2NlZWRlZCJ9fSwgeyJldGFnIjogIlcvXCI2ZDA1Yjk0OC0yNDkwLTRiNGUtOGI5
+      ZS0zYWIwOGFhY2IwYWJcIiIsICJuYW1lIjogImJhcDEiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMv
+      MGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3Jn
+      L3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRk
+      cmVzc1Bvb2xzL2JhcDEiLCAicHJvcGVydGllcyI6IHsibG9hZEJhbGFuY2luZ1J1bGVzIjogW3si
+      aWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkw
+      L3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFs
+      YW5jZXJzL2xiMS9sb2FkQmFsYW5jaW5nUnVsZXMvcnVsZTEifV0sICJwcm92aXNpb25pbmdTdGF0
+      ZSI6ICJTdWNjZWVkZWQifX0sIHsiZXRhZyI6ICJXL1wiNmQwNWI5NDgtMjQ5MC00YjRlLThiOWUt
+      M2FiMDhhYWNiMGFiXCIiLCAibmFtZSI6ICJiYXAyIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBi
+      MWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9w
+      cm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvYmFja2VuZEFkZHJl
+      c3NQb29scy9iYXAyIiwgInByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2Nl
+      ZWRlZCJ9fV0sICJpbmJvdW5kTmF0UG9vbHMiOiBbXSwgInJlc291cmNlR3VpZCI6ICJmODE2ODZm
+      Mi0wZGI0LTRiOTktYjRhYi1lMTRkZGFmOTVmZDkiLCAibG9hZEJhbGFuY2luZ1J1bGVzIjogW3si
+      ZXRhZyI6ICJXL1wiNmQwNWI5NDgtMjQ5MC00YjRlLThiOWUtM2FiMDhhYWNiMGFiXCIiLCAiaWQi
+      OiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jl
+      c291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5j
+      ZXJzL2xiMS9sb2FkQmFsYW5jaW5nUnVsZXMvcnVsZTEiLCAicHJvcGVydGllcyI6IHsiYmFja2Vu
+      ZEFkZHJlc3NQb29sIjogeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEt
+      YWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29m
+      dC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMvYmFwMSJ9LCAi
+      aWRsZVRpbWVvdXRJbk1pbnV0ZXMiOiA0LCAiZW5hYmxlRmxvYXRpbmdJUCI6IGZhbHNlLCAiZnJv
+      bnRlbmRQb3J0IjogNDAsICJwcm90b2NvbCI6ICJUY3AiLCAiZnJvbnRlbmRJUENvbmZpZ3VyYXRp
+      b24iOiB7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3
+      MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsv
+      bG9hZEJhbGFuY2Vycy9sYjEvZnJvbnRlbmRJUENvbmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNlckZy
+      b250RW5kIn0sICJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAibG9hZERpc3RyaWJ1
+      dGlvbiI6ICJEZWZhdWx0IiwgImJhY2tlbmRQb3J0IjogNDB9LCAibmFtZSI6ICJydWxlMSJ9LCB7
+      InByb3BlcnRpZXMiOiB7ImJhY2tlbmRBZGRyZXNzUG9vbCI6IHsiZXRhZyI6ICJXL1wiNmQwNWI5
+      NDgtMjQ5MC00YjRlLThiOWUtM2FiMDhhYWNiMGFiXCIiLCAibmFtZSI6ICJiYXAxIiwgImlkIjog
+      Ii9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNv
+      dXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vy
+      cy9sYjEvYmFja2VuZEFkZHJlc3NQb29scy9iYXAxIiwgInByb3BlcnRpZXMiOiB7ImxvYWRCYWxh
+      bmNpbmdSdWxlcyI6IFt7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1h
+      ZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0
+      Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvbG9hZEJhbGFuY2luZ1J1bGVzL3J1bGUxIn1dLCAi
+      cHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn19LCAiZW5hYmxlRmxvYXRpbmdJUCI6IGZh
+      bHNlLCAiZnJvbnRlbmRQb3J0IjogNjAsICJwcm90b2NvbCI6ICJ0Y3AiLCAiZnJvbnRlbmRJUENv
+      bmZpZ3VyYXRpb24iOiB7ImV0YWciOiAiVy9cIjZkMDViOTQ4LTI0OTAtNGI0ZS04YjllLTNhYjA4
+      YWFjYjBhYlwiIiwgInByb3BlcnRpZXMiOiB7ImxvYWRCYWxhbmNpbmdSdWxlcyI6IFt7ImlkIjog
+      Ii9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNv
+      dXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vy
+      cy9sYjEvbG9hZEJhbGFuY2luZ1J1bGVzL3J1bGUxIn1dLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAi
+      U3VjY2VlZGVkIiwgInByaXZhdGVJUEFsbG9jYXRpb25NZXRob2QiOiAiRHluYW1pYyIsICJwdWJs
+      aWNJUEFkZHJlc3MiOiB7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1h
+      ZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0
+      Lk5ldHdvcmsvcHVibGljSVBBZGRyZXNzZXMvUHVibGljSVBsYjEifX0sICJpZCI6ICIvc3Vic2Ny
+      aXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91
+      cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zy
+      b250ZW5kSVBDb25maWd1cmF0aW9ucy9Mb2FkQmFsYW5jZXJGcm9udEVuZCIsICJuYW1lIjogIkxv
+      YWRCYWxhbmNlckZyb250RW5kIn0sICJsb2FkRGlzdHJpYnV0aW9uIjogImRlZmF1bHQiLCAiYmFj
+      a2VuZFBvcnQiOiA2MH0sICJuYW1lIjogInJ1bGUyIn1dfSwgImlkIjogIi9zdWJzY3JpcHRpb25z
+      LzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNy
+      Zy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEifQ==
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Length: ['5521']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b8f6e706-494e-11e6-9c80-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o539ew9mu7sPtvf3Hny6vZ/NHmxn97Pz7QeTBw+m093Jg/u7n/6+
+        H+mL7fWKR3NDV9q6rKYZhoc3rvKmXZsvCOdVXrdF3tBXTCf58LJoqHmxvHjdZi139Ho9neb5LJ/J
+        m9TMEmEthDw/2P304NPzve2d2WR/e3/y8OH2ZD+bbOe7oOL5w/vns4f25fO6Wrb5cnb28qRanhcX
+        65oRBBrfkyapwQePnb3n3uieAcbp0mKE5+d0Uu8OjerujWh/XUaQB1PWm0d58NUtZlMealxcUpOz
+        l8el4Zkv8nZeMVGfXtMsFNPuK+tJWUzpjdmMKNjrn1r8EKekg0ze3H2pn9D0fOTj9UvCUbi5JDK9
+        WpdMSMuJ8nTGRW/9EEfmEMT3NBrvE4Py3Zr+DYfZHej/V0ax1x2F/+f33R/2czdMb4BWbRSrKQuk
+        6l15fm4HPqgr4rj+SEF8I/PQQYa4TT4pVvcCjrN85f2qv3xfh/fRJJu+pQlUUC+rqsTgrNLwRmn5
+        kCZ+kq+opU+jH+b4+3wYGQU+j6D5c8aCrq1OAf1iIXuQLJkn2SqUnv/XUbiH4c8ZcT0o1NhhT61Z
+        HVNry9LyBODx/NyS131iUGYL8iM7aH6hoXmCsefP+M/tmAcEI8Tw50wwXFtHXPnFWgA3JALBk0Yg
+        rLR4vdkJwJyGgv9zOgPuEzMA5roQw5+zGfCgUOMBh4leCYBSy59Tkg6gORAD+pg70cVjx/uyqlsa
+        z/5O+LUKz8C3+TKblPkzQq8l2p69pCbnWdnkYatiVuZvikVerduz5RfFct3yJO2HrWj8bTUlZ4CI
+        +ma66kwLdTF7WjRtXUzWGChaPc3Ps3XZdloqxp64U9v/V81dH0NWSKEpUSWAx/7qps4bTyD0oVL7
+        OR2l+4RYwwl9iOGPhJ6wvDVJB9D8YKH/tCPWyqAD3/5I6L/O3PUxvK3Qyy/WG6BuJ0zKjR4AtwoN
+        7M/p8Kk1YS0/QrT+X6ICqLHlxG+3bZcVVyILu+Gndf6L1pTofpm1c/ryo7vE420wOmpTkKTVl1l5
+        tnydU8plBjz3OiK1XC8mef3l+UuQBw3uu691/ukX+443zHDCQ+X6/5oJD9H6f+GE91WPzvde+Gls
+        Lnfvh216c7nnvnZzKb9YoS6Wk2q9nL3IWraU9Nb37HekQYe/dC+ySuHv8BV18Ev+H2uIMGmSGgAA
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/d5ba7d16-6708-4464-9ba4-5ae72fdd9f9a?api-version=2016-03-30']
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:08:34 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1193']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b99c9b18-494e-11e6-821c-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o539ew9mu7sPtvf3Hny6vZ/NHmxn97Pz7QeTBw+m093Jg/u7n/6+
+        H+mL7fWKR3NDV9q6rKYZhoc3rvKmXZsvCOdVXrdF3tBXTCf58LJoqHmxvHjdZi139Ho9neb5LJ/J
+        m9TMEmEthDw/2P304NPzve2d2WR/e3/y8OH2ZD+bbOe7oOL5w/vns4f25fO6Wrb5cnb28qRanhcX
+        65oRBBrfkyapwQePnb3n3uieAcbp0mKE5+d0Uu8OjerujWh/XUaQB1PWm0d58NUtZlMealxcUpOz
+        l8el4Zkv8nZeMVGfXtMsFNPuK+tJWUzpjdmMKNjrn1r8EKekg0ze3H2pn9D0fOTj9UvCUbi5JDK9
+        WpdMSMuJ8nTGRW/9EEfmEMT3NBrvE4Py3Zr+DYfZHej/V0ax1x2F/+f33R/2czdMb4BWbRSrKQuk
+        6l15fm4HPqgr4rj+SEF8I/PQQYa4TT4pVvcCjrN85f2qv3xfh/fRJJu+pQlUUC+rqsTgrNLwRmn5
+        kCZ+kq+opU+jH+b4+3wYGQU+j6D5c8aCrq1OAf1iIXuQLJkn2SqUnv/XUbiH4c8ZcT0o1NhhT61Z
+        HVNry9LyBODx/NyS131iUGYL8iM7aH6hoXmCsefP+M/tmAcEI8Tw50wwXFtHXPnFWgA3JALBk0Yg
+        rLR4vdkJwJyGgv9zOgPuEzMA5roQw5+zGfCgUOMBh4leCYBSy59Tkg6gORAD+pg70cVjx/uyqlsa
+        z/5O+LUKz8C3+TKblPkzQq8l2p69pCbnWdnkYatiVuZvikVerduz5RfFct3yJO2HrWj8bTUlZ4CI
+        +ma66kwLdTF7WjRtXUzWGChaPc3Ps3XZdloqxp64U9v/V81dH0NWSKEpUSWAx/7qps4bTyD0oVL7
+        OR2l+4RYwwl9iOGPhJ6wvDVJB9D8YKH/tCPWyqAD3/5I6L/O3PUxvK3Qyy/WG6BuJ0zKjR4AtwoN
+        7M/p8Kk1YS0/QrT+X6ICqLHlxG+3bZcVVyILu+Gndf6L1pTofpm1c/ryo7vE420wOmpTkKTVl1l5
+        tnydU8plBjz3OiK1XC8mef3l+UuQBw3uu691/ukX+443zHDCQ+X6/5oJD9H6f+GE91WPzvde+Gls
+        Lnfvh216c7nnvnZzKb9YoS6Wk2q9nL3IWraU9Nb37HekQYe/dC+ySuHv8BV18Ev+H2uIMGmSGgAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:08:35 GMT']
+      ETag: [W/"0437d117-4276-4ad7-a5af-7b77cc1b7516"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b9cbe65e-494e-11e6-aff7-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o539ew9mu7sPtvf3Hny6vZ/NHmxn97Pz7QeTBw+m093Jg/u7n/6+
+        H+mL7fWKR3NDV9q6rKYZhoc3rvKmXZsvCOdVXrdF3tBXTCf58LJoqHmxvHjdZi139Ho9neb5LJ/J
+        m9TMEmEthDw/2P304NPzve2d2WR/e3/y8OH2ZD+bbOe7oOL5w/vns4f25fO6Wrb5cnb28qRanhcX
+        65oRBBrfkyapwQePnb3n3uieAcbp0mKE5+d0Uu8OjerujWh/XUaQB1PWm0d58NUtZlMealxcUpOz
+        l8el4Zkv8nZeMVGfXtMsFNPuK+tJWUzpjdmMKNjrn1r8EKekg0ze3H2pn9D0fOTj9UvCUbi5JDK9
+        WpdMSMuJ8nTGRW/9EEfmEMT3NBrvE4Py3Zr+DYfZHej/V0ax1x2F/+f33R/2czdMb4BWbRSrKQuk
+        6l15fm4HPqgr4rj+SEF8I/PQQYa4TT4pVvcCjrN85f2qv3xfh/fRJJu+pQlUUC+rqsTgrNLwRmn5
+        kCZ+kq+opU+jH+b4+3wYGQU+j6D5c8aCrq1OAf1iIXuQLJkn2SqUnv/XUbiH4c8ZcT0o1NhhT61Z
+        HVNry9LyBODx/NyS131iUGYL8iM7aH6hoXmCsefP+M/tmAcEI8Tw50wwXFtHXPnFWgA3JALBk0Yg
+        rLR4vdkJwJyGgv9zOgPuEzMA5roQw5+zGfCgUOMBh4leCYBSy59Tkg6gORAD+pg70cVjx/uyqlsa
+        z/5O+LUKz8C3+TKblPkzQq8l2p69pCbnWdnkYatiVuZvikVerduz5RfFct3yJO2HrWj8bTUlZ4CI
+        +ma66kwLdTF7WjRtXUzWGChaPc3Ps3XZdloqxp64U9v/V81dH0NWSKEpUSWAx/7qps4bTyD0oVL7
+        OR2l+4RYwwl9iOGPhJ6wvDVJB9D8YKH/tCPWyqAD3/5I6L/O3PUxvK3Qyy/WG6BuJ0zKjR4AtwoN
+        7M/p8Kk1YS0/QrT+X6ICqLHlxG+3bZcVVyILu+Gndf6L1pTofpm1c/ryo7vE420wOmpTkKTVl1l5
+        tnydU8plBjz3OiK1XC8mef3l+UuQBw3uu691/ukX+443zHDCQ+X6/5oJD9H6f+GE91WPzvde+Gls
+        Lnfvh216c7nnvnZzKb9YoS6Wk2q9nL3IWraU9Nb37HekQYe/dC+ySuHv8BV18Ev+H2uIMGmSGgAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:08:35 GMT']
+      ETag: [W/"0437d117-4276-4ad7-a5af-7b77cc1b7516"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJldGFnIjogIlcvXCIwNDM3ZDExNy00Mjc2LTRhZDctYTVhZi03Yjc3Y2MxYjc1MTZcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW3siZXRhZyI6ICJX
+      L1wiMDQzN2QxMTctNDI3Ni00YWQ3LWE1YWYtN2I3N2NjMWI3NTE2XCIiLCAibmFtZSI6ICJwcm9i
+      ZTEiLCAicHJvcGVydGllcyI6IHsibnVtYmVyT2ZQcm9iZXMiOiA1LCAicHJvdG9jb2wiOiAiSHR0
+      cCIsICJyZXF1ZXN0UGF0aCI6ICIvdGVzdDEiLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2Vl
+      ZGVkIiwgInBvcnQiOiAxLCAiaW50ZXJ2YWxJblNlY29uZHMiOiAyMH0sICJpZCI6ICIvc3Vic2Ny
+      aXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91
+      cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL3By
+      b2Jlcy9wcm9iZTEifSwgeyJldGFnIjogIlcvXCIwNDM3ZDExNy00Mjc2LTRhZDctYTVhZi03Yjc3
+      Y2MxYjc1MTZcIiIsICJuYW1lIjogInByb2JlMiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFm
+      NjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJv
+      dmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL3Byb2Jlcy9wcm9iZTIi
+      LCAicHJvcGVydGllcyI6IHsicHJvdG9jb2wiOiAiVGNwIiwgInBvcnQiOiAyLCAicHJvdmlzaW9u
+      aW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgIm51bWJlck9mUHJvYmVzIjogMiwgImludGVydmFsSW5T
+      ZWNvbmRzIjogMTV9fV0sICJmcm9udGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJldGFnIjogIlcv
+      XCIwNDM3ZDExNy00Mjc2LTRhZDctYTVhZi03Yjc3Y2MxYjc1MTZcIiIsICJwcm9wZXJ0aWVzIjog
+      eyJsb2FkQmFsYW5jaW5nUnVsZXMiOiBbeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0x
+      YmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJz
+      L01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2xvYWRCYWxhbmNpbmdSdWxlcy9y
+      dWxlMSJ9LCB7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNi
+      OTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdv
+      cmsvbG9hZEJhbGFuY2Vycy9sYjEvbG9hZEJhbGFuY2luZ1J1bGVzL3J1bGUyIn1dLCAicHJvdmlz
+      aW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgInByaXZhdGVJUEFsbG9jYXRpb25NZXRob2QiOiAi
+      RHluYW1pYyIsICJwdWJsaWNJUEFkZHJlc3MiOiB7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2
+      NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92
+      aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvcHVibGljSVBBZGRyZXNzZXMvUHVibGljSVBsYjEifX0s
+      ICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1
+      OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRC
+      YWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9ucy9Mb2FkQmFsYW5jZXJGcm9udEVu
+      ZCIsICJuYW1lIjogIkxvYWRCYWxhbmNlckZyb250RW5kIn0sIHsiZXRhZyI6ICJXL1wiMDQzN2Qx
+      MTctNDI3Ni00YWQ3LWE1YWYtN2I3N2NjMWI3NTE2XCIiLCAicHJvcGVydGllcyI6IHsicHJvdmlz
+      aW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgInByaXZhdGVJUEFsbG9jYXRpb25NZXRob2QiOiAi
+      RHluYW1pYyIsICJwdWJsaWNJUEFkZHJlc3MiOiB7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2
+      NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92
+      aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvcHVibGljSVBBZGRyZXNzZXMvcHVibGljaXAzIn19LCAi
+      aWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkw
+      L3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFs
+      YW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMvaXBjb25maWcxIiwgIm5hbWUiOiAi
+      aXBjb25maWcxIn1dLCAib3V0Ym91bmROYXRSdWxlcyI6IFtdLCAicHJvdmlzaW9uaW5nU3RhdGUi
+      OiAiU3VjY2VlZGVkIiwgImluYm91bmROYXRSdWxlcyI6IFtdLCAiYmFja2VuZEFkZHJlc3NQb29s
+      cyI6IFt7ImV0YWciOiAiVy9cIjA0MzdkMTE3LTQyNzYtNGFkNy1hNWFmLTdiNzdjYzFiNzUxNlwi
+      IiwgIm5hbWUiOiAibGIxYmVwb29sIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFi
+      ZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMv
+      TWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvYmFja2VuZEFkZHJlc3NQb29scy9s
+      YjFiZXBvb2wiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVk
+      In19LCB7ImV0YWciOiAiVy9cIjA0MzdkMTE3LTQyNzYtNGFkNy1hNWFmLTdiNzdjYzFiNzUxNlwi
+      IiwgIm5hbWUiOiAiYmFwMSIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRk
+      ZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jv
+      c29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMvYmFwMSIs
+      ICJwcm9wZXJ0aWVzIjogeyJsb2FkQmFsYW5jaW5nUnVsZXMiOiBbeyJpZCI6ICIvc3Vic2NyaXB0
+      aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMv
+      bGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2xvYWRC
+      YWxhbmNpbmdSdWxlcy9ydWxlMSJ9LCB7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFi
+      ZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMv
+      TWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvbG9hZEJhbGFuY2luZ1J1bGVzL3J1
+      bGUyIn1dLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn19LCB7ImV0YWciOiAiVy9c
+      IjA0MzdkMTE3LTQyNzYtNGFkNy1hNWFmLTdiNzdjYzFiNzUxNlwiIiwgIm5hbWUiOiAiYmFwMiIs
+      ICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1
+      OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRC
+      YWxhbmNlcnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMvYmFwMiIsICJwcm9wZXJ0aWVzIjogeyJw
+      cm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQifX1dLCAiaW5ib3VuZE5hdFBvb2xzIjogW10s
+      ICJyZXNvdXJjZUd1aWQiOiAiZjgxNjg2ZjItMGRiNC00Yjk5LWI0YWItZTE0ZGRhZjk1ZmQ5Iiwg
+      ImxvYWRCYWxhbmNpbmdSdWxlcyI6IFt7ImV0YWciOiAiVy9cIjA0MzdkMTE3LTQyNzYtNGFkNy1h
+      NWFmLTdiNzdjYzFiNzUxNlwiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAt
+      NGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWlj
+      cm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvbG9hZEJhbGFuY2luZ1J1bGVzL3J1bGUx
+      IiwgInByb3BlcnRpZXMiOiB7ImJhY2tlbmRBZGRyZXNzUG9vbCI6IHsiaWQiOiAiL3N1YnNjcmlw
+      dGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBz
+      L2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNr
+      ZW5kQWRkcmVzc1Bvb2xzL2JhcDEifSwgImlkbGVUaW1lb3V0SW5NaW51dGVzIjogMjAsICJlbmFi
+      bGVGbG9hdGluZ0lQIjogdHJ1ZSwgImZyb250ZW5kUG9ydCI6IDQwLCAicHJvdG9jb2wiOiAidWRw
+      IiwgImZyb250ZW5kSVBDb25maWd1cmF0aW9uIjogeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFm
+      NjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJv
+      dmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25m
+      aWd1cmF0aW9ucy9Mb2FkQmFsYW5jZXJGcm9udEVuZCJ9LCAicHJvdmlzaW9uaW5nU3RhdGUiOiAi
+      U3VjY2VlZGVkIiwgImxvYWREaXN0cmlidXRpb24iOiAic291cmNlaXAiLCAiYmFja2VuZFBvcnQi
+      OiA0MH0sICJuYW1lIjogInJ1bGUxIn0sIHsiZXRhZyI6ICJXL1wiMDQzN2QxMTctNDI3Ni00YWQ3
+      LWE1YWYtN2I3N2NjMWI3NTE2XCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJm
+      MC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9N
+      aWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9sb2FkQmFsYW5jaW5nUnVsZXMvcnVs
+      ZTIiLCAicHJvcGVydGllcyI6IHsiYmFja2VuZEFkZHJlc3NQb29sIjogeyJpZCI6ICIvc3Vic2Ny
+      aXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91
+      cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Jh
+      Y2tlbmRBZGRyZXNzUG9vbHMvYmFwMSJ9LCAiaWRsZVRpbWVvdXRJbk1pbnV0ZXMiOiA0LCAiZW5h
+      YmxlRmxvYXRpbmdJUCI6IGZhbHNlLCAiZnJvbnRlbmRQb3J0IjogNjAsICJwcm90b2NvbCI6ICJU
+      Y3AiLCAiZnJvbnRlbmRJUENvbmZpZ3VyYXRpb24iOiB7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBi
+      MWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9w
+      cm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJvbnRlbmRJUENv
+      bmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNlckZyb250RW5kIn0sICJwcm92aXNpb25pbmdTdGF0ZSI6
+      ICJTdWNjZWVkZWQiLCAibG9hZERpc3RyaWJ1dGlvbiI6ICJEZWZhdWx0IiwgImJhY2tlbmRQb3J0
+      IjogNjB9LCAibmFtZSI6ICJydWxlMiJ9XX0sICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3
+      MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlk
+      ZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxIn0=
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Length: ['5285']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b9e9377a-494e-11e6-b270-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o08f7h7k9/fvb0/PDz7d3n/wYG97cr6bb092pvvnDx7en3y6P/19
+        P9IX2+sVj+aGrrR1WU0zDA9vXOVNuzZfEM6rvG6LvKGvmE7y4WXRUPNiefG6zVru6PV6Os3zWT6T
+        N6mZJcJaCHl+sPvpwafne9s7s8n+9v7k4cPtyX422c53QcXzh/fPZw/ty+d1tWzz5ezs5Um1PC8u
+        1jUjCDS+J01Sgw8eO3vPvdE9A4zTpcUIz8/ppN4dGtXdG9H+uowgD6asN4/y4KtbzKY81Li4pCZn
+        L49LwzNf5O28YqI+vaZZKKbdV9aTspjSG7MZUbDXP7X4IU5JB5m8uftSP6Hp+cjH65eEo3BzSWR6
+        tS6ZkJYT5emMi976IY7MIYjvaTTeJwbluzX9Gw6zO9D/r4xirzsK/8/vuz/s526Y3gCt2ihWUxZI
+        1bvy/NwOfFBXxHH9kYL4Ruahgwxxm3xSrO4FHGf5yvtVf/m+Du+jSTZ9SxOooF5WVYnBWaXhjdLy
+        IU38JF9RS59GP8zx9/kwMgp8HkHz54wFXVudAvrFQvYgWTJPslUoPf+vo3APw58z4npQqLHDnlqz
+        OqbWlqXlCcDj+bklr/vEoMwW5Ed20PxCQ/MEY8+f8Z/bMQ8IRojhz5lguLaOuPKLtQBuSASCJ41A
+        WGnxerMTgDkNBf/ndAbcJ2YAzHUhhj9nM+BBocYDDhO9EgCllj+nJB1AcyAG9DF3oovHjvdlVbc0
+        nv2d8GsVnoFv82U2KfNnhF5LtD17SU3aep2HjYpZmb8pFnm1bs+WXxTLdctztNeBReNvqyk5A0TU
+        r2arzrRQF7OnRdPWxWSNgaLVayYi9Ro2VZQ9eafG/6+avD6GrJFCW6JaAI/91c2dN55A6kOt9nM6
+        SvcJ8YaT+hDDH0k9YXlrkg6g+cFS/2lHFpVBB76NSP15Vja3E/v9sBWN30r9m+ltpP5pfp6ty7bT
+        UjH2RIra/r9q7voY3lbo5RfrDlC3EyblRheAW4UW9ud0+NSasJYfIVr/L1EB1Nhy4rfbtsuKK5GF
+        3fDTOv9Fa8p0v8zaOX350V3i8TYYHbUpSNLqy6w8W77OKecyA55d47dcLyZ5/eX5S5AHDe67r3X+
+        6Rf7jjfMcMJD5fr/mgkP0fp/4YT3VY/O9174aWwud++HbXpzuee+dnMpv1ihLpaTar2cvchatpT0
+        1vfsd6RBh790L7JK4e/wFXXwS/4fSnW+qZMaAAA=
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/463d4abf-5c04-4e31-a199-4e6a49851692?api-version=2016-03-30']
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:08:35 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1190']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [ba91a7e8-494e-11e6-a7d8-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o08f7h7k9/fvb0/PDz7d3n/wYG97cr6bb092pvvnDx7en3y6P/19
+        P9IX2+sVj+aGrrR1WU0zDA9vXOVNuzZfEM6rvG6LvKGvmE7y4WXRUPNiefG6zVru6PV6Os3zWT6T
+        N6mZJcJaCHl+sPvpwafne9s7s8n+9v7k4cPtyX422c53QcXzh/fPZw/ty+d1tWzz5ezs5Um1PC8u
+        1jUjCDS+J01Sgw8eO3vPvdE9A4zTpcUIz8/ppN4dGtXdG9H+uowgD6asN4/y4KtbzKY81Li4pCZn
+        L49LwzNf5O28YqI+vaZZKKbdV9aTspjSG7MZUbDXP7X4IU5JB5m8uftSP6Hp+cjH65eEo3BzSWR6
+        tS6ZkJYT5emMi976IY7MIYjvaTTeJwbluzX9Gw6zO9D/r4xirzsK/8/vuz/s526Y3gCt2ihWUxZI
+        1bvy/NwOfFBXxHH9kYL4Ruahgwxxm3xSrO4FHGf5yvtVf/m+Du+jSTZ9SxOooF5WVYnBWaXhjdLy
+        IU38JF9RS59GP8zx9/kwMgp8HkHz54wFXVudAvrFQvYgWTJPslUoPf+vo3APw58z4npQqLHDnlqz
+        OqbWlqXlCcDj+bklr/vEoMwW5Ed20PxCQ/MEY8+f8Z/bMQ8IRojhz5lguLaOuPKLtQBuSASCJ41A
+        WGnxerMTgDkNBf/ndAbcJ2YAzHUhhj9nM+BBocYDDhO9EgCllj+nJB1AcyAG9DF3oovHjvdlVbc0
+        nv2d8GsVnoFv82U2KfNnhF5LtD17SU3aep2HjYpZmb8pFnm1bs+WXxTLdctztNeBReNvqyk5A0TU
+        r2arzrRQF7OnRdPWxWSNgaLVayYi9Ro2VZQ9eafG/6+avD6GrJFCW6JaAI/91c2dN55A6kOt9nM6
+        SvcJ8YaT+hDDH0k9YXlrkg6g+cFS/2lHFpVBB76NSP15Vja3E/v9sBWN30r9m+ltpP5pfp6ty7bT
+        UjH2RIra/r9q7voY3lbo5RfrDlC3EyblRheAW4UW9ud0+NSasJYfIVr/L1EB1Nhy4rfbtsuKK5GF
+        3fDTOv9Fa8p0v8zaOX350V3i8TYYHbUpSNLqy6w8W77OKecyA55d47dcLyZ5/eX5S5AHDe67r3X+
+        6Rf7jjfMcMJD5fr/mgkP0fp/4YT3VY/O9174aWwud++HbXpzuee+dnMpv1ihLpaTar2cvchatpT0
+        1vfsd6RBh790L7JK4e/wFXXwS/4fSnW+qZMaAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:08:36 GMT']
+      ETag: [W/"6918e545-cf86-4772-bf1e-b0c4f795b64c"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJldGFnIjogIlcvXCI2OTE4ZTU0NS1jZjg2LTQ3NzItYmYxZS1iMGM0Zjc5NWI2NGNcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW3siZXRhZyI6ICJX
+      L1wiNjkxOGU1NDUtY2Y4Ni00NzcyLWJmMWUtYjBjNGY3OTViNjRjXCIiLCAibmFtZSI6ICJwcm9i
+      ZTEiLCAicHJvcGVydGllcyI6IHsibnVtYmVyT2ZQcm9iZXMiOiA1LCAicHJvdG9jb2wiOiAiSHR0
+      cCIsICJyZXF1ZXN0UGF0aCI6ICIvdGVzdDEiLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2Vl
+      ZGVkIiwgInBvcnQiOiAxLCAiaW50ZXJ2YWxJblNlY29uZHMiOiAyMH0sICJpZCI6ICIvc3Vic2Ny
+      aXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91
+      cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL3By
+      b2Jlcy9wcm9iZTEifSwgeyJldGFnIjogIlcvXCI2OTE4ZTU0NS1jZjg2LTQ3NzItYmYxZS1iMGM0
+      Zjc5NWI2NGNcIiIsICJuYW1lIjogInByb2JlMiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFm
+      NjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJv
+      dmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL3Byb2Jlcy9wcm9iZTIi
+      LCAicHJvcGVydGllcyI6IHsicHJvdG9jb2wiOiAiVGNwIiwgInBvcnQiOiAyLCAicHJvdmlzaW9u
+      aW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgIm51bWJlck9mUHJvYmVzIjogMiwgImludGVydmFsSW5T
+      ZWNvbmRzIjogMTV9fV0sICJmcm9udGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJldGFnIjogIlcv
+      XCI2OTE4ZTU0NS1jZjg2LTQ3NzItYmYxZS1iMGM0Zjc5NWI2NGNcIiIsICJwcm9wZXJ0aWVzIjog
+      eyJsb2FkQmFsYW5jaW5nUnVsZXMiOiBbeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0x
+      YmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJz
+      L01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2xvYWRCYWxhbmNpbmdSdWxlcy9y
+      dWxlMSJ9LCB7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNi
+      OTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdv
+      cmsvbG9hZEJhbGFuY2Vycy9sYjEvbG9hZEJhbGFuY2luZ1J1bGVzL3J1bGUyIn1dLCAicHJvdmlz
+      aW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgInByaXZhdGVJUEFsbG9jYXRpb25NZXRob2QiOiAi
+      RHluYW1pYyIsICJwdWJsaWNJUEFkZHJlc3MiOiB7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2
+      NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92
+      aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvcHVibGljSVBBZGRyZXNzZXMvUHVibGljSVBsYjEifX0s
+      ICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1
+      OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRC
+      YWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9ucy9Mb2FkQmFsYW5jZXJGcm9udEVu
+      ZCIsICJuYW1lIjogIkxvYWRCYWxhbmNlckZyb250RW5kIn0sIHsiZXRhZyI6ICJXL1wiNjkxOGU1
+      NDUtY2Y4Ni00NzcyLWJmMWUtYjBjNGY3OTViNjRjXCIiLCAicHJvcGVydGllcyI6IHsicHJvdmlz
+      aW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgInByaXZhdGVJUEFsbG9jYXRpb25NZXRob2QiOiAi
+      RHluYW1pYyIsICJwdWJsaWNJUEFkZHJlc3MiOiB7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2
+      NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92
+      aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvcHVibGljSVBBZGRyZXNzZXMvcHVibGljaXAzIn19LCAi
+      aWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkw
+      L3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFs
+      YW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMvaXBjb25maWcxIiwgIm5hbWUiOiAi
+      aXBjb25maWcxIn1dLCAib3V0Ym91bmROYXRSdWxlcyI6IFtdLCAicHJvdmlzaW9uaW5nU3RhdGUi
+      OiAiU3VjY2VlZGVkIiwgImluYm91bmROYXRSdWxlcyI6IFtdLCAiYmFja2VuZEFkZHJlc3NQb29s
+      cyI6IFt7ImV0YWciOiAiVy9cIjY5MThlNTQ1LWNmODYtNDc3Mi1iZjFlLWIwYzRmNzk1YjY0Y1wi
+      IiwgIm5hbWUiOiAibGIxYmVwb29sIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFi
+      ZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMv
+      TWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvYmFja2VuZEFkZHJlc3NQb29scy9s
+      YjFiZXBvb2wiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVk
+      In19LCB7ImV0YWciOiAiVy9cIjY5MThlNTQ1LWNmODYtNDc3Mi1iZjFlLWIwYzRmNzk1YjY0Y1wi
+      IiwgIm5hbWUiOiAiYmFwMSIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRk
+      ZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jv
+      c29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMvYmFwMSIs
+      ICJwcm9wZXJ0aWVzIjogeyJsb2FkQmFsYW5jaW5nUnVsZXMiOiBbeyJpZCI6ICIvc3Vic2NyaXB0
+      aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMv
+      bGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2xvYWRC
+      YWxhbmNpbmdSdWxlcy9ydWxlMSJ9LCB7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFi
+      ZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMv
+      TWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvbG9hZEJhbGFuY2luZ1J1bGVzL3J1
+      bGUyIn1dLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn19LCB7ImV0YWciOiAiVy9c
+      IjY5MThlNTQ1LWNmODYtNDc3Mi1iZjFlLWIwYzRmNzk1YjY0Y1wiIiwgIm5hbWUiOiAiYmFwMiIs
+      ICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1
+      OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRC
+      YWxhbmNlcnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMvYmFwMiIsICJwcm9wZXJ0aWVzIjogeyJw
+      cm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQifX1dLCAiaW5ib3VuZE5hdFBvb2xzIjogW10s
+      ICJyZXNvdXJjZUd1aWQiOiAiZjgxNjg2ZjItMGRiNC00Yjk5LWI0YWItZTE0ZGRhZjk1ZmQ5Iiwg
+      ImxvYWRCYWxhbmNpbmdSdWxlcyI6IFt7ImV0YWciOiAiVy9cIjY5MThlNTQ1LWNmODYtNDc3Mi1i
+      ZjFlLWIwYzRmNzk1YjY0Y1wiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAt
+      NGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWlj
+      cm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvbG9hZEJhbGFuY2luZ1J1bGVzL3J1bGUx
+      IiwgInByb3BlcnRpZXMiOiB7ImJhY2tlbmRBZGRyZXNzUG9vbCI6IHsiaWQiOiAiL3N1YnNjcmlw
+      dGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBz
+      L2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNr
+      ZW5kQWRkcmVzc1Bvb2xzL2JhcDEifSwgImlkbGVUaW1lb3V0SW5NaW51dGVzIjogMjAsICJlbmFi
+      bGVGbG9hdGluZ0lQIjogdHJ1ZSwgImZyb250ZW5kUG9ydCI6IDQwLCAicHJvdG9jb2wiOiAiVWRw
+      IiwgImZyb250ZW5kSVBDb25maWd1cmF0aW9uIjogeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFm
+      NjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJv
+      dmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25m
+      aWd1cmF0aW9ucy9Mb2FkQmFsYW5jZXJGcm9udEVuZCJ9LCAicHJvdmlzaW9uaW5nU3RhdGUiOiAi
+      U3VjY2VlZGVkIiwgImxvYWREaXN0cmlidXRpb24iOiAiU291cmNlSVAiLCAiYmFja2VuZFBvcnQi
+      OiA0MH0sICJuYW1lIjogInJ1bGUxIn0sIHsiZXRhZyI6ICJXL1wiNjkxOGU1NDUtY2Y4Ni00Nzcy
+      LWJmMWUtYjBjNGY3OTViNjRjXCIiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJm
+      MC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9N
+      aWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9sb2FkQmFsYW5jaW5nUnVsZXMvcnVs
+      ZTIiLCAicHJvcGVydGllcyI6IHsiYmFja2VuZEFkZHJlc3NQb29sIjogeyJldGFnIjogIlcvXCI2
+      OTE4ZTU0NS1jZjg2LTQ3NzItYmYxZS1iMGM0Zjc5NWI2NGNcIiIsICJuYW1lIjogImJhcDIiLCAi
+      aWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkw
+      L3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFs
+      YW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVzc1Bvb2xzL2JhcDIiLCAicHJvcGVydGllcyI6IHsicHJv
+      dmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn19LCAiaWRsZVRpbWVvdXRJbk1pbnV0ZXMiOiA0
+      LCAiZW5hYmxlRmxvYXRpbmdJUCI6IGZhbHNlLCAiZnJvbnRlbmRQb3J0IjogNjAsICJwcm90b2Nv
+      bCI6ICJUY3AiLCAiZnJvbnRlbmRJUENvbmZpZ3VyYXRpb24iOiB7ImV0YWciOiAiVy9cIjY5MThl
+      NTQ1LWNmODYtNDc3Mi1iZjFlLWIwYzRmNzk1YjY0Y1wiIiwgInByb3BlcnRpZXMiOiB7InByb3Zp
+      c2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJwcml2YXRlSVBBbGxvY2F0aW9uTWV0aG9kIjog
+      IkR5bmFtaWMiLCAicHVibGljSVBBZGRyZXNzIjogeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFm
+      NjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJv
+      dmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3B1YmxpY0lQQWRkcmVzc2VzL3B1YmxpY2lwMyJ9fSwg
+      ImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5
+      MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJh
+      bGFuY2Vycy9sYjEvZnJvbnRlbmRJUENvbmZpZ3VyYXRpb25zL2lwY29uZmlnMSIsICJuYW1lIjog
+      ImlwY29uZmlnMSJ9LCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImxvYWREaXN0
+      cmlidXRpb24iOiAic291cmNlaXBwcm90b2NvbCIsICJiYWNrZW5kUG9ydCI6IDYwfSwgIm5hbWUi
+      OiAicnVsZTIifV19LCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFl
+      YzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQu
+      TmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMSJ9
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Length: ['5727']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bab3b4b8-494e-11e6-b7ba-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o3u7D/b28/P72/em559u7z/YP9g+yB/e26ZfsvvZg53z/em93/cj
+        fbG9XvFobuhKW5fVNMPw8MZV3rRr8wXhvMrrtsgb+orpJB9eFg01L5YXr9us5Y5er6fTPJ/lM3mT
+        mlkirIWQ5we7nx58er63vTOb7G/vTx4+3J7sZ5PtfBdUPH94/3z20L58XlfLNl/Ozl6eVMvz4mJd
+        M4JA43vSJDX44LGz99wb3TPAOF1ajPD8nE7q3aFR3b0R7a/LCPJgynrzKA++usVsykONi0tqcvby
+        uDQ880Xezism6tNrmoVi2n1lPSmLKb0xmxEFe/1Tix/ilHSQyZu7L/UTmp6PfLx+STgKN5dEplfr
+        kglpOVGezrjorR/iyByC+J5G431iUL5b07/hMGmg/p/fd3/Yzx0lvAFagStWU2Zl1Vjy/NwOfFDK
+        4rj+SLS+kXnoIEPcJp8Uq3sBxzl2wvP/I8HaC4ZJA/X/jAqW/PJ9JchHk2z6lthWCfiyqsqAFh4V
+        rPQROpN8RS19zvi5pU5kFPg8gubPmeC5tjoF9IuF7EGyZJ5kq1Bn/L+Owj0Mf86I60Ghxg57as2y
+        Qq0tS8sTgMfzc0te94lBmcX7G7abNGF7Pq1+bsc8wFIhhj9iqa9LXveJQZlZ6oMtRh8uDdKSwiOC
+        ZTt0GyqK/zcSJsTw/yV8N+BW0isBUGr5c0rSATQHYkwfc6ew8NjxvqzqlsazvxN+rSpj4Nt8mU3K
+        /Bmh1xJtz15Sk7Ze52GjYlbmb4pFXq3bs+UXxXLd8hztdWDR+NtqSs4DEfWr2aozLdTF7GnRtHUx
+        WWOgaPWaiUi9hk0VZU/LUeP/V01eH0PWw6HtUS2Ax/7q5s4bTyD1oS7/OR2l+4R4w0l9iOGPpJ6w
+        vDVJB9D0Y14fXccueOwgVZg/7QigcuXAtxFRP8/K5nayvh+2okFbUX8zfR9Rf2neDF9R1D2Bopf+
+        XzVzfQxZ5EPfwMq596v+Yp0B6nbCNN3oAHCr0L7+nA6fWhPW8iNE6/8lCoAaC2NRm2+3bZcnVyIU
+        u+Gndf6L1pRHf5m1c/ryo7vE7G0wOmpTkMjVl1l5tnydk4zOgGfX9C3Xi0lef3lO3E1Uogb33dc6
+        //SLfccbZjjhoWr9f82Eh2j9v3DC+zpI53sv/DQ2l7v3wza9udxzX7u5lF+sUBfLSbVezl5kLdtJ
+        eut79jtSpcNfuhdZpfB3+Io6+CX/D/D8WgPxGgAA
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/a2d64eac-a3fe-4b47-83a5-551b66a5e58c?api-version=2016-03-30']
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:08:37 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1192']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bb5ce64a-494e-11e6-808b-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o3u7D/b28/P72/em559u7z/YP9g+yB/e26ZfsvvZg53z/em93/cj
+        fbG9XvFobuhKW5fVNMPw8MZV3rRr8wXhvMrrtsgb+orpJB9eFg01L5YXr9us5Y5er6fTPJ/lM3mT
+        mlkirIWQ5we7nx58er63vTOb7G/vTx4+3J7sZ5PtfBdUPH94/3z20L58XlfLNl/Ozl6eVMvz4mJd
+        M4JA43vSJDX44LGz99wb3TPAOF1ajPD8nE7q3aFR3b0R7a/LCPJgynrzKA++usVsykONi0tqcvby
+        uDQ880Xezism6tNrmoVi2n1lPSmLKb0xmxEFe/1Tix/ilHSQyZu7L/UTmp6PfLx+STgKN5dEplfr
+        kglpOVGezrjorR/iyByC+J5G431iUL5b07/hMGmg/p/fd3/Yzx0lvAFagStWU2Zl1Vjy/NwOfFDK
+        4rj+SLS+kXnoIEPcJp8Uq3sBxzl2wvP/I8HaC4ZJA/X/jAqW/PJ9JchHk2z6lthWCfiyqsqAFh4V
+        rPQROpN8RS19zvi5pU5kFPg8gubPmeC5tjoF9IuF7EGyZJ5kq1Bn/L+Owj0Mf86I60Ghxg57as2y
+        Qq0tS8sTgMfzc0te94lBmcX7G7abNGF7Pq1+bsc8wFIhhj9iqa9LXveJQZlZ6oMtRh8uDdKSwiOC
+        ZTt0GyqK/zcSJsTw/yV8N+BW0isBUGr5c0rSATQHYkwfc6ew8NjxvqzqlsazvxN+rSpj4Nt8mU3K
+        /Bmh1xJtz15Sk7Ze52GjYlbmb4pFXq3bs+UXxXLd8hztdWDR+NtqSs4DEfWr2aozLdTF7GnRtHUx
+        WWOgaPWaiUi9hk0VZU/LUeP/V01eH0PWw6HtUS2Ax/7q5s4bTyD1oS7/OR2l+4R4w0l9iOGPpJ6w
+        vDVJB9D0Y14fXccueOwgVZg/7QigcuXAtxFRP8/K5nayvh+2okFbUX8zfR9Rf2neDF9R1D2Bopf+
+        XzVzfQxZ5EPfwMq596v+Yp0B6nbCNN3oAHCr0L7+nA6fWhPW8iNE6/8lCoAaC2NRm2+3bZcnVyIU
+        u+Gndf6L1pRHf5m1c/ryo7vE7G0wOmpTkMjVl1l5tnydk4zOgGfX9C3Xi0lef3lO3E1Uogb33dc6
+        //SLfccbZjjhoWr9f82Eh2j9v3DC+zpI53sv/DQ2l7v3wza9udxzX7u5lF+sUBfLSbVezl5kLdtJ
+        eut79jtSpcNfuhdZpfB3+Io6+CX/D/D8WgPxGgAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:08:38 GMT']
+      ETag: [W/"31724ef5-3cf6-4748-8e93-748a5a70f4c3"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bb8f97c8-494e-11e6-b708-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o3u7D/b28/P72/em559u7z/YP9g+yB/e26ZfsvvZg53z/em93/cj
+        fbG9XvFobuhKW5fVNMPw8MZV3rRr8wXhvMrrtsgb+orpJB9eFg01L5YXr9us5Y5er6fTPJ/lM3mT
+        mlkirIWQ5we7nx58er63vTOb7G/vTx4+3J7sZ5PtfBdUPH94/3z20L58XlfLNl/Ozl6eVMvz4mJd
+        M4JA43vSJDX44LGz99wb3TPAOF1ajPD8nE7q3aFR3b0R7a/LCPJgynrzKA++usVsykONi0tqcvby
+        uDQ880Xezism6tNrmoVi2n1lPSmLKb0xmxEFe/1Tix/ilHSQyZu7L/UTmp6PfLx+STgKN5dEplfr
+        kglpOVGezrjorR/iyByC+J5G431iUL5b07/hMGmg/p/fd3/Yzx0lvAFagStWU2Zl1Vjy/NwOfFDK
+        4rj+SLS+kXnoIEPcJp8Uq3sBxzl2wvP/I8HaC4ZJA/X/jAqW/PJ9JchHk2z6lthWCfiyqsqAFh4V
+        rPQROpN8RS19zvi5pU5kFPg8gubPmeC5tjoF9IuF7EGyZJ5kq1Bn/L+Owj0Mf86I60Ghxg57as2y
+        Qq0tS8sTgMfzc0te94lBmcX7G7abNGF7Pq1+bsc8wFIhhj9iqa9LXveJQZlZ6oMtRh8uDdKSwiOC
+        ZTt0GyqK/zcSJsTw/yV8N+BW0isBUGr5c0rSATQHYkwfc6ew8NjxvqzqlsazvxN+rSpj4Nt8mU3K
+        /Bmh1xJtz15Sk7Ze52GjYlbmb4pFXq3bs+UXxXLd8hztdWDR+NtqSs4DEfWr2aozLdTF7GnRtHUx
+        WWOgaPWaiUi9hk0VZU/LUeP/V01eH0PWw6HtUS2Ax/7q5s4bTyD1oS7/OR2l+4R4w0l9iOGPpJ6w
+        vDVJB9D0Y14fXccueOwgVZg/7QigcuXAtxFRP8/K5nayvh+2okFbUX8zfR9Rf2neDF9R1D2Bopf+
+        XzVzfQxZ5EPfwMq596v+Yp0B6nbCNN3oAHCr0L7+nA6fWhPW8iNE6/8lCoAaC2NRm2+3bZcnVyIU
+        u+Gndf6L1pRHf5m1c/ryo7vE7G0wOmpTkMjVl1l5tnydk4zOgGfX9C3Xi0lef3lO3E1Uogb33dc6
+        //SLfccbZjjhoWr9f82Eh2j9v3DC+zpI53sv/DQ2l7v3wza9udxzX7u5lF+sUBfLSbVezl5kLdtJ
+        eut79jtSpcNfuhdZpfB3+Io6+CX/D/D8WgPxGgAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:08:38 GMT']
+      ETag: [W/"31724ef5-3cf6-4748-8e93-748a5a70f4c3"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bbc46c90-494e-11e6-821d-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o3u7D/b28/P72/em559u7z/YP9g+yB/e26ZfsvvZg53z/em93/cj
+        fbG9XvFobuhKW5fVNMPw8MZV3rRr8wXhvMrrtsgb+orpJB9eFg01L5YXr9us5Y5er6fTPJ/lM3mT
+        mlkirIWQ5we7nx58er63vTOb7G/vTx4+3J7sZ5PtfBdUPH94/3z20L58XlfLNl/Ozl6eVMvz4mJd
+        M4JA43vSJDX44LGz99wb3TPAOF1ajPD8nE7q3aFR3b0R7a/LCPJgynrzKA++usVsykONi0tqcvby
+        uDQ880Xezism6tNrmoVi2n1lPSmLKb0xmxEFe/1Tix/ilHSQyZu7L/UTmp6PfLx+STgKN5dEplfr
+        kglpOVGezrjorR/iyByC+J5G431iUL5b07/hMGmg/p/fd3/Yzx0lvAFagStWU2Zl1Vjy/NwOfFDK
+        4rj+SLS+kXnoIEPcJp8Uq3sBxzl2wvP/I8HaC4ZJA/X/jAqW/PJ9JchHk2z6lthWCfiyqsqAFh4V
+        rPQROpN8RS19zvi5pU5kFPg8gubPmeC5tjoF9IuF7EGyZJ5kq1Bn/L+Owj0Mf86I60Ghxg57as2y
+        Qq0tS8sTgMfzc0te94lBmcX7G7abNGF7Pq1+bsc8wFIhhj9iqa9LXveJQZlZ6oMtRh8uDdKSwiOC
+        ZTt0GyqK/zcSJsTw/yV8N+BW0isBUGr5c0rSATQHYkwfc6ew8NjxvqzqlsazvxN+rSpj4Nt8mU3K
+        /Bmh1xJtz15Sk7Ze52GjYlbmb4pFXq3bs+UXxXLd8hztdWDR+NtqSs4DEfWr2aozLdTF7GnRtHUx
+        WWOgaPWaiUi9hk0VZU/LUeP/V01eH0PWw6HtUS2Ax/7q5s4bTyD1oS7/OR2l+4R4w0l9iOGPpJ6w
+        vDVJB9D0Y14fXccueOwgVZg/7QigcuXAtxFRP8/K5nayvh+2okFbUX8zfR9Rf2neDF9R1D2Bopf+
+        XzVzfQxZ5EPfwMq596v+Yp0B6nbCNN3oAHCr0L7+nA6fWhPW8iNE6/8lCoAaC2NRm2+3bZcnVyIU
+        u+Gndf6L1pRHf5m1c/ryo7vE7G0wOmpTkMjVl1l5tnydk4zOgGfX9C3Xi0lef3lO3E1Uogb33dc6
+        //SLfccbZjjhoWr9f82Eh2j9v3DC+zpI53sv/DQ2l7v3wza9udxzX7u5lF+sUBfLSbVezl5kLdtJ
+        eut79jtSpcNfuhdZpfB3+Io6+CX/D/D8WgPxGgAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:08:38 GMT']
+      ETag: [W/"31724ef5-3cf6-4748-8e93-748a5a70f4c3"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJldGFnIjogIlcvXCIzMTcyNGVmNS0zY2Y2LTQ3NDgtOGU5My03NDhhNWE3MGY0YzNcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW3siZXRhZyI6ICJX
+      L1wiMzE3MjRlZjUtM2NmNi00NzQ4LThlOTMtNzQ4YTVhNzBmNGMzXCIiLCAibmFtZSI6ICJwcm9i
+      ZTEiLCAicHJvcGVydGllcyI6IHsibnVtYmVyT2ZQcm9iZXMiOiA1LCAicHJvdG9jb2wiOiAiSHR0
+      cCIsICJyZXF1ZXN0UGF0aCI6ICIvdGVzdDEiLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2Vl
+      ZGVkIiwgInBvcnQiOiAxLCAiaW50ZXJ2YWxJblNlY29uZHMiOiAyMH0sICJpZCI6ICIvc3Vic2Ny
+      aXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91
+      cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL3By
+      b2Jlcy9wcm9iZTEifSwgeyJldGFnIjogIlcvXCIzMTcyNGVmNS0zY2Y2LTQ3NDgtOGU5My03NDhh
+      NWE3MGY0YzNcIiIsICJuYW1lIjogInByb2JlMiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFm
+      NjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJv
+      dmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL3Byb2Jlcy9wcm9iZTIi
+      LCAicHJvcGVydGllcyI6IHsicHJvdG9jb2wiOiAiVGNwIiwgInBvcnQiOiAyLCAicHJvdmlzaW9u
+      aW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgIm51bWJlck9mUHJvYmVzIjogMiwgImludGVydmFsSW5T
+      ZWNvbmRzIjogMTV9fV0sICJmcm9udGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJldGFnIjogIlcv
+      XCIzMTcyNGVmNS0zY2Y2LTQ3NDgtOGU5My03NDhhNWE3MGY0YzNcIiIsICJwcm9wZXJ0aWVzIjog
+      eyJsb2FkQmFsYW5jaW5nUnVsZXMiOiBbeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0x
+      YmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJz
+      L01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2xvYWRCYWxhbmNpbmdSdWxlcy9y
+      dWxlMSJ9XSwgInByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJwcml2YXRlSVBBbGxv
+      Y2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVibGljSVBBZGRyZXNzIjogeyJpZCI6ICIvc3Vi
+      c2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VH
+      cm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3B1YmxpY0lQQWRkcmVzc2Vz
+      L1B1YmxpY0lQbGIxIn19LCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRh
+      LWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3Nv
+      ZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlvbnMvTG9h
+      ZEJhbGFuY2VyRnJvbnRFbmQiLCAibmFtZSI6ICJMb2FkQmFsYW5jZXJGcm9udEVuZCJ9LCB7ImV0
+      YWciOiAiVy9cIjMxNzI0ZWY1LTNjZjYtNDc0OC04ZTkzLTc0OGE1YTcwZjRjM1wiIiwgInByb3Bl
+      cnRpZXMiOiB7ImxvYWRCYWxhbmNpbmdSdWxlcyI6IFt7ImlkIjogIi9zdWJzY3JpcHRpb25zLzBi
+      MWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9w
+      cm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvbG9hZEJhbGFuY2lu
+      Z1J1bGVzL3J1bGUyIn1dLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgInByaXZh
+      dGVJUEFsbG9jYXRpb25NZXRob2QiOiAiRHluYW1pYyIsICJwdWJsaWNJUEFkZHJlc3MiOiB7Imlk
+      IjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9y
+      ZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvcHVibGljSVBB
+      ZGRyZXNzZXMvcHVibGljaXAzIn19LCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJm
+      MC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9N
+      aWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9mcm9udGVuZElQQ29uZmlndXJhdGlv
+      bnMvaXBjb25maWcxIiwgIm5hbWUiOiAiaXBjb25maWcxIn1dLCAib3V0Ym91bmROYXRSdWxlcyI6
+      IFtdLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgImluYm91bmROYXRSdWxlcyI6
+      IFtdLCAiYmFja2VuZEFkZHJlc3NQb29scyI6IFt7ImV0YWciOiAiVy9cIjMxNzI0ZWY1LTNjZjYt
+      NDc0OC04ZTkzLTc0OGE1YTcwZjRjM1wiIiwgIm5hbWUiOiAibGIxYmVwb29sIiwgImlkIjogIi9z
+      dWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJj
+      ZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9s
+      YjEvYmFja2VuZEFkZHJlc3NQb29scy9sYjFiZXBvb2wiLCAicHJvcGVydGllcyI6IHsicHJvdmlz
+      aW9uaW5nU3RhdGUiOiAiU3VjY2VlZGVkIn19LCB7ImV0YWciOiAiVy9cIjMxNzI0ZWY1LTNjZjYt
+      NDc0OC04ZTkzLTc0OGE1YTcwZjRjM1wiIiwgIm5hbWUiOiAiYmFwMSIsICJpZCI6ICIvc3Vic2Ny
+      aXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91
+      cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Jh
+      Y2tlbmRBZGRyZXNzUG9vbHMvYmFwMSIsICJwcm9wZXJ0aWVzIjogeyJsb2FkQmFsYW5jaW5nUnVs
+      ZXMiOiBbeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjky
+      NzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3Jr
+      L2xvYWRCYWxhbmNlcnMvbGIxL2xvYWRCYWxhbmNpbmdSdWxlcy9ydWxlMSJ9XSwgInByb3Zpc2lv
+      bmluZ1N0YXRlIjogIlN1Y2NlZWRlZCJ9fSwgeyJldGFnIjogIlcvXCIzMTcyNGVmNS0zY2Y2LTQ3
+      NDgtOGU5My03NDhhNWE3MGY0YzNcIiIsICJuYW1lIjogImJhcDIiLCAiaWQiOiAiL3N1YnNjcmlw
+      dGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBz
+      L2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNr
+      ZW5kQWRkcmVzc1Bvb2xzL2JhcDIiLCAicHJvcGVydGllcyI6IHsibG9hZEJhbGFuY2luZ1J1bGVz
+      IjogW3siaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5Mjcy
+      ZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9s
+      b2FkQmFsYW5jZXJzL2xiMS9sb2FkQmFsYW5jaW5nUnVsZXMvcnVsZTIifV0sICJwcm92aXNpb25p
+      bmdTdGF0ZSI6ICJTdWNjZWVkZWQifX1dLCAiaW5ib3VuZE5hdFBvb2xzIjogW10sICJyZXNvdXJj
+      ZUd1aWQiOiAiZjgxNjg2ZjItMGRiNC00Yjk5LWI0YWItZTE0ZGRhZjk1ZmQ5IiwgImxvYWRCYWxh
+      bmNpbmdSdWxlcyI6IFt7ImV0YWciOiAiVy9cIjMxNzI0ZWY1LTNjZjYtNDc0OC04ZTkzLTc0OGE1
+      YTcwZjRjM1wiIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMz
+      LWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5l
+      dHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvbG9hZEJhbGFuY2luZ1J1bGVzL3J1bGUyIiwgInByb3Bl
+      cnRpZXMiOiB7ImJhY2tlbmRBZGRyZXNzUG9vbCI6IHsiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIx
+      ZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3By
+      b3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRkcmVz
+      c1Bvb2xzL2JhcDIifSwgImlkbGVUaW1lb3V0SW5NaW51dGVzIjogNCwgImVuYWJsZUZsb2F0aW5n
+      SVAiOiBmYWxzZSwgImZyb250ZW5kUG9ydCI6IDYwLCAicHJvdG9jb2wiOiAiVGNwIiwgImZyb250
+      ZW5kSVBDb25maWd1cmF0aW9uIjogeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYw
+      LTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJzL01p
+      Y3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2Zyb250ZW5kSVBDb25maWd1cmF0aW9u
+      cy9pcGNvbmZpZzEifSwgInByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJsb2FkRGlz
+      dHJpYnV0aW9uIjogIlNvdXJjZUlQUHJvdG9jb2wiLCAiYmFja2VuZFBvcnQiOiA2MH0sICJuYW1l
+      IjogInJ1bGUyIn1dfSwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1h
+      ZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0
+      Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEifQ==
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Length: ['4531']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bbe911d8-494e-11e6-b89a-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o91P75/nk3v3t7P7O7Pt/emDe9sPZ+fZ9vn96b0H988f3tu9f/D7
+        fqQvttcrHs0NXWnrsppmGB7euMqbdm2+IJxXed0WeUNfMZ3kw8uioebF8uJ1m7Xc0ev1dJrns3wm
+        b1IzS4S1EPL8YPfTg0/P97Z3ZpP97f3Jw4fbk/1ssp3vgornD++fzx7al8/ratnmy9nZy5NqeV5c
+        rGtGEGh8T5qkBh88dvaee6N7BhinS4sRnp/TSb07NKq7N6L9dRlBHkxZbx7lwVe3mE15qHFxSU3O
+        Xh6Xhme+yNt5xUR9ek2zUEy7r6wnZTGlN2YzomCvf2rxQ5ySDjJ5c/elfkLT85GP1y9xf9hff4kd
+        mTcEy3rFasqTqrIrzw9zcO/Bb3Fcf8Rk38g8dJAhJpNPitW9kMXCMbjpIyK9WpdMRqvs5OmMit76
+        IY7LIYjvwV/uE4Py3Zr+3QuGSQP1//y++8N+rr98Xwny0SSbviW2VQK+rKoyoIVHBSt9hM4kX1FL
+        nzN+bqkTGQU+j6D5cyZ4rq1OAf1iIXuQLJkn2SrUGf+vo3APw/9PEXcv6Pv/jcQNMfw5I64HhRo7
+        7Kk1KyJqbfWFPAF4PD+35HWfGJS/Gd3Zh0uDtKTwiGDZTrrV9/H8v5QwPob/L+G7AQeLXgmAUsuf
+        U5IOoOn7gT66TkvhsYN8WdUtDeLTnfBr1RMD3+bLbFLmzwinlgh69pKanGdlk4etilmZvykWebVu
+        z5ZfFMt1yzOzH7aiQbfVlGwnUfLNdNWZC+pi9rRo2rqYrDE6tHrNlDt7+dK8Gb6iqHsqjl76f9XM
+        9TFUJewjqSoAj/1Vf7FqgbqdME03qgJuFZrPn9PhU2vCWn6EaP2/RAFQY2EsavPttu3y5EqEYjf8
+        tM5/0ZqyLC+zdk5ffnSXmL0NRkdtChK5+jIrz5avc5LRGfDc68jWcr2Y5PWX58TdRCVqcN99rfNP
+        v9h3vGGGEx6q1v/XTHiI1v8LJ7yvg3S+98JPY3O5ez9s05vLPfe1m0v5xQp1sZxU6+XsRdaynaS3
+        vme/I1U6/KV7kVUKf4evqINf8v8AC5gLnA8VAAA=
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/23e17fa2-81f7-43d1-aef5-442103079880?api-version=2016-03-30']
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:08:38 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1192']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bc9378ec-494e-11e6-a788-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o91P75/nk3v3t7P7O7Pt/emDe9sPZ+fZ9vn96b0H988f3tu9f/D7
+        fqQvttcrHs0NXWnrsppmGB7euMqbdm2+IJxXed0WeUNfMZ3kw8uioebF8uJ1m7Xc0ev1dJrns3wm
+        b1IzS4S1EPL8YPfTg0/P97Z3ZpP97f3Jw4fbk/1ssp3vgornD++fzx7al8/ratnmy9nZy5NqeV5c
+        rGtGEGh8T5qkBh88dvaee6N7BhinS4sRnp/TSb07NKq7N6L9dRlBHkxZbx7lwVe3mE15qHFxSU3O
+        Xh6Xhme+yNt5xUR9ek2zUEy7r6wnZTGlN2YzomCvf2rxQ5ySDjJ5c/elfkLT85GP1y9xf9hff4kd
+        mTcEy3rFasqTqrIrzw9zcO/Bb3Fcf8Rk38g8dJAhJpNPitW9kMXCMbjpIyK9WpdMRqvs5OmMit76
+        IY7LIYjvwV/uE4Py3Zr+3QuGSQP1//y++8N+rr98Xwny0SSbviW2VQK+rKoyoIVHBSt9hM4kX1FL
+        nzN+bqkTGQU+j6D5cyZ4rq1OAf1iIXuQLJkn2SrUGf+vo3APw/9PEXcv6Pv/jcQNMfw5I64HhRo7
+        7Kk1KyJqbfWFPAF4PD+35HWfGJS/Gd3Zh0uDtKTwiGDZTrrV9/H8v5QwPob/L+G7AQeLXgmAUsuf
+        U5IOoOn7gT66TkvhsYN8WdUtDeLTnfBr1RMD3+bLbFLmzwinlgh69pKanGdlk4etilmZvykWebVu
+        z5ZfFMt1yzOzH7aiQbfVlGwnUfLNdNWZC+pi9rRo2rqYrDE6tHrNlDt7+dK8Gb6iqHsqjl76f9XM
+        9TFUJewjqSoAj/1Vf7FqgbqdME03qgJuFZrPn9PhU2vCWn6EaP2/RAFQY2EsavPttu3y5EqEYjf8
+        tM5/0ZqyLC+zdk5ffnSXmL0NRkdtChK5+jIrz5avc5LRGfDc68jWcr2Y5PWX58TdRCVqcN99rfNP
+        v9h3vGGGEx6q1v/XTHiI1v8LJ7yvg3S+98JPY3O5ez9s05vLPfe1m0v5xQp1sZxU6+XsRdaynaS3
+        vme/I1U6/KV7kVUKf4evqINf8v8AC5gLnA8VAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:08:40 GMT']
+      ETag: [W/"165feb35-a50d-4c73-9dfa-f5c375f93158"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJldGFnIjogIlcvXCIxNjVmZWIzNS1hNTBkLTRjNzMtOWRmYS1mNWMzNzVmOTMxNThcIiIsICJs
+      b2NhdGlvbiI6ICJ3ZXN0dXMiLCAicHJvcGVydGllcyI6IHsicHJvYmVzIjogW3siZXRhZyI6ICJX
+      L1wiMTY1ZmViMzUtYTUwZC00YzczLTlkZmEtZjVjMzc1ZjkzMTU4XCIiLCAibmFtZSI6ICJwcm9i
+      ZTEiLCAicHJvcGVydGllcyI6IHsibnVtYmVyT2ZQcm9iZXMiOiA1LCAicHJvdG9jb2wiOiAiSHR0
+      cCIsICJyZXF1ZXN0UGF0aCI6ICIvdGVzdDEiLCAicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3VjY2Vl
+      ZGVkIiwgInBvcnQiOiAxLCAiaW50ZXJ2YWxJblNlY29uZHMiOiAyMH0sICJpZCI6ICIvc3Vic2Ny
+      aXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91
+      cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL3By
+      b2Jlcy9wcm9iZTEifSwgeyJldGFnIjogIlcvXCIxNjVmZWIzNS1hNTBkLTRjNzMtOWRmYS1mNWMz
+      NzVmOTMxNThcIiIsICJuYW1lIjogInByb2JlMiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFm
+      NjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJv
+      dmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL3Byb2Jlcy9wcm9iZTIi
+      LCAicHJvcGVydGllcyI6IHsicHJvdG9jb2wiOiAiVGNwIiwgInBvcnQiOiAyLCAicHJvdmlzaW9u
+      aW5nU3RhdGUiOiAiU3VjY2VlZGVkIiwgIm51bWJlck9mUHJvYmVzIjogMiwgImludGVydmFsSW5T
+      ZWNvbmRzIjogMTV9fV0sICJmcm9udGVuZElQQ29uZmlndXJhdGlvbnMiOiBbeyJldGFnIjogIlcv
+      XCIxNjVmZWIzNS1hNTBkLTRjNzMtOWRmYS1mNWMzNzVmOTMxNThcIiIsICJwcm9wZXJ0aWVzIjog
+      eyJwcm92aXNpb25pbmdTdGF0ZSI6ICJTdWNjZWVkZWQiLCAicHJpdmF0ZUlQQWxsb2NhdGlvbk1l
+      dGhvZCI6ICJEeW5hbWljIiwgInB1YmxpY0lQQWRkcmVzcyI6IHsiaWQiOiAiL3N1YnNjcmlwdGlv
+      bnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xi
+      c3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9wdWJsaWNJUEFkZHJlc3Nlcy9QdWJsaWNJ
+      UGxiMSJ9fSwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNi
+      OTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdv
+      cmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJvbnRlbmRJUENvbmZpZ3VyYXRpb25zL0xvYWRCYWxhbmNl
+      ckZyb250RW5kIiwgIm5hbWUiOiAiTG9hZEJhbGFuY2VyRnJvbnRFbmQifSwgeyJldGFnIjogIlcv
+      XCIxNjVmZWIzNS1hNTBkLTRjNzMtOWRmYS1mNWMzNzVmOTMxNThcIiIsICJwcm9wZXJ0aWVzIjog
+      eyJsb2FkQmFsYW5jaW5nUnVsZXMiOiBbeyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0x
+      YmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJz
+      L01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2xvYWRCYWxhbmNpbmdSdWxlcy9y
+      dWxlMiJ9XSwgInByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJwcml2YXRlSVBBbGxv
+      Y2F0aW9uTWV0aG9kIjogIkR5bmFtaWMiLCAicHVibGljSVBBZGRyZXNzIjogeyJpZCI6ICIvc3Vi
+      c2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VH
+      cm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL3B1YmxpY0lQQWRkcmVzc2Vz
+      L3B1YmxpY2lwMyJ9fSwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1h
+      ZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9sYnNyZy9wcm92aWRlcnMvTWljcm9zb2Z0
+      Lk5ldHdvcmsvbG9hZEJhbGFuY2Vycy9sYjEvZnJvbnRlbmRJUENvbmZpZ3VyYXRpb25zL2lwY29u
+      ZmlnMSIsICJuYW1lIjogImlwY29uZmlnMSJ9XSwgIm91dGJvdW5kTmF0UnVsZXMiOiBbXSwgInBy
+      b3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2NlZWRlZCIsICJpbmJvdW5kTmF0UnVsZXMiOiBbXSwgImJh
+      Y2tlbmRBZGRyZXNzUG9vbHMiOiBbeyJldGFnIjogIlcvXCIxNjVmZWIzNS1hNTBkLTRjNzMtOWRm
+      YS1mNWMzNzVmOTMxNThcIiIsICJuYW1lIjogImxiMWJlcG9vbCIsICJpZCI6ICIvc3Vic2NyaXB0
+      aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMv
+      bGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2JhY2tl
+      bmRBZGRyZXNzUG9vbHMvbGIxYmVwb29sIiwgInByb3BlcnRpZXMiOiB7InByb3Zpc2lvbmluZ1N0
+      YXRlIjogIlN1Y2NlZWRlZCJ9fSwgeyJldGFnIjogIlcvXCIxNjVmZWIzNS1hNTBkLTRjNzMtOWRm
+      YS1mNWMzNzVmOTMxNThcIiIsICJuYW1lIjogImJhcDEiLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMv
+      MGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2xic3Jn
+      L3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2FkQmFsYW5jZXJzL2xiMS9iYWNrZW5kQWRk
+      cmVzc1Bvb2xzL2JhcDEiLCAicHJvcGVydGllcyI6IHsicHJvdmlzaW9uaW5nU3RhdGUiOiAiU3Vj
+      Y2VlZGVkIn19LCB7ImV0YWciOiAiVy9cIjE2NWZlYjM1LWE1MGQtNGM3My05ZGZhLWY1YzM3NWY5
+      MzE1OFwiIiwgIm5hbWUiOiAiYmFwMiIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0x
+      YmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvbGJzcmcvcHJvdmlkZXJz
+      L01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIxL2JhY2tlbmRBZGRyZXNzUG9vbHMv
+      YmFwMiIsICJwcm9wZXJ0aWVzIjogeyJsb2FkQmFsYW5jaW5nUnVsZXMiOiBbeyJpZCI6ICIvc3Vi
+      c2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VH
+      cm91cHMvbGJzcmcvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL2xvYWRCYWxhbmNlcnMvbGIx
+      L2xvYWRCYWxhbmNpbmdSdWxlcy9ydWxlMiJ9XSwgInByb3Zpc2lvbmluZ1N0YXRlIjogIlN1Y2Nl
+      ZWRlZCJ9fV0sICJpbmJvdW5kTmF0UG9vbHMiOiBbXSwgInJlc291cmNlR3VpZCI6ICJmODE2ODZm
+      Mi0wZGI0LTRiOTktYjRhYi1lMTRkZGFmOTVmZDkiLCAibG9hZEJhbGFuY2luZ1J1bGVzIjogW119
+      LCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5
+      NTkwL3Jlc291cmNlR3JvdXBzL2xic3JnL3Byb3ZpZGVycy9NaWNyb3NvZnQuTmV0d29yay9sb2Fk
+      QmFsYW5jZXJzL2xiMSJ9
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Length: ['3378']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bcb8938c-494e-11e6-974f-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o1m+f7B3b3d3+9PZ7t72/qfZ+fbDWX6wvb+fTw7u7d7L708e/L4f
+        6Yvt9YpHc0NX2rqsphmGhzeu8qZdmy8I51Vet0Xe0FdMJ/nwsmioebG8eN1mLXf0ej2d5vksn8mb
+        1MwSYS2EPD/Y/fTg0/O97Z3ZZH97f/Lw4fZkP5ts57ug4vnD++ezh/bl87patvlydvbypFqeFxfr
+        mhEEGt+TJqnBB4+dvefe6J4BxunSYoTn53RS7w6N6u6NaH9dRpAHU9abR3nw1S1mUx5qXFxSk7OX
+        x6XhmS/ydl4xUZ9e0ywU0+4r60lZTOmN2Ywo2OufWvwQp6SDTN7cfamf0PR85OP1S9wf9tdfYkfm
+        DcGyXrGa8qSq7Mrzwxzce/BbHNcfMdk3Mg8dZIjJ5JNide9mFpNfvq/D+2iSTd/SBCqol1VVYnAb
+        VSBN/CRfUUufRj/M8ff5MDIKfB5B8+eMBV1bnQL6xUL2IFkyT7JVKD3/r6NwD8P/TxF3L+j7/43E
+        DTH8fxVx5RerRdyQCMSrdcmdfM9+TR1M5CP5ID4n3CpkqJ/TWaHWhLX8CNH6OZsKD4o0bqspKThq
+        8+22XXW/ruqWvtoNP63zX7QmD/xl1s7py4/utvRHMDpqU5BRry+z8mz5Oic7PgOeezthm+V6Mcnr
+        L89fgjxocN99rexBv9h3vGGGEx4y+f9rJjxE6/+FE/5mOjDfe+GnsbncvR+26c3lnvvazaX8YoW6
+        WE6q9XL2Imv7Al+t2+Ev3Yus6fg7fEUd/JL/By9CJi4rDwAA
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/2cc062f6-866e-4d57-b348-bf6d32a30a0a?api-version=2016-03-30']
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:08:40 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1189']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDY4NDQ5MTczLCJuYmYiOjE0Njg0NDkxNzMsImV4cCI6MTQ2ODQ1MzA3MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJmYW1pbHlfbmFtZSI6IkFkbWluMiIsImdpdmVuX25hbWUiOiJBZG1pbjIiLCJncm91cHMiOlsiZTRiYjBiNTYtMTAxNC00MGY4LTg4YWItM2Q4YThjYjBlMDg2IiwiNmI5Nzc2MWEtZDdkMC00OGY2LWFkNTYtZjM4ZDMyN2M4NTUzIl0sImlwYWRkciI6IjE2Ny4yMjAuMS4xODYiLCJuYW1lIjoiQWRtaW4yIiwib2lkIjoiNTk2M2Y1MGMtN2M0My00MDVjLWFmN2UtNTMyOTRkZTc2YWJkIiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.kZtuf8CvnUpGxDXkw1ZYI32ME3reYyq6gyZghjgRlXqIA_6BG7IT12ghLCoOLUwsBweCUWGLELj0v7zEGrCs_PKE8_AKo3PjU1KL3H01FXC1VY2wvTNaZ0D3r7P_VU8OnuUHDP2fQwsEZoCT90PJBt8QVor-VlTGjkyNB7MM-xbwlKs4fgnfVn1VkP41dHAbu-nNUIGa9-ZVXVHp7Ew8UJ_QhdVqBmgf5Ofys1ZauGy8-sDT8gY6SjbSIA60tlA0m91nDV2YuMcDi5dzGSYEfvW15UyMfTY0Qf77qRaSXjBTGSpqGkGoTOvakCGwh0GG08GvtFhol43AQ0P-7-GbWg]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.10586-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 networkmanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bd639712-494e-11e6-b582-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbsrg/providers/Microsoft.Network/loadBalancers/lb1?api-version=2016-03-30
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9qJzsfjTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
+        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWrulpOmvri7qqvLYpbXzd0vimldNdV5O36Rt1dV/fZuWWWz
+        J1mZLaf43qGQt9kFkPju3d/3o1m+f7B3b3d3+9PZ7t72/qfZ+fbDWX6wvb+fTw7u7d7L708e/L4f
+        6Yvt9YpHc0NX2rqsphmGhzeu8qZdmy8I51Vet0Xe0FdMJ/nwsmioebG8eN1mLXf0ej2d5vksn8mb
+        1MwSYS2EPD/Y/fTg0/O97Z3ZZH97f/Lw4fZkP5ts57ug4vnD++ezh/bl87patvlydvbypFqeFxfr
+        mhEEGt+TJqnBB4+dvefe6J4BxunSYoTn53RS7w6N6u6NaH9dRpAHU9abR3nw1S1mUx5qXFxSk7OX
+        x6XhmS/ydl4xUZ9e0ywU0+4r60lZTOmN2Ywo2OufWvwQp6SDTN7cfamf0PR85OP1S9wf9tdfYkfm
+        DcGyXrGa8qSq7Mrzwxzce/BbHNcfMdk3Mg8dZIjJ5JNide9mFpNfvq/D+2iSTd/SBCqol1VVYnAb
+        VSBN/CRfUUufRj/M8ff5MDIKfB5B8+eMBV1bnQL6xUL2IFkyT7JVKD3/r6NwD8P/TxF3L+j7/43E
+        DTH8fxVx5RerRdyQCMSrdcmdfM9+TR1M5CP5ID4n3CpkqJ/TWaHWhLX8CNH6OZsKD4o0bqspKThq
+        8+22XXW/ruqWvtoNP63zX7QmD/xl1s7py4/utvRHMDpqU5BRry+z8mz5Oic7PgOeezthm+V6Mcnr
+        L89fgjxocN99rexBv9h3vGGGEx4y+f9rJjxE6/+FE/5mOjDfe+GnsbncvR+26c3lnvvazaX8YoW6
+        WE6q9XL2Imv7Al+t2+Ev3Yus6fg7fEUd/JL/By9CJi4rDwAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Wed, 13 Jul 2016 23:08:41 GMT']
+      ETag: [W/"de482311-6d12-46af-9de8-44eb8313e5b7"]
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]


### PR DESCRIPTION
Adds commands for application gateway subresources. Due to the performance issues with app-gateways, there are currently no VCR tests for the subresource commands.

Also, note that there are no update commands for these subresources, for a couple reasons:

1. XPlat does not have set/update commands for these.
2. You can use the generic `az network application-gateway update --set [...]` to update.