### PR TITLE
Document 'az --version' under 'az --help' command

### DIFF
--- a/src/azure/cli/_help.py
+++ b/src/azure/cli/_help.py
@@ -22,7 +22,7 @@ def show_help(nouns, parser, is_group):
     help_file.load(parser)
 
     if len(nouns) == 0:
-        print('\nSpecial intro help for az')
+        print("\nFor version info, use 'az --version'")
         help_file.command = ''
 
     print_detailed_help(help_file)


### PR DESCRIPTION
Fixes #581.

Example output:
```
$ az --help

For version info, use 'az --version'

...
```