### PR TITLE
Storage Module Updates Part 2: Table and Queue

### DIFF
--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/__init__.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/__init__.py
@@ -8,3 +8,4 @@
 import azure.cli.command_modules.storage._params
 import azure.cli.command_modules.storage.generated
 import azure.cli.command_modules.storage.custom
+import azure.cli.command_modules.storage._help

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_factory.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_factory.py
@@ -8,6 +8,8 @@ from azure.mgmt.storage import StorageManagementClient
 from azure.storage import CloudStorageAccount
 from azure.storage.blob import BlockBlobService
 from azure.storage.file import FileService
+from azure.storage.table import TableService
+from azure.storage.queue import QueueService
 from azure.storage._error import _ERROR_STORAGE_MISSING_INFO
 
 from azure.cli.commands.client_factory import get_mgmt_service_client, get_data_service_client
@@ -49,6 +51,22 @@ def blob_data_service_factory(kwargs):
     blob_service = blob_types.get(blob_type, BlockBlobService)
     return _get_data_service_client(
         blob_service,
+        kwargs.pop('account_name', None),
+        kwargs.pop('account_key', None),
+        connection_string=kwargs.pop('connection_string', None),
+        sas_token=kwargs.pop('sas_token', None))
+
+def table_data_service_factory(kwargs):
+    return _get_data_service_client(
+        TableService,
+        kwargs.pop('account_name', None),
+        kwargs.pop('account_key', None),
+        connection_string=kwargs.pop('connection_string', None),
+        sas_token=kwargs.pop('sas_token', None))
+
+def queue_data_service_factory(kwargs):
+    return _get_data_service_client(
+        QueueService,
         kwargs.pop('account_name', None),
         kwargs.pop('account_key', None),
         connection_string=kwargs.pop('connection_string', None),

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_help.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_help.py
@@ -6,3 +6,21 @@
 from azure.cli.help_files import helps #pylint: disable=unused-import
 
 #pylint: disable=line-too-long
+
+helps['storage entity insert'] = """
+    type: command
+    short-summary: Insert a new entity into the table.
+    long-summary: Inserts a new entity into the table. When inserting an entity into a table, you must specify values for the PartitionKey and RowKey system properties. Together, these properties form the primary key and must be unique within the table. Both the PartitionKey and RowKey values may be up to 64 KB in size. If you are using an integer value as a key, you should convert the integer to a fixed-width string, because they are canonically sorted. For example, you should convert the value 1 to 0000001 to ensure proper sorting.
+    parameters:
+        - name: --table-name -t
+          type: string
+          short-summary: 'The name of the table to insert the entity into.'
+        - name: --entity -e
+          type: list
+          short-summary: 'A space-separated list of key=value pairs. Must contain a PartitionKey and a RowKey.'
+        - name: --if-exists
+          type: string
+          short-summary: 'Specify what should happen if an entity already exists for the specified PartitionKey and RowKey.'
+        - name: --timeout
+          short-summary: The server timeout, expressed in seconds.
+"""

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
@@ -7,6 +7,8 @@
 import argparse
 import os
 
+from six import u as unicode_string
+
 from azure.cli.commands.parameters import \
     (tags_type, get_resource_name_completion_list, get_enum_type_completion_list)
 from azure.cli.commands import register_cli_argument, register_extra_cli_argument, CliArgumentType
@@ -23,7 +25,11 @@ from ._validators import \
     (validate_datetime, validate_datetime_as_string, get_file_path_validator, validate_metadata,
      validate_container_permission, validate_resource_types, validate_services, validate_ip_range,
      validate_table_permission, validate_queue_permission, validate_entity, validate_select,
-     validate_unicode_string, IgnoreAction)
+     IgnoreAction)
+
+# CONSTANTS
+
+IGNORE_TYPE = CliArgumentType(help=argparse.SUPPRESS, nargs='?', action=IgnoreAction, required=False)
 
 # COMPLETERS
 
@@ -57,7 +63,7 @@ def entity_completer(prefix, action, parsed_args, **kwargs): # pylint: disable=u
     # This is a workaround for the fact that argcomplete always inserts a space after completion
     # In this case, we want the cursor to remain positioned just after the text. We would ideally
     # like it to append the = sign, but argcomplete irritatingly escapes it.
-    if prefix == 'RowKey' or prefix == 'PartitionKey':
+    if prefix in ['RowKey', 'PartitionKey']:
         return []
     return ['RowKey!', 'RowKey*', 'PartitionKey!', 'PartitionKey*']
 
@@ -109,7 +115,6 @@ file_name_type = CliArgumentType(options_list=('--file-name', '-f'), completer=g
 share_name_type = CliArgumentType(options_list=('--share-name', '-s'), help='The file share name.', completer=get_storage_name_completion_list(FileService, 'list_shares'))
 table_name_type = CliArgumentType(options_list=('--table-name', '-t'), completer=get_storage_name_completion_list(TableService, 'list_tables'))
 queue_name_type = CliArgumentType(options_list=('--queue-name', '-q'), help='The queue name.', completer=get_storage_name_completion_list(QueueService, 'list_queues'))
-IGNORE_TYPE = CliArgumentType(help=argparse.SUPPRESS, nargs='?', action=IgnoreAction, required=False)
 
 # PARAMETER REGISTRATIONS
 
@@ -269,7 +274,7 @@ register_cli_argument('storage queue policy', 'permission', options_list=('--per
 
 register_cli_argument('storage message', 'queue_name', queue_name_type)
 register_cli_argument('storage message', 'message_id', options_list=('--id',))
-register_cli_argument('storage message', 'content', type=validate_unicode_string)
+register_cli_argument('storage message', 'content', type=unicode_string)
 
 ###################################################################################################
 

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
@@ -110,14 +110,6 @@ def validate_services(string):
         raise ValueError
     return Services(_str=''.join(set(string)))
 
-def validate_unicode_string(string):
-    try:
-        # Python2
-        return unicode(string)
-    except NameError:
-        # Python3
-        return string
-
 def validate_client_parameters(namespace):
     """ Retrieves storage connection parameters from environment variables and parses out
     connection string into account name and key """

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
@@ -15,6 +15,13 @@ from azure.cli.commands.validators import validate_key_value_pairs
 from azure.mgmt.storage import StorageManagementClient
 from azure.storage.models import ResourceTypes, Services
 from azure.storage.blob.models import ContainerPermissions
+from azure.storage.table.models import TablePermissions
+from azure.storage.queue.models import QueuePermissions
+
+class IgnoreAction(argparse.Action): # pylint: disable=too-few-public-methods
+    def __call__(self, parser, namespace, values, option_string=None):
+        raise argparse.ArgumentError(None, 'unrecognized argument: {} {}'.format(
+            option_string, values or ''))
 
 def validate_container_permission(string):
     ''' Validates that permission string contains only a combination
@@ -23,6 +30,22 @@ def validate_container_permission(string):
         raise ValueError('valid values are (r)ead, (w)rite, (d)elete, (l)ist or a combination ' + \
                          'thereof (ex: rw)')
     return ContainerPermissions(_str=''.join(set(string)))
+
+def validate_table_permission(string):
+    ''' Validates that permission string contains only a combination
+    of (r)ead, (a)dd, (u)pdate, (d)elete. '''
+    if set(string) - set('raud'):
+        raise ValueError('valid values are (r)ead, (a)dd, (u)pdate, (d)elete or a combination ' + \
+                         'thereof (ex: ra)')
+    return TablePermissions(_str=''.join(set(string)))
+
+def validate_queue_permission(string):
+    ''' Validates that permission string contains only a combination
+    of (r)ead, (a)dd, (u)pdate, (p)rocess [delete]. '''
+    if set(string) - set('raup'):
+        raise ValueError('valid values are (r)ead, (a)dd, (u)pdate, (p)rocess [delete] or a '
+                         'combination thereof (ex: ra)')
+    return QueuePermissions(_str=''.join(set(string)))
 
 def validate_datetime_as_string(string):
     ''' Validates UTC datettime in format '%Y-%m-%d\'T\'%H:%M\'Z\''. '''
@@ -33,6 +56,29 @@ def validate_datetime(string):
     ''' Validates UTC datettime in format '%Y-%m-%d\'T\'%H:%M\'Z\''. '''
     date_format = '%Y-%m-%dT%H:%MZ'
     return datetime.strptime(string, date_format)
+
+def validate_entity(namespace):
+    ''' Converts a list of key value pairs into a dictionary. Ensures that required
+    RowKey and PartitionKey are converted to the correct case and included. '''
+    values = dict(x.split('=', 1) for x in namespace.entity)
+    keys = values.keys()
+    for key in keys:
+        if key.lower() == 'rowkey':
+            val = values[key]
+            del values[key]
+            values['RowKey'] = val
+        elif key.lower() == 'partitionkey':
+            val = values[key]
+            del values[key]
+            values['PartitionKey'] = val
+    keys = values.keys()
+    missing_keys = 'RowKey ' if 'RowKey' not in keys else ''
+    missing_keys = '{}PartitionKey'.format(missing_keys) \
+        if 'PartitionKey' not in keys else missing_keys
+    if missing_keys:
+        raise argparse.ArgumentError(
+            None, 'incorrect usage: entity requires: {}'.format(missing_keys))
+    namespace.entity = values
 
 def validate_ip_range(string):
     ''' Validates an IP address or IP address range. '''
@@ -53,12 +99,24 @@ def validate_resource_types(string):
         raise ValueError
     return ResourceTypes(_str=''.join(set(string)))
 
+def validate_select(namespace):
+    if namespace.select:
+        namespace.select = ','.join(namespace.select)
+
 def validate_services(string):
     ''' Validates that services string contains only a combination
     of (b)lob, (q)ueue, (t)able, (f)ile '''
     if set(string) - set("bqtf"):
         raise ValueError
     return Services(_str=''.join(set(string)))
+
+def validate_unicode_string(string):
+    try:
+        # Python2
+        return unicode(string)
+    except NameError:
+        # Python3
+        return string
 
 def validate_client_parameters(namespace):
     """ Retrieves storage connection parameters from environment variables and parses out
@@ -96,15 +154,6 @@ def get_file_path_validator(default_file_param=None):
     """ Creates a namespace validator that splits out 'path' into 'directory_name' and 'file_name'.
     Allows another path-type parameter to be named which can supply a default filename. """
     def validator(namespace):
-        # directory_name and file_name should be treated as unrecognized
-        unrecognized = ''
-        if namespace.directory_name is not None:
-            unrecognized = '--directory-name '
-        if namespace.file_name is not None:
-            unrecognized = '{}{}'.format(unrecognized, '--file-name')
-        if unrecognized:
-            raise argparse.ArgumentError(None, 'unrecognized arguments: {}'.format(unrecognized))
-
         path = namespace.path
         dir_name, file_name = os.path.split(path) if path else (None, '')
 

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/custom.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/custom.py
@@ -10,6 +10,8 @@ from sys import stderr
 
 from azure.storage.blob import BlockBlobService
 from azure.storage.file import FileService
+from azure.storage.table import TableService
+from azure.storage.queue import QueueService
 from azure.mgmt.storage.models import Kind
 
 from azure.cli.command_modules.storage._factory import storage_client_factory
@@ -171,6 +173,10 @@ def _get_service_container_type(client):
         return 'container'
     elif isinstance(client, FileService):
         return 'share'
+    elif isinstance(client, TableService):
+        return 'table'
+    elif isinstance(client, QueueService):
+        return 'queue'
     else:
         raise ValueError('Unsupported service {}'.format(type(client)))
 
@@ -226,3 +232,14 @@ def delete_acl_policy(client, container_name, policy_name):
     acl = _get_acl(client, container_name)
     del acl[policy_name]
     return _set_acl(client, container_name, acl)
+
+def insert_table_entity(client, table_name, entity, if_exists='fail', timeout=None):
+    if if_exists == 'fail':
+        client.insert_entity(table_name, entity, timeout)
+    elif if_exists == 'merge':
+        client.insert_or_merge_entity(table_name, entity, timeout)
+    elif if_exists == 'replace':
+        client.insert_or_replace_entity(table_name, entity, timeout)
+    else:
+        raise CLIError("Unrecognized value '{}' for --if-exists".format(if_exists))
+

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/generated.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/generated.py
@@ -88,8 +88,8 @@ cli_storage_data_plane_command('storage blob copy cancel', BlockBlobService.abor
 
 # share commands
 factory = file_data_service_factory
-cli_storage_data_plane_command('storage share list', FileService.list_shares, factory, simple_output_query='items[*].{Name:name,"Quota (GB)":properties.quota}')
-cli_storage_data_plane_command('storage share contents', FileService.list_directories_and_files, factory, simple_output_query='items[*].{Name:name, Size:properties.contentLength}')
+cli_storage_data_plane_command('storage share list', FileService.list_shares, factory, simple_output_query='items[*].{Name:name,"Quota (GB)":properties.quota} | sort_by(@, &Name)')
+cli_storage_data_plane_command('storage share contents', FileService.list_directories_and_files, factory, simple_output_query='items[*].{Name:name, Size:properties.contentLength} | sort_by(@, &Name)')
 cli_storage_data_plane_command('storage share create', FileService.create_share, factory)
 cli_storage_data_plane_command('storage share delete', FileService.delete_share, factory)
 cli_storage_data_plane_command('storage share generate-sas', FileService.generate_share_shared_access_signature, factory)
@@ -136,7 +136,7 @@ cli_storage_data_plane_command('storage table generate-sas', TableService.genera
 cli_storage_data_plane_command('storage table stats', TableService.get_table_service_stats, factory)
 cli_storage_data_plane_command('storage table service-properties show', TableService.get_table_service_properties, factory)
 cli_storage_data_plane_command('storage table service-properties update', TableService.set_table_service_properties, factory)
-cli_storage_data_plane_command('storage table list', TableService.list_tables, factory, simple_output_query='items[*].{Name:name}')
+cli_storage_data_plane_command('storage table list', TableService.list_tables, factory, simple_output_query='items[*].{Name:name} | sort_by(@, &Name)')
 cli_storage_data_plane_command('storage table create', TableService.create_table, factory)
 cli_storage_data_plane_command('storage table exists', TableService.exists, factory)
 cli_storage_data_plane_command('storage table delete', TableService.delete_table, factory)
@@ -162,7 +162,7 @@ cli_storage_data_plane_command('storage queue generate-sas', QueueService.genera
 cli_storage_data_plane_command('storage queue stats', QueueService.get_queue_service_stats, factory)
 cli_storage_data_plane_command('storage queue service-properties show', QueueService.get_queue_service_properties, factory)
 cli_storage_data_plane_command('storage queue service-properties update', QueueService.set_queue_service_properties, factory)
-cli_storage_data_plane_command('storage queue list', QueueService.list_queues, factory, simple_output_query='items[*].{Name:name}')
+cli_storage_data_plane_command('storage queue list', QueueService.list_queues, factory, simple_output_query='items[*].{Name:name} | sort_by(@, &Name)')
 cli_storage_data_plane_command('storage queue create', QueueService.create_queue, factory)
 cli_storage_data_plane_command('storage queue delete', QueueService.delete_queue, factory)
 cli_storage_data_plane_command('storage queue metadata show', QueueService.get_queue_metadata, factory)
@@ -177,7 +177,7 @@ cli_storage_data_plane_command('storage queue policy update', set_acl_policy, fa
 # queue message commands
 cli_storage_data_plane_command('storage message put', QueueService.put_message, factory)
 cli_storage_data_plane_command('storage message get', QueueService.get_messages, factory)
-cli_storage_data_plane_command('storage message peek', QueueService.peek_messages, factory, simple_output_query='[*].{ID:id, Content:content, Insertion:insertionTime, Expiration:expirationTime}')
+cli_storage_data_plane_command('storage message peek', QueueService.peek_messages, factory, simple_output_query='[*].{ID:id, Content:content, Insertion:insertionTime, Expiration:expirationTime} | sort_by(@, &Insertion)')
 cli_storage_data_plane_command('storage message delete', QueueService.delete_message, factory)
 cli_storage_data_plane_command('storage message clear', QueueService.clear_messages, factory)
 cli_storage_data_plane_command('storage message update', QueueService.update_message, factory)

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/generated.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/generated.py
@@ -10,6 +10,8 @@ from azure.mgmt.storage.operations import StorageAccountsOperations
 from azure.storage.blob import BlockBlobService
 from azure.storage.blob.baseblobservice import BaseBlobService
 from azure.storage.file import FileService
+from azure.storage.table import TableService
+from azure.storage.queue import QueueService
 from azure.storage import CloudStorageAccount
 
 from azure.cli.commands import cli_command
@@ -17,12 +19,13 @@ from azure.cli.commands import cli_command
 from azure.cli.command_modules.storage._command_type import cli_storage_data_plane_command
 from azure.cli.command_modules.storage._factory import \
     (storage_client_factory, blob_data_service_factory, file_data_service_factory,
-     cloud_storage_account_service_factory)
+     table_data_service_factory, queue_data_service_factory, cloud_storage_account_service_factory)
 from azure.cli.command_modules.storage.custom import \
     (create_storage_account, list_storage_accounts, show_storage_account_usage,
      set_storage_account_properties, show_storage_account_connection_string,
      renew_storage_account_keys, upload_blob, get_acl_policy,
-     create_acl_policy, delete_acl_policy, list_acl_policies, set_acl_policy)
+     create_acl_policy, delete_acl_policy, list_acl_policies, set_acl_policy,
+     insert_table_entity)
 from azure.cli.command_modules.storage._validators import transform_acl_list_output, transform_url
 
 # storage account commands
@@ -126,3 +129,55 @@ cli_storage_data_plane_command('storage file service-properties show', FileServi
 cli_storage_data_plane_command('storage file service-properties update', FileService.set_file_service_properties, factory)
 cli_storage_data_plane_command('storage file copy start', FileService.copy_file, factory)
 cli_storage_data_plane_command('storage file copy cancel', FileService.abort_copy_file, factory)
+
+# table commands
+factory = table_data_service_factory
+cli_storage_data_plane_command('storage table generate-sas', TableService.generate_table_shared_access_signature, factory)
+cli_storage_data_plane_command('storage table stats', TableService.get_table_service_stats, factory)
+cli_storage_data_plane_command('storage table service-properties show', TableService.get_table_service_properties, factory)
+cli_storage_data_plane_command('storage table service-properties update', TableService.set_table_service_properties, factory)
+cli_storage_data_plane_command('storage table list', TableService.list_tables, factory, simple_output_query='items[*].{Name:name}')
+cli_storage_data_plane_command('storage table create', TableService.create_table, factory)
+cli_storage_data_plane_command('storage table exists', TableService.exists, factory)
+cli_storage_data_plane_command('storage table delete', TableService.delete_table, factory)
+cli_storage_data_plane_command('storage table policy create', create_acl_policy, factory)
+cli_storage_data_plane_command('storage table policy delete', delete_acl_policy, factory)
+cli_storage_data_plane_command('storage table policy show', get_acl_policy, factory)
+cli_storage_data_plane_command('storage table policy list', list_acl_policies, factory, simple_output_query=transform_acl_list_output)
+cli_storage_data_plane_command('storage table policy update', set_acl_policy, factory)
+cli_storage_data_plane_command('storage table batch commit', TableService.commit_batch, factory)
+cli_storage_data_plane_command('storage table batch create', TableService.batch, factory)
+
+# table entity commands
+cli_storage_data_plane_command('storage entity query', TableService.query_entities, factory)
+cli_storage_data_plane_command('storage entity show', TableService.get_entity, factory)
+cli_storage_data_plane_command('storage entity insert', insert_table_entity, factory)
+cli_storage_data_plane_command('storage entity replace', TableService.update_entity, factory)
+cli_storage_data_plane_command('storage entity merge', TableService.merge_entity, factory)
+cli_storage_data_plane_command('storage entity delete', TableService.delete_entity, factory)
+
+# queue commands
+factory = queue_data_service_factory
+cli_storage_data_plane_command('storage queue generate-sas', QueueService.generate_queue_shared_access_signature, factory)
+cli_storage_data_plane_command('storage queue stats', QueueService.get_queue_service_stats, factory)
+cli_storage_data_plane_command('storage queue service-properties show', QueueService.get_queue_service_properties, factory)
+cli_storage_data_plane_command('storage queue service-properties update', QueueService.set_queue_service_properties, factory)
+cli_storage_data_plane_command('storage queue list', QueueService.list_queues, factory, simple_output_query='items[*].{Name:name}')
+cli_storage_data_plane_command('storage queue create', QueueService.create_queue, factory)
+cli_storage_data_plane_command('storage queue delete', QueueService.delete_queue, factory)
+cli_storage_data_plane_command('storage queue metadata show', QueueService.get_queue_metadata, factory)
+cli_storage_data_plane_command('storage queue metadata update', QueueService.set_queue_metadata, factory)
+cli_storage_data_plane_command('storage queue exists', QueueService.exists, factory)
+cli_storage_data_plane_command('storage queue policy create', create_acl_policy, factory)
+cli_storage_data_plane_command('storage queue policy delete', delete_acl_policy, factory)
+cli_storage_data_plane_command('storage queue policy show', get_acl_policy, factory)
+cli_storage_data_plane_command('storage queue policy list', list_acl_policies, factory, simple_output_query=transform_acl_list_output)
+cli_storage_data_plane_command('storage queue policy update', set_acl_policy, factory)
+
+# queue message commands
+cli_storage_data_plane_command('storage message put', QueueService.put_message, factory)
+cli_storage_data_plane_command('storage message get', QueueService.get_messages, factory)
+cli_storage_data_plane_command('storage message peek', QueueService.peek_messages, factory, simple_output_query='[*].{ID:id, Content:content, Insertion:insertionTime, Expiration:expirationTime}')
+cli_storage_data_plane_command('storage message delete', QueueService.delete_message, factory)
+cli_storage_data_plane_command('storage message clear', QueueService.clear_messages, factory)
+cli_storage_data_plane_command('storage message update', QueueService.update_message, factory)

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_queue_scenario.yaml
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_queue_scenario.yaml
@@ -1,0 +1,743 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDcwODY0NTM5LCJuYmYiOjE0NzA4NjQ1MzksImV4cCI6MTQ3MDg2ODQzOSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6NzIwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjEuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.KrRgb_rPOfKbJwOa-fiUX7KWPa8KUyAZefsrML2GaaGBvAz8KvFL9gX_XuNrHhZysjs-1pdtM9O_wqgLWR7hTb2_If45U3tAE06_ewAV00oXVlx6gs7kz9JcNeivG8hcuddUrIyZwFlpYPkWfl4gko79OzqneeZUVIB15rBW9WwL9X6iB_bLx1JWkIguNn-ofQCOhcBkEtpsduoYNAj7SCfargT5Q5vs0Hw-MVhuriLHrxyBIzTcAAPR4o5_XW-0uR7FeNgyJPsvjltEl3HR4IRE56a4_UJD-dlBmX-Rx4YWcPLH-fDsW4Ky-JzcFhfU35ypCbHnBPTckmakCPzIHA]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 storagemanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [c354bb9e-5f43-11e6-bd83-a0b3ccf7272a]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_queue_scenario_test/providers/Microsoft.Storage/storageAccounts/dummystorage.listKeys?api-version=2016-01-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR2/z
+        6+ajR9/jX15ki/yjR/ht96PRR6u8XhRNU1RLavDRs3VZ0oeXWblGm73vtL/XvXvfWf9gtXPwZfHs
+        9ymPv9t8vv+TTyaXx0V99fynXn/+1asHP6g+/fTiTfV7n88vfvKnF7PF7M10p/7pJ58+e9keX0yq
+        6tWXF/PV/OD6uj1+lb/aqy4+++yjXzLqoLJHvW5E5ct7n9zdP/vJ7NkXP/F8tVq//Mlvz3Yu333n
+        7u7J7019frWzt/PTyy8PTl6czj55+Z2Ds+f79d23b5tvP3h2ce/J8Xfflb/3m4e/6PNflN97+NNP
+        Xzw5efrui4erb9/7CaDy/V+S/D+Z8QoQIQEAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Wed, 10 Aug 2016 21:45:32 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage418031177315:SWfIFIHFhwF/eO6wVf4l59+f5ybQHAwkBfpVzKFGLeE=']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [c395e09c-5f43-11e6-9600-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:45:33 GMT']
+      x-ms-meta-a: [b]
+      x-ms-meta-c: [d]
+      x-ms-version: ['2015-07-08']
+    method: PUT
+    uri: https://dummystorage.queue.core.windows.net/queue1
+  response:
+    body: {string: ''}
+    headers:
+      Date: ['Wed, 10 Aug 2016 21:45:31 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage418031177315:K+S/J0z2KWPn2JQMX+WsyCHreBAS7tWjAcw88WsJhl0=']
+      Connection: [keep-alive]
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [c3de2aa4-5f43-11e6-bae9-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:45:33 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.queue.core.windows.net/queue1?comp=metadata
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: [no-cache]
+      Date: ['Wed, 10 Aug 2016 21:45:31 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-approximate-messages-count: ['0']
+      x-ms-meta-a: [b]
+      x-ms-meta-c: [d]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage418031177315:dNPAtKksf4S1N6u0xiTyPauqxtKWmjsgCP9P28iJJ7Q=']
+      Connection: [keep-alive]
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [c4020c8a-5f43-11e6-aa5e-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:45:33 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.queue.core.windows.net/?comp=list
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults\
+        \ ServiceEndpoint=\"https://vcrstorage418031177315.queue.core.windows.net/\"\
+        ><Queues><Queue><Name>queue1</Name></Queue></Queues><NextMarker /></EnumerationResults>"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/xml]
+      Date: ['Wed, 10 Aug 2016 21:45:32 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage418031177315:k+Lb/2myYmiyiC1Yg568JCrQdUHsSR6HUKaowjXplVY=']
+      Connection: [keep-alive]
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [c427fd68-5f43-11e6-b709-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:45:33 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.queue.core.windows.net/queue1?comp=metadata
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: [no-cache]
+      Date: ['Wed, 10 Aug 2016 21:45:33 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-approximate-messages-count: ['0']
+      x-ms-meta-a: [b]
+      x-ms-meta-c: [d]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage418031177315:3MKobL1XMgVDc/D/IO85SztACLLfh9Zgk6vxaOIVEHU=']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [c44e1b82-5f43-11e6-b3a7-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:45:34 GMT']
+      x-ms-meta-e: [f]
+      x-ms-meta-g: [h]
+      x-ms-version: ['2015-07-08']
+    method: PUT
+    uri: https://dummystorage.queue.core.windows.net/queue1?comp=metadata
+  response:
+    body: {string: ''}
+    headers:
+      Content-Length: ['0']
+      Date: ['Wed, 10 Aug 2016 21:45:32 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage418031177315:303NSy5PYKvyFxW9kQ7cZ7OHunGvuKhvlxh/V4DDSyo=']
+      Connection: [keep-alive]
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [c47bcc50-5f43-11e6-8f6b-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:45:34 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.queue.core.windows.net/queue1?comp=metadata
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: [no-cache]
+      Date: ['Wed, 10 Aug 2016 21:45:33 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-approximate-messages-count: ['0']
+      x-ms-meta-e: [f]
+      x-ms-meta-g: [h]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage418031177315:+o3hs48e4w0cjcC7z/JOFdunoJkjO4PKzJafoizA0I0=']
+      Connection: [keep-alive]
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [c4a01a30-5f43-11e6-911b-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:45:34 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers\
+        \ />"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/xml]
+      Date: ['Wed, 10 Aug 2016 21:45:33 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage418031177315:hN/VDMMRNGyETCinLA6Q6//HEFUVEDhuQUrOrrlsMOc=']
+      Connection: [keep-alive]
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [c4cc6502-5f43-11e6-9005-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:45:35 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers\
+        \ />"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/xml]
+      Date: ['Wed, 10 Aug 2016 21:45:33 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0ndXRmLTgnPz4KPFNpZ25lZElkZW50aWZpZXJz
+      PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MTwvSWQ+PEFjY2Vzc1BvbGljeT48U3RhcnQ+MjAx
+      Ni0wMS0wMVQwMDowMFo8L1N0YXJ0PjxFeHBpcnk+MjAxNi0wNS0wMVQwMDowMFo8L0V4cGlyeT48
+      UGVybWlzc2lvbj5yYXVwPC9QZXJtaXNzaW9uPjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRlbnRp
+      Zmllcj48L1NpZ25lZElkZW50aWZpZXJzPg==
+    headers:
+      Authorization: ['SharedKey vcrstorage418031177315:j+IoZTuh7wJ+u3xEAGY2z2CU/rXQU/ZLI0KFH3BlwNg=']
+      Connection: [keep-alive]
+      Content-Length: ['253']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [c4e4bed8-5f43-11e6-96dc-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:45:35 GMT']
+      x-ms-version: ['2015-07-08']
+    method: PUT
+    uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
+  response:
+    body: {string: ''}
+    headers:
+      Content-Length: ['0']
+      Date: ['Wed, 10 Aug 2016 21:45:33 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage418031177315:DXJoBkVmabBe0zBuWJkdLuKFQ+RN5LZtarhAT5C7cX4=']
+      Connection: [keep-alive]
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [c508f774-5f43-11e6-b7e4-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:45:35 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rpau</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/xml]
+      Date: ['Wed, 10 Aug 2016 21:45:34 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage418031177315:NgyGCrrNHo2keFniS1oiKggfCSat3WYZCk9/e9qH6UI=']
+      Connection: [keep-alive]
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [c533b426-5f43-11e6-9524-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:45:35 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rpau</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/xml]
+      Date: ['Wed, 10 Aug 2016 21:45:34 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage418031177315:hTdjD+j2ly6zn/HUPejoLZkwGSAImwuB5zy/gtKqzdc=']
+      Connection: [keep-alive]
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [c55b499c-5f43-11e6-8c3f-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:45:35 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rpau</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/xml]
+      Date: ['Wed, 10 Aug 2016 21:45:34 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0ndXRmLTgnPz4KPFNpZ25lZElkZW50aWZpZXJz
+      PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MTwvSWQ+PEFjY2Vzc1BvbGljeT48U3RhcnQ+MjAx
+      Ni0wMS0wMVQwMDowMDowMFo8L1N0YXJ0PjxFeHBpcnk+MjAxNi0wNS0wMVQwMDowMDowMFo8L0V4
+      cGlyeT48UGVybWlzc2lvbj5yYTwvUGVybWlzc2lvbj48L0FjY2Vzc1BvbGljeT48L1NpZ25lZElk
+      ZW50aWZpZXI+PC9TaWduZWRJZGVudGlmaWVycz4=
+    headers:
+      Authorization: ['SharedKey vcrstorage418031177315:e1aNBRYFqhmgk4Vc89CoTvAzeE88fI2xxgc3XBHXwYg=']
+      Connection: [keep-alive]
+      Content-Length: ['257']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [c5743ba4-5f43-11e6-b5d2-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:45:36 GMT']
+      x-ms-version: ['2015-07-08']
+    method: PUT
+    uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
+  response:
+    body: {string: ''}
+    headers:
+      Content-Length: ['0']
+      Date: ['Wed, 10 Aug 2016 21:45:34 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage418031177315:on+i9sa97AniUnLdEhTxCYClVA9Sbdxei4/YhDWNChQ=']
+      Connection: [keep-alive]
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [c5924cec-5f43-11e6-bd5f-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:45:36 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>ra</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/xml]
+      Date: ['Wed, 10 Aug 2016 21:45:34 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage418031177315:RSYixe/M/iS9KBVSbXwMqVj21k0IFjKBAoFB2NKOCHw=']
+      Connection: [keep-alive]
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [c5bef79c-5f43-11e6-9290-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:45:36 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>ra</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/xml]
+      Date: ['Wed, 10 Aug 2016 21:45:35 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0ndXRmLTgnPz4KPFNpZ25lZElkZW50aWZpZXJz
+      IC8+
+    headers:
+      Authorization: ['SharedKey vcrstorage418031177315:q4cCXh8AOx4UgnTDuaI7Qeevat26ZdYujNG2Ig1sILQ=']
+      Connection: [keep-alive]
+      Content-Length: ['60']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [c5d92adc-5f43-11e6-bf24-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:45:36 GMT']
+      x-ms-version: ['2015-07-08']
+    method: PUT
+    uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
+  response:
+    body: {string: ''}
+    headers:
+      Content-Length: ['0']
+      Date: ['Wed, 10 Aug 2016 21:45:35 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage418031177315:5evJLATsa8tw7zOx+U1F1AwQ+7oRxJy2rJngwe7lnJA=']
+      Connection: [keep-alive]
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [c5f5a3b8-5f43-11e6-bb16-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:45:37 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers\
+        \ />"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/xml]
+      Date: ['Wed, 10 Aug 2016 21:45:35 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0ndXRmLTgnPz4KPFF1ZXVlTWVzc2FnZT48TWVz
+      c2FnZVRleHQ+dGVzdCBtZXNzYWdlPC9NZXNzYWdlVGV4dD48L1F1ZXVlTWVzc2FnZT4=
+    headers:
+      Authorization: ['SharedKey vcrstorage418031177315:2/PdN/RIinAyuJnexVzg83YSk08kt26nkgWtjApuiqs=']
+      Connection: [keep-alive]
+      Content-Length: ['107']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [c62e342e-5f43-11e6-b7b5-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:45:37 GMT']
+      x-ms-version: ['2015-07-08']
+    method: POST
+    uri: https://dummystorage.queue.core.windows.net/queue1/messages
+  response:
+    body: {string: ''}
+    headers:
+      Date: ['Wed, 10 Aug 2016 21:45:35 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage418031177315:QSFBrXHIl2RRhlu84RTXoJqLD0T9LPrwPxAuM4kM8x8=']
+      Connection: [keep-alive]
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [c65c0a92-5f43-11e6-ac45-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:45:37 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.queue.core.windows.net/queue1/messages?peekonly=true
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>32631453-0700-46c6-9a94-73b9889f5fd6</MessageId><InsertionTime>Wed,\
+        \ 10 Aug 2016 21:45:36 GMT</InsertionTime><ExpirationTime>Wed, 17 Aug 2016\
+        \ 21:45:36 GMT</ExpirationTime><DequeueCount>0</DequeueCount><MessageText>test\
+        \ message</MessageText></QueueMessage></QueueMessagesList>"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/xml]
+      Date: ['Wed, 10 Aug 2016 21:45:35 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage418031177315:cHZHrFGeuIUOW75WMsGb2rIM/DRVtjyQWax40I9Y70Y=']
+      Connection: [keep-alive]
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [c680d468-5f43-11e6-a979-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:45:37 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.queue.core.windows.net/queue1/messages
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>32631453-0700-46c6-9a94-73b9889f5fd6</MessageId><InsertionTime>Wed,\
+        \ 10 Aug 2016 21:45:36 GMT</InsertionTime><ExpirationTime>Wed, 17 Aug 2016\
+        \ 21:45:36 GMT</ExpirationTime><DequeueCount>1</DequeueCount><PopReceipt>AgAAAAMAAAAAAAAAggCTmVDz0QE=</PopReceipt><TimeNextVisible>Wed,\
+        \ 10 Aug 2016 21:46:06 GMT</TimeNextVisible><MessageText>test message</MessageText></QueueMessage></QueueMessagesList>"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/xml]
+      Date: ['Wed, 10 Aug 2016 21:45:37 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0ndXRmLTgnPz4KPFF1ZXVlTWVzc2FnZT48TWVz
+      c2FnZVRleHQ+bmV3IG1lc3NhZ2UhPC9NZXNzYWdlVGV4dD48L1F1ZXVlTWVzc2FnZT4=
+    headers:
+      Authorization: ['SharedKey vcrstorage418031177315:CiySodSM7AiM2ciBqznetvS7h56c1Bx/tuL/YaySumE=']
+      Connection: [keep-alive]
+      Content-Length: ['107']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [c6abccd2-5f43-11e6-ab2a-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:45:38 GMT']
+      x-ms-version: ['2015-07-08']
+    method: PUT
+    uri: https://dummystorage.queue.core.windows.net/queue1/messages/32631453-0700-46c6-9a94-73b9889f5fd6?popreceipt=AgAAAAMAAAAAAAAAggCTmVDz0QE%3D&visibilitytimeout=1
+  response:
+    body: {string: ''}
+    headers:
+      Content-Length: ['0']
+      Date: ['Wed, 10 Aug 2016 21:45:35 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-popreceipt: [AwAAAAMAAAAAAAAARIJ6iFDz0QEBAAAA]
+      x-ms-time-next-visible: ['Wed, 10 Aug 2016 21:45:38 GMT']
+      x-ms-version: ['2015-07-08']
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage418031177315:bYMuNGLO3PDGWVZs0Jvj8yGlgond43crJNW2PY/ne24=']
+      Connection: [keep-alive]
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [c80a81e4-5f43-11e6-ad29-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:45:40 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.queue.core.windows.net/queue1/messages?peekonly=true
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>32631453-0700-46c6-9a94-73b9889f5fd6</MessageId><InsertionTime>Wed,\
+        \ 10 Aug 2016 21:45:36 GMT</InsertionTime><ExpirationTime>Wed, 17 Aug 2016\
+        \ 21:45:36 GMT</ExpirationTime><DequeueCount>1</DequeueCount><MessageText>new\
+        \ message!</MessageText></QueueMessage></QueueMessagesList>"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/xml]
+      Date: ['Wed, 10 Aug 2016 21:45:39 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0ndXRmLTgnPz4KPFF1ZXVlTWVzc2FnZT48TWVz
+      c2FnZVRleHQ+c2Vjb25kIG1lc3NhZ2U8L01lc3NhZ2VUZXh0PjwvUXVldWVNZXNzYWdlPg==
+    headers:
+      Authorization: ['SharedKey vcrstorage418031177315:R15FVwdla25HVXmaxKdz1CSMT5EHMtG8ViF9V5+oE6A=']
+      Connection: [keep-alive]
+      Content-Length: ['109']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [c830ba74-5f43-11e6-8612-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:45:40 GMT']
+      x-ms-version: ['2015-07-08']
+    method: POST
+    uri: https://dummystorage.queue.core.windows.net/queue1/messages
+  response:
+    body: {string: ''}
+    headers:
+      Date: ['Wed, 10 Aug 2016 21:45:39 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 201, message: Created}
+- request:
+    body: !!binary |
+      PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0ndXRmLTgnPz4KPFF1ZXVlTWVzc2FnZT48TWVz
+      c2FnZVRleHQ+dGhpcmQgbWVzc2FnZTwvTWVzc2FnZVRleHQ+PC9RdWV1ZU1lc3NhZ2U+
+    headers:
+      Authorization: ['SharedKey vcrstorage418031177315:wxncsAVecuIxFf8VDj3OZkD9dxHS5YYNg44sbnlBeBE=']
+      Connection: [keep-alive]
+      Content-Length: ['108']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [c85abc58-5f43-11e6-91e3-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:45:41 GMT']
+      x-ms-version: ['2015-07-08']
+    method: POST
+    uri: https://dummystorage.queue.core.windows.net/queue1/messages
+  response:
+    body: {string: ''}
+    headers:
+      Date: ['Wed, 10 Aug 2016 21:45:40 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage418031177315:1byqEhMfSi3WLx/Ag4BMBfi2x2gw2IjiixqLIO30WwE=']
+      Connection: [keep-alive]
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [c88a7bd8-5f43-11e6-a0eb-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:45:41 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.queue.core.windows.net/queue1/messages?numofmessages=32&peekonly=true
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>32631453-0700-46c6-9a94-73b9889f5fd6</MessageId><InsertionTime>Wed,\
+        \ 10 Aug 2016 21:45:36 GMT</InsertionTime><ExpirationTime>Wed, 17 Aug 2016\
+        \ 21:45:36 GMT</ExpirationTime><DequeueCount>1</DequeueCount><MessageText>new\
+        \ message!</MessageText></QueueMessage><QueueMessage><MessageId>8812297f-d577-44c9-a065-2133dd9bdc75</MessageId><InsertionTime>Wed,\
+        \ 10 Aug 2016 21:45:39 GMT</InsertionTime><ExpirationTime>Wed, 17 Aug 2016\
+        \ 21:45:39 GMT</ExpirationTime><DequeueCount>0</DequeueCount><MessageText>second\
+        \ message</MessageText></QueueMessage><QueueMessage><MessageId>82d3a3b1-f175-44f2-bfde-f35d7dbae551</MessageId><InsertionTime>Wed,\
+        \ 10 Aug 2016 21:45:40 GMT</InsertionTime><ExpirationTime>Wed, 17 Aug 2016\
+        \ 21:45:40 GMT</ExpirationTime><DequeueCount>0</DequeueCount><MessageText>third\
+        \ message</MessageText></QueueMessage></QueueMessagesList>"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/xml]
+      Date: ['Wed, 10 Aug 2016 21:45:39 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage418031177315:SG5oSqMMm468F5Tns9cBcryBRj0HFz1lO4iIQADgte0=']
+      Connection: [keep-alive]
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [c8aece3e-5f43-11e6-8d0f-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:45:41 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.queue.core.windows.net/queue1/messages
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>32631453-0700-46c6-9a94-73b9889f5fd6</MessageId><InsertionTime>Wed,\
+        \ 10 Aug 2016 21:45:36 GMT</InsertionTime><ExpirationTime>Wed, 17 Aug 2016\
+        \ 21:45:36 GMT</ExpirationTime><DequeueCount>2</DequeueCount><PopReceipt>AgAAAAMAAAAAAAAAIWi/m1Dz0QE=</PopReceipt><TimeNextVisible>Wed,\
+        \ 10 Aug 2016 21:46:10 GMT</TimeNextVisible><MessageText>new message!</MessageText></QueueMessage></QueueMessagesList>"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/xml]
+      Date: ['Wed, 10 Aug 2016 21:45:39 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage418031177315:oJZZCnHnPV2ipFrZXWXorFGNhOcCoRr33yVzz94HRdM=']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [c8dd45dc-5f43-11e6-b81d-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:45:41 GMT']
+      x-ms-version: ['2015-07-08']
+    method: DELETE
+    uri: https://dummystorage.queue.core.windows.net/queue1/messages/32631453-0700-46c6-9a94-73b9889f5fd6?popreceipt=AgAAAAMAAAAAAAAAIWi%2Fm1Dz0QE%3D
+  response:
+    body: {string: ''}
+    headers:
+      Content-Length: ['0']
+      Date: ['Wed, 10 Aug 2016 21:45:40 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage418031177315:vyIF5qiwKwP0CyReV3d6cMSMVSthS/VK3Q8LBHEGj0c=']
+      Connection: [keep-alive]
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [c900ed4c-5f43-11e6-afe0-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:45:42 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.queue.core.windows.net/queue1/messages?numofmessages=32&peekonly=true
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>8812297f-d577-44c9-a065-2133dd9bdc75</MessageId><InsertionTime>Wed,\
+        \ 10 Aug 2016 21:45:39 GMT</InsertionTime><ExpirationTime>Wed, 17 Aug 2016\
+        \ 21:45:39 GMT</ExpirationTime><DequeueCount>0</DequeueCount><MessageText>second\
+        \ message</MessageText></QueueMessage><QueueMessage><MessageId>82d3a3b1-f175-44f2-bfde-f35d7dbae551</MessageId><InsertionTime>Wed,\
+        \ 10 Aug 2016 21:45:40 GMT</InsertionTime><ExpirationTime>Wed, 17 Aug 2016\
+        \ 21:45:40 GMT</ExpirationTime><DequeueCount>0</DequeueCount><MessageText>third\
+        \ message</MessageText></QueueMessage></QueueMessagesList>"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/xml]
+      Date: ['Wed, 10 Aug 2016 21:45:40 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage418031177315:N3L5ZoB77j4zXybf7ucuegoG46AETnneWV+GIlEQuU0=']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [c92a8d8a-5f43-11e6-9771-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:45:42 GMT']
+      x-ms-version: ['2015-07-08']
+    method: DELETE
+    uri: https://dummystorage.queue.core.windows.net/queue1/messages
+  response:
+    body: {string: ''}
+    headers:
+      Content-Length: ['0']
+      Date: ['Wed, 10 Aug 2016 21:45:40 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage418031177315:i6TOFGy+Huw279Bs2pcm4rElkzrt65g6wsypM6Fxwz8=']
+      Connection: [keep-alive]
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [c94e0098-5f43-11e6-82aa-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:45:42 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.queue.core.windows.net/queue1/messages?numofmessages=32&peekonly=true
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList\
+        \ />"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/xml]
+      Date: ['Wed, 10 Aug 2016 21:45:41 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage418031177315:tIEEzbUHQokhwTihcZUZLl/Zs1XuasN+M86G48+TslM=']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [c974bdca-5f43-11e6-a365-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:45:42 GMT']
+      x-ms-version: ['2015-07-08']
+    method: DELETE
+    uri: https://dummystorage.queue.core.windows.net/queue1
+  response:
+    body: {string: ''}
+    headers:
+      Content-Length: ['0']
+      Date: ['Wed, 10 Aug 2016 21:45:41 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage418031177315:sivkW0ZJbQH6T+i5DVw+g8f6nkEfmB/uEjVbPXWswbw=']
+      Connection: [keep-alive]
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [c998a700-5f43-11e6-8c12-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:45:43 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.queue.core.windows.net/queue1?comp=metadata
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>QueueNotFound</Code><Message>The\
+        \ specified queue does not exist.\nRequestId:d473bfe0-0003-0111-4350-f3259a000000\n\
+        Time:2016-08-10T21:45:41.5595300Z</Message></Error>"}
+    headers:
+      Content-Length: ['217']
+      Content-Type: [application/xml]
+      Date: ['Wed, 10 Aug 2016 21:45:40 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 404, message: The specified queue does not exist.}
+version: 1

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_table_scenario.yaml
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_table_scenario.yaml
@@ -1,0 +1,889 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDcwODYwMTYzLCJuYmYiOjE0NzA4NjAxNjMsImV4cCI6MTQ3MDg2NDA2MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6NzIwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjEuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.NIGzbcLdKg82jBzOTKWw-d9wVUhzOuPlY29z3a_adLV4iYZ4i3DomUjjjaGZqg5-x-3pwth3APp96Xko9Icqf0CKOpNWMb-mohX0SibMnvWyzBGuTXn8EPh-D658-NVDX9uRJD1PfzgAIjuyFEGoUCGWtuq7Yxh7H_UZibM1VzH_UqMqK6MWZb7aqEqDx2_2o-T9aKtxXVriCEWxZYyA8-1u8fczYWJBfAREG9rMv_S9sH7taqEaVndA-pK12vf3IxkzbjnmibHAjTII9BhDghdY0CA6ZG9IaCe3u4yjju3mlR0nVwgqTLM-h2rvE-rBA3Xt9omTx6Rs7C_eeFyr6A]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 storagemanagementclient/0.30.0rc5 Azure-SDK-For-Python
+          AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [edfcffec-5f3e-11e6-ad5b-a0b3ccf7272a]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_table_scenario_test/providers/Microsoft.Storage/storageAccounts/dummystorage.listKeys?api-version=2016-01-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR2/z
+        6+ajR9/jX15ki/yjR/ht96PRR6u8XhRNU1RLavDRs3VZ0oeXWblGm9/n7JP89dVPfufl+Ysf/MTv
+        9fC4Plnd3//i2cG9l1fn55PXX7x89hP3fzD96XdP937R9dOTn/5k8Z3lVz+5On178OXvc/r6wXKx
+        +3lbfOcXXbx78xP16ouXZ68u3n756ZfHn3320S8ZdVDZo143ovL87sHdL8uDd9er7/w+l18cX5yW
+        P7V+Pf3y3e+V//T+zu5P/T7vzpuLs+Jy/2391Xd/Ms+uivbb5/nd59nv/Z3dd/fe7i2u3r7+ydXd
+        yfR4983ian7yenXy4MuLnwAq3/8lyf8DIMtEEyEBAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Wed, 10 Aug 2016 21:10:56 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJUYWJsZU5hbWUiOiAidGFibGUxIn0=
+    headers:
+      Accept: [application/json;odata=minimalmetadata]
+      Authorization: ['SharedKey vcrstorage674541728147:grW+OzEeqZlFbYJKSE9sTibnz9+v91UaLXQwJK6Gm5I=']
+      Connection: [keep-alive]
+      Content-Length: ['23']
+      Content-Type: [application/json]
+      DataServiceVersion: [3.0;NetFx]
+      MaxDataServiceVersion: ['3.0']
+      Prefer: [return-no-content]
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [ee2c80b4-5f3e-11e6-a47c-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:10:56 GMT']
+      x-ms-version: ['2015-07-08']
+    method: POST
+    uri: https://dummystorage.table.core.windows.net/Tables
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      DataServiceId: ['https://vcrstorage674541728147.table.core.windows.net/Tables(''table1'')']
+      Date: ['Wed, 10 Aug 2016 21:10:55 GMT']
+      Location: ['https://vcrstorage674541728147.table.core.windows.net/Tables(''table1'')']
+      Preference-Applied: [return-no-content]
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      X-Content-Type-Options: [nosniff]
+      x-ms-version: ['2015-07-08']
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/json;odata=nometadata]
+      Authorization: ['SharedKey vcrstorage674541728147:oc76pG2o5sfV8UJ/jShYjdADaJb0JYpEcGJLdupoOfw=']
+      Connection: [keep-alive]
+      DataServiceVersion: [3.0;NetFx]
+      MaxDataServiceVersion: ['3.0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [ee70b9f4-5f3e-11e6-87eb-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:10:57 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.table.core.windows.net/Tables('table1')
+  response:
+    body: {string: '{"TableName":"table1"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json;odata=nometadata;streaming=true;charset=utf-8]
+      Date: ['Wed, 10 Aug 2016 21:10:55 GMT']
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      X-Content-Type-Options: [nosniff]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json;odata=nometadata]
+      Authorization: ['SharedKey vcrstorage674541728147:dRoukWng4JBJATBZ70tW8mex+8DCcbskqAIX6m5wh4o=']
+      Connection: [keep-alive]
+      DataServiceVersion: [3.0;NetFx]
+      MaxDataServiceVersion: ['3.0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [ee987798-5f3e-11e6-aa8e-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:10:57 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.table.core.windows.net/Tables
+  response:
+    body: {string: '{"value":[{"TableName":"table1"}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json;odata=nometadata;streaming=true;charset=utf-8]
+      Date: ['Wed, 10 Aug 2016 21:10:56 GMT']
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      X-Content-Type-Options: [nosniff]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage674541728147:S+QOIauANa4ZJ4nnnUS796fOwJPokNF/Zxk7xvxA8lE=']
+      Connection: [keep-alive]
+      DataServiceVersion: [3.0;NetFx]
+      MaxDataServiceVersion: ['3.0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [eebf3802-5f3e-11e6-ab1d-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:10:57 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.table.core.windows.net/table1?comp=acl
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers\
+        \ />"}
+    headers:
+      Content-Type: [application/xml]
+      Date: ['Wed, 10 Aug 2016 21:10:56 GMT']
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage674541728147:RUbDV+8mjC7VCTZI1V/Ohmqz8XTsV1eZFyVayRpxMtU=']
+      Connection: [keep-alive]
+      DataServiceVersion: [3.0;NetFx]
+      MaxDataServiceVersion: ['3.0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [eee804f0-5f3e-11e6-8b65-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:10:58 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.table.core.windows.net/table1?comp=acl
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers\
+        \ />"}
+    headers:
+      Content-Type: [application/xml]
+      Date: ['Wed, 10 Aug 2016 21:10:57 GMT']
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0ndXRmLTgnPz4KPFNpZ25lZElkZW50aWZpZXJz
+      PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MTwvSWQ+PEFjY2Vzc1BvbGljeT48UGVybWlzc2lv
+      bj5yPC9QZXJtaXNzaW9uPjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRlbnRpZmllcj48L1NpZ25l
+      ZElkZW50aWZpZXJzPg==
+    headers:
+      Authorization: ['SharedKey vcrstorage674541728147:2Z0/cLQKoCZkdgRYbaHEzrnvJITgpN4DRykBrYBWizw=']
+      Connection: [keep-alive]
+      Content-Length: ['184']
+      DataServiceVersion: [3.0;NetFx]
+      MaxDataServiceVersion: ['3.0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [eefc33d8-5f3e-11e6-a148-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:10:58 GMT']
+      x-ms-version: ['2015-07-08']
+    method: PUT
+    uri: https://dummystorage.table.core.windows.net/table1?comp=acl
+  response:
+    body: {string: ''}
+    headers:
+      Content-Length: ['0']
+      Date: ['Wed, 10 Aug 2016 21:10:57 GMT']
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage674541728147:RUbDV+8mjC7VCTZI1V/Ohmqz8XTsV1eZFyVayRpxMtU=']
+      Connection: [keep-alive]
+      DataServiceVersion: [3.0;NetFx]
+      MaxDataServiceVersion: ['3.0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [ef11492c-5f3e-11e6-b44b-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:10:58 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.table.core.windows.net/table1?comp=acl
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>r</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    headers:
+      Content-Type: [application/xml]
+      Date: ['Wed, 10 Aug 2016 21:10:57 GMT']
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0ndXRmLTgnPz4KPFNpZ25lZElkZW50aWZpZXJz
+      PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MjwvSWQ+PEFjY2Vzc1BvbGljeT48U3RhcnQ+MjAx
+      Ni0wMS0wMVQwMDowMFo8L1N0YXJ0PjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRlbnRpZmllcj48
+      U2lnbmVkSWRlbnRpZmllcj48SWQ+dGVzdDE8L0lkPjxBY2Nlc3NQb2xpY3k+PFBlcm1pc3Npb24+
+      cjwvUGVybWlzc2lvbj48L0FjY2Vzc1BvbGljeT48L1NpZ25lZElkZW50aWZpZXI+PC9TaWduZWRJ
+      ZGVudGlmaWVycz4=
+    headers:
+      Authorization: ['SharedKey vcrstorage674541728147:2Z0/cLQKoCZkdgRYbaHEzrnvJITgpN4DRykBrYBWizw=']
+      Connection: [keep-alive]
+      Content-Length: ['296']
+      DataServiceVersion: [3.0;NetFx]
+      MaxDataServiceVersion: ['3.0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [ef26133a-5f3e-11e6-ac18-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:10:58 GMT']
+      x-ms-version: ['2015-07-08']
+    method: PUT
+    uri: https://dummystorage.table.core.windows.net/table1?comp=acl
+  response:
+    body: {string: ''}
+    headers:
+      Content-Length: ['0']
+      Date: ['Wed, 10 Aug 2016 21:10:57 GMT']
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage674541728147:RUbDV+8mjC7VCTZI1V/Ohmqz8XTsV1eZFyVayRpxMtU=']
+      Connection: [keep-alive]
+      DataServiceVersion: [3.0;NetFx]
+      MaxDataServiceVersion: ['3.0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [ef3ad450-5f3e-11e6-b392-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:10:58 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.table.core.windows.net/table1?comp=acl
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>r</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    headers:
+      Content-Type: [application/xml]
+      Date: ['Wed, 10 Aug 2016 21:10:57 GMT']
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0ndXRmLTgnPz4KPFNpZ25lZElkZW50aWZpZXJz
+      PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MjwvSWQ+PEFjY2Vzc1BvbGljeT48U3RhcnQ+MjAx
+      Ni0wMS0wMVQwMDowMDowMFo8L1N0YXJ0PjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRlbnRpZmll
+      cj48U2lnbmVkSWRlbnRpZmllcj48SWQ+dGVzdDE8L0lkPjxBY2Nlc3NQb2xpY3k+PFBlcm1pc3Np
+      b24+cjwvUGVybWlzc2lvbj48L0FjY2Vzc1BvbGljeT48L1NpZ25lZElkZW50aWZpZXI+PFNpZ25l
+      ZElkZW50aWZpZXI+PElkPnRlc3QzPC9JZD48QWNjZXNzUG9saWN5PjxFeHBpcnk+MjAxOC0wMS0w
+      MVQwMDowMFo8L0V4cGlyeT48L0FjY2Vzc1BvbGljeT48L1NpZ25lZElkZW50aWZpZXI+PC9TaWdu
+      ZWRJZGVudGlmaWVycz4=
+    headers:
+      Authorization: ['SharedKey vcrstorage674541728147:2Z0/cLQKoCZkdgRYbaHEzrnvJITgpN4DRykBrYBWizw=']
+      Connection: [keep-alive]
+      Content-Length: ['413']
+      DataServiceVersion: [3.0;NetFx]
+      MaxDataServiceVersion: ['3.0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [ef4fe698-5f3e-11e6-83de-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:10:58 GMT']
+      x-ms-version: ['2015-07-08']
+    method: PUT
+    uri: https://dummystorage.table.core.windows.net/table1?comp=acl
+  response:
+    body: {string: ''}
+    headers:
+      Content-Length: ['0']
+      Date: ['Wed, 10 Aug 2016 21:10:57 GMT']
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage674541728147:dxYpe983QFVVYqaqwgvPvz0VPJ+xRJmn6x84C4/D7Ac=']
+      Connection: [keep-alive]
+      DataServiceVersion: [3.0;NetFx]
+      MaxDataServiceVersion: ['3.0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [ef64d1ca-5f3e-11e6-af8c-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:10:59 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.table.core.windows.net/table1?comp=acl
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>r</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    headers:
+      Content-Type: [application/xml]
+      Date: ['Wed, 10 Aug 2016 21:10:57 GMT']
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0ndXRmLTgnPz4KPFNpZ25lZElkZW50aWZpZXJz
+      PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MjwvSWQ+PEFjY2Vzc1BvbGljeT48U3RhcnQ+MjAx
+      Ni0wMS0wMVQwMDowMDowMFo8L1N0YXJ0PjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRlbnRpZmll
+      cj48U2lnbmVkSWRlbnRpZmllcj48SWQ+dGVzdDE8L0lkPjxBY2Nlc3NQb2xpY3k+PFBlcm1pc3Np
+      b24+cjwvUGVybWlzc2lvbj48L0FjY2Vzc1BvbGljeT48L1NpZ25lZElkZW50aWZpZXI+PFNpZ25l
+      ZElkZW50aWZpZXI+PElkPnRlc3Q0PC9JZD48QWNjZXNzUG9saWN5PjxTdGFydD4yMDE2LTAxLTAx
+      VDAwOjAwWjwvU3RhcnQ+PEV4cGlyeT4yMDE2LTA1LTAxVDAwOjAwWjwvRXhwaXJ5PjxQZXJtaXNz
+      aW9uPnJhdWQ8L1Blcm1pc3Npb24+PC9BY2Nlc3NQb2xpY3k+PC9TaWduZWRJZGVudGlmaWVyPjxT
+      aWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MzwvSWQ+PEFjY2Vzc1BvbGljeT48RXhwaXJ5PjIwMTgt
+      MDEtMDFUMDA6MDA6MDBaPC9FeHBpcnk+PC9BY2Nlc3NQb2xpY3k+PC9TaWduZWRJZGVudGlmaWVy
+      PjwvU2lnbmVkSWRlbnRpZmllcnM+
+    headers:
+      Authorization: ['SharedKey vcrstorage674541728147:YaS2QNVpb3qKV5R91hTGrN/aK6nAT7EMSYTCJLYe8mY=']
+      Connection: [keep-alive]
+      Content-Length: ['591']
+      DataServiceVersion: [3.0;NetFx]
+      MaxDataServiceVersion: ['3.0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [ef79e426-5f3e-11e6-95bd-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:10:59 GMT']
+      x-ms-version: ['2015-07-08']
+    method: PUT
+    uri: https://dummystorage.table.core.windows.net/table1?comp=acl
+  response:
+    body: {string: ''}
+    headers:
+      Content-Length: ['0']
+      Date: ['Wed, 10 Aug 2016 21:10:57 GMT']
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage674541728147:dxYpe983QFVVYqaqwgvPvz0VPJ+xRJmn6x84C4/D7Ac=']
+      Connection: [keep-alive]
+      DataServiceVersion: [3.0;NetFx]
+      MaxDataServiceVersion: ['3.0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [ef942766-5f3e-11e6-bcd1-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:10:59 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.table.core.windows.net/table1?comp=acl
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>r</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    headers:
+      Content-Type: [application/xml]
+      Date: ['Wed, 10 Aug 2016 21:10:58 GMT']
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage674541728147:dxYpe983QFVVYqaqwgvPvz0VPJ+xRJmn6x84C4/D7Ac=']
+      Connection: [keep-alive]
+      DataServiceVersion: [3.0;NetFx]
+      MaxDataServiceVersion: ['3.0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [efb9de6c-5f3e-11e6-9951-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:10:59 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.table.core.windows.net/table1?comp=acl
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>r</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    headers:
+      Content-Type: [application/xml]
+      Date: ['Wed, 10 Aug 2016 21:10:57 GMT']
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage674541728147:dxYpe983QFVVYqaqwgvPvz0VPJ+xRJmn6x84C4/D7Ac=']
+      Connection: [keep-alive]
+      DataServiceVersion: [3.0;NetFx]
+      MaxDataServiceVersion: ['3.0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [efe1179c-5f3e-11e6-a29c-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:10:59 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.table.core.windows.net/table1?comp=acl
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>r</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    headers:
+      Content-Type: [application/xml]
+      Date: ['Wed, 10 Aug 2016 21:10:58 GMT']
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage674541728147:F8eSsuJIqGtLuNBQHEiDYlfEJgnaAxsTLFraTyjD5EM=']
+      Connection: [keep-alive]
+      DataServiceVersion: [3.0;NetFx]
+      MaxDataServiceVersion: ['3.0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [f008f448-5f3e-11e6-b804-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:11:00 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.table.core.windows.net/table1?comp=acl
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>r</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    headers:
+      Content-Type: [application/xml]
+      Date: ['Wed, 10 Aug 2016 21:10:59 GMT']
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage674541728147:F8eSsuJIqGtLuNBQHEiDYlfEJgnaAxsTLFraTyjD5EM=']
+      Connection: [keep-alive]
+      DataServiceVersion: [3.0;NetFx]
+      MaxDataServiceVersion: ['3.0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [f0302434-5f3e-11e6-bcf0-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:11:00 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.table.core.windows.net/table1?comp=acl
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>r</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    headers:
+      Content-Type: [application/xml]
+      Date: ['Wed, 10 Aug 2016 21:10:59 GMT']
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage674541728147:F8eSsuJIqGtLuNBQHEiDYlfEJgnaAxsTLFraTyjD5EM=']
+      Connection: [keep-alive]
+      DataServiceVersion: [3.0;NetFx]
+      MaxDataServiceVersion: ['3.0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [f0579148-5f3e-11e6-9f33-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:11:00 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.table.core.windows.net/table1?comp=acl
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>r</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    headers:
+      Content-Type: [application/xml]
+      Date: ['Wed, 10 Aug 2016 21:10:59 GMT']
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0ndXRmLTgnPz4KPFNpZ25lZElkZW50aWZpZXJz
+      PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MjwvSWQ+PEFjY2Vzc1BvbGljeT48U3RhcnQ+MjAx
+      Ni0wMS0wMVQwMDowMDowMFo8L1N0YXJ0PjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRlbnRpZmll
+      cj48U2lnbmVkSWRlbnRpZmllcj48SWQ+dGVzdDE8L0lkPjxBY2Nlc3NQb2xpY3k+PFBlcm1pc3Np
+      b24+cmE8L1Blcm1pc3Npb24+PC9BY2Nlc3NQb2xpY3k+PC9TaWduZWRJZGVudGlmaWVyPjxTaWdu
+      ZWRJZGVudGlmaWVyPjxJZD50ZXN0NDwvSWQ+PEFjY2Vzc1BvbGljeT48U3RhcnQ+MjAxNi0wMS0w
+      MVQwMDowMDowMFo8L1N0YXJ0PjxFeHBpcnk+MjAxNi0wNS0wMVQwMDowMDowMFo8L0V4cGlyeT48
+      UGVybWlzc2lvbj5yYXVkPC9QZXJtaXNzaW9uPjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRlbnRp
+      Zmllcj48U2lnbmVkSWRlbnRpZmllcj48SWQ+dGVzdDM8L0lkPjxBY2Nlc3NQb2xpY3k+PEV4cGly
+      eT4yMDE4LTAxLTAxVDAwOjAwOjAwWjwvRXhwaXJ5PjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRl
+      bnRpZmllcj48L1NpZ25lZElkZW50aWZpZXJzPg==
+    headers:
+      Authorization: ['SharedKey vcrstorage674541728147:h3Mb2nHfYkTWu7Aow9n7R4OWHxUs+K7BSNEzB+YuYDE=']
+      Connection: [keep-alive]
+      Content-Length: ['598']
+      DataServiceVersion: [3.0;NetFx]
+      MaxDataServiceVersion: ['3.0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [f06d032c-5f3e-11e6-bc8a-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:11:00 GMT']
+      x-ms-version: ['2015-07-08']
+    method: PUT
+    uri: https://dummystorage.table.core.windows.net/table1?comp=acl
+  response:
+    body: {string: ''}
+    headers:
+      Content-Length: ['0']
+      Date: ['Wed, 10 Aug 2016 21:10:59 GMT']
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage674541728147:F8eSsuJIqGtLuNBQHEiDYlfEJgnaAxsTLFraTyjD5EM=']
+      Connection: [keep-alive]
+      DataServiceVersion: [3.0;NetFx]
+      MaxDataServiceVersion: ['3.0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [f08c4f5c-5f3e-11e6-be05-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:11:00 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.table.core.windows.net/table1?comp=acl
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>ra</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    headers:
+      Content-Type: [application/xml]
+      Date: ['Wed, 10 Aug 2016 21:11:01 GMT']
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage674541728147:yGZtg9J5XhcvzWj7nlNSSIvsSF/DB2SmWfi3CpyhOH8=']
+      Connection: [keep-alive]
+      DataServiceVersion: [3.0;NetFx]
+      MaxDataServiceVersion: ['3.0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [f1a157a4-5f3e-11e6-8b01-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:11:02 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.table.core.windows.net/table1?comp=acl
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>ra</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    headers:
+      Content-Type: [application/xml]
+      Date: ['Wed, 10 Aug 2016 21:11:01 GMT']
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0ndXRmLTgnPz4KPFNpZ25lZElkZW50aWZpZXJz
+      PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MjwvSWQ+PEFjY2Vzc1BvbGljeT48U3RhcnQ+MjAx
+      Ni0wMS0wMVQwMDowMDowMFo8L1N0YXJ0PjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRlbnRpZmll
+      cj48U2lnbmVkSWRlbnRpZmllcj48SWQ+dGVzdDQ8L0lkPjxBY2Nlc3NQb2xpY3k+PFN0YXJ0PjIw
+      MTYtMDEtMDFUMDA6MDA6MDBaPC9TdGFydD48RXhwaXJ5PjIwMTYtMDUtMDFUMDA6MDA6MDBaPC9F
+      eHBpcnk+PFBlcm1pc3Npb24+cmF1ZDwvUGVybWlzc2lvbj48L0FjY2Vzc1BvbGljeT48L1NpZ25l
+      ZElkZW50aWZpZXI+PFNpZ25lZElkZW50aWZpZXI+PElkPnRlc3QzPC9JZD48QWNjZXNzUG9saWN5
+      PjxFeHBpcnk+MjAxOC0wMS0wMVQwMDowMDowMFo8L0V4cGlyeT48L0FjY2Vzc1BvbGljeT48L1Np
+      Z25lZElkZW50aWZpZXI+PC9TaWduZWRJZGVudGlmaWVycz4=
+    headers:
+      Authorization: ['SharedKey vcrstorage674541728147:aSyCLVjtlzbyVr8mnf1ECmflpin0rQVufJhMFYwbaK8=']
+      Connection: [keep-alive]
+      Content-Length: ['491']
+      DataServiceVersion: [3.0;NetFx]
+      MaxDataServiceVersion: ['3.0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [f1b65e14-5f3e-11e6-acd2-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:11:02 GMT']
+      x-ms-version: ['2015-07-08']
+    method: PUT
+    uri: https://dummystorage.table.core.windows.net/table1?comp=acl
+  response:
+    body: {string: ''}
+    headers:
+      Content-Length: ['0']
+      Date: ['Wed, 10 Aug 2016 21:11:01 GMT']
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Authorization: ['SharedKey vcrstorage674541728147:tYPVCbDDugafjl0J+W/3pT0TomsqjkPulvuBFWWPJDo=']
+      Connection: [keep-alive]
+      DataServiceVersion: [3.0;NetFx]
+      MaxDataServiceVersion: ['3.0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [f1ccc800-5f3e-11e6-b1d6-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:11:03 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.table.core.windows.net/table1?comp=acl
+  response:
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    headers:
+      Content-Type: [application/xml]
+      Date: ['Wed, 10 Aug 2016 21:11:01 GMT']
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJ2YWx1ZSI6ICJzb21ldGhpbmciLCAiUm93S2V5IjogIjAwMSIsICJuYW1lIjogInRlc3QiLCAi
+      UGFydGl0aW9uS2V5IjogIjAwMSJ9
+    headers:
+      Accept: [application/json;odata=minimalmetadata]
+      Authorization: ['SharedKey vcrstorage674541728147:oYS7rQev63xuxw8Z2qA5VuADcCtuO1FcD97S/TEl3hA=']
+      Connection: [keep-alive]
+      Content-Length: ['78']
+      Content-Type: [application/json]
+      DataServiceVersion: [3.0;NetFx]
+      MaxDataServiceVersion: ['3.0']
+      Prefer: [return-no-content]
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [f1f161c8-5f3e-11e6-b121-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:11:03 GMT']
+      x-ms-version: ['2015-07-08']
+    method: POST
+    uri: https://dummystorage.table.core.windows.net/table1
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      DataServiceId: ['https://vcrstorage674541728147.table.core.windows.net/table1(PartitionKey=''001'',RowKey=''001'')']
+      Date: ['Wed, 10 Aug 2016 21:11:01 GMT']
+      ETag: [W/"datetime'2016-08-10T21%3A11%3A01.2703238Z'"]
+      Location: ['https://vcrstorage674541728147.table.core.windows.net/table1(PartitionKey=''001'',RowKey=''001'')']
+      Preference-Applied: [return-no-content]
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      X-Content-Type-Options: [nosniff]
+      x-ms-version: ['2015-07-08']
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/json;odata=minimalmetadata]
+      Authorization: ['SharedKey vcrstorage674541728147:6X6XLDHNP31JQuCFQsw6cIdy2+6ztEZHr1rzJWEMgRM=']
+      Connection: [keep-alive]
+      DataServiceVersion: [3.0;NetFx]
+      MaxDataServiceVersion: ['3.0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [f21b1590-5f3e-11e6-a35b-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:11:03 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.table.core.windows.net/table1(PartitionKey='001',RowKey='001')
+  response:
+    body: {string: '{"odata.metadata":"https://vcrstorage674541728147.table.core.windows.net/$metadata#table1/@Element","odata.etag":"W/\"datetime''2016-08-10T21%3A11%3A01.2703238Z''\"","PartitionKey":"001","RowKey":"001","Timestamp":"2016-08-10T21:11:01.2703238Z","value":"something","name":"test"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
+      Date: ['Wed, 10 Aug 2016 21:11:01 GMT']
+      ETag: [W/"datetime'2016-08-10T21%3A11%3A01.2703238Z'"]
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      X-Content-Type-Options: [nosniff]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json;odata=minimalmetadata]
+      Authorization: ['SharedKey vcrstorage674541728147:6X6XLDHNP31JQuCFQsw6cIdy2+6ztEZHr1rzJWEMgRM=']
+      Connection: [keep-alive]
+      DataServiceVersion: [3.0;NetFx]
+      MaxDataServiceVersion: ['3.0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [f2419e3e-5f3e-11e6-8734-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:11:03 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.table.core.windows.net/table1(PartitionKey='001',RowKey='001')?%24select=name
+  response:
+    body: {string: '{"odata.metadata":"https://vcrstorage674541728147.table.core.windows.net/$metadata#table1/@Element&$select=name","odata.etag":"W/\"datetime''2016-08-10T21%3A11%3A01.2703238Z''\"","name":"test"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
+      Date: ['Wed, 10 Aug 2016 21:11:02 GMT']
+      ETag: [W/"datetime'2016-08-10T21%3A11%3A01.2703238Z'"]
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      X-Content-Type-Options: [nosniff]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJ2YWx1ZSI6ICJuZXd2YWwiLCAiUm93S2V5IjogIjAwMSIsICJuYW1lIjogInRlc3QiLCAiUGFy
+      dGl0aW9uS2V5IjogIjAwMSJ9
+    headers:
+      Accept: [application/json;odata=minimalmetadata]
+      Authorization: ['SharedKey vcrstorage674541728147:TiuKuUtpOxEQGY0T2V5pks88QZC+lTE0A8PyhR1XHmQ=']
+      Connection: [keep-alive]
+      Content-Length: ['75']
+      Content-Type: [application/json]
+      DataServiceVersion: [3.0;NetFx]
+      If-Match: ['*']
+      MaxDataServiceVersion: ['3.0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [f269a6f6-5f3e-11e6-a843-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:11:04 GMT']
+      x-ms-version: ['2015-07-08']
+    method: MERGE
+    uri: https://dummystorage.table.core.windows.net/table1(PartitionKey='001',RowKey='001')
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Wed, 10 Aug 2016 21:11:02 GMT']
+      ETag: [W/"datetime'2016-08-10T21%3A11%3A02.6113589Z'"]
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      X-Content-Type-Options: [nosniff]
+      x-ms-version: ['2015-07-08']
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/json;odata=minimalmetadata]
+      Authorization: ['SharedKey vcrstorage674541728147:cGO2INWuD1LAkK7snO7O47fsG/DglXmc+RYPkjrEq2k=']
+      Connection: [keep-alive]
+      DataServiceVersion: [3.0;NetFx]
+      MaxDataServiceVersion: ['3.0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [f28dbe76-5f3e-11e6-8f00-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:11:04 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.table.core.windows.net/table1(PartitionKey='001',RowKey='001')
+  response:
+    body: {string: '{"odata.metadata":"https://vcrstorage674541728147.table.core.windows.net/$metadata#table1/@Element","odata.etag":"W/\"datetime''2016-08-10T21%3A11%3A02.6113589Z''\"","PartitionKey":"001","RowKey":"001","Timestamp":"2016-08-10T21:11:02.6113589Z","name":"test","value":"newval"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
+      Date: ['Wed, 10 Aug 2016 21:11:03 GMT']
+      ETag: [W/"datetime'2016-08-10T21%3A11%3A02.6113589Z'"]
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      X-Content-Type-Options: [nosniff]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJSb3dLZXkiOiAiMDAxIiwgIlBhcnRpdGlvbktleSI6ICIwMDEiLCAiY2F0IjogImhhdCJ9
+    headers:
+      Accept: [application/json;odata=minimalmetadata]
+      Authorization: ['SharedKey vcrstorage674541728147:urk1mVCdtBx/CAesQh+4lkyNfwZpUzVaZ7ULMBL1EBE=']
+      Connection: [keep-alive]
+      Content-Length: ['54']
+      Content-Type: [application/json]
+      DataServiceVersion: [3.0;NetFx]
+      If-Match: ['*']
+      MaxDataServiceVersion: ['3.0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [f2b7d310-5f3e-11e6-98df-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:11:04 GMT']
+      x-ms-version: ['2015-07-08']
+    method: PUT
+    uri: https://dummystorage.table.core.windows.net/table1(PartitionKey='001',RowKey='001')
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Wed, 10 Aug 2016 21:11:02 GMT']
+      ETag: [W/"datetime'2016-08-10T21%3A11%3A03.1298372Z'"]
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      X-Content-Type-Options: [nosniff]
+      x-ms-version: ['2015-07-08']
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/json;odata=minimalmetadata]
+      Authorization: ['SharedKey vcrstorage674541728147:cGO2INWuD1LAkK7snO7O47fsG/DglXmc+RYPkjrEq2k=']
+      Connection: [keep-alive]
+      DataServiceVersion: [3.0;NetFx]
+      MaxDataServiceVersion: ['3.0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [f2e586ac-5f3e-11e6-b5e0-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:11:04 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.table.core.windows.net/table1(PartitionKey='001',RowKey='001')
+  response:
+    body: {string: '{"odata.metadata":"https://vcrstorage674541728147.table.core.windows.net/$metadata#table1/@Element","odata.etag":"W/\"datetime''2016-08-10T21%3A11%3A03.1298372Z''\"","PartitionKey":"001","RowKey":"001","Timestamp":"2016-08-10T21:11:03.1298372Z","cat":"hat"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
+      Date: ['Wed, 10 Aug 2016 21:11:02 GMT']
+      ETag: [W/"datetime'2016-08-10T21%3A11%3A03.1298372Z'"]
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      X-Content-Type-Options: [nosniff]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json;odata=minimalmetadata]
+      Authorization: ['SharedKey vcrstorage674541728147:Kr+e2wcF6d4gQejAsGW9Wdd2pmM20BnRYuJoIaHFTJo=']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      DataServiceVersion: [3.0;NetFx]
+      If-Match: ['*']
+      MaxDataServiceVersion: ['3.0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [f30bea54-5f3e-11e6-abb9-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:11:05 GMT']
+      x-ms-version: ['2015-07-08']
+    method: DELETE
+    uri: https://dummystorage.table.core.windows.net/table1(PartitionKey='001',RowKey='001')
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Wed, 10 Aug 2016 21:11:03 GMT']
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      X-Content-Type-Options: [nosniff]
+      x-ms-version: ['2015-07-08']
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/json;odata=minimalmetadata]
+      Authorization: ['SharedKey vcrstorage674541728147:WHeBScY0l/KlTrwFeZXh1G4nrWl3ZUpI2JXzT4K9qhI=']
+      Connection: [keep-alive]
+      DataServiceVersion: [3.0;NetFx]
+      MaxDataServiceVersion: ['3.0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [f3312c10-5f3e-11e6-829f-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:11:05 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.table.core.windows.net/table1(PartitionKey='001',RowKey='001')
+  response:
+    body: {string: '{"odata.error":{"code":"ResourceNotFound","message":{"lang":"en-US","value":"The
+        specified resource does not exist.\nRequestId:661f88ed-0002-00ca-094b-f3a3bb000000\nTime:2016-08-10T21:11:04.5732694Z"}}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
+      Date: ['Wed, 10 Aug 2016 21:11:04 GMT']
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      X-Content-Type-Options: [nosniff]
+      x-ms-version: ['2015-07-08']
+    status: {code: 404, message: Not Found}
+- request:
+    body: null
+    headers:
+      Accept: [application/json;odata=minimalmetadata]
+      Authorization: ['SharedKey vcrstorage674541728147:zD34RcebuhOn9Ujtvgxhl7FJE3oNpVg3X7089mAlBSA=']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      DataServiceVersion: [3.0;NetFx]
+      MaxDataServiceVersion: ['3.0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [f35498ae-5f3e-11e6-b8cc-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:11:05 GMT']
+      x-ms-version: ['2015-07-08']
+    method: DELETE
+    uri: https://dummystorage.table.core.windows.net/Tables('table1')
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Wed, 10 Aug 2016 21:11:04 GMT']
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      X-Content-Type-Options: [nosniff]
+      x-ms-version: ['2015-07-08']
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/json;odata=nometadata]
+      Authorization: ['SharedKey vcrstorage674541728147:bQNA2VUA+dJZ2rd9mN3pH1Z1mswr2JedGb5bFOZSnWA=']
+      Connection: [keep-alive]
+      DataServiceVersion: [3.0;NetFx]
+      MaxDataServiceVersion: ['3.0']
+      User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
+      x-ms-client-request-id: [f37cc11e-5f3e-11e6-b939-a0b3ccf7272a]
+      x-ms-date: ['Wed, 10 Aug 2016 21:11:05 GMT']
+      x-ms-version: ['2015-07-08']
+    method: GET
+    uri: https://dummystorage.table.core.windows.net/Tables('table1')
+  response:
+    body: {string: '{"odata.error":{"code":"ResourceNotFound","message":{"lang":"en-US","value":"The
+        specified resource does not exist.\nRequestId:9b93d2d9-0002-0054-3e4b-f3dafc000000\nTime:2016-08-10T21:11:05.1321676Z"}}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json;odata=nometadata;streaming=true;charset=utf-8]
+      Date: ['Wed, 10 Aug 2016 21:11:05 GMT']
+      Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
+      X-Content-Type-Options: [nosniff]
+      x-ms-version: ['2015-07-08']
+    status: {code: 404, message: Not Found}
+version: 1


### PR DESCRIPTION
This PR adds the bulk of the commands required by issue #641 and #642. There will be a third PR that puts the finishing touches on certain commands across all four services. Known issues:

- `table batch` commands currently do not work
- `queue/table stats` commands require no parameters, but throw exceptions (possible service issue)
- `entity query` currently uses an OData filter. This may or may not be acceptable.
- `blob/file/table/queue generate-sas` commands will be addressed in the next PR.
- `blob/file/table/queue service-properties update` will be addressed, if possible, in the next PR.
