### PR TITLE
[Storage] Storage Updates Round 3

### DIFF
--- a/azure-cli.pyproj
+++ b/azure-cli.pyproj
@@ -71,6 +71,15 @@
     <Compile Include="command_modules\azure-cli-feedback\azure\__init__.py" />
     <Compile Include="command_modules\azure-cli-feedback\setup.py" />
     <Compile Include="azure\cli\utils\vcr_test_base.py" />
+    <Compile Include="command_modules\azure-cli-keyvault\azure\cli\command_modules\keyvault\custom.py" />
+    <Compile Include="command_modules\azure-cli-keyvault\azure\cli\command_modules\keyvault\generated.py" />
+    <Compile Include="command_modules\azure-cli-keyvault\azure\cli\command_modules\keyvault\tests\test_keyvault_commands.py" />
+    <Compile Include="command_modules\azure-cli-keyvault\azure\cli\command_modules\keyvault\tests\__init__.py" />
+    <Compile Include="command_modules\azure-cli-keyvault\azure\cli\command_modules\keyvault\_help.py" />
+    <Compile Include="command_modules\azure-cli-keyvault\azure\cli\command_modules\keyvault\_params.py" />
+    <Compile Include="command_modules\azure-cli-keyvault\azure\cli\command_modules\keyvault\_validators.py" />
+    <Compile Include="command_modules\azure-cli-keyvault\azure\cli\command_modules\keyvault\__init__.py" />
+    <Compile Include="command_modules\azure-cli-keyvault\setup.py" />
     <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_app_gateway\lib\app_gateway_creation_client.py" />
     <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_app_gateway\lib\credentials.py" />
     <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_app_gateway\lib\exceptions.py" />
@@ -607,6 +616,14 @@
     <Folder Include="command_modules\azure-cli-feedback\azure\cli\" />
     <Folder Include="command_modules\azure-cli-feedback\azure\cli\command_modules\" />
     <Folder Include="command_modules\azure-cli-feedback\azure\cli\command_modules\feedback\" />
+    <Folder Include="command_modules\azure-cli-keyvault\" />
+    <Folder Include="command_modules\azure-cli-keyvault\azure\" />
+    <Folder Include="command_modules\azure-cli-keyvault\azure\cli\" />
+    <Folder Include="command_modules\azure-cli-keyvault\azure\cli\command_modules\" />
+    <Folder Include="command_modules\azure-cli-keyvault\azure\cli\command_modules\keyvault\" />
+    <Folder Include="command_modules\azure-cli-keyvault\azure\cli\command_modules\keyvault\tests\" />
+    <Folder Include="command_modules\azure-cli-keyvault\azure\cli\command_modules\keyvault\tests\recordings\" />
+    <Folder Include="command_modules\azure-cli-keyvault\azure\cli\command_modules\keyvault\tests\__pycache__\" />
     <Folder Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_app_gateway\" />
     <Folder Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_app_gateway\lib\" />
     <Folder Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_app_gateway\lib\models\" />
@@ -739,6 +756,10 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="command_modules\azure-cli-component\requirements.txt" />
+    <Content Include="command_modules\azure-cli-keyvault\azure\cli\command_modules\keyvault\tests\recordings\test_key_vault_mgmt.yaml" />
+    <Content Include="command_modules\azure-cli-keyvault\azure\cli\command_modules\keyvault\tests\__pycache__\test_keyvault_commands.cpython-35.pyc" />
+    <Content Include="command_modules\azure-cli-keyvault\README.rst" />
+    <Content Include="command_modules\azure-cli-keyvault\requirements.txt" />
     <Content Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_app_gateway\azuredeploy.json" />
     <Content Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_app_gateway\azuredeploy_tests.md">
       <SubType>Code</SubType>

--- a/src/azure/cli/commands/__init__.py
+++ b/src/azure/cli/commands/__init__.py
@@ -58,10 +58,12 @@ class CliCommandArgument(object):
 
         # We'll do an early fault detection to find any instances where we have inconsistent
         # set of parameters for argparse
-        if not self.options_list and 'required' in self.options:
+        if not self.options_list and 'required' in self.options: # pylint: disable=access-member-before-definition
             raise ValueError(message="You can't specify both required and an options_list")
         if not self.options.get('dest', False):
             raise ValueError('Missing dest')
+        if not self.options_list: # pylint: disable=access-member-before-definition
+            self.options_list = ('--{}'.format(self.options['dest'].replace('_', '-')),)
 
     def __getattr__(self, name):
         if name in self._NAMED_ARGUMENTS:

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_factory.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_factory.py
@@ -26,7 +26,7 @@ No credentials specifed to access storage service. Please provide any of the fol
         option or AZURE_STORAGE_ACCOUNT environment variable)
 """
 
-def _get_data_service_client(service, name=None, key=None, connection_string=None, sas_token=None):
+def generic_data_service_factory(service, name=None, key=None, connection_string=None, sas_token=None):
     try:
         return get_data_service_client(service, name, key, connection_string, sas_token)
     except ValueError as val_exception:
@@ -39,7 +39,7 @@ def storage_client_factory(**_):
     return get_mgmt_service_client(StorageManagementClient)
 
 def file_data_service_factory(kwargs):
-    return _get_data_service_client(
+    return generic_data_service_factory(
         FileService,
         kwargs.pop('account_name', None),
         kwargs.pop('account_key', None),
@@ -49,7 +49,7 @@ def file_data_service_factory(kwargs):
 def blob_data_service_factory(kwargs):
     blob_type = kwargs.get('blob_type')
     blob_service = blob_types.get(blob_type, BlockBlobService)
-    return _get_data_service_client(
+    return generic_data_service_factory(
         blob_service,
         kwargs.pop('account_name', None),
         kwargs.pop('account_key', None),
@@ -57,7 +57,7 @@ def blob_data_service_factory(kwargs):
         sas_token=kwargs.pop('sas_token', None))
 
 def table_data_service_factory(kwargs):
-    return _get_data_service_client(
+    return generic_data_service_factory(
         TableService,
         kwargs.pop('account_name', None),
         kwargs.pop('account_key', None),
@@ -65,7 +65,7 @@ def table_data_service_factory(kwargs):
         sas_token=kwargs.pop('sas_token', None))
 
 def queue_data_service_factory(kwargs):
-    return _get_data_service_client(
+    return generic_data_service_factory(
         QueueService,
         kwargs.pop('account_name', None),
         kwargs.pop('account_key', None),

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_factory.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_factory.py
@@ -26,7 +26,8 @@ No credentials specifed to access storage service. Please provide any of the fol
         option or AZURE_STORAGE_ACCOUNT environment variable)
 """
 
-def generic_data_service_factory(service, name=None, key=None, connection_string=None, sas_token=None):
+def generic_data_service_factory(service, name=None, key=None, connection_string=None,
+                                 sas_token=None):
     try:
         return get_data_service_client(service, name, key, connection_string, sas_token)
     except ValueError as val_exception:

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
@@ -6,7 +6,6 @@
 # pylint: disable=line-too-long
 import argparse
 import os
-import urllib
 
 from six import u as unicode_string
 
@@ -23,15 +22,15 @@ from azure.storage.blob.models import ContentSettings as BlobContentSettings, Co
 from azure.storage.file import FileService
 from azure.storage.file.models import ContentSettings as FileContentSettings, SharePermissions, FilePermissions
 from azure.storage.table import TableService
-from azure.storage.table.models import TablePermissions
 from azure.storage.queue import QueueService
 from azure.storage.queue.models import QueuePermissions
 
 from ._validators import \
     (validate_datetime, validate_datetime_as_string, get_file_path_validator, validate_metadata,
-     get_permission_validator, get_permission_help_string, validate_resource_types,
-     validate_services, validate_ip_range, validate_entity, validate_select,
-     get_content_setting_validator, validate_datetime_as_string, validate_encryption,
+     get_permission_validator, table_permission_validator, get_permission_help_string,
+     validate_resource_types, validate_services, validate_ip_range, validate_entity,
+     validate_select,
+     get_content_setting_validator, validate_encryption,
      process_file_download_namespace, process_logging_update_namespace,
      process_metric_update_namespace, IgnoreAction)
 
@@ -333,18 +332,18 @@ register_cli_argument('storage account generate-sas', 'resource_types', help='Th
 register_cli_argument('storage account generate-sas', 'expiry', help='Specifies the UTC datetime (Y-m-d\'T\'H:M\'Z\') at which the SAS becomes invalid.', type=validate_datetime_as_string)
 register_cli_argument('storage account generate-sas', 'start', help='Specifies the UTC datetime (Y-m-d\'T\'H:M\'Z\') at which the SAS becomes valid. Defaults to the time of the request.', type=validate_datetime_as_string)
 
-help_format='The permissions the SAS grants. Allowed values: {}. Do not use if a stored access policy is referenced with --id that specifies this value. Can be combined.'
+help_format = 'The permissions the SAS grants. Allowed values: {}. Do not use if a stored access policy is referenced with --id that specifies this value. Can be combined.'
 register_cli_argument('storage account generate-sas', 'permission', options_list=('--permissions',), help='The permissions the SAS grants. Allowed values: {}. Can be combined.'.format(get_permission_help_string(AccountPermissions)), type=get_permission_validator(AccountPermissions))
 register_cli_argument('storage container generate-sas', 'permission', options_list=('--permissions',), help=help_format.format(get_permission_help_string(ContainerPermissions)), type=get_permission_validator(ContainerPermissions))
 register_cli_argument('storage blob generate-sas', 'permission', options_list=('--permissions',), help=help_format.format(get_permission_help_string(BlobPermissions),), type=get_permission_validator(BlobPermissions))
 register_cli_argument('storage share generate-sas', 'permission', options_list=('--permissions',), help=help_format.format(get_permission_help_string(SharePermissions)), type=get_permission_validator(SharePermissions))
 register_cli_argument('storage file generate-sas', 'permission', options_list=('--permissions',), help=help_format.format(get_permission_help_string(FilePermissions)), type=get_permission_validator(FilePermissions))
-register_cli_argument('storage table generate-sas', 'permission', options_list=('--permissions',), help=help_format.format(get_permission_help_string(TablePermissions)), type=get_permission_validator(TablePermissions))
+register_cli_argument('storage table generate-sas', 'permission', options_list=('--permissions',), help=help_format.format('(r)ead/query (a)dd (u)pdate (d)elete'), type=table_permission_validator)
 register_cli_argument('storage queue generate-sas', 'permission', options_list=('--permissions',), help=help_format.format(get_permission_help_string(QueuePermissions)), type=get_permission_validator(QueuePermissions))
 
 register_cli_argument('storage container policy', 'permission', options_list=('--permissions',), help='Allowed values: {}. Can be combined.'.format(get_permission_help_string(ContainerPermissions)), type=get_permission_validator(ContainerPermissions))
 register_cli_argument('storage share policy', 'permission', options_list=('--permissions',), help='Allowed values: {}. Can be combined.'.format(get_permission_help_string(SharePermissions)), type=get_permission_validator(SharePermissions))
-register_cli_argument('storage table policy', 'permission', options_list=('--permissions',), help='Allowed values: {}. Can be combined.'.format(get_permission_help_string(TablePermissions)), type=get_permission_validator(TablePermissions))
+register_cli_argument('storage table policy', 'permission', options_list=('--permissions',), help='Allowed values: {}. Can be combined.'.format('(r)ead/query (a)dd (u)pdate (d)elete'), type=table_permission_validator)
 register_cli_argument('storage queue policy', 'permission', options_list=('--permissions',), help='Allowed values: {}. Can be combined.'.format(get_permission_help_string(QueuePermissions)), type=get_permission_validator(QueuePermissions))
 
 register_cli_argument('storage logging show', 'services', help='The storage services from which to retrieve logging info: (b)lob (q)ueue (t)able. Can be combined.')

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
@@ -16,33 +16,48 @@ from azure.mgmt.storage import StorageManagementClient
 from azure.storage.models import ResourceTypes, Services
 from azure.storage.table import TablePermissions
 
+# region ACTIONS
+
 class IgnoreAction(argparse.Action): # pylint: disable=too-few-public-methods
     def __call__(self, parser, namespace, values, option_string=None):
         raise argparse.ArgumentError(None, 'unrecognized argument: {} {}'.format(
             option_string, values or ''))
 
-def get_permission_help_string(permission_class):
-    allowed_values = [x.lower() for x in dir(permission_class) if not x.startswith('__')]
-    return ' '.join(['({}){}'.format(x[0], x[1:]) for x in allowed_values])
+# endregion
 
-def get_permission_validator(permission_class):
+# region PARAMETER VALIDATORS
 
-    allowed_values = [x.lower() for x in dir(permission_class) if not x.startswith('__')]
-    allowed_string = ''.join(x[0] for x in allowed_values)
+def validate_client_parameters(namespace):
+    """ Retrieves storage connection parameters from environment variables and parses out
+    connection string into account name and key """
+    n = namespace
 
-    def validator(string):
-        if set(string) - set(allowed_string):
-            help_string = get_permission_help_string(permission_class)
-            raise ValueError('valid values are {} or a combination thereof.'.format(help_string))
-        return permission_class(_str=string)
-    return validator
+    if not n.connection_string:
+        n.connection_string = os.environ.get('AZURE_STORAGE_CONNECTION_STRING')
 
-def table_permission_validator(string):
-    """ A special case for table because the SDK associates the QUERY permission with 'r' """
-    if set(string) - set('raud'):
-        help_string = '(r)ead/query (a)dd (u)pdate (d)elete'
-        raise ValueError('valid values are {} or a combination thereof.'.format(help_string))
-    return TablePermissions(_str=string)
+    # if connection string supplied or in environment variables, extract account key and name
+    if n.connection_string:
+        conn_dict = validate_key_value_pairs(n.connection_string)
+        n.account_name = conn_dict['AccountName']
+        n.account_key = conn_dict['AccountKey']
+
+    # otherwise, simply try to retrieve the remaining variables from environment variables
+    if not n.account_name:
+        n.account_name = os.environ.get('AZURE_STORAGE_ACCOUNT')
+    if not n.account_key:
+        n.account_key = os.environ.get('AZURE_STORAGE_KEY')
+    if not n.sas_token:
+        n.sas_token = os.environ.get('AZURE_SAS_TOKEN')
+
+    # if account name is specified but no key, attempt to query
+    if n.account_name and not n.account_key:
+        scf = get_mgmt_service_client(StorageManagementClient)
+        acc_id = next((x for x in scf.storage_accounts.list() if x.name == n.account_name), None).id
+        if acc_id:
+            from azure.cli.commands.arm import parse_resource_id
+            rg = parse_resource_id(acc_id)['resource_group']
+            n.account_key = \
+                scf.storage_accounts.list_keys(rg, n.account_name).keys[0].value #pylint: disable=no-member
 
 def get_content_setting_validator(settings_class):
     def validator(namespace):
@@ -61,37 +76,6 @@ def get_content_setting_validator(settings_class):
         del namespace.content_md5,
         del namespace.content_cache_control
     return validator
-
-def process_logging_update_namespace(namespace):
-    services = namespace.services
-    if set(services) - set('bqt'):
-        raise ValueError('--services: valid values are (b)lob (q)ueue '
-                         '(t)able or a combination thereof (ex: bt).')
-    log = namespace.log
-    if set(log) - set('rwd'):
-        raise ValueError('--log: valid values are (r)ead (w)rite (d)elete '
-                         'or a combination thereof (ex: rw).')
-
-def process_metric_update_namespace(namespace):
-    namespace.hour = namespace.hour == 'enable'
-    namespace.minute = namespace.minute == 'enable'
-    namespace.api = namespace.api == 'enable' if namespace.api else None
-    if namespace.hour is None and namespace.minute is None:
-        raise argparse.ArgumentError(
-            None, 'incorrect usage: must specify --hour and/or --minute')
-    if (namespace.hour or namespace.minute) and namespace.api is None:
-        raise argparse.ArgumentError(
-            None, 'incorrect usage: specify --api when hour or minute metrics are enabled')
-
-def validate_datetime_as_string(string):
-    ''' Validates UTC datettime in format '%Y-%m-%d\'T\'%H:%M\'Z\''. '''
-    date_format = '%Y-%m-%dT%H:%MZ'
-    return datetime.strptime(string, date_format).strftime(date_format)
-
-def validate_datetime(string):
-    ''' Validates UTC datettime in format '%Y-%m-%d\'T\'%H:%M\'Z\''. '''
-    date_format = '%Y-%m-%dT%H:%MZ'
-    return datetime.strptime(string, date_format)
 
 def validate_encryption(namespace):
     ''' Builds up the encryption object for storage account operations based on the
@@ -140,68 +124,6 @@ def validate_entity(namespace):
     values = {key: cast_val(key, val) for key, val in values.items()}
     namespace.entity = values
 
-def validate_ip_range(string):
-    ''' Validates an IPv4 address or address range. '''
-    ip_format = r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}'
-    if not re.match("^{}$".format(ip_format), string):
-        if not re.match("^{}-{}$".format(ip_format, ip_format), string):
-            raise ValueError
-    return string
-
-def validate_metadata(namespace):
-    if namespace.metadata:
-        namespace.metadata = dict(x.split('=', 1) for x in namespace.metadata)
-
-def validate_resource_types(string):
-    ''' Validates that resource types string contains only a combination
-    of (s)ervice, (c)ontainer, (o)bject '''
-    if set(string) - set("sco"):
-        raise ValueError
-    return ResourceTypes(_str=''.join(set(string)))
-
-def validate_select(namespace):
-    if namespace.select:
-        namespace.select = ','.join(namespace.select)
-
-def validate_services(string):
-    ''' Validates that services string contains only a combination
-    of (b)lob, (q)ueue, (t)able, (f)ile '''
-    if set(string) - set("bqtf"):
-        raise ValueError
-    return Services(_str=''.join(set(string)))
-
-def validate_client_parameters(namespace):
-    """ Retrieves storage connection parameters from environment variables and parses out
-    connection string into account name and key """
-    n = namespace
-
-    if not n.connection_string:
-        n.connection_string = os.environ.get('AZURE_STORAGE_CONNECTION_STRING')
-
-    # if connection string supplied or in environment variables, extract account key and name
-    if n.connection_string:
-        conn_dict = validate_key_value_pairs(n.connection_string)
-        n.account_name = conn_dict['AccountName']
-        n.account_key = conn_dict['AccountKey']
-
-    # otherwise, simply try to retrieve the remaining variables from environment variables
-    if not n.account_name:
-        n.account_name = os.environ.get('AZURE_STORAGE_ACCOUNT')
-    if not n.account_key:
-        n.account_key = os.environ.get('AZURE_STORAGE_KEY')
-    if not n.sas_token:
-        n.sas_token = os.environ.get('AZURE_SAS_TOKEN')
-
-    # if account name is specified but no key, attempt to query
-    if n.account_name and not n.account_key:
-        scf = get_mgmt_service_client(StorageManagementClient)
-        acc_id = next((x for x in scf.storage_accounts.list() if x.name == n.account_name), None).id
-        if acc_id:
-            from azure.cli.commands.arm import parse_resource_id
-            rg = parse_resource_id(acc_id)['resource_group']
-            n.account_key = \
-                scf.storage_accounts.list_keys(rg, n.account_name).keys[0].value #pylint: disable=no-member
-
 def get_file_path_validator(default_file_param=None):
     """ Creates a namespace validator that splits out 'path' into 'directory_name' and 'file_name'.
     Allows another path-type parameter to be named which can supply a default filename. """
@@ -217,6 +139,44 @@ def get_file_path_validator(default_file_param=None):
         del namespace.path
     return validator
 
+def validate_metadata(namespace):
+    if namespace.metadata:
+        namespace.metadata = dict(x.split('=', 1) for x in namespace.metadata)
+
+def get_permission_help_string(permission_class):
+    allowed_values = [x.lower() for x in dir(permission_class) if not x.startswith('__')]
+    return ' '.join(['({}){}'.format(x[0], x[1:]) for x in allowed_values])
+
+def get_permission_validator(permission_class):
+
+    allowed_values = [x.lower() for x in dir(permission_class) if not x.startswith('__')]
+    allowed_string = ''.join(x[0] for x in allowed_values)
+
+    def validator(namespace):
+        if namespace.permission:
+            if set(namespace.permission) - set(allowed_string):
+                help_string = get_permission_help_string(permission_class)
+                raise ValueError(
+                    'valid values are {} or a combination thereof.'.format(help_string))
+            namespace.permission = permission_class(_str=namespace.permission)
+    return validator
+
+def table_permission_validator(namespace):
+    """ A special case for table because the SDK associates the QUERY permission with 'r' """
+    if namespace.permission:
+        if set(namespace.permission) - set('raud'):
+            help_string = '(r)ead/query (a)dd (u)pdate (d)elete'
+            raise ValueError('valid values are {} or a combination thereof.'.format(help_string))
+        namespace.permission = TablePermissions(_str=namespace.permission)
+
+def validate_select(namespace):
+    if namespace.select:
+        namespace.select = ','.join(namespace.select)
+
+# endregion
+
+# region COMMAND VALIDATORS
+
 def process_file_download_namespace(namespace):
 
     get_file_path_validator()(namespace)
@@ -225,6 +185,67 @@ def process_file_download_namespace(namespace):
     if not dest or os.path.isdir(dest):
         namespace.file_path = os.path.join(dest, namespace.file_name) \
             if dest else namespace.file_name
+
+def process_logging_update_namespace(namespace):
+    services = namespace.services
+    if set(services) - set('bqt'):
+        raise ValueError('--services: valid values are (b)lob (q)ueue '
+                         '(t)able or a combination thereof (ex: bt).')
+    log = namespace.log
+    if set(log) - set('rwd'):
+        raise ValueError('--log: valid values are (r)ead (w)rite (d)elete '
+                         'or a combination thereof (ex: rw).')
+
+def process_metric_update_namespace(namespace):
+    namespace.hour = namespace.hour == 'enable'
+    namespace.minute = namespace.minute == 'enable'
+    namespace.api = namespace.api == 'enable' if namespace.api else None
+    if namespace.hour is None and namespace.minute is None:
+        raise argparse.ArgumentError(
+            None, 'incorrect usage: must specify --hour and/or --minute')
+    if (namespace.hour or namespace.minute) and namespace.api is None:
+        raise argparse.ArgumentError(
+            None, 'incorrect usage: specify --api when hour or minute metrics are enabled')
+
+# endregion
+
+# region TYPES
+
+def datetime_string_type(string):
+    ''' Validates UTC datettime in format '%Y-%m-%d\'T\'%H:%M\'Z\''. '''
+    date_format = '%Y-%m-%dT%H:%MZ'
+    return datetime.strptime(string, date_format).strftime(date_format)
+
+def datetime_type(string):
+    ''' Validates UTC datettime in format '%Y-%m-%d\'T\'%H:%M\'Z\''. '''
+    date_format = '%Y-%m-%dT%H:%MZ'
+    return datetime.strptime(string, date_format)
+
+def ipv4_range_type(string):
+    ''' Validates an IPv4 address or address range. '''
+    ip_format = r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}'
+    if not re.match("^{}$".format(ip_format), string):
+        if not re.match("^{}-{}$".format(ip_format, ip_format), string):
+            raise ValueError
+    return string
+
+def resource_type_type(string):
+    ''' Validates that resource types string contains only a combination
+    of (s)ervice, (c)ontainer, (o)bject '''
+    if set(string) - set("sco"):
+        raise ValueError
+    return ResourceTypes(_str=''.join(set(string)))
+
+def services_type(string):
+    ''' Validates that services string contains only a combination
+    of (b)lob, (q)ueue, (t)able, (f)ile '''
+    if set(string) - set("bqtf"):
+        raise ValueError
+    return Services(_str=''.join(set(string)))
+
+# endregion
+
+# region TRANSFORMS
 
 def transform_acl_list_output(result):
     """ Transform to convert SDK output into a form that is more readily
@@ -248,11 +269,11 @@ def transform_cors_list_output(result):
             new_entry['Service'] = service_name
             service_name = ''
             new_entry['Rule'] = i + 1
-            new_entry['Methods'] = ', '.join((x for x in rule['allowedMethods']))
-            new_entry['Origins'] = ', '.join((x for x in rule['allowedOrigins']))
-            new_entry['Exposed Headers'] = ', '.join((x for x in rule['exposedHeaders']))
-            new_entry['Allowed Headers'] = ', '.join((x for x in rule['allowedHeaders']))
-            new_entry['Max Age (sec)'] = rule['maxAgeInSeconds']
+            new_entry['AllowedMethods'] = ', '.join((x for x in rule['allowedMethods']))
+            new_entry['AllowedOrigins'] = ', '.join((x for x in rule['allowedOrigins']))
+            new_entry['ExposedHeaders'] = ', '.join((x for x in rule['exposedHeaders']))
+            new_entry['AllowedHeaders'] = ', '.join((x for x in rule['allowedHeaders']))
+            new_entry['MaxAgeInSeconds'] = rule['maxAgeInSeconds']
             new_result.append(new_entry)
     return new_result
 
@@ -284,8 +305,8 @@ def transform_file_list_output(result):
             is_dir = True
         new_entry['Name'] = item_name
         new_entry['Type'] = 'dir' if is_dir else 'file'
-        new_entry['Size (bytes)'] = '' if is_dir else item['properties']['contentLength']
-        new_entry['Modified'] = item['properties']['lastModified']
+        new_entry['ContentLength'] = '' if is_dir else item['properties']['contentLength']
+        new_entry['LastModified'] = item['properties']['lastModified']
         new_result.append(new_entry)
     return sorted(new_result, key=lambda k: k['Name'])
 
@@ -297,7 +318,7 @@ def transform_logging_list_output(result):
         new_entry['Read'] = result[key]['read']
         new_entry['Write'] = result[key]['write']
         new_entry['Delete'] = result[key]['delete']
-        new_entry['Retain (Days)'] = result[key]['retentionPolicy']['days']
+        new_entry['RetentionPolicy'] = result[key]['retentionPolicy']['days']
         new_result.append(new_entry)
     return new_result
 
@@ -312,8 +333,8 @@ def transform_metrics_list_output(result):
             service_name = ''
             new_entry['Interval'] = interval
             new_entry['Enabled'] = item['enabled']
-            new_entry['Include APIs'] = item['includeApis']
-            new_entry['Retain (Days)'] = item['retentionPolicy']['days']
+            new_entry['IncludeApis'] = item['includeApis']
+            new_entry['RetentionPolicy)'] = item['retentionPolicy']['days']
             new_result.append(new_entry)
     return new_result
 
@@ -322,3 +343,5 @@ def transform_url(result):
     result = re.sub('//', '/', result)
     result = re.sub('/', '//', result, count=1)
     return result
+
+#endregion

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
@@ -235,6 +235,27 @@ def transform_acl_list_output(result):
         new_result.append(new_entry)
     return new_result
 
+def transform_file_list_output(result):
+    """ Transform to convert SDK file/dir list output to something that
+    more clearly distinguishes between files and directories. """
+    new_result = []
+
+    for item in result['items']:
+        new_entry = OrderedDict()
+        item_name = item['name']
+        try:
+            _ = item['properties']['contentLength']
+            is_dir = False
+        except KeyError:
+            item_name = '{}/'.format(item_name)
+            is_dir = True
+        new_entry['Name'] = item_name
+        new_entry['Type'] = 'dir' if is_dir else 'file'
+        new_entry['Size (bytes)'] = '' if is_dir else item['properties']['contentLength'] 
+        new_entry['Modified'] = item['properties']['lastModified']
+        new_result.append(new_entry)
+    return sorted(new_result, key=lambda k: k['Name'])
+
 def transform_url(result):
     """ Ensures the resulting URL string does not contain extra / characters """
     result = re.sub('//', '/', result)

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/custom.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/custom.py
@@ -8,13 +8,18 @@
 from __future__ import print_function
 from sys import stderr
 
+from azure.cli.commands.client_factory import get_data_service_client
+
+from azure.mgmt.storage.models import Kind
+from azure.storage.models import Logging, Metrics, CorsRule, RetentionPolicy
 from azure.storage.blob import BlockBlobService
+from azure.storage.blob.baseblobservice import BaseBlobService
 from azure.storage.file import FileService
 from azure.storage.table import TableService
 from azure.storage.queue import QueueService
-from azure.mgmt.storage.models import Kind
 
-from azure.cli.command_modules.storage._factory import storage_client_factory
+from azure.cli.command_modules.storage._factory import \
+    (storage_client_factory, generic_data_service_factory)
 from azure.cli._util import CLIError
 
 def _update_progress(current, total):
@@ -79,7 +84,7 @@ def create_storage_account(resource_group_name, account_name, sku, location,
         location=location,
         tags=tags,
         custom_domain=CustomDomain(custom_domain) if custom_domain else None,
-        encryption=Encryption(encryption) if encryption else None,
+        encryption=encryption,
         access_tier=AccessTier(access_tier) if access_tier else None)
     return scf.storage_accounts.create(resource_group_name, account_name, params)
 
@@ -94,28 +99,16 @@ def set_storage_account_properties(
         sku=Sku(sku) if sku else None,
         tags=tags,
         custom_domain=CustomDomain(custom_domain) if custom_domain else None,
-        encryption=Encryption(encryption) if encryption else None,
+        encryption=encryption,
         access_tier=AccessTier(access_tier) if access_tier else None)
     return scf.storage_accounts.update(resource_group_name, account_name, params)
 
 def upload_blob( # pylint: disable=too-many-locals
         client, container_name, blob_name, blob_type, file_path,
-        content_type=None, content_disposition=None,
-        content_encoding=None, content_language=None, content_md5=None,
-        content_cache_control=None, metadata=None, validate_content=False, maxsize_condition=None,
+        content_settings=None, metadata=None, validate_content=False, maxsize_condition=None,
         max_connections=2, max_retries=5, retry_wait=1, lease_id=None, if_modified_since=None,
         if_unmodified_since=None, if_match=None, if_none_match=None, timeout=None):
     '''Upload a blob to a container.'''
-    from azure.storage.blob import ContentSettings
-    content_settings = ContentSettings(
-        content_type=content_type,
-        content_disposition=content_disposition,
-        content_encoding=content_encoding,
-        content_language=content_language,
-        content_md5=content_md5,
-        cache_control=content_cache_control
-    )
-
     def upload_append_blob():
         if not client.exists(container_name, blob_name):
             client.create_blob(
@@ -243,3 +236,164 @@ def insert_table_entity(client, table_name, entity, if_exists='fail', timeout=No
     else:
         raise CLIError("Unrecognized value '{}' for --if-exists".format(if_exists))
 
+class ServiceProperties(object):
+
+    def __init__(self, name, service):
+
+        self.name = name
+        self.service = service
+        self.client = None
+
+    def init_client(self, account_name=None, account_key=None, connection_string=None,
+                    sas_token=None):
+        if not self.client:
+            self.client = generic_data_service_factory(
+                self.service, account_name, account_key, connection_string, sas_token)
+
+    def get_service_properties(self):
+        if not self.client:
+            raise CLIError('Must call init_client before attempting get_service_properties!')
+        return getattr(self.client, 'get_{}_service_properties'.format(self.name))
+
+    def set_service_properties(self):
+        if not self.client:
+            raise CLIError('Must call init_client before attempting set_service_properties!')
+        return getattr(self.client, 'set_{}_service_properties'.format(self.name))
+
+    def get_logging(self, account_name=None, account_key=None, connection_string=None,
+                    sas_token=None, timeout=None):
+        self.init_client(account_name, account_key, connection_string, sas_token)
+        return self.get_service_properties()(timeout=timeout).__dict__['logging']
+
+    def set_logging(self, read, write, delete, retention, account_name=None, account_key=None,
+                    connection_string=None, sas_token=None, timeout=None):
+        self.init_client(account_name, account_key, connection_string, sas_token)
+        retention_policy = RetentionPolicy(
+            enabled = retention != 0,
+            days = retention
+        )
+        logging = Logging(delete, read, write, retention_policy)
+        self.set_service_properties()(logging=logging, timeout=timeout)
+        return self.get_service_properties()(timeout=timeout).__dict__['logging']
+
+    def get_cors(self, account_name=None, account_key=None, connection_string=None,
+                    sas_token=None, timeout=None):
+        self.init_client(account_name, account_key, connection_string, sas_token)
+        return self.get_service_properties()(timeout=timeout).__dict__['cors']
+
+    def add_cors(self, origins, methods, max_age, exposed_headers=None, allowed_headers=None,
+                 account_name=None, account_key=None, connection_string=None, sas_token=None,
+                 timeout=None):
+        cors = self.get_cors(account_name, account_key, connection_string, sas_token, timeout)
+        new_rule = CorsRule(origins, methods, max_age, exposed_headers, allowed_headers)
+        cors.append(new_rule)
+        return self.set_service_properties()(cors=cors, timeout=timeout)
+
+    def clear_cors(self, account_name=None, account_key=None, connection_string=None,
+                   sas_token=None, timeout=None):
+        self.init_client(account_name, account_key, connection_string, sas_token)
+        return self.set_service_properties()(cors=[], timeout=timeout)
+
+    def get_metrics(self, interval, account_name=None, account_key=None, connection_string=None,
+                    sas_token=None, timeout=None):
+        self.init_client(account_name, account_key, connection_string, sas_token)
+        props = self.get_service_properties()(timeout=timeout)
+        metrics = {}
+        if interval == 'both':
+            metrics['hour'] = props.__dict__['hour_metrics']
+            metrics['minute'] = props.__dict__['minute_metrics']
+        else:
+            metrics = props.__dict__['{}_metrics'.format(interval)]
+        return metrics
+
+    def set_metrics(self, retention, hour, minute, api=None, account_name=None, account_key=None,
+            connection_string=None, sas_token=None, timeout=None):
+        self.init_client(account_name, account_key, connection_string, sas_token)
+        retention_policy = RetentionPolicy(
+            enabled = retention != 0,
+            days = retention
+        )
+        hour_metrics = Metrics(hour, api, retention_policy) if hour is not None else None
+        minute_metrics = Metrics(minute, api, retention_policy) if minute is not None else None
+        self.set_service_properties()(
+            hour_metrics=hour_metrics, minute_metrics=minute_metrics, timeout=timeout)
+        props = self.get_service_properties()(timeout=timeout)
+        metrics = {}
+        metrics['hour'] = props.__dict__['hour_metrics']
+        metrics['minute'] = props.__dict__['minute_metrics']
+        return metrics
+
+SERVICES = {
+    'b': ServiceProperties('blob', BaseBlobService),
+    'f': ServiceProperties('file', FileService),
+    'q': ServiceProperties('queue', QueueService),
+    't': ServiceProperties('table', TableService)
+}
+
+def list_cors(services='bfqt', account_name=None, account_key=None, connection_string=None,
+             sas_token=None, timeout=None):
+    results = {}
+    for character in services:
+        properties = SERVICES[character]
+        results[properties.name] = properties.get_cors(
+            account_name, account_key, connection_string, sas_token, timeout)
+    return results
+
+def add_cors(services, origins, methods, max_age=0, exposed_headers=None, allowed_headers=None,
+             account_name=None, account_key=None, connection_string=None, sas_token=None,
+             timeout=None):
+    results = {}
+    for character in services:
+        properties = SERVICES[character]
+        results[properties.name] = properties.add_cors(
+            origins, methods, max_age, exposed_headers, allowed_headers, account_name, account_key,
+            connection_string, sas_token, timeout)
+    return results
+
+def clear_cors(services, account_name=None, account_key=None, connection_string=None,
+                sas_token=None, timeout=None):
+    results = {}
+    for character in services:
+        properties = SERVICES[character]
+        results[properties.name] = properties.clear_cors(
+            account_name, account_key, connection_string, sas_token, timeout)
+    return results
+
+
+def set_logging(services, log, retention, account_name=None, account_key=None,
+                connection_string=None, sas_token=None, timeout=None):
+    results = {}
+    for character in services:
+        properties = SERVICES[character]
+        results[properties.name] = properties.set_logging(
+            'r' in log, 'w' in log, 'd' in log, retention, account_name, account_key,
+            connection_string, sas_token, timeout)
+    return results
+
+def set_metrics(services, retention, hour=None, minute=None, api=None, account_name=None,
+                account_key=None, connection_string=None, sas_token=None, timeout=None):
+    results = {}
+    for character in services:
+        properties = SERVICES[character]
+        results[properties.name] = properties.set_metrics(
+            retention, hour, minute, api, account_name, account_key, connection_string,
+            sas_token, timeout)
+    return results
+
+def get_logging(services='bqt', account_name=None, account_key=None, connection_string=None,
+                sas_token=None, timeout=None):
+    results = {}
+    for character in services:
+        properties = SERVICES[character]
+        results[properties.name] = properties.get_logging(
+            account_name, account_key, connection_string, sas_token, timeout)
+    return results
+
+def get_metrics(services='bfqt', interval='both', account_name=None, account_key=None,
+                connection_string=None, sas_token=None, timeout=None):
+    results = {}
+    for character in services:
+        properties = SERVICES[character]
+        results[properties.name] = properties.get_metrics(
+            interval, account_name, account_key, connection_string, sas_token, timeout)
+    return results

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/custom.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/custom.py
@@ -8,8 +8,6 @@
 from __future__ import print_function
 from sys import stderr
 
-from azure.cli.commands.client_factory import get_data_service_client
-
 from azure.mgmt.storage.models import Kind
 from azure.storage.models import Logging, Metrics, CorsRule, RetentionPolicy
 from azure.storage.blob import BlockBlobService
@@ -269,15 +267,14 @@ class ServiceProperties(object):
                     connection_string=None, sas_token=None, timeout=None):
         self.init_client(account_name, account_key, connection_string, sas_token)
         retention_policy = RetentionPolicy(
-            enabled = retention != 0,
-            days = retention
+            enabled=retention != 0,
+            days=retention
         )
         logging = Logging(delete, read, write, retention_policy)
-        self.set_service_properties()(logging=logging, timeout=timeout)
-        return self.get_service_properties()(timeout=timeout).__dict__['logging']
+        return self.set_service_properties()(logging=logging, timeout=timeout)
 
     def get_cors(self, account_name=None, account_key=None, connection_string=None,
-                    sas_token=None, timeout=None):
+                 sas_token=None, timeout=None):
         self.init_client(account_name, account_key, connection_string, sas_token)
         return self.get_service_properties()(timeout=timeout).__dict__['cors']
 
@@ -303,25 +300,20 @@ class ServiceProperties(object):
             metrics['hour'] = props.__dict__['hour_metrics']
             metrics['minute'] = props.__dict__['minute_metrics']
         else:
-            metrics = props.__dict__['{}_metrics'.format(interval)]
+            metrics[interval] = props.__dict__['{}_metrics'.format(interval)]
         return metrics
 
     def set_metrics(self, retention, hour, minute, api=None, account_name=None, account_key=None,
-            connection_string=None, sas_token=None, timeout=None):
+                    connection_string=None, sas_token=None, timeout=None):
         self.init_client(account_name, account_key, connection_string, sas_token)
         retention_policy = RetentionPolicy(
-            enabled = retention != 0,
-            days = retention
+            enabled=retention != 0,
+            days=retention
         )
         hour_metrics = Metrics(hour, api, retention_policy) if hour is not None else None
         minute_metrics = Metrics(minute, api, retention_policy) if minute is not None else None
-        self.set_service_properties()(
+        return self.set_service_properties()(
             hour_metrics=hour_metrics, minute_metrics=minute_metrics, timeout=timeout)
-        props = self.get_service_properties()(timeout=timeout)
-        metrics = {}
-        metrics['hour'] = props.__dict__['hour_metrics']
-        metrics['minute'] = props.__dict__['minute_metrics']
-        return metrics
 
 SERVICES = {
     'b': ServiceProperties('blob', BaseBlobService),
@@ -331,7 +323,7 @@ SERVICES = {
 }
 
 def list_cors(services='bfqt', account_name=None, account_key=None, connection_string=None,
-             sas_token=None, timeout=None):
+              sas_token=None, timeout=None):
     results = {}
     for character in services:
         properties = SERVICES[character]
@@ -342,43 +334,39 @@ def list_cors(services='bfqt', account_name=None, account_key=None, connection_s
 def add_cors(services, origins, methods, max_age=0, exposed_headers=None, allowed_headers=None,
              account_name=None, account_key=None, connection_string=None, sas_token=None,
              timeout=None):
-    results = {}
     for character in services:
         properties = SERVICES[character]
-        results[properties.name] = properties.add_cors(
+        properties.add_cors(
             origins, methods, max_age, exposed_headers, allowed_headers, account_name, account_key,
             connection_string, sas_token, timeout)
-    return results
+    return None
 
 def clear_cors(services, account_name=None, account_key=None, connection_string=None,
-                sas_token=None, timeout=None):
-    results = {}
+               sas_token=None, timeout=None):
     for character in services:
         properties = SERVICES[character]
-        results[properties.name] = properties.clear_cors(
+        properties.clear_cors(
             account_name, account_key, connection_string, sas_token, timeout)
-    return results
+    return None
 
 
 def set_logging(services, log, retention, account_name=None, account_key=None,
                 connection_string=None, sas_token=None, timeout=None):
-    results = {}
     for character in services:
         properties = SERVICES[character]
-        results[properties.name] = properties.set_logging(
+        properties.set_logging(
             'r' in log, 'w' in log, 'd' in log, retention, account_name, account_key,
             connection_string, sas_token, timeout)
-    return results
+    return None
 
 def set_metrics(services, retention, hour=None, minute=None, api=None, account_name=None,
                 account_key=None, connection_string=None, sas_token=None, timeout=None):
-    results = {}
     for character in services:
         properties = SERVICES[character]
-        results[properties.name] = properties.set_metrics(
+        properties.set_metrics(
             retention, hour, minute, api, account_name, account_key, connection_string,
             sas_token, timeout)
-    return results
+    return None
 
 def get_logging(services='bqt', account_name=None, account_key=None, connection_string=None,
                 sas_token=None, timeout=None):

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/generated.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/generated.py
@@ -27,7 +27,8 @@ from azure.cli.command_modules.storage.custom import \
      create_acl_policy, delete_acl_policy, list_acl_policies, set_acl_policy,
      insert_table_entity, list_cors, add_cors, clear_cors,
      get_logging, set_logging, get_metrics, set_metrics)
-from azure.cli.command_modules.storage._validators import transform_acl_list_output, transform_url
+from azure.cli.command_modules.storage._validators import \
+    (transform_acl_list_output, transform_file_list_output, transform_url)
 
 # storage account commands
 factory = lambda kwargs: storage_client_factory().storage_accounts
@@ -89,7 +90,6 @@ cli_storage_data_plane_command('storage blob copy cancel', BlockBlobService.abor
 # share commands
 factory = file_data_service_factory
 cli_storage_data_plane_command('storage share list', FileService.list_shares, factory, simple_output_query='items[*].{Name:name,"Quota (GB)":properties.quota} | sort_by(@, &Name)')
-cli_storage_data_plane_command('storage share contents', FileService.list_directories_and_files, factory, simple_output_query='items[*].{Name:name, Size:properties.contentLength} | sort_by(@, &Name)')
 cli_storage_data_plane_command('storage share create', FileService.create_share, factory)
 cli_storage_data_plane_command('storage share delete', FileService.delete_share, factory)
 cli_storage_data_plane_command('storage share generate-sas', FileService.generate_share_shared_access_signature, factory)
@@ -114,6 +114,7 @@ cli_storage_data_plane_command('storage directory metadata show', FileService.ge
 cli_storage_data_plane_command('storage directory metadata update', FileService.set_directory_metadata, factory)
 
 # file commands
+cli_storage_data_plane_command('storage file list', FileService.list_directories_and_files, factory, simple_output_query=transform_file_list_output)
 cli_storage_data_plane_command('storage file delete', FileService.delete_file, factory)
 cli_storage_data_plane_command('storage file resize', FileService.resize_file, factory)
 cli_storage_data_plane_command('storage file url', FileService.make_file_url, factory, transform=transform_url)

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/generated.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/generated.py
@@ -28,7 +28,9 @@ from azure.cli.command_modules.storage.custom import \
      insert_table_entity, list_cors, add_cors, clear_cors,
      get_logging, set_logging, get_metrics, set_metrics)
 from azure.cli.command_modules.storage._validators import \
-    (transform_acl_list_output, transform_file_list_output, transform_url)
+    (transform_acl_list_output, transform_cors_list_output, transform_entity_query_output,
+     transform_file_list_output, transform_logging_list_output, transform_metrics_list_output,
+     transform_url)
 
 # storage account commands
 factory = lambda kwargs: storage_client_factory().storage_accounts
@@ -146,7 +148,7 @@ cli_storage_data_plane_command('storage table batch commit', TableService.commit
 cli_storage_data_plane_command('storage table batch create', TableService.batch, factory)
 
 # table entity commands
-cli_storage_data_plane_command('storage entity query', TableService.query_entities, factory)
+cli_storage_data_plane_command('storage entity query', TableService.query_entities, factory, simple_output_query=transform_entity_query_output)
 cli_storage_data_plane_command('storage entity show', TableService.get_entity, factory)
 cli_storage_data_plane_command('storage entity insert', insert_table_entity, factory)
 cli_storage_data_plane_command('storage entity replace', TableService.update_entity, factory)
@@ -178,14 +180,14 @@ cli_storage_data_plane_command('storage message clear', QueueService.clear_messa
 cli_storage_data_plane_command('storage message update', QueueService.update_message, factory)
 
 # cors commands
-cli_storage_data_plane_command('storage cors list', list_cors, None)
+cli_storage_data_plane_command('storage cors list', list_cors, None, simple_output_query=transform_cors_list_output)
 cli_storage_data_plane_command('storage cors add', add_cors, None)
 cli_storage_data_plane_command('storage cors clear', clear_cors, None)
 
 # logging commands
-cli_storage_data_plane_command('storage logging show', get_logging, None)
+cli_storage_data_plane_command('storage logging show', get_logging, None, simple_output_query=transform_logging_list_output)
 cli_storage_data_plane_command('storage logging update', set_logging, None)
 
 # metrics commands
-cli_storage_data_plane_command('storage metrics show', get_metrics, None)
+cli_storage_data_plane_command('storage metrics show', get_metrics, None, simple_output_query=transform_metrics_list_output)
 cli_storage_data_plane_command('storage metrics update', set_metrics, None)

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/generated.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/generated.py
@@ -25,7 +25,8 @@ from azure.cli.command_modules.storage.custom import \
      set_storage_account_properties, show_storage_account_connection_string,
      renew_storage_account_keys, upload_blob, get_acl_policy,
      create_acl_policy, delete_acl_policy, list_acl_policies, set_acl_policy,
-     insert_table_entity)
+     insert_table_entity, list_cors, add_cors, clear_cors,
+     get_logging, set_logging, get_metrics, set_metrics)
 from azure.cli.command_modules.storage._validators import transform_acl_list_output, transform_url
 
 # storage account commands
@@ -74,10 +75,9 @@ cli_storage_data_plane_command('storage blob update', BlockBlobService.set_blob_
 cli_storage_data_plane_command('storage blob exists', BaseBlobService.exists, factory)
 cli_storage_data_plane_command('storage blob download', BaseBlobService.get_blob_to_path, factory)
 cli_storage_data_plane_command('storage blob upload', upload_blob, factory)
-cli_storage_data_plane_command('storage blob service-properties show', BlockBlobService.get_blob_service_properties, factory)
-cli_storage_data_plane_command('storage blob service-properties update', BlockBlobService.set_blob_service_properties, factory)
 cli_storage_data_plane_command('storage blob metadata show', BlockBlobService.get_blob_metadata, factory)
 cli_storage_data_plane_command('storage blob metadata update', BlockBlobService.set_blob_metadata, factory)
+cli_storage_data_plane_command('storage blob service-properties show', BaseBlobService.get_blob_service_properties, factory)
 cli_storage_data_plane_command('storage blob lease acquire', BlockBlobService.acquire_blob_lease, factory)
 cli_storage_data_plane_command('storage blob lease renew', BlockBlobService.renew_blob_lease, factory)
 cli_storage_data_plane_command('storage blob lease release', BlockBlobService.release_blob_lease, factory)
@@ -125,8 +125,6 @@ cli_storage_data_plane_command('storage file download', FileService.get_file_to_
 cli_storage_data_plane_command('storage file upload', FileService.create_file_from_path, factory)
 cli_storage_data_plane_command('storage file metadata show', FileService.get_file_metadata, factory)
 cli_storage_data_plane_command('storage file metadata update', FileService.set_file_metadata, factory)
-cli_storage_data_plane_command('storage file service-properties show', FileService.get_file_service_properties, factory)
-cli_storage_data_plane_command('storage file service-properties update', FileService.set_file_service_properties, factory)
 cli_storage_data_plane_command('storage file copy start', FileService.copy_file, factory)
 cli_storage_data_plane_command('storage file copy cancel', FileService.abort_copy_file, factory)
 
@@ -134,8 +132,6 @@ cli_storage_data_plane_command('storage file copy cancel', FileService.abort_cop
 factory = table_data_service_factory
 cli_storage_data_plane_command('storage table generate-sas', TableService.generate_table_shared_access_signature, factory)
 cli_storage_data_plane_command('storage table stats', TableService.get_table_service_stats, factory)
-cli_storage_data_plane_command('storage table service-properties show', TableService.get_table_service_properties, factory)
-cli_storage_data_plane_command('storage table service-properties update', TableService.set_table_service_properties, factory)
 cli_storage_data_plane_command('storage table list', TableService.list_tables, factory, simple_output_query='items[*].{Name:name} | sort_by(@, &Name)')
 cli_storage_data_plane_command('storage table create', TableService.create_table, factory)
 cli_storage_data_plane_command('storage table exists', TableService.exists, factory)
@@ -160,8 +156,6 @@ cli_storage_data_plane_command('storage entity delete', TableService.delete_enti
 factory = queue_data_service_factory
 cli_storage_data_plane_command('storage queue generate-sas', QueueService.generate_queue_shared_access_signature, factory)
 cli_storage_data_plane_command('storage queue stats', QueueService.get_queue_service_stats, factory)
-cli_storage_data_plane_command('storage queue service-properties show', QueueService.get_queue_service_properties, factory)
-cli_storage_data_plane_command('storage queue service-properties update', QueueService.set_queue_service_properties, factory)
 cli_storage_data_plane_command('storage queue list', QueueService.list_queues, factory, simple_output_query='items[*].{Name:name} | sort_by(@, &Name)')
 cli_storage_data_plane_command('storage queue create', QueueService.create_queue, factory)
 cli_storage_data_plane_command('storage queue delete', QueueService.delete_queue, factory)
@@ -181,3 +175,16 @@ cli_storage_data_plane_command('storage message peek', QueueService.peek_message
 cli_storage_data_plane_command('storage message delete', QueueService.delete_message, factory)
 cli_storage_data_plane_command('storage message clear', QueueService.clear_messages, factory)
 cli_storage_data_plane_command('storage message update', QueueService.update_message, factory)
+
+# cors commands
+cli_storage_data_plane_command('storage cors list', list_cors, None)
+cli_storage_data_plane_command('storage cors add', add_cors, None)
+cli_storage_data_plane_command('storage cors clear', clear_cors, None)
+
+# logging commands
+cli_storage_data_plane_command('storage logging show', get_logging, None)
+cli_storage_data_plane_command('storage logging update', set_logging, None)
+
+# metrics commands
+cli_storage_data_plane_command('storage metrics show', get_metrics, None)
+cli_storage_data_plane_command('storage metrics update', set_metrics, None)

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_blob_acl_scenario.yaml
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_blob_acl_scenario.yaml
@@ -4,7 +4,7 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDcwNzc3MTE5LCJuYmYiOjE0NzA3NzcxMTksImV4cCI6MTQ3MDc4MTAxOSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6NzIwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.jXqDMpx2zNxU3RceHO6Uxjef0WrH0--YyjQhISga0m7RMlNi87VJIfQgG8gb7nQHwzEXeCSFBrJ5exs0Oya7sggHlgl7xxTn0gu33XHG5Sg4CZJsKymygx1qHG7SfN843zPVpG5t9EzXn_xQZl8i4E97D-4cTOCVUUiUdd_8p3SgehAhQ3rjvuqrOHBAoq8BY3foJrRYgpEEfHxyCXHoTt7H0e9JnF5Gy-ANGCr3oCQxa6J6ks4Z51GmVkoTm4ilsEuk3Ox6T_kh1eWZwXx04_lVDR1wqoo66qSVSci27BsRzD2fnk0OFqlK5LKAV6IiaaO7HShWg3zU-I2ZDU5jaw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDcxMjgyNDA1LCJuYmYiOjE0NzEyODI0MDUsImV4cCI6MTQ3MTI4NjMwNSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6NzIwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjEuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.VGKXsuHHplz2RKW1PolZIRGSsQwxExx9UVzCkSoS1wKER27wwmXNcBM4dFN5SZLsrwRHH7pVmHPCKUEEtFb0Ae1OnsNrOag7yaH9rAqkXlMgmymWHnBWULXKwb1Q8iJJLDfBElavEUwHOIKfJGQAtYdJ_XPon_imVLATcg_dlX0dS4ixyrbvKbo3L17GzyUHsMbgy0_S2LpuC4JK0h__s_Ujl5HYmf9n2rDZzc7LOWA8VuQhAGnsqWkPA4igoyVlc36YeBlkYsd8DSkhhXRTkIOpxogXZuovN6ikUifyHWzB5PNvHs0gHLaoQPQnGS5aa-UdNc19zXfi4Iqw2RiqPQ]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
@@ -12,7 +12,7 @@ interactions:
           msrest_azure/0.4.1 storagemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [7a5525b4-5e77-11e6-8e07-a0b3ccf7272a]
+      x-ms-client-request-id: [74437c68-6313-11e6-a82a-a0b3ccf7272a]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_blob_acl_scenario/providers/Microsoft.Storage/storageAccounts/dummystorage.listKeys?api-version=2016-01-01
   response:
@@ -20,64 +20,64 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR2/z
-        6+ajR9/jX15ki/yjR/ht96PRR6u8XhRNU1RLavDRs3VZ0oeXWblGm+vvLj5f/T7XF59OHz7bOX0w
-        vT59Uv3kk51PH04uf9FPf7pz+nv/5PGnF19++urZ6cmXP1h/9e7uvQf3ltXq/CenL75aXfxel7/P
-        yS+6eDI/+M6Xk9NXOycnF5flwcNPfuKzzz76JaMOKnvU60ZU6jefvH7dls+/+/b3+fx4Ubx5cS+7
-        29z7dOfBerpaPl8sdt7evX56VizWB9+d7mSn57/Xq98n+2LvJ1bzl7/3/puHZ68vfvLq6foni93s
-        5fmz1e6DT3/q7evPL4+Byvd/SfL/APs+cz8hAQAA
+        6+ajR9/jX15ki/yjR/ht96PRR6u8XhRNU1RLavDRs3VZ0oeXWblGm5PJT87ufZV/+vrzz+82+1+c
+        TX+vavWLXhW7yyfT+pMv9l6cfnH3J3+y+e5i9Xt/enX6tPl9XuzmD1/uNT+4WL66+5NPP/2Ji28X
+        F9VP3fu9n30++WL6k79X/nz3xZft8WefffRLRh1U9qjXjah8+4vv3M+y50/ePX/z1bPm7Kc+/clP
+        7r+efOf3Objc/73fzn5icW/vpz69//u8XP3eD778wZPZg69OT776RffqB7vl5dnJ8vXBw/XkJ37i
+        k8mnJz9dV8uf2Lt8dfoTk9dPLoDK939J8v8AUbwZiCEBAAA=
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Tue, 09 Aug 2016 21:23:11 GMT']
+      Date: ['Mon, 15 Aug 2016 18:09:47 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1193']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage928507519704:uvXlD63fEJQIcxNM0xpUF1410+hVap+YZ32oo8RMf+Y=']
+      Authorization: ['SharedKey vcrstorage692046317547:4vJllRUxsLIVVoNg96+emKbqCc0QlRZrWiTXf+mIQZk=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [7a819488-5e77-11e6-9195-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:23:13 GMT']
+      x-ms-client-request-id: [74891eb0-6313-11e6-ace0-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:09:49 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
+    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?restype=container&comp=acl
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers\
         \ />"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Tue, 09 Aug 2016 21:23:11 GMT']
-      ETag: ['"0x8D3C09B5D9587E5"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:23:11 GMT']
+      Date: ['Mon, 15 Aug 2016 18:09:48 GMT']
+      ETag: ['"0x8D3C5375798AEC4"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:09:47 GMT']
       Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage928507519704:DPJrabV+PAWqdM1Qj6AGkKS0KwCNTX4wcoax8+8vJGs=']
+      Authorization: ['SharedKey vcrstorage692046317547:qEcYlndMh3ABe8VZJvguzgcJW2wPnIoEcJRB6oNHQXY=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [7aa2ddf8-5e77-11e6-9249-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:23:13 GMT']
+      x-ms-client-request-id: [74ae21be-6313-11e6-9a91-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:09:49 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
+    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?restype=container&comp=acl
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers\
         \ />"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Tue, 09 Aug 2016 21:23:13 GMT']
-      ETag: ['"0x8D3C09B5D9587E5"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:23:11 GMT']
+      Date: ['Mon, 15 Aug 2016 18:09:48 GMT']
+      ETag: ['"0x8D3C5375798AEC4"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:09:47 GMT']
       Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
@@ -88,42 +88,42 @@ interactions:
       bj5sPC9QZXJtaXNzaW9uPjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRlbnRpZmllcj48L1NpZ25l
       ZElkZW50aWZpZXJzPg==
     headers:
-      Authorization: ['SharedKey vcrstorage928507519704:LciWcsxYnQr2yDZy5pMo8aPnfNisccBxQyjLpL0c014=']
+      Authorization: ['SharedKey vcrstorage692046317547:5hrvhf9N1TScMh3Rm5xc2YjW1WCLwWUzagyK1RVaouo=']
       Connection: [keep-alive]
       Content-Length: ['184']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [7ab753e8-5e77-11e6-8036-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:23:13 GMT']
+      x-ms-client-request-id: [74c33d24-6313-11e6-bf22-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:09:49 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
+    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?restype=container&comp=acl
   response:
     body: {string: ''}
     headers:
-      Date: ['Tue, 09 Aug 2016 21:23:13 GMT']
-      ETag: ['"0x8D3C09B5E5DB293"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:23:12 GMT']
+      Date: ['Mon, 15 Aug 2016 18:09:48 GMT']
+      ETag: ['"0x8D3C537587AA855"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:09:48 GMT']
       Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage928507519704:xeTUm8Tjr/xUMkdG+kcXz26ZEPsa5Mh1T2y//qYzZKc=']
+      Authorization: ['SharedKey vcrstorage692046317547:2CbHMgz025aLSTjV+WpzMdvs0NKy4ioJ2GPNoFntBNM=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [7acbc9d8-5e77-11e6-a546-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:23:13 GMT']
+      x-ms-client-request-id: [74d9e736-6313-11e6-9742-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:09:49 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
+    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?restype=container&comp=acl
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Tue, 09 Aug 2016 21:23:11 GMT']
-      ETag: ['"0x8D3C09B5E5DB293"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:23:12 GMT']
+      Date: ['Mon, 15 Aug 2016 18:09:48 GMT']
+      ETag: ['"0x8D3C537587AA855"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:09:48 GMT']
       Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
@@ -136,375 +136,375 @@ interactions:
       MDA6MDBaPC9TdGFydD48L0FjY2Vzc1BvbGljeT48L1NpZ25lZElkZW50aWZpZXI+PC9TaWduZWRJ
       ZGVudGlmaWVycz4=
     headers:
-      Authorization: ['SharedKey vcrstorage928507519704:1Qrq6T+KXiSkYi1LNnyLdFc+O5dN3TwjhOWYKZ23xAA=']
+      Authorization: ['SharedKey vcrstorage692046317547:F8LmbNRUkoXdO1RuvkWs4RrZJqqdsiSja7lCy6420oM=']
       Connection: [keep-alive]
       Content-Length: ['296']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [7ae34d90-5e77-11e6-9bad-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:23:13 GMT']
+      x-ms-client-request-id: [74f0f9de-6313-11e6-b8ea-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:09:49 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
+    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?restype=container&comp=acl
   response:
     body: {string: ''}
     headers:
-      Date: ['Tue, 09 Aug 2016 21:23:11 GMT']
-      ETag: ['"0x8D3C09B5E895CBB"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:23:12 GMT']
+      Date: ['Mon, 15 Aug 2016 18:09:48 GMT']
+      ETag: ['"0x8D3C53758A87A65"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:09:49 GMT']
       Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage928507519704:9PslgiCaKmvkl4PSTIRGXjeIKgVOOpES5JGeqwErBJI=']
+      Authorization: ['SharedKey vcrstorage692046317547:GYULi6hDPTi0B74EhOlVNQSb1ib92Mc5Suw3YsNIano=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [7af2e0a4-5e77-11e6-a1e9-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:23:13 GMT']
+      x-ms-client-request-id: [75076ec0-6313-11e6-b3c2-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:09:50 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
+    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?restype=container&comp=acl
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Tue, 09 Aug 2016 21:23:12 GMT']
-      ETag: ['"0x8D3C09B5E895CBB"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:23:12 GMT']
+      Date: ['Mon, 15 Aug 2016 18:09:48 GMT']
+      ETag: ['"0x8D3C53758A87A65"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:09:49 GMT']
       Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
       PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0ndXRmLTgnPz4KPFNpZ25lZElkZW50aWZpZXJz
+      PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MzwvSWQ+PEFjY2Vzc1BvbGljeT48RXhwaXJ5PjIw
+      MTgtMDEtMDFUMDA6MDBaPC9FeHBpcnk+PC9BY2Nlc3NQb2xpY3k+PC9TaWduZWRJZGVudGlmaWVy
       PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MTwvSWQ+PEFjY2Vzc1BvbGljeT48UGVybWlzc2lv
       bj5sPC9QZXJtaXNzaW9uPjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRlbnRpZmllcj48U2lnbmVk
       SWRlbnRpZmllcj48SWQ+dGVzdDI8L0lkPjxBY2Nlc3NQb2xpY3k+PFN0YXJ0PjIwMTYtMDEtMDFU
-      MDA6MDA6MDBaPC9TdGFydD48L0FjY2Vzc1BvbGljeT48L1NpZ25lZElkZW50aWZpZXI+PFNpZ25l
-      ZElkZW50aWZpZXI+PElkPnRlc3QzPC9JZD48QWNjZXNzUG9saWN5PjxFeHBpcnk+MjAxOC0wMS0w
-      MVQwMDowMFo8L0V4cGlyeT48L0FjY2Vzc1BvbGljeT48L1NpZ25lZElkZW50aWZpZXI+PC9TaWdu
+      MDA6MDA6MDBaPC9TdGFydD48L0FjY2Vzc1BvbGljeT48L1NpZ25lZElkZW50aWZpZXI+PC9TaWdu
       ZWRJZGVudGlmaWVycz4=
     headers:
-      Authorization: ['SharedKey vcrstorage928507519704:k0Jtb9EB0rw1aWwbrM7tZqzGOx4BK2FwqPa3nS9ZuQk=']
+      Authorization: ['SharedKey vcrstorage692046317547:mTy5A1Y1L7kZjfEPCpPEhS0haPh9vQdQCE+sQUVxP3c=']
       Connection: [keep-alive]
       Content-Length: ['413']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [7b075698-5e77-11e6-bcfc-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:23:13 GMT']
+      x-ms-client-request-id: [751eaf42-6313-11e6-a003-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:09:50 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
+    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?restype=container&comp=acl
   response:
     body: {string: ''}
     headers:
-      Date: ['Tue, 09 Aug 2016 21:23:12 GMT']
-      ETag: ['"0x8D3C09B5EAD8BC7"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:23:13 GMT']
+      Date: ['Mon, 15 Aug 2016 18:09:48 GMT']
+      ETag: ['"0x8D3C53758D64C7E"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:09:49 GMT']
       Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage928507519704:muHTpnCXNDBQTy2uGtvsN74QaeJy3CH5IK2Z9krKAOE=']
+      Authorization: ['SharedKey vcrstorage692046317547:5u1wT2KnxMDOgDlM1K2uK4V5JSVzMTnoT1AQkkaS8/g=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [7b1b0914-5e77-11e6-b97b-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:23:14 GMT']
+      x-ms-client-request-id: [7535fb28-6313-11e6-8484-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:09:50 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
+    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?restype=container&comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Tue, 09 Aug 2016 21:23:11 GMT']
-      ETag: ['"0x8D3C09B5EAD8BC7"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:23:13 GMT']
+      Date: ['Mon, 15 Aug 2016 18:09:49 GMT']
+      ETag: ['"0x8D3C53758D64C7E"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:09:49 GMT']
       Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
       PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0ndXRmLTgnPz4KPFNpZ25lZElkZW50aWZpZXJz
-      PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MTwvSWQ+PEFjY2Vzc1BvbGljeT48UGVybWlzc2lv
-      bj5sPC9QZXJtaXNzaW9uPjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRlbnRpZmllcj48U2lnbmVk
-      SWRlbnRpZmllcj48SWQ+dGVzdDI8L0lkPjxBY2Nlc3NQb2xpY3k+PFN0YXJ0PjIwMTYtMDEtMDFU
-      MDA6MDA6MDBaPC9TdGFydD48L0FjY2Vzc1BvbGljeT48L1NpZ25lZElkZW50aWZpZXI+PFNpZ25l
-      ZElkZW50aWZpZXI+PElkPnRlc3Q0PC9JZD48QWNjZXNzUG9saWN5PjxTdGFydD4yMDE2LTAxLTAx
-      VDAwOjAwWjwvU3RhcnQ+PEV4cGlyeT4yMDE2LTA1LTAxVDAwOjAwWjwvRXhwaXJ5PjxQZXJtaXNz
-      aW9uPnJ3ZGw8L1Blcm1pc3Npb24+PC9BY2Nlc3NQb2xpY3k+PC9TaWduZWRJZGVudGlmaWVyPjxT
-      aWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MzwvSWQ+PEFjY2Vzc1BvbGljeT48RXhwaXJ5PjIwMTgt
-      MDEtMDFUMDA6MDA6MDBaPC9FeHBpcnk+PC9BY2Nlc3NQb2xpY3k+PC9TaWduZWRJZGVudGlmaWVy
+      PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MzwvSWQ+PEFjY2Vzc1BvbGljeT48RXhwaXJ5PjIw
+      MTgtMDEtMDFUMDA6MDA6MDBaPC9FeHBpcnk+PC9BY2Nlc3NQb2xpY3k+PC9TaWduZWRJZGVudGlm
+      aWVyPjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0NDwvSWQ+PEFjY2Vzc1BvbGljeT48U3RhcnQ+
+      MjAxNi0wMS0wMVQwMDowMFo8L1N0YXJ0PjxFeHBpcnk+MjAxNi0wNS0wMVQwMDowMFo8L0V4cGly
+      eT48UGVybWlzc2lvbj5yd2RsPC9QZXJtaXNzaW9uPjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRl
+      bnRpZmllcj48U2lnbmVkSWRlbnRpZmllcj48SWQ+dGVzdDE8L0lkPjxBY2Nlc3NQb2xpY3k+PFBl
+      cm1pc3Npb24+bDwvUGVybWlzc2lvbj48L0FjY2Vzc1BvbGljeT48L1NpZ25lZElkZW50aWZpZXI+
+      PFNpZ25lZElkZW50aWZpZXI+PElkPnRlc3QyPC9JZD48QWNjZXNzUG9saWN5PjxTdGFydD4yMDE2
+      LTAxLTAxVDAwOjAwOjAwWjwvU3RhcnQ+PC9BY2Nlc3NQb2xpY3k+PC9TaWduZWRJZGVudGlmaWVy
       PjwvU2lnbmVkSWRlbnRpZmllcnM+
     headers:
-      Authorization: ['SharedKey vcrstorage928507519704:xiNYl6Ku/N0evjvsF9RDovb7Gdcg2Iart+UuWTYRL6w=']
+      Authorization: ['SharedKey vcrstorage692046317547:6a11nPE4O+oNF9/rMjiD1AJUsebIqpF8AuGPwFGfRUM=']
       Connection: [keep-alive]
       Content-Length: ['591']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [7b31a242-5e77-11e6-9817-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:23:14 GMT']
+      x-ms-client-request-id: [754ade62-6313-11e6-a920-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:09:50 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
+    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?restype=container&comp=acl
   response:
     body: {string: ''}
     headers:
-      Date: ['Tue, 09 Aug 2016 21:23:11 GMT']
-      ETag: ['"0x8D3C09B5ED8245B"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:23:13 GMT']
+      Date: ['Mon, 15 Aug 2016 18:09:49 GMT']
+      ETag: ['"0x8D3C5375903F772"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:09:49 GMT']
       Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage928507519704:aqC6fNCpknXLZNPKQbbd+VPuzAi+DF2fQkLkUsIOafU=']
+      Authorization: ['SharedKey vcrstorage692046317547:6wMzC1NnN+LMieo/lSOL7sC4N1Zp02Hb/5inToc/nOg=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [7b429526-5e77-11e6-bb44-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:23:14 GMT']
+      x-ms-client-request-id: [75640366-6313-11e6-9060-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:09:50 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
+    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?restype=container&comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Tue, 09 Aug 2016 21:23:11 GMT']
-      ETag: ['"0x8D3C09B5ED8245B"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:23:13 GMT']
+      Date: ['Mon, 15 Aug 2016 18:09:49 GMT']
+      ETag: ['"0x8D3C5375903F772"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:09:49 GMT']
       Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage928507519704:kIoVZ87o4s5QeyQN6LrrTCNJiSA2luh43OkALKTJd5o=']
+      Authorization: ['SharedKey vcrstorage692046317547:/Rpx5D+6GqCPXxBk1JsnvO0B9u0di/uPw0RFKuCVZas=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [7b614610-5e77-11e6-927f-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:23:14 GMT']
+      x-ms-client-request-id: [75904924-6313-11e6-b947-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:09:50 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
+    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?restype=container&comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Tue, 09 Aug 2016 21:23:14 GMT']
-      ETag: ['"0x8D3C09B5ED8245B"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:23:13 GMT']
+      Date: ['Mon, 15 Aug 2016 18:09:49 GMT']
+      ETag: ['"0x8D3C5375903F772"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:09:49 GMT']
       Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage928507519704:t6PZd310ccIGAHQTpxOrQOaoiSI57P4IBxyE3li1QpU=']
+      Authorization: ['SharedKey vcrstorage692046317547:HJQrkEgCpFz3ZcMp0Tmzd+cG952o+klaAoXBVBlzJeg=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [7b837a08-5e77-11e6-9528-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:23:14 GMT']
+      x-ms-client-request-id: [75b7611a-6313-11e6-9b92-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:09:51 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
+    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?restype=container&comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Tue, 09 Aug 2016 21:23:12 GMT']
-      ETag: ['"0x8D3C09B5ED8245B"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:23:13 GMT']
+      Date: ['Mon, 15 Aug 2016 18:09:49 GMT']
+      ETag: ['"0x8D3C5375903F772"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:09:49 GMT']
       Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage928507519704:wFDUURtOb0VpVudM3ADBzCF40S4NbuShR9Qwv1Z+Iuk=']
+      Authorization: ['SharedKey vcrstorage692046317547:4IRtAq3WSryKjNqy9Z1dBKUU+ovC/tQwLHqSdu5XTB0=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [7ba203dc-5e77-11e6-af36-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:23:14 GMT']
+      x-ms-client-request-id: [75dd6248-6313-11e6-a489-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:09:51 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
+    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?restype=container&comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Tue, 09 Aug 2016 21:23:12 GMT']
-      ETag: ['"0x8D3C09B5ED8245B"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:23:13 GMT']
+      Date: ['Mon, 15 Aug 2016 18:09:49 GMT']
+      ETag: ['"0x8D3C5375903F772"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:09:49 GMT']
       Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage928507519704:MVaB8GCmtaDuWkVTp8n0mRkCt2oUqcZNPg3cn9cAIcM=']
+      Authorization: ['SharedKey vcrstorage692046317547:AvfHLQam6dAolsDaFyAvk/EI0IdNSWXJPjKyOjZL5Eg=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [7bc03f7e-5e77-11e6-93fc-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:23:15 GMT']
+      x-ms-client-request-id: [76088726-6313-11e6-ab69-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:09:51 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
+    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?restype=container&comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Tue, 09 Aug 2016 21:23:14 GMT']
-      ETag: ['"0x8D3C09B5ED8245B"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:23:13 GMT']
+      Date: ['Mon, 15 Aug 2016 18:09:50 GMT']
+      ETag: ['"0x8D3C5375903F772"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:09:49 GMT']
       Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage928507519704:RcA3ymRs0E0WI13ExPglyB6rQd0MbzHfyVI8Kp5KI+0=']
+      Authorization: ['SharedKey vcrstorage692046317547:8buSsJ0lnIvoUkrRnDU8D0vtQInZNKsM1QO/0x3UC3E=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [7be2c198-5e77-11e6-ab34-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:23:15 GMT']
+      x-ms-client-request-id: [762ca8d8-6313-11e6-a2de-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:09:51 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
+    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?restype=container&comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Tue, 09 Aug 2016 21:23:13 GMT']
-      ETag: ['"0x8D3C09B5ED8245B"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:23:13 GMT']
+      Date: ['Mon, 15 Aug 2016 18:09:50 GMT']
+      ETag: ['"0x8D3C5375903F772"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:09:49 GMT']
       Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
       PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0ndXRmLTgnPz4KPFNpZ25lZElkZW50aWZpZXJz
-      PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MTwvSWQ+PEFjY2Vzc1BvbGljeT48UGVybWlzc2lv
-      bj5yPC9QZXJtaXNzaW9uPjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRlbnRpZmllcj48U2lnbmVk
-      SWRlbnRpZmllcj48SWQ+dGVzdDI8L0lkPjxBY2Nlc3NQb2xpY3k+PFN0YXJ0PjIwMTYtMDEtMDFU
-      MDA6MDA6MDBaPC9TdGFydD48L0FjY2Vzc1BvbGljeT48L1NpZ25lZElkZW50aWZpZXI+PFNpZ25l
-      ZElkZW50aWZpZXI+PElkPnRlc3Q0PC9JZD48QWNjZXNzUG9saWN5PjxTdGFydD4yMDE2LTAxLTAx
-      VDAwOjAwOjAwWjwvU3RhcnQ+PEV4cGlyeT4yMDE2LTA1LTAxVDAwOjAwOjAwWjwvRXhwaXJ5PjxQ
-      ZXJtaXNzaW9uPnJ3ZGw8L1Blcm1pc3Npb24+PC9BY2Nlc3NQb2xpY3k+PC9TaWduZWRJZGVudGlm
-      aWVyPjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MzwvSWQ+PEFjY2Vzc1BvbGljeT48RXhwaXJ5
-      PjIwMTgtMDEtMDFUMDA6MDA6MDBaPC9FeHBpcnk+PC9BY2Nlc3NQb2xpY3k+PC9TaWduZWRJZGVu
+      PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MzwvSWQ+PEFjY2Vzc1BvbGljeT48RXhwaXJ5PjIw
+      MTgtMDEtMDFUMDA6MDA6MDBaPC9FeHBpcnk+PC9BY2Nlc3NQb2xpY3k+PC9TaWduZWRJZGVudGlm
+      aWVyPjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MjwvSWQ+PEFjY2Vzc1BvbGljeT48U3RhcnQ+
+      MjAxNi0wMS0wMVQwMDowMDowMFo8L1N0YXJ0PjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRlbnRp
+      Zmllcj48U2lnbmVkSWRlbnRpZmllcj48SWQ+dGVzdDE8L0lkPjxBY2Nlc3NQb2xpY3k+PFBlcm1p
+      c3Npb24+cjwvUGVybWlzc2lvbj48L0FjY2Vzc1BvbGljeT48L1NpZ25lZElkZW50aWZpZXI+PFNp
+      Z25lZElkZW50aWZpZXI+PElkPnRlc3Q0PC9JZD48QWNjZXNzUG9saWN5PjxTdGFydD4yMDE2LTAx
+      LTAxVDAwOjAwOjAwWjwvU3RhcnQ+PEV4cGlyeT4yMDE2LTA1LTAxVDAwOjAwOjAwWjwvRXhwaXJ5
+      PjxQZXJtaXNzaW9uPnJ3ZGw8L1Blcm1pc3Npb24+PC9BY2Nlc3NQb2xpY3k+PC9TaWduZWRJZGVu
       dGlmaWVyPjwvU2lnbmVkSWRlbnRpZmllcnM+
     headers:
-      Authorization: ['SharedKey vcrstorage928507519704:TL+V97ILGr53SgPIiE+5g2cyZTcGA7K+Fe+eAtu7pNE=']
+      Authorization: ['SharedKey vcrstorage692046317547:4dcXoh/pEoYOrXDSJqo1dzg0EDiPzKdRbxc0XTGPH8M=']
       Connection: [keep-alive]
       Content-Length: ['597']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [7bf56278-5e77-11e6-999c-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:23:15 GMT']
+      x-ms-client-request-id: [7642af86-6313-11e6-a913-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:09:52 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
+    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?restype=container&comp=acl
   response:
     body: {string: ''}
     headers:
-      Date: ['Tue, 09 Aug 2016 21:23:13 GMT']
-      ETag: ['"0x8D3C09B5F9B6973"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:23:14 GMT']
+      Date: ['Mon, 15 Aug 2016 18:09:50 GMT']
+      ETag: ['"0x8D3C53759FAA266"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:09:51 GMT']
       Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage928507519704:EKKzy5aJEQN+Wz6Qs10KrrYc38lpqUQnatYMnf5f+ag=']
+      Authorization: ['SharedKey vcrstorage692046317547:AWZYOFODPDhlb2dLFrC/2ZzBwGEpGvoeoSccoEAZYDU=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [7c062e46-5e77-11e6-981f-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:23:15 GMT']
+      x-ms-client-request-id: [7658ada2-6313-11e6-a368-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:09:52 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
+    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?restype=container&comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>r</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>r</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Tue, 09 Aug 2016 21:23:13 GMT']
-      ETag: ['"0x8D3C09B5F9B6973"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:23:14 GMT']
+      Date: ['Mon, 15 Aug 2016 18:09:50 GMT']
+      ETag: ['"0x8D3C53759FAA266"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:09:51 GMT']
       Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage928507519704:IPNMevQLO0uJfRdbJ7J56spvNYAhhpNxcs1iO9bh4pw=']
+      Authorization: ['SharedKey vcrstorage692046317547:GKRHihhklH9Rdh77MGIvRYTZhey9wVTAdd1ztdGgShQ=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [7c29e92c-5e77-11e6-9a65-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:23:15 GMT']
+      x-ms-client-request-id: [76805c3e-6313-11e6-884d-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:09:52 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
+    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?restype=container&comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>r</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>r</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Tue, 09 Aug 2016 21:23:14 GMT']
-      ETag: ['"0x8D3C09B5F9B6973"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:23:14 GMT']
+      Date: ['Mon, 15 Aug 2016 18:09:50 GMT']
+      ETag: ['"0x8D3C53759FAA266"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:09:51 GMT']
       Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
       PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0ndXRmLTgnPz4KPFNpZ25lZElkZW50aWZpZXJz
-      PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MjwvSWQ+PEFjY2Vzc1BvbGljeT48U3RhcnQ+MjAx
-      Ni0wMS0wMVQwMDowMDowMFo8L1N0YXJ0PjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRlbnRpZmll
-      cj48U2lnbmVkSWRlbnRpZmllcj48SWQ+dGVzdDQ8L0lkPjxBY2Nlc3NQb2xpY3k+PFN0YXJ0PjIw
-      MTYtMDEtMDFUMDA6MDA6MDBaPC9TdGFydD48RXhwaXJ5PjIwMTYtMDUtMDFUMDA6MDA6MDBaPC9F
-      eHBpcnk+PFBlcm1pc3Npb24+cndkbDwvUGVybWlzc2lvbj48L0FjY2Vzc1BvbGljeT48L1NpZ25l
-      ZElkZW50aWZpZXI+PFNpZ25lZElkZW50aWZpZXI+PElkPnRlc3QzPC9JZD48QWNjZXNzUG9saWN5
-      PjxFeHBpcnk+MjAxOC0wMS0wMVQwMDowMDowMFo8L0V4cGlyeT48L0FjY2Vzc1BvbGljeT48L1Np
+      PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MzwvSWQ+PEFjY2Vzc1BvbGljeT48RXhwaXJ5PjIw
+      MTgtMDEtMDFUMDA6MDA6MDBaPC9FeHBpcnk+PC9BY2Nlc3NQb2xpY3k+PC9TaWduZWRJZGVudGlm
+      aWVyPjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0NDwvSWQ+PEFjY2Vzc1BvbGljeT48U3RhcnQ+
+      MjAxNi0wMS0wMVQwMDowMDowMFo8L1N0YXJ0PjxFeHBpcnk+MjAxNi0wNS0wMVQwMDowMDowMFo8
+      L0V4cGlyeT48UGVybWlzc2lvbj5yd2RsPC9QZXJtaXNzaW9uPjwvQWNjZXNzUG9saWN5PjwvU2ln
+      bmVkSWRlbnRpZmllcj48U2lnbmVkSWRlbnRpZmllcj48SWQ+dGVzdDI8L0lkPjxBY2Nlc3NQb2xp
+      Y3k+PFN0YXJ0PjIwMTYtMDEtMDFUMDA6MDA6MDBaPC9TdGFydD48L0FjY2Vzc1BvbGljeT48L1Np
       Z25lZElkZW50aWZpZXI+PC9TaWduZWRJZGVudGlmaWVycz4=
     headers:
-      Authorization: ['SharedKey vcrstorage928507519704:F9K1d39LRVJ8Ulu7vLT+OPzaNiGhDBq8HgxlpjnVM/I=']
+      Authorization: ['SharedKey vcrstorage692046317547:jQhl8JnxwT0EVvEnm7KIMDlHpF4LKYTbc76jLT3jZ8c=']
       Connection: [keep-alive]
       Content-Length: ['491']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [7c3e8624-5e77-11e6-bb4f-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:23:15 GMT']
+      x-ms-client-request-id: [7696b582-6313-11e6-a625-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:09:52 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
+    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?restype=container&comp=acl
   response:
     body: {string: ''}
     headers:
-      Date: ['Tue, 09 Aug 2016 21:23:14 GMT']
-      ETag: ['"0x8D3C09B5FE4B200"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:23:15 GMT']
+      Date: ['Mon, 15 Aug 2016 18:09:50 GMT']
+      ETag: ['"0x8D3C5375A4EA38F"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:09:51 GMT']
       Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage928507519704:5H935v1XjevgK7+r7mqn8clUQXaCujurifL86caI/8M=']
+      Authorization: ['SharedKey vcrstorage692046317547:UKqqnagRr6evsKqaIS0iJQPuH7YXzj1oZJ8uR1D7p/I=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [7c4e4058-5e77-11e6-a5a1-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:23:16 GMT']
+      x-ms-client-request-id: [76b35762-6313-11e6-87c7-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:09:52 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
+    uri: https://dummystorage.blob.core.windows.net/acltestcontainer?restype=container&comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Tue, 09 Aug 2016 21:23:12 GMT']
-      ETag: ['"0x8D3C09B5FE4B200"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:23:15 GMT']
+      Date: ['Mon, 15 Aug 2016 18:09:51 GMT']
+      ETag: ['"0x8D3C5375A4EA38F"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:09:51 GMT']
       Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_file_acl_scenario.yaml
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_file_acl_scenario.yaml
@@ -4,7 +4,7 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDcwNzc3MTE5LCJuYmYiOjE0NzA3NzcxMTksImV4cCI6MTQ3MDc4MTAxOSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6NzIwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.jXqDMpx2zNxU3RceHO6Uxjef0WrH0--YyjQhISga0m7RMlNi87VJIfQgG8gb7nQHwzEXeCSFBrJ5exs0Oya7sggHlgl7xxTn0gu33XHG5Sg4CZJsKymygx1qHG7SfN843zPVpG5t9EzXn_xQZl8i4E97D-4cTOCVUUiUdd_8p3SgehAhQ3rjvuqrOHBAoq8BY3foJrRYgpEEfHxyCXHoTt7H0e9JnF5Gy-ANGCr3oCQxa6J6ks4Z51GmVkoTm4ilsEuk3Ox6T_kh1eWZwXx04_lVDR1wqoo66qSVSci27BsRzD2fnk0OFqlK5LKAV6IiaaO7HShWg3zU-I2ZDU5jaw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDcxMjgyNDA1LCJuYmYiOjE0NzEyODI0MDUsImV4cCI6MTQ3MTI4NjMwNSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6NzIwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjEuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.VGKXsuHHplz2RKW1PolZIRGSsQwxExx9UVzCkSoS1wKER27wwmXNcBM4dFN5SZLsrwRHH7pVmHPCKUEEtFb0Ae1OnsNrOag7yaH9rAqkXlMgmymWHnBWULXKwb1Q8iJJLDfBElavEUwHOIKfJGQAtYdJ_XPon_imVLATcg_dlX0dS4ixyrbvKbo3L17GzyUHsMbgy0_S2LpuC4JK0h__s_Ujl5HYmf9n2rDZzc7LOWA8VuQhAGnsqWkPA4igoyVlc36YeBlkYsd8DSkhhXRTkIOpxogXZuovN6ikUifyHWzB5PNvHs0gHLaoQPQnGS5aa-UdNc19zXfi4Iqw2RiqPQ]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
@@ -12,7 +12,7 @@ interactions:
           msrest_azure/0.4.1 storagemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [0cbd6aec-5e78-11e6-ac4b-a0b3ccf7272a]
+      x-ms-client-request-id: [aa2ccc64-6313-11e6-8ed1-a0b3ccf7272a]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_file_acl_scenario/providers/Microsoft.Storage/storageAccounts/dummystorage.listKeys?api-version=2016-01-01
   response:
@@ -20,64 +20,64 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR2/z
-        6+ajR9/jX15ki/yjR/ht96PRR6u8XhRNU1RLavDRs3VZ0oeXWblGm2b/85P7v/fBy/beg/Od+7Mv
-        Xy4me69e/PTFs58si+zt8t3rs+Wz5u6Xp1cP669ePfy9viqfXH23OXm9k81+8Pn1T/2i0+Pd+yfn
-        n3xx8W5+dX937/fOVr/o6Xd+r+PPPvvol4w6qOxRrxtReXf+Yv/6J4vvvv7q3v675fP6q7ufPPzO
-        D36vT6pXs3zv2evqu/f23zxY3fv2w58829n5iYc/Nf29777+9LKZv5pO937v/DtPPr1cPvjqXfn7
-        PPvkyaffnT749hdfPDnfuQAq3/8lyf8Dq9VcTiEBAAA=
+        6+ajR9/jX15ki/yjR/ht96PRR6u8XhRNU1RLavDRs3VZ0oeXWblGmwfXs09nn+78Xt+Z3L1Y/dTv
+        tfeyOX/wxb2ffvHtBxc/8Z29k73j/afrn/69XxbzT8vZgy8++X0mO9MX+Xd/8BPfvf97NfdfnS5+
+        4uXD32eeLX7R/e/OfvJV89Xeu2q3/OonPvvso18y6qCyR71uROXF73W9el59/nvtL55f3tt9u3v5
+        +/zkV4urT37vH3xZvq6OX0++ffnqePl7TfPvtj/5ez38vXbP94u372a/1w8+eVFV33l2Mcmr6+OX
+        T949Ofh9mue789Xlly9flJ98fgFUvv9Lkv8HM+8mEyEBAAA=
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Tue, 09 Aug 2016 21:27:18 GMT']
+      Date: ['Mon, 15 Aug 2016 18:11:17 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1194']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage329302498477:KootSpAqSBgaes4yi6MigEjnuEJokE3I70B4G19I6Oo=']
+      Authorization: ['SharedKey vcrstorage004175316338:Pp7m4X832+Zq3B6YuPeD1eDXRW97zYPuY7Yo6H5Lu2o=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [0ce2acac-5e78-11e6-8929-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:27:18 GMT']
+      x-ms-client-request-id: [aa6d91ee-6313-11e6-b945-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:11:19 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
+    uri: https://dummystorage.file.core.windows.net/acltestshare?restype=share&comp=acl
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers\
         \ />"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Tue, 09 Aug 2016 21:27:17 GMT']
-      ETag: ['"0x8D3C09BF01FC0FE"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:27:17 GMT']
+      Date: ['Mon, 15 Aug 2016 18:11:18 GMT']
+      ETag: ['"0x8D3C5378D72C148"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:11:17 GMT']
       Server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage329302498477:asvqIHBWmhBeVAqHZucm7I+bxoUIB72KeWDT/Qw9iJg=']
+      Authorization: ['SharedKey vcrstorage004175316338:2KAXE+BAsh/S/tVjvBK+hiJhLS4FwCA+bE2NIB/byO8=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [0d100622-5e78-11e6-86d0-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:27:18 GMT']
+      x-ms-client-request-id: [aa972130-6313-11e6-a8d4-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:11:19 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
+    uri: https://dummystorage.file.core.windows.net/acltestshare?restype=share&comp=acl
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers\
         \ />"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Tue, 09 Aug 2016 21:27:16 GMT']
-      ETag: ['"0x8D3C09BF01FC0FE"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:27:17 GMT']
+      Date: ['Mon, 15 Aug 2016 18:11:19 GMT']
+      ETag: ['"0x8D3C5378D72C148"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:11:17 GMT']
       Server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
@@ -88,42 +88,42 @@ interactions:
       bj5sPC9QZXJtaXNzaW9uPjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRlbnRpZmllcj48L1NpZ25l
       ZElkZW50aWZpZXJzPg==
     headers:
-      Authorization: ['SharedKey vcrstorage329302498477:CDAaob/KnH7T4G5QjOSAt54NlaTbrpcaXAAa3k40Ry0=']
+      Authorization: ['SharedKey vcrstorage004175316338:ULovESFmnVmhzRRdcdCmQkUpFgECxF75ZpLYyU/OkvQ=']
       Connection: [keep-alive]
       Content-Length: ['184']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [0d2ce1f8-5e78-11e6-8eb9-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:27:19 GMT']
+      x-ms-client-request-id: [aaaf4376-6313-11e6-9037-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:11:20 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
+    uri: https://dummystorage.file.core.windows.net/acltestshare?restype=share&comp=acl
   response:
     body: {string: ''}
     headers:
-      Date: ['Tue, 09 Aug 2016 21:27:17 GMT']
-      ETag: ['"0x8D3C09BF0A4531D"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:27:17 GMT']
+      Date: ['Mon, 15 Aug 2016 18:11:19 GMT']
+      ETag: ['"0x8D3C5378E4BA0A2"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:11:19 GMT']
       Server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage329302498477:nDAOpW+SWEfsFfLvbr0jrMncvtxV9124M7nj5rGfwKQ=']
+      Authorization: ['SharedKey vcrstorage004175316338:j2E8qdayiWZcq4BKQTQ+af6woYNx0MOMDMzoyW0PBZk=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [0d5cfb08-5e78-11e6-9423-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:27:19 GMT']
+      x-ms-client-request-id: [aadb94e8-6313-11e6-a6b8-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:11:20 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
+    uri: https://dummystorage.file.core.windows.net/acltestshare?restype=share&comp=acl
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Tue, 09 Aug 2016 21:27:17 GMT']
-      ETag: ['"0x8D3C09BF0A4531D"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:27:17 GMT']
+      Date: ['Mon, 15 Aug 2016 18:11:18 GMT']
+      ETag: ['"0x8D3C5378E4BA0A2"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:11:19 GMT']
       Server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
@@ -136,375 +136,375 @@ interactions:
       MDA6MDBaPC9TdGFydD48L0FjY2Vzc1BvbGljeT48L1NpZ25lZElkZW50aWZpZXI+PC9TaWduZWRJ
       ZGVudGlmaWVycz4=
     headers:
-      Authorization: ['SharedKey vcrstorage329302498477:9BLzcfx5bBAIpPsqyeDqZ00tzUmAGfSkcI+cw+62Uj8=']
+      Authorization: ['SharedKey vcrstorage004175316338:ENmk34Bl00rIJJalk0xitaZ97EIV8BjW5A4xrYUpxi4=']
       Connection: [keep-alive]
       Content-Length: ['296']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [0d7dcf26-5e78-11e6-aae7-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:27:19 GMT']
+      x-ms-client-request-id: [aaf5b3b8-6313-11e6-ae44-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:11:20 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
+    uri: https://dummystorage.file.core.windows.net/acltestshare?restype=share&comp=acl
   response:
     body: {string: ''}
     headers:
-      Date: ['Tue, 09 Aug 2016 21:27:17 GMT']
-      ETag: ['"0x8D3C09BF0F407BC"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:27:18 GMT']
+      Date: ['Mon, 15 Aug 2016 18:11:18 GMT']
+      ETag: ['"0x8D3C5378EA2D132"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:11:19 GMT']
       Server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage329302498477:bXXitoOmW0jw47RFgkkP6/T0E4zbtdhE3u0PUPlJwV0=']
+      Authorization: ['SharedKey vcrstorage004175316338:qEY15N0hjHBcgJr7SPjB7snSnca8LlfdLHDG8DpZvqg=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [0da7ccae-5e78-11e6-a4d0-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:27:19 GMT']
+      x-ms-client-request-id: [ab335252-6313-11e6-994c-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:11:20 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
+    uri: https://dummystorage.file.core.windows.net/acltestshare?restype=share&comp=acl
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Tue, 09 Aug 2016 21:27:18 GMT']
-      ETag: ['"0x8D3C09BF0F407BC"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:27:18 GMT']
+      Date: ['Mon, 15 Aug 2016 18:11:19 GMT']
+      ETag: ['"0x8D3C5378EA2D132"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:11:19 GMT']
       Server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
       PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0ndXRmLTgnPz4KPFNpZ25lZElkZW50aWZpZXJz
+      PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MzwvSWQ+PEFjY2Vzc1BvbGljeT48RXhwaXJ5PjIw
+      MTgtMDEtMDFUMDA6MDBaPC9FeHBpcnk+PC9BY2Nlc3NQb2xpY3k+PC9TaWduZWRJZGVudGlmaWVy
       PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MTwvSWQ+PEFjY2Vzc1BvbGljeT48UGVybWlzc2lv
       bj5sPC9QZXJtaXNzaW9uPjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRlbnRpZmllcj48U2lnbmVk
       SWRlbnRpZmllcj48SWQ+dGVzdDI8L0lkPjxBY2Nlc3NQb2xpY3k+PFN0YXJ0PjIwMTYtMDEtMDFU
-      MDA6MDA6MDBaPC9TdGFydD48L0FjY2Vzc1BvbGljeT48L1NpZ25lZElkZW50aWZpZXI+PFNpZ25l
-      ZElkZW50aWZpZXI+PElkPnRlc3QzPC9JZD48QWNjZXNzUG9saWN5PjxFeHBpcnk+MjAxOC0wMS0w
-      MVQwMDowMFo8L0V4cGlyeT48L0FjY2Vzc1BvbGljeT48L1NpZ25lZElkZW50aWZpZXI+PC9TaWdu
+      MDA6MDA6MDBaPC9TdGFydD48L0FjY2Vzc1BvbGljeT48L1NpZ25lZElkZW50aWZpZXI+PC9TaWdu
       ZWRJZGVudGlmaWVycz4=
     headers:
-      Authorization: ['SharedKey vcrstorage329302498477:rA6NVG2QC0jrcLKK76GSrFAueQZOrvjHOGx0JjVU22Q=']
+      Authorization: ['SharedKey vcrstorage004175316338:9bXI9LzK4w91LMWWd45yiARfycQ1h3u0p+i2kUjIfFU=']
       Connection: [keep-alive]
       Content-Length: ['413']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [0dbc90b8-5e78-11e6-8362-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:27:20 GMT']
+      x-ms-client-request-id: [ab4cb49e-6313-11e6-8695-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:11:21 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
+    uri: https://dummystorage.file.core.windows.net/acltestshare?restype=share&comp=acl
   response:
     body: {string: ''}
     headers:
-      Date: ['Tue, 09 Aug 2016 21:27:18 GMT']
-      ETag: ['"0x8D3C09BF142AACC"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:27:18 GMT']
+      Date: ['Mon, 15 Aug 2016 18:11:20 GMT']
+      ETag: ['"0x8D3C5378EF4F7CB"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:11:20 GMT']
       Server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage329302498477:fpV8exgHD+bhRGFofk8YmIc2OzA6JwoOlRouh6AsQHQ=']
+      Authorization: ['SharedKey vcrstorage004175316338:bcuAq1rWX1/ssfOmio97H7Z6K1lTIfzGPlo/49n55mk=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [0df6bdc0-5e78-11e6-a16f-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:27:20 GMT']
+      x-ms-client-request-id: [ab862c90-6313-11e6-b934-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:11:21 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
+    uri: https://dummystorage.file.core.windows.net/acltestshare?restype=share&comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Tue, 09 Aug 2016 21:27:18 GMT']
-      ETag: ['"0x8D3C09BF142AACC"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:27:18 GMT']
+      Date: ['Mon, 15 Aug 2016 18:11:19 GMT']
+      ETag: ['"0x8D3C5378EF4F7CB"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:11:20 GMT']
       Server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
       PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0ndXRmLTgnPz4KPFNpZ25lZElkZW50aWZpZXJz
-      PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0NDwvSWQ+PEFjY2Vzc1BvbGljeT48U3RhcnQ+MjAx
-      Ni0wMS0wMVQwMDowMFo8L1N0YXJ0PjxFeHBpcnk+MjAxNi0wNS0wMVQwMDowMFo8L0V4cGlyeT48
-      UGVybWlzc2lvbj5yd2RsPC9QZXJtaXNzaW9uPjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRlbnRp
-      Zmllcj48U2lnbmVkSWRlbnRpZmllcj48SWQ+dGVzdDE8L0lkPjxBY2Nlc3NQb2xpY3k+PFBlcm1p
-      c3Npb24+bDwvUGVybWlzc2lvbj48L0FjY2Vzc1BvbGljeT48L1NpZ25lZElkZW50aWZpZXI+PFNp
-      Z25lZElkZW50aWZpZXI+PElkPnRlc3QyPC9JZD48QWNjZXNzUG9saWN5PjxTdGFydD4yMDE2LTAx
-      LTAxVDAwOjAwOjAwWjwvU3RhcnQ+PC9BY2Nlc3NQb2xpY3k+PC9TaWduZWRJZGVudGlmaWVyPjxT
-      aWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MzwvSWQ+PEFjY2Vzc1BvbGljeT48RXhwaXJ5PjIwMTgt
-      MDEtMDFUMDA6MDA6MDBaPC9FeHBpcnk+PC9BY2Nlc3NQb2xpY3k+PC9TaWduZWRJZGVudGlmaWVy
+      PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MzwvSWQ+PEFjY2Vzc1BvbGljeT48RXhwaXJ5PjIw
+      MTgtMDEtMDFUMDA6MDA6MDBaPC9FeHBpcnk+PC9BY2Nlc3NQb2xpY3k+PC9TaWduZWRJZGVudGlm
+      aWVyPjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0NDwvSWQ+PEFjY2Vzc1BvbGljeT48U3RhcnQ+
+      MjAxNi0wMS0wMVQwMDowMFo8L1N0YXJ0PjxFeHBpcnk+MjAxNi0wNS0wMVQwMDowMFo8L0V4cGly
+      eT48UGVybWlzc2lvbj5yd2RsPC9QZXJtaXNzaW9uPjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRl
+      bnRpZmllcj48U2lnbmVkSWRlbnRpZmllcj48SWQ+dGVzdDE8L0lkPjxBY2Nlc3NQb2xpY3k+PFBl
+      cm1pc3Npb24+bDwvUGVybWlzc2lvbj48L0FjY2Vzc1BvbGljeT48L1NpZ25lZElkZW50aWZpZXI+
+      PFNpZ25lZElkZW50aWZpZXI+PElkPnRlc3QyPC9JZD48QWNjZXNzUG9saWN5PjxTdGFydD4yMDE2
+      LTAxLTAxVDAwOjAwOjAwWjwvU3RhcnQ+PC9BY2Nlc3NQb2xpY3k+PC9TaWduZWRJZGVudGlmaWVy
       PjwvU2lnbmVkSWRlbnRpZmllcnM+
     headers:
-      Authorization: ['SharedKey vcrstorage329302498477:q1xR91Idx/I6vUe7zEwmtZyCEAqa1Q4LuxyfbBlsjZ8=']
+      Authorization: ['SharedKey vcrstorage004175316338:Gz65ltdgBC2yKwoEhYwv4xPkOVGQ2dc8izAodQXp/B0=']
       Connection: [keep-alive]
       Content-Length: ['591']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [0e09acc8-5e78-11e6-ad56-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:27:20 GMT']
+      x-ms-client-request-id: [aba1dd12-6313-11e6-b3c0-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:11:21 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
+    uri: https://dummystorage.file.core.windows.net/acltestshare?restype=share&comp=acl
   response:
     body: {string: ''}
     headers:
-      Date: ['Tue, 09 Aug 2016 21:27:18 GMT']
-      ETag: ['"0x8D3C09BF17A1835"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:27:19 GMT']
+      Date: ['Mon, 15 Aug 2016 18:11:20 GMT']
+      ETag: ['"0x8D3C5378F41C63B"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:11:20 GMT']
       Server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage329302498477:6DRizt34t5HQBhmtoBZUEfbI1DTv1c5/o4fYWS15/ko=']
+      Authorization: ['SharedKey vcrstorage004175316338:DM66hb6wSZwyPM1Ii7MM7pFjGgBlNN2cn2IsJuVRGWE=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [0e2d8eb8-5e78-11e6-b14b-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:27:20 GMT']
+      x-ms-client-request-id: [abea24e8-6313-11e6-af96-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:11:22 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
+    uri: https://dummystorage.file.core.windows.net/acltestshare?restype=share&comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Tue, 09 Aug 2016 21:27:19 GMT']
-      ETag: ['"0x8D3C09BF17A1835"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:27:19 GMT']
+      Date: ['Mon, 15 Aug 2016 18:11:20 GMT']
+      ETag: ['"0x8D3C5378F41C63B"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:11:20 GMT']
       Server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage329302498477:NAVyxyghofGNmuRrIH1s2xdYV5uJAyACMEGQ2I5CglQ=']
+      Authorization: ['SharedKey vcrstorage004175316338:t/FwvLhjGD6+F4VJ87SeX+86PdXqmdhKymulDt3dNh4=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [0e5a99f6-5e78-11e6-975a-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:27:21 GMT']
+      x-ms-client-request-id: [ac14ce02-6313-11e6-a4b0-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:11:22 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
+    uri: https://dummystorage.file.core.windows.net/acltestshare?restype=share&comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Tue, 09 Aug 2016 21:27:19 GMT']
-      ETag: ['"0x8D3C09BF17A1835"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:27:19 GMT']
+      Date: ['Mon, 15 Aug 2016 18:11:20 GMT']
+      ETag: ['"0x8D3C5378F41C63B"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:11:20 GMT']
       Server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage329302498477:Z8SBU3ethse+wL+fZPhk6KRvy8s+224sgfOf8Vtxbl8=']
+      Authorization: ['SharedKey vcrstorage004175316338:685XS46G3djTug1DAiqvE94gKW2AKCxC3tDKdMfeOW8=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [0e7a0e52-5e78-11e6-b4c8-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:27:21 GMT']
+      x-ms-client-request-id: [ac40ad48-6313-11e6-b305-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:11:22 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
+    uri: https://dummystorage.file.core.windows.net/acltestshare?restype=share&comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Tue, 09 Aug 2016 21:27:19 GMT']
-      ETag: ['"0x8D3C09BF17A1835"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:27:19 GMT']
+      Date: ['Mon, 15 Aug 2016 18:11:20 GMT']
+      ETag: ['"0x8D3C5378F41C63B"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:11:20 GMT']
       Server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage329302498477:e+eRETe9EWshc2C2RQ8iHIio6Tjbwzilra57GZIJk20=']
+      Authorization: ['SharedKey vcrstorage004175316338:6udwMB8o1zxtjBD6r5rAetViNfUa4jbAgLITGHpYaA4=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [0ea1e89a-5e78-11e6-ba36-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:27:21 GMT']
+      x-ms-client-request-id: [ac6be5ec-6313-11e6-9943-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:11:22 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
+    uri: https://dummystorage.file.core.windows.net/acltestshare?restype=share&comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Tue, 09 Aug 2016 21:27:20 GMT']
-      ETag: ['"0x8D3C09BF17A1835"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:27:19 GMT']
+      Date: ['Mon, 15 Aug 2016 18:11:21 GMT']
+      ETag: ['"0x8D3C5378F41C63B"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:11:20 GMT']
       Server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage329302498477:2oKku1vP1iI4QkPCIzYDiRXHWOzjketLjlOtddyrCaQ=']
+      Authorization: ['SharedKey vcrstorage004175316338:43zC4bizcexe9VM/1P89NmZvJyluez/FpxHNxGJQV5U=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [0ecc8278-5e78-11e6-9d47-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:27:21 GMT']
+      x-ms-client-request-id: [ac98854c-6313-11e6-809d-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:11:23 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
+    uri: https://dummystorage.file.core.windows.net/acltestshare?restype=share&comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Tue, 09 Aug 2016 21:27:19 GMT']
-      ETag: ['"0x8D3C09BF17A1835"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:27:19 GMT']
+      Date: ['Mon, 15 Aug 2016 18:11:22 GMT']
+      ETag: ['"0x8D3C5378F41C63B"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:11:20 GMT']
       Server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage329302498477:fnOOMqNKuEm2pwIjDXakX0dByubcCHYdnHf/yUr/+Ts=']
+      Authorization: ['SharedKey vcrstorage004175316338:FnFRvhtpwbBs7vMagIayA/o7IcUCXRvBbsPyy6BKMh4=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [0ef1c428-5e78-11e6-947c-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:27:22 GMT']
+      x-ms-client-request-id: [acc5cc54-6313-11e6-983a-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:11:23 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
+    uri: https://dummystorage.file.core.windows.net/acltestshare?restype=share&comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Tue, 09 Aug 2016 21:27:21 GMT']
-      ETag: ['"0x8D3C09BF17A1835"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:27:19 GMT']
+      Date: ['Mon, 15 Aug 2016 18:11:22 GMT']
+      ETag: ['"0x8D3C5378F41C63B"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:11:20 GMT']
       Server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
       PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0ndXRmLTgnPz4KPFNpZ25lZElkZW50aWZpZXJz
-      PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0NDwvSWQ+PEFjY2Vzc1BvbGljeT48U3RhcnQ+MjAx
-      Ni0wMS0wMVQwMDowMDowMFo8L1N0YXJ0PjxFeHBpcnk+MjAxNi0wNS0wMVQwMDowMDowMFo8L0V4
-      cGlyeT48UGVybWlzc2lvbj5yd2RsPC9QZXJtaXNzaW9uPjwvQWNjZXNzUG9saWN5PjwvU2lnbmVk
-      SWRlbnRpZmllcj48U2lnbmVkSWRlbnRpZmllcj48SWQ+dGVzdDE8L0lkPjxBY2Nlc3NQb2xpY3k+
-      PFBlcm1pc3Npb24+cjwvUGVybWlzc2lvbj48L0FjY2Vzc1BvbGljeT48L1NpZ25lZElkZW50aWZp
-      ZXI+PFNpZ25lZElkZW50aWZpZXI+PElkPnRlc3QyPC9JZD48QWNjZXNzUG9saWN5PjxTdGFydD4y
-      MDE2LTAxLTAxVDAwOjAwOjAwWjwvU3RhcnQ+PC9BY2Nlc3NQb2xpY3k+PC9TaWduZWRJZGVudGlm
-      aWVyPjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MzwvSWQ+PEFjY2Vzc1BvbGljeT48RXhwaXJ5
-      PjIwMTgtMDEtMDFUMDA6MDA6MDBaPC9FeHBpcnk+PC9BY2Nlc3NQb2xpY3k+PC9TaWduZWRJZGVu
+      PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MzwvSWQ+PEFjY2Vzc1BvbGljeT48RXhwaXJ5PjIw
+      MTgtMDEtMDFUMDA6MDA6MDBaPC9FeHBpcnk+PC9BY2Nlc3NQb2xpY3k+PC9TaWduZWRJZGVudGlm
+      aWVyPjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MjwvSWQ+PEFjY2Vzc1BvbGljeT48U3RhcnQ+
+      MjAxNi0wMS0wMVQwMDowMDowMFo8L1N0YXJ0PjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRlbnRp
+      Zmllcj48U2lnbmVkSWRlbnRpZmllcj48SWQ+dGVzdDE8L0lkPjxBY2Nlc3NQb2xpY3k+PFBlcm1p
+      c3Npb24+cjwvUGVybWlzc2lvbj48L0FjY2Vzc1BvbGljeT48L1NpZ25lZElkZW50aWZpZXI+PFNp
+      Z25lZElkZW50aWZpZXI+PElkPnRlc3Q0PC9JZD48QWNjZXNzUG9saWN5PjxTdGFydD4yMDE2LTAx
+      LTAxVDAwOjAwOjAwWjwvU3RhcnQ+PEV4cGlyeT4yMDE2LTA1LTAxVDAwOjAwOjAwWjwvRXhwaXJ5
+      PjxQZXJtaXNzaW9uPnJ3ZGw8L1Blcm1pc3Npb24+PC9BY2Nlc3NQb2xpY3k+PC9TaWduZWRJZGVu
       dGlmaWVyPjwvU2lnbmVkSWRlbnRpZmllcnM+
     headers:
-      Authorization: ['SharedKey vcrstorage329302498477:ZV65KyzRA02ZZC+zdgN59agWwjAxAhsGoeE3SHjsHVU=']
+      Authorization: ['SharedKey vcrstorage004175316338:pfmsvhWoPhVPBLVFFFIi+UH51JGFU50pfyGqpLwhzQs=']
       Connection: [keep-alive]
       Content-Length: ['597']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [0f0e78e8-5e78-11e6-9258-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:27:22 GMT']
+      x-ms-client-request-id: [ace0e06e-6313-11e6-8b01-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:11:23 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
+    uri: https://dummystorage.file.core.windows.net/acltestshare?restype=share&comp=acl
   response:
     body: {string: ''}
     headers:
-      Date: ['Tue, 09 Aug 2016 21:27:21 GMT']
-      ETag: ['"0x8D3C09BF2888388"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:27:21 GMT']
+      Date: ['Mon, 15 Aug 2016 18:11:22 GMT']
+      ETag: ['"0x8D3C537907B90E0"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:11:22 GMT']
       Server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage329302498477:zpsjSS/Ewf/EdMhbQ9Hw/5yMoeJ11itk3/GY85X2SR8=']
+      Authorization: ['SharedKey vcrstorage004175316338:zaOuZUnxIhMo+b7qz7VhJBYcmbAu6QesPCSMTTyq6AU=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [0f3c47a2-5e78-11e6-87a4-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:27:22 GMT']
+      x-ms-client-request-id: [ad0acb82-6313-11e6-b528-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:11:24 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
+    uri: https://dummystorage.file.core.windows.net/acltestshare?restype=share&comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>r</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>r</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Tue, 09 Aug 2016 21:27:21 GMT']
-      ETag: ['"0x8D3C09BF2888388"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:27:21 GMT']
+      Date: ['Mon, 15 Aug 2016 18:11:22 GMT']
+      ETag: ['"0x8D3C537907B90E0"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:11:22 GMT']
       Server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage329302498477:VXYZHKPPDTdLjx0NOn2wTlIYSd9Hs26Kr1QW0WRnNas=']
+      Authorization: ['SharedKey vcrstorage004175316338:MbgrLgnTYZ09PnUtTyfQu3IPm9ffgjcmqUpGEUiYl28=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [0f6b7626-5e78-11e6-8490-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:27:22 GMT']
+      x-ms-client-request-id: [ad3e1c92-6313-11e6-9cf1-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:11:24 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
+    uri: https://dummystorage.file.core.windows.net/acltestshare?restype=share&comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>r</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>r</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Tue, 09 Aug 2016 21:27:20 GMT']
-      ETag: ['"0x8D3C09BF2888388"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:27:21 GMT']
+      Date: ['Mon, 15 Aug 2016 18:11:23 GMT']
+      ETag: ['"0x8D3C537907B90E0"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:11:22 GMT']
       Server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
       PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0ndXRmLTgnPz4KPFNpZ25lZElkZW50aWZpZXJz
-      PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0NDwvSWQ+PEFjY2Vzc1BvbGljeT48U3RhcnQ+MjAx
-      Ni0wMS0wMVQwMDowMDowMFo8L1N0YXJ0PjxFeHBpcnk+MjAxNi0wNS0wMVQwMDowMDowMFo8L0V4
-      cGlyeT48UGVybWlzc2lvbj5yd2RsPC9QZXJtaXNzaW9uPjwvQWNjZXNzUG9saWN5PjwvU2lnbmVk
-      SWRlbnRpZmllcj48U2lnbmVkSWRlbnRpZmllcj48SWQ+dGVzdDI8L0lkPjxBY2Nlc3NQb2xpY3k+
-      PFN0YXJ0PjIwMTYtMDEtMDFUMDA6MDA6MDBaPC9TdGFydD48L0FjY2Vzc1BvbGljeT48L1NpZ25l
-      ZElkZW50aWZpZXI+PFNpZ25lZElkZW50aWZpZXI+PElkPnRlc3QzPC9JZD48QWNjZXNzUG9saWN5
-      PjxFeHBpcnk+MjAxOC0wMS0wMVQwMDowMDowMFo8L0V4cGlyeT48L0FjY2Vzc1BvbGljeT48L1Np
+      PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MzwvSWQ+PEFjY2Vzc1BvbGljeT48RXhwaXJ5PjIw
+      MTgtMDEtMDFUMDA6MDA6MDBaPC9FeHBpcnk+PC9BY2Nlc3NQb2xpY3k+PC9TaWduZWRJZGVudGlm
+      aWVyPjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0NDwvSWQ+PEFjY2Vzc1BvbGljeT48U3RhcnQ+
+      MjAxNi0wMS0wMVQwMDowMDowMFo8L1N0YXJ0PjxFeHBpcnk+MjAxNi0wNS0wMVQwMDowMDowMFo8
+      L0V4cGlyeT48UGVybWlzc2lvbj5yd2RsPC9QZXJtaXNzaW9uPjwvQWNjZXNzUG9saWN5PjwvU2ln
+      bmVkSWRlbnRpZmllcj48U2lnbmVkSWRlbnRpZmllcj48SWQ+dGVzdDI8L0lkPjxBY2Nlc3NQb2xp
+      Y3k+PFN0YXJ0PjIwMTYtMDEtMDFUMDA6MDA6MDBaPC9TdGFydD48L0FjY2Vzc1BvbGljeT48L1Np
       Z25lZElkZW50aWZpZXI+PC9TaWduZWRJZGVudGlmaWVycz4=
     headers:
-      Authorization: ['SharedKey vcrstorage329302498477:Cjn+feu1MNyMt8sDWgnb7WwbveRfdbifbJRz1FBzqnY=']
+      Authorization: ['SharedKey vcrstorage004175316338:dhdkRkKHb1bNRUmm8vags2eJo9UksJySE3wErQaBaIQ=']
       Connection: [keep-alive]
       Content-Length: ['491']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [0f87b5a4-5e78-11e6-adc4-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:27:23 GMT']
+      x-ms-client-request-id: [ad58a7a2-6313-11e6-94c3-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:11:24 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
+    uri: https://dummystorage.file.core.windows.net/acltestshare?restype=share&comp=acl
   response:
     body: {string: ''}
     headers:
-      Date: ['Tue, 09 Aug 2016 21:27:21 GMT']
-      ETag: ['"0x8D3C09BF2F7D3B0"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:27:21 GMT']
+      Date: ['Mon, 15 Aug 2016 18:11:23 GMT']
+      ETag: ['"0x8D3C53790F2D26D"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:11:23 GMT']
       Server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage329302498477:/wrQnnbR6pLPTks3pYIwSIDpJmA1tQrUPvSJ6v7LNfA=']
+      Authorization: ['SharedKey vcrstorage004175316338:5QEGuIH81B25rtHnzAxnnNztVA7fqSA3sbniqHoWnrQ=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [0fab707a-5e78-11e6-8e6e-a0b3ccf7272a]
-      x-ms-date: ['Tue, 09 Aug 2016 21:27:23 GMT']
+      x-ms-client-request-id: [ad829448-6313-11e6-9a55-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:11:24 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
+    uri: https://dummystorage.file.core.windows.net/acltestshare?restype=share&comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Tue, 09 Aug 2016 21:27:21 GMT']
-      ETag: ['"0x8D3C09BF2F7D3B0"']
-      Last-Modified: ['Tue, 09 Aug 2016 21:27:21 GMT']
+      Date: ['Mon, 15 Aug 2016 18:11:22 GMT']
+      ETag: ['"0x8D3C53790F2D26D"']
+      Last-Modified: ['Mon, 15 Aug 2016 18:11:23 GMT']
       Server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_queue_scenario.yaml
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_queue_scenario.yaml
@@ -4,7 +4,7 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDcwODY0NTM5LCJuYmYiOjE0NzA4NjQ1MzksImV4cCI6MTQ3MDg2ODQzOSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6NzIwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjEuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.KrRgb_rPOfKbJwOa-fiUX7KWPa8KUyAZefsrML2GaaGBvAz8KvFL9gX_XuNrHhZysjs-1pdtM9O_wqgLWR7hTb2_If45U3tAE06_ewAV00oXVlx6gs7kz9JcNeivG8hcuddUrIyZwFlpYPkWfl4gko79OzqneeZUVIB15rBW9WwL9X6iB_bLx1JWkIguNn-ofQCOhcBkEtpsduoYNAj7SCfargT5Q5vs0Hw-MVhuriLHrxyBIzTcAAPR4o5_XW-0uR7FeNgyJPsvjltEl3HR4IRE56a4_UJD-dlBmX-Rx4YWcPLH-fDsW4Ky-JzcFhfU35ypCbHnBPTckmakCPzIHA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDcxMjgyNDA1LCJuYmYiOjE0NzEyODI0MDUsImV4cCI6MTQ3MTI4NjMwNSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6NzIwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjEuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.VGKXsuHHplz2RKW1PolZIRGSsQwxExx9UVzCkSoS1wKER27wwmXNcBM4dFN5SZLsrwRHH7pVmHPCKUEEtFb0Ae1OnsNrOag7yaH9rAqkXlMgmymWHnBWULXKwb1Q8iJJLDfBElavEUwHOIKfJGQAtYdJ_XPon_imVLATcg_dlX0dS4ixyrbvKbo3L17GzyUHsMbgy0_S2LpuC4JK0h__s_Ujl5HYmf9n2rDZzc7LOWA8VuQhAGnsqWkPA4igoyVlc36YeBlkYsd8DSkhhXRTkIOpxogXZuovN6ikUifyHWzB5PNvHs0gHLaoQPQnGS5aa-UdNc19zXfi4Iqw2RiqPQ]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
@@ -12,7 +12,7 @@ interactions:
           msrest_azure/0.4.1 storagemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [c354bb9e-5f43-11e6-bd83-a0b3ccf7272a]
+      x-ms-client-request-id: [e0f1a802-6313-11e6-be62-a0b3ccf7272a]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_queue_scenario_test/providers/Microsoft.Storage/storageAccounts/dummystorage.listKeys?api-version=2016-01-01
   response:
@@ -20,32 +20,32 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR2/z
-        6+ajR9/jX15ki/yjR/ht96PRR6u8XhRNU1RLavDRs3VZ0oeXWblGm73vtL/XvXvfWf9gtXPwZfHs
-        9ymPv9t8vv+TTyaXx0V99fynXn/+1asHP6g+/fTiTfV7n88vfvKnF7PF7M10p/7pJ58+e9keX0yq
-        6tWXF/PV/OD6uj1+lb/aqy4+++yjXzLqoLJHvW5E5ct7n9zdP/vJ7NkXP/F8tVq//Mlvz3Yu333n
-        7u7J7019frWzt/PTyy8PTl6czj55+Z2Ds+f79d23b5tvP3h2ce/J8Xfflb/3m4e/6PNflN97+NNP
-        Xzw5efrui4erb9/7CaDy/V+S/D+Z8QoQIQEAAA==
+        6+ajR9/jX15ki/yjR/ht96PRR6u8XhRNU1RLavDRs3VZ0oeXWblGm/3yF306y3Z+n3sX9btPzu/O
+        Tx6+/u7z/d0ffLH71V55vHx1fnb13c+Xk59ui0+f5j81+0Wff3myP724/kWvfzI7nuXNxd3mk+9+
+        +eblvdV3vpxXL35yb1389ItPf+Kzzz76JaMOKnvU60ZU2nL35ZOTty9W2eSL1Rd733n3k28Pdnd3
+        f/r+dHH/5O3nl/fq+9XnJ5O2vLe7fPYT2bufvnt2Xu78Xs3Bu+ry2f7up5//3j9R/MTL41/0g/Yn
+        m5/6Rae/d/bs3uqnLoDK939J8v8A64uhmyEBAAA=
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Wed, 10 Aug 2016 21:45:32 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:49 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage418031177315:SWfIFIHFhwF/eO6wVf4l59+f5ybQHAwkBfpVzKFGLeE=']
+      Authorization: ['SharedKey vcrstorage156388220623:M9mjKOlV4LNqjPimLS9IJrEd8pKTP3V61+147aRAYdE=']
       Connection: [keep-alive]
       Content-Length: ['0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [c395e09c-5f43-11e6-9600-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:45:33 GMT']
+      x-ms-client-request-id: [e132b77e-6313-11e6-8446-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:12:51 GMT']
       x-ms-meta-a: [b]
       x-ms-meta-c: [d]
       x-ms-version: ['2015-07-08']
@@ -54,18 +54,18 @@ interactions:
   response:
     body: {string: ''}
     headers:
-      Date: ['Wed, 10 Aug 2016 21:45:31 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:50 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage418031177315:K+S/J0z2KWPn2JQMX+WsyCHreBAS7tWjAcw88WsJhl0=']
+      Authorization: ['SharedKey vcrstorage156388220623:VrHDzWE9kbF4CJLWcUGnWUmbD+w/3CqZ3GF9so7XssE=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [c3de2aa4-5f43-11e6-bae9-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:45:33 GMT']
+      x-ms-client-request-id: [e161ca7a-6313-11e6-88ae-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:12:51 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1?comp=metadata
@@ -73,7 +73,7 @@ interactions:
     body: {string: ''}
     headers:
       Cache-Control: [no-cache]
-      Date: ['Wed, 10 Aug 2016 21:45:31 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:51 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-approximate-messages-count: ['0']
       x-ms-meta-a: [b]
@@ -83,33 +83,33 @@ interactions:
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage418031177315:dNPAtKksf4S1N6u0xiTyPauqxtKWmjsgCP9P28iJJ7Q=']
+      Authorization: ['SharedKey vcrstorage156388220623:DJkXCldWSemjP3YhS4eUjwVLvUisvr7Kr9jO1TWZKMA=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [c4020c8a-5f43-11e6-aa5e-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:45:33 GMT']
+      x-ms-client-request-id: [e1880574-6313-11e6-8569-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:12:52 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/?comp=list
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults\
-        \ ServiceEndpoint=\"https://vcrstorage418031177315.queue.core.windows.net/\"\
+        \ ServiceEndpoint=\"https://vcrstorage156388220623.queue.core.windows.net/\"\
         ><Queues><Queue><Name>queue1</Name></Queue></Queues><NextMarker /></EnumerationResults>"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/xml]
-      Date: ['Wed, 10 Aug 2016 21:45:32 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:50 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage418031177315:k+Lb/2myYmiyiC1Yg568JCrQdUHsSR6HUKaowjXplVY=']
+      Authorization: ['SharedKey vcrstorage156388220623:FH/96l4NBppmBKsA5ksX57+dJKeI8c2oGknOclxPmqA=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [c427fd68-5f43-11e6-b709-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:45:33 GMT']
+      x-ms-client-request-id: [e1af2818-6313-11e6-8799-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:12:52 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1?comp=metadata
@@ -117,7 +117,7 @@ interactions:
     body: {string: ''}
     headers:
       Cache-Control: [no-cache]
-      Date: ['Wed, 10 Aug 2016 21:45:33 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:50 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-approximate-messages-count: ['0']
       x-ms-meta-a: [b]
@@ -127,12 +127,12 @@ interactions:
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage418031177315:3MKobL1XMgVDc/D/IO85SztACLLfh9Zgk6vxaOIVEHU=']
+      Authorization: ['SharedKey vcrstorage156388220623:QQ+4gosAFkR1Ytxsg88VhIH6S9Odpfbsf8P0oHO9GOA=']
       Connection: [keep-alive]
       Content-Length: ['0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [c44e1b82-5f43-11e6-b3a7-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:45:34 GMT']
+      x-ms-client-request-id: [e1d44468-6313-11e6-b267-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:12:52 GMT']
       x-ms-meta-e: [f]
       x-ms-meta-g: [h]
       x-ms-version: ['2015-07-08']
@@ -142,18 +142,18 @@ interactions:
     body: {string: ''}
     headers:
       Content-Length: ['0']
-      Date: ['Wed, 10 Aug 2016 21:45:32 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:51 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 204, message: No Content}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage418031177315:303NSy5PYKvyFxW9kQ7cZ7OHunGvuKhvlxh/V4DDSyo=']
+      Authorization: ['SharedKey vcrstorage156388220623:ukloaqXeksZ7DHAWh8RluKkqDbsFBd127KgFE0d2jrU=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [c47bcc50-5f43-11e6-8f6b-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:45:34 GMT']
+      x-ms-client-request-id: [e200e638-6313-11e6-a5a7-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:12:52 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1?comp=metadata
@@ -161,7 +161,7 @@ interactions:
     body: {string: ''}
     headers:
       Cache-Control: [no-cache]
-      Date: ['Wed, 10 Aug 2016 21:45:33 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:53 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-approximate-messages-count: ['0']
       x-ms-meta-e: [f]
@@ -171,11 +171,11 @@ interactions:
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage418031177315:+o3hs48e4w0cjcC7z/JOFdunoJkjO4PKzJafoizA0I0=']
+      Authorization: ['SharedKey vcrstorage156388220623:57jl4AQoCZxAYVCQdtQBvOFZbaSIbOAnPyvICHLAFGI=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [c4a01a30-5f43-11e6-911b-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:45:34 GMT']
+      x-ms-client-request-id: [e2269064-6313-11e6-868d-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:12:53 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
@@ -185,18 +185,18 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/xml]
-      Date: ['Wed, 10 Aug 2016 21:45:33 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:52 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage418031177315:hN/VDMMRNGyETCinLA6Q6//HEFUVEDhuQUrOrrlsMOc=']
+      Authorization: ['SharedKey vcrstorage156388220623:c2fC2lgjC5qKKPCkrVdvK4/IfD3H7lkJaSVIWzO7saY=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [c4cc6502-5f43-11e6-9005-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:45:35 GMT']
+      x-ms-client-request-id: [e24f77f6-6313-11e6-9c7d-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:12:53 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
@@ -206,7 +206,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/xml]
-      Date: ['Wed, 10 Aug 2016 21:45:33 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:52 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
@@ -218,12 +218,12 @@ interactions:
       UGVybWlzc2lvbj5yYXVwPC9QZXJtaXNzaW9uPjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRlbnRp
       Zmllcj48L1NpZ25lZElkZW50aWZpZXJzPg==
     headers:
-      Authorization: ['SharedKey vcrstorage418031177315:j+IoZTuh7wJ+u3xEAGY2z2CU/rXQU/ZLI0KFH3BlwNg=']
+      Authorization: ['SharedKey vcrstorage156388220623:rUn8+6fnTuFfL3Hv4sLCJx2Mdg6LVmJ+wqYQP2BDqug=']
       Connection: [keep-alive]
       Content-Length: ['253']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [c4e4bed8-5f43-11e6-96dc-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:45:35 GMT']
+      x-ms-client-request-id: [e2642ba8-6313-11e6-af1c-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:12:53 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
@@ -231,18 +231,18 @@ interactions:
     body: {string: ''}
     headers:
       Content-Length: ['0']
-      Date: ['Wed, 10 Aug 2016 21:45:33 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:52 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 204, message: No Content}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage418031177315:DXJoBkVmabBe0zBuWJkdLuKFQ+RN5LZtarhAT5C7cX4=']
+      Authorization: ['SharedKey vcrstorage156388220623:jQR570dhT2hi1d/eb5/jlqsEPekl62taSCOLE7gZplw=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [c508f774-5f43-11e6-b7e4-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:45:35 GMT']
+      x-ms-client-request-id: [e27a7a4c-6313-11e6-9999-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:12:53 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
@@ -251,18 +251,18 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/xml]
-      Date: ['Wed, 10 Aug 2016 21:45:34 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:52 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage418031177315:NgyGCrrNHo2keFniS1oiKggfCSat3WYZCk9/e9qH6UI=']
+      Authorization: ['SharedKey vcrstorage156388220623:McnwcbOINo4oSAjLnu3jCUAdSsE7dlOpac+rvDK1m4I=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [c533b426-5f43-11e6-9524-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:45:35 GMT']
+      x-ms-client-request-id: [e29e451a-6313-11e6-b5c3-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:12:53 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
@@ -271,18 +271,18 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/xml]
-      Date: ['Wed, 10 Aug 2016 21:45:34 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:52 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage418031177315:hTdjD+j2ly6zn/HUPejoLZkwGSAImwuB5zy/gtKqzdc=']
+      Authorization: ['SharedKey vcrstorage156388220623:ZhLOo0Gu0GPGbyzKgnmbnOk6L9EyT3R4MQqjtlQ8xws=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [c55b499c-5f43-11e6-8c3f-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:45:35 GMT']
+      x-ms-client-request-id: [e2c6b58c-6313-11e6-9fd9-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:12:54 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
@@ -291,7 +291,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/xml]
-      Date: ['Wed, 10 Aug 2016 21:45:34 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:52 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
@@ -303,12 +303,12 @@ interactions:
       cGlyeT48UGVybWlzc2lvbj5yYTwvUGVybWlzc2lvbj48L0FjY2Vzc1BvbGljeT48L1NpZ25lZElk
       ZW50aWZpZXI+PC9TaWduZWRJZGVudGlmaWVycz4=
     headers:
-      Authorization: ['SharedKey vcrstorage418031177315:e1aNBRYFqhmgk4Vc89CoTvAzeE88fI2xxgc3XBHXwYg=']
+      Authorization: ['SharedKey vcrstorage156388220623:jA5VrYBzx5ZnFhqiPsirF5YmSoK7Luc6oz9pcwu4coU=']
       Connection: [keep-alive]
       Content-Length: ['257']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [c5743ba4-5f43-11e6-b5d2-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:45:36 GMT']
+      x-ms-client-request-id: [e2dc741c-6313-11e6-987d-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:12:54 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
@@ -316,18 +316,18 @@ interactions:
     body: {string: ''}
     headers:
       Content-Length: ['0']
-      Date: ['Wed, 10 Aug 2016 21:45:34 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:52 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 204, message: No Content}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage418031177315:on+i9sa97AniUnLdEhTxCYClVA9Sbdxei4/YhDWNChQ=']
+      Authorization: ['SharedKey vcrstorage156388220623:45Tc3Oxbl2PchFgwGS/jNvKKL54IQcAXake1LL+ypAc=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [c5924cec-5f43-11e6-bd5f-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:45:36 GMT']
+      x-ms-client-request-id: [e2faa964-6313-11e6-a79c-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:12:54 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
@@ -336,18 +336,18 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/xml]
-      Date: ['Wed, 10 Aug 2016 21:45:34 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:52 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage418031177315:RSYixe/M/iS9KBVSbXwMqVj21k0IFjKBAoFB2NKOCHw=']
+      Authorization: ['SharedKey vcrstorage156388220623:6oXfExoqavo1ry/LerYryXQ2w0vrKSJArgYmpsO8pXM=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [c5bef79c-5f43-11e6-9290-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:45:36 GMT']
+      x-ms-client-request-id: [e3277e74-6313-11e6-b669-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:12:54 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
@@ -356,7 +356,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/xml]
-      Date: ['Wed, 10 Aug 2016 21:45:35 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:53 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
@@ -365,12 +365,12 @@ interactions:
       PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0ndXRmLTgnPz4KPFNpZ25lZElkZW50aWZpZXJz
       IC8+
     headers:
-      Authorization: ['SharedKey vcrstorage418031177315:q4cCXh8AOx4UgnTDuaI7Qeevat26ZdYujNG2Ig1sILQ=']
+      Authorization: ['SharedKey vcrstorage156388220623:lknWg4PWxHfpG5tE/z7ngYoHPOF0bTdK1tjigb2yNTg=']
       Connection: [keep-alive]
       Content-Length: ['60']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [c5d92adc-5f43-11e6-bf24-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:45:36 GMT']
+      x-ms-client-request-id: [e33d2d02-6313-11e6-8e8e-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:12:54 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
@@ -378,18 +378,18 @@ interactions:
     body: {string: ''}
     headers:
       Content-Length: ['0']
-      Date: ['Wed, 10 Aug 2016 21:45:35 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:53 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 204, message: No Content}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage418031177315:5evJLATsa8tw7zOx+U1F1AwQ+7oRxJy2rJngwe7lnJA=']
+      Authorization: ['SharedKey vcrstorage156388220623:3ljJf2UGky7CMRDLwMVIHNO6keC0m6vbqG00COvh4Cw=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [c5f5a3b8-5f43-11e6-bb16-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:45:37 GMT']
+      x-ms-client-request-id: [e354ebfa-6313-11e6-b953-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:12:55 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
@@ -399,7 +399,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/xml]
-      Date: ['Wed, 10 Aug 2016 21:45:35 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:53 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
@@ -408,65 +408,65 @@ interactions:
       PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0ndXRmLTgnPz4KPFF1ZXVlTWVzc2FnZT48TWVz
       c2FnZVRleHQ+dGVzdCBtZXNzYWdlPC9NZXNzYWdlVGV4dD48L1F1ZXVlTWVzc2FnZT4=
     headers:
-      Authorization: ['SharedKey vcrstorage418031177315:2/PdN/RIinAyuJnexVzg83YSk08kt26nkgWtjApuiqs=']
+      Authorization: ['SharedKey vcrstorage156388220623:q0RMah4YPPfdTRBUhz4m9VdUKetPO05d75v/FSoVOAU=']
       Connection: [keep-alive]
       Content-Length: ['107']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [c62e342e-5f43-11e6-b7b5-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:45:37 GMT']
+      x-ms-client-request-id: [e37a424c-6313-11e6-a3e9-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:12:55 GMT']
       x-ms-version: ['2015-07-08']
     method: POST
     uri: https://dummystorage.queue.core.windows.net/queue1/messages
   response:
     body: {string: ''}
     headers:
-      Date: ['Wed, 10 Aug 2016 21:45:35 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:53 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage418031177315:QSFBrXHIl2RRhlu84RTXoJqLD0T9LPrwPxAuM4kM8x8=']
+      Authorization: ['SharedKey vcrstorage156388220623:gSesQdjGHJijMESKtlN2hWIZYAxEbPbD5/aBV6/IR3A=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [c65c0a92-5f43-11e6-ac45-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:45:37 GMT']
+      x-ms-client-request-id: [e3a10592-6313-11e6-8884-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:12:55 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1/messages?peekonly=true
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>32631453-0700-46c6-9a94-73b9889f5fd6</MessageId><InsertionTime>Wed,\
-        \ 10 Aug 2016 21:45:36 GMT</InsertionTime><ExpirationTime>Wed, 17 Aug 2016\
-        \ 21:45:36 GMT</ExpirationTime><DequeueCount>0</DequeueCount><MessageText>test\
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>44170840-4d02-466b-a7ed-0c3fe305136e</MessageId><InsertionTime>Mon,\
+        \ 15 Aug 2016 18:12:53 GMT</InsertionTime><ExpirationTime>Mon, 22 Aug 2016\
+        \ 18:12:53 GMT</ExpirationTime><DequeueCount>0</DequeueCount><MessageText>test\
         \ message</MessageText></QueueMessage></QueueMessagesList>"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/xml]
-      Date: ['Wed, 10 Aug 2016 21:45:35 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:54 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage418031177315:cHZHrFGeuIUOW75WMsGb2rIM/DRVtjyQWax40I9Y70Y=']
+      Authorization: ['SharedKey vcrstorage156388220623:sFjZ9estabhuSQpTYfcCXI+iv3zJ+10UmlHk5uYc344=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [c680d468-5f43-11e6-a979-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:45:37 GMT']
+      x-ms-client-request-id: [e3c71512-6313-11e6-9a74-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:12:55 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1/messages
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>32631453-0700-46c6-9a94-73b9889f5fd6</MessageId><InsertionTime>Wed,\
-        \ 10 Aug 2016 21:45:36 GMT</InsertionTime><ExpirationTime>Wed, 17 Aug 2016\
-        \ 21:45:36 GMT</ExpirationTime><DequeueCount>1</DequeueCount><PopReceipt>AgAAAAMAAAAAAAAAggCTmVDz0QE=</PopReceipt><TimeNextVisible>Wed,\
-        \ 10 Aug 2016 21:46:06 GMT</TimeNextVisible><MessageText>test message</MessageText></QueueMessage></QueueMessagesList>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>44170840-4d02-466b-a7ed-0c3fe305136e</MessageId><InsertionTime>Mon,\
+        \ 15 Aug 2016 18:12:53 GMT</InsertionTime><ExpirationTime>Mon, 22 Aug 2016\
+        \ 18:12:53 GMT</ExpirationTime><DequeueCount>1</DequeueCount><PopReceipt>AgAAAAMAAAAAAAAA8JxptiD30QE=</PopReceipt><TimeNextVisible>Mon,\
+        \ 15 Aug 2016 18:13:24 GMT</TimeNextVisible><MessageText>test message</MessageText></QueueMessage></QueueMessagesList>"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/xml]
-      Date: ['Wed, 10 Aug 2016 21:45:37 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:54 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
@@ -475,45 +475,45 @@ interactions:
       PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0ndXRmLTgnPz4KPFF1ZXVlTWVzc2FnZT48TWVz
       c2FnZVRleHQ+bmV3IG1lc3NhZ2UhPC9NZXNzYWdlVGV4dD48L1F1ZXVlTWVzc2FnZT4=
     headers:
-      Authorization: ['SharedKey vcrstorage418031177315:CiySodSM7AiM2ciBqznetvS7h56c1Bx/tuL/YaySumE=']
+      Authorization: ['SharedKey vcrstorage156388220623:VJtYDgsK3W5tpPzNRMWUyuW0p4Taq9oJ3ZPSpBjY/T0=']
       Connection: [keep-alive]
       Content-Length: ['107']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [c6abccd2-5f43-11e6-ab2a-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:45:38 GMT']
+      x-ms-client-request-id: [e3ed5e8c-6313-11e6-a203-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:12:56 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.queue.core.windows.net/queue1/messages/32631453-0700-46c6-9a94-73b9889f5fd6?popreceipt=AgAAAAMAAAAAAAAAggCTmVDz0QE%3D&visibilitytimeout=1
+    uri: https://dummystorage.queue.core.windows.net/queue1/messages/44170840-4d02-466b-a7ed-0c3fe305136e?visibilitytimeout=1&popreceipt=AgAAAAMAAAAAAAAA8JxptiD30QE%3D
   response:
     body: {string: ''}
     headers:
       Content-Length: ['0']
-      Date: ['Wed, 10 Aug 2016 21:45:35 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:54 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-popreceipt: [AwAAAAMAAAAAAAAARIJ6iFDz0QEBAAAA]
-      x-ms-time-next-visible: ['Wed, 10 Aug 2016 21:45:38 GMT']
+      x-ms-popreceipt: [AwAAAAMAAAAAAAAAjENIpSD30QEBAAAA]
+      x-ms-time-next-visible: ['Mon, 15 Aug 2016 18:12:55 GMT']
       x-ms-version: ['2015-07-08']
     status: {code: 204, message: No Content}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage418031177315:bYMuNGLO3PDGWVZs0Jvj8yGlgond43crJNW2PY/ne24=']
+      Authorization: ['SharedKey vcrstorage156388220623:SWdro5flTKqsAUEbizR6iyRc4jAPOOwuHxV4+YEMsDA=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [c80a81e4-5f43-11e6-ad29-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:45:40 GMT']
+      x-ms-client-request-id: [e546653e-6313-11e6-a522-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:12:58 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1/messages?peekonly=true
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>32631453-0700-46c6-9a94-73b9889f5fd6</MessageId><InsertionTime>Wed,\
-        \ 10 Aug 2016 21:45:36 GMT</InsertionTime><ExpirationTime>Wed, 17 Aug 2016\
-        \ 21:45:36 GMT</ExpirationTime><DequeueCount>1</DequeueCount><MessageText>new\
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>44170840-4d02-466b-a7ed-0c3fe305136e</MessageId><InsertionTime>Mon,\
+        \ 15 Aug 2016 18:12:53 GMT</InsertionTime><ExpirationTime>Mon, 22 Aug 2016\
+        \ 18:12:53 GMT</ExpirationTime><DequeueCount>1</DequeueCount><MessageText>new\
         \ message!</MessageText></QueueMessage></QueueMessagesList>"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/xml]
-      Date: ['Wed, 10 Aug 2016 21:45:39 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:56 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
@@ -522,19 +522,19 @@ interactions:
       PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0ndXRmLTgnPz4KPFF1ZXVlTWVzc2FnZT48TWVz
       c2FnZVRleHQ+c2Vjb25kIG1lc3NhZ2U8L01lc3NhZ2VUZXh0PjwvUXVldWVNZXNzYWdlPg==
     headers:
-      Authorization: ['SharedKey vcrstorage418031177315:R15FVwdla25HVXmaxKdz1CSMT5EHMtG8ViF9V5+oE6A=']
+      Authorization: ['SharedKey vcrstorage156388220623:rSM4E/8yVssnB5LOdmVHxTqt2dImS+k/6VjH1di2lGU=']
       Connection: [keep-alive]
       Content-Length: ['109']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [c830ba74-5f43-11e6-8612-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:45:40 GMT']
+      x-ms-client-request-id: [e571bd2c-6313-11e6-afd9-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:12:58 GMT']
       x-ms-version: ['2015-07-08']
     method: POST
     uri: https://dummystorage.queue.core.windows.net/queue1/messages
   response:
     body: {string: ''}
     headers:
-      Date: ['Wed, 10 Aug 2016 21:45:39 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:57 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 201, message: Created}
@@ -543,129 +543,129 @@ interactions:
       PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0ndXRmLTgnPz4KPFF1ZXVlTWVzc2FnZT48TWVz
       c2FnZVRleHQ+dGhpcmQgbWVzc2FnZTwvTWVzc2FnZVRleHQ+PC9RdWV1ZU1lc3NhZ2U+
     headers:
-      Authorization: ['SharedKey vcrstorage418031177315:wxncsAVecuIxFf8VDj3OZkD9dxHS5YYNg44sbnlBeBE=']
+      Authorization: ['SharedKey vcrstorage156388220623:3mX26aEf1Innq1wMPDwDsshwIX+lAsCbfrS9fgJcNBY=']
       Connection: [keep-alive]
       Content-Length: ['108']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [c85abc58-5f43-11e6-91e3-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:45:41 GMT']
+      x-ms-client-request-id: [e598ecf0-6313-11e6-aae8-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:12:58 GMT']
       x-ms-version: ['2015-07-08']
     method: POST
     uri: https://dummystorage.queue.core.windows.net/queue1/messages
   response:
     body: {string: ''}
     headers:
-      Date: ['Wed, 10 Aug 2016 21:45:40 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:56 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage418031177315:1byqEhMfSi3WLx/Ag4BMBfi2x2gw2IjiixqLIO30WwE=']
+      Authorization: ['SharedKey vcrstorage156388220623:AiDTHgs2KyukxqCeo93bXHtD/89ULRwrR4/FjqARqVY=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [c88a7bd8-5f43-11e6-a0eb-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:45:41 GMT']
+      x-ms-client-request-id: [e5c0609c-6313-11e6-8ab9-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:12:59 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1/messages?numofmessages=32&peekonly=true
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>32631453-0700-46c6-9a94-73b9889f5fd6</MessageId><InsertionTime>Wed,\
-        \ 10 Aug 2016 21:45:36 GMT</InsertionTime><ExpirationTime>Wed, 17 Aug 2016\
-        \ 21:45:36 GMT</ExpirationTime><DequeueCount>1</DequeueCount><MessageText>new\
-        \ message!</MessageText></QueueMessage><QueueMessage><MessageId>8812297f-d577-44c9-a065-2133dd9bdc75</MessageId><InsertionTime>Wed,\
-        \ 10 Aug 2016 21:45:39 GMT</InsertionTime><ExpirationTime>Wed, 17 Aug 2016\
-        \ 21:45:39 GMT</ExpirationTime><DequeueCount>0</DequeueCount><MessageText>second\
-        \ message</MessageText></QueueMessage><QueueMessage><MessageId>82d3a3b1-f175-44f2-bfde-f35d7dbae551</MessageId><InsertionTime>Wed,\
-        \ 10 Aug 2016 21:45:40 GMT</InsertionTime><ExpirationTime>Wed, 17 Aug 2016\
-        \ 21:45:40 GMT</ExpirationTime><DequeueCount>0</DequeueCount><MessageText>third\
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>44170840-4d02-466b-a7ed-0c3fe305136e</MessageId><InsertionTime>Mon,\
+        \ 15 Aug 2016 18:12:53 GMT</InsertionTime><ExpirationTime>Mon, 22 Aug 2016\
+        \ 18:12:53 GMT</ExpirationTime><DequeueCount>1</DequeueCount><MessageText>new\
+        \ message!</MessageText></QueueMessage><QueueMessage><MessageId>344c148d-c3dc-44c8-9aba-572098a661a8</MessageId><InsertionTime>Mon,\
+        \ 15 Aug 2016 18:12:56 GMT</InsertionTime><ExpirationTime>Mon, 22 Aug 2016\
+        \ 18:12:56 GMT</ExpirationTime><DequeueCount>0</DequeueCount><MessageText>second\
+        \ message</MessageText></QueueMessage><QueueMessage><MessageId>f04f0b32-291e-4848-b75f-236c5bc0e517</MessageId><InsertionTime>Mon,\
+        \ 15 Aug 2016 18:12:57 GMT</InsertionTime><ExpirationTime>Mon, 22 Aug 2016\
+        \ 18:12:57 GMT</ExpirationTime><DequeueCount>0</DequeueCount><MessageText>third\
         \ message</MessageText></QueueMessage></QueueMessagesList>"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/xml]
-      Date: ['Wed, 10 Aug 2016 21:45:39 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:58 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage418031177315:SG5oSqMMm468F5Tns9cBcryBRj0HFz1lO4iIQADgte0=']
+      Authorization: ['SharedKey vcrstorage156388220623:pU/KN2i3U4bXJNAfEUQ1yhGz78WQTpYiMySCR0D0W3Q=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [c8aece3e-5f43-11e6-8d0f-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:45:41 GMT']
+      x-ms-client-request-id: [e5e67338-6313-11e6-8c08-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:12:59 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1/messages
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>32631453-0700-46c6-9a94-73b9889f5fd6</MessageId><InsertionTime>Wed,\
-        \ 10 Aug 2016 21:45:36 GMT</InsertionTime><ExpirationTime>Wed, 17 Aug 2016\
-        \ 21:45:36 GMT</ExpirationTime><DequeueCount>2</DequeueCount><PopReceipt>AgAAAAMAAAAAAAAAIWi/m1Dz0QE=</PopReceipt><TimeNextVisible>Wed,\
-        \ 10 Aug 2016 21:46:10 GMT</TimeNextVisible><MessageText>new message!</MessageText></QueueMessage></QueueMessagesList>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>44170840-4d02-466b-a7ed-0c3fe305136e</MessageId><InsertionTime>Mon,\
+        \ 15 Aug 2016 18:12:53 GMT</InsertionTime><ExpirationTime>Mon, 22 Aug 2016\
+        \ 18:12:53 GMT</ExpirationTime><DequeueCount>2</DequeueCount><PopReceipt>AgAAAAMAAAAAAAAAts2JuCD30QE=</PopReceipt><TimeNextVisible>Mon,\
+        \ 15 Aug 2016 18:13:27 GMT</TimeNextVisible><MessageText>new message!</MessageText></QueueMessage></QueueMessagesList>"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/xml]
-      Date: ['Wed, 10 Aug 2016 21:45:39 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:57 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage418031177315:oJZZCnHnPV2ipFrZXWXorFGNhOcCoRr33yVzz94HRdM=']
+      Authorization: ['SharedKey vcrstorage156388220623:mZsJgk0E/4sduxr0VcfYThKgDZu13sL5KtVsz8CIvWQ=']
       Connection: [keep-alive]
       Content-Length: ['0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [c8dd45dc-5f43-11e6-b81d-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:45:41 GMT']
+      x-ms-client-request-id: [e60d2cc6-6313-11e6-8b8c-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:12:59 GMT']
       x-ms-version: ['2015-07-08']
     method: DELETE
-    uri: https://dummystorage.queue.core.windows.net/queue1/messages/32631453-0700-46c6-9a94-73b9889f5fd6?popreceipt=AgAAAAMAAAAAAAAAIWi%2Fm1Dz0QE%3D
+    uri: https://dummystorage.queue.core.windows.net/queue1/messages/44170840-4d02-466b-a7ed-0c3fe305136e?popreceipt=AgAAAAMAAAAAAAAAts2JuCD30QE%3D
   response:
     body: {string: ''}
     headers:
       Content-Length: ['0']
-      Date: ['Wed, 10 Aug 2016 21:45:40 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:58 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 204, message: No Content}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage418031177315:vyIF5qiwKwP0CyReV3d6cMSMVSthS/VK3Q8LBHEGj0c=']
+      Authorization: ['SharedKey vcrstorage156388220623:KM+9wdblplsQ988Mm5l5SupNpMNg/7u3TItKfPYODXw=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [c900ed4c-5f43-11e6-afe0-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:45:42 GMT']
+      x-ms-client-request-id: [e634b1f0-6313-11e6-9c7e-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:12:59 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1/messages?numofmessages=32&peekonly=true
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>8812297f-d577-44c9-a065-2133dd9bdc75</MessageId><InsertionTime>Wed,\
-        \ 10 Aug 2016 21:45:39 GMT</InsertionTime><ExpirationTime>Wed, 17 Aug 2016\
-        \ 21:45:39 GMT</ExpirationTime><DequeueCount>0</DequeueCount><MessageText>second\
-        \ message</MessageText></QueueMessage><QueueMessage><MessageId>82d3a3b1-f175-44f2-bfde-f35d7dbae551</MessageId><InsertionTime>Wed,\
-        \ 10 Aug 2016 21:45:40 GMT</InsertionTime><ExpirationTime>Wed, 17 Aug 2016\
-        \ 21:45:40 GMT</ExpirationTime><DequeueCount>0</DequeueCount><MessageText>third\
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>344c148d-c3dc-44c8-9aba-572098a661a8</MessageId><InsertionTime>Mon,\
+        \ 15 Aug 2016 18:12:56 GMT</InsertionTime><ExpirationTime>Mon, 22 Aug 2016\
+        \ 18:12:56 GMT</ExpirationTime><DequeueCount>0</DequeueCount><MessageText>second\
+        \ message</MessageText></QueueMessage><QueueMessage><MessageId>f04f0b32-291e-4848-b75f-236c5bc0e517</MessageId><InsertionTime>Mon,\
+        \ 15 Aug 2016 18:12:57 GMT</InsertionTime><ExpirationTime>Mon, 22 Aug 2016\
+        \ 18:12:57 GMT</ExpirationTime><DequeueCount>0</DequeueCount><MessageText>third\
         \ message</MessageText></QueueMessage></QueueMessagesList>"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/xml]
-      Date: ['Wed, 10 Aug 2016 21:45:40 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:58 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage418031177315:N3L5ZoB77j4zXybf7ucuegoG46AETnneWV+GIlEQuU0=']
+      Authorization: ['SharedKey vcrstorage156388220623:t5hVXi1YjU6gCuEB8GknNGbus4xy51UeV8b10RmJQxg=']
       Connection: [keep-alive]
       Content-Length: ['0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [c92a8d8a-5f43-11e6-9771-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:45:42 GMT']
+      x-ms-client-request-id: [e6587f0c-6313-11e6-abc7-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:13:00 GMT']
       x-ms-version: ['2015-07-08']
     method: DELETE
     uri: https://dummystorage.queue.core.windows.net/queue1/messages
@@ -673,18 +673,18 @@ interactions:
     body: {string: ''}
     headers:
       Content-Length: ['0']
-      Date: ['Wed, 10 Aug 2016 21:45:40 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:59 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 204, message: No Content}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage418031177315:i6TOFGy+Huw279Bs2pcm4rElkzrt65g6wsypM6Fxwz8=']
+      Authorization: ['SharedKey vcrstorage156388220623:fbM8PM5mwuWWRgO1Zs4F7H7bQpDWHKQuxq4PscMg/Bs=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [c94e0098-5f43-11e6-82aa-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:45:42 GMT']
+      x-ms-client-request-id: [e68cc0a6-6313-11e6-951a-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:13:00 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1/messages?numofmessages=32&peekonly=true
@@ -694,19 +694,19 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/xml]
-      Date: ['Wed, 10 Aug 2016 21:45:41 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:58 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage418031177315:tIEEzbUHQokhwTihcZUZLl/Zs1XuasN+M86G48+TslM=']
+      Authorization: ['SharedKey vcrstorage156388220623:NlYzJ9zjLO9ZkJwEx3M+7oDyKr1AwHkXGxznKS8qc3Q=']
       Connection: [keep-alive]
       Content-Length: ['0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [c974bdca-5f43-11e6-a365-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:45:42 GMT']
+      x-ms-client-request-id: [e6b4ea0c-6313-11e6-a1cb-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:13:00 GMT']
       x-ms-version: ['2015-07-08']
     method: DELETE
     uri: https://dummystorage.queue.core.windows.net/queue1
@@ -714,29 +714,29 @@ interactions:
     body: {string: ''}
     headers:
       Content-Length: ['0']
-      Date: ['Wed, 10 Aug 2016 21:45:41 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:59 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 204, message: No Content}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage418031177315:sivkW0ZJbQH6T+i5DVw+g8f6nkEfmB/uEjVbPXWswbw=']
+      Authorization: ['SharedKey vcrstorage156388220623:VEmZ0eD+6o3hU8XqU4mv6dRVIvjUeyVyqX91qrCjO5g=']
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [c998a700-5f43-11e6-8c12-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:45:43 GMT']
+      x-ms-client-request-id: [e6dacb5a-6313-11e6-9e92-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:13:01 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1?comp=metadata
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>QueueNotFound</Code><Message>The\
-        \ specified queue does not exist.\nRequestId:d473bfe0-0003-0111-4350-f3259a000000\n\
-        Time:2016-08-10T21:45:41.5595300Z</Message></Error>"}
+        \ specified queue does not exist.\nRequestId:96f1119f-0003-0080-7720-f72215000000\n\
+        Time:2016-08-15T18:13:00.2306615Z</Message></Error>"}
     headers:
       Content-Length: ['217']
       Content-Type: [application/xml]
-      Date: ['Wed, 10 Aug 2016 21:45:40 GMT']
+      Date: ['Mon, 15 Aug 2016 18:12:59 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 404, message: The specified queue does not exist.}

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_table_scenario.yaml
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_table_scenario.yaml
@@ -4,7 +4,7 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDcwODYwMTYzLCJuYmYiOjE0NzA4NjAxNjMsImV4cCI6MTQ3MDg2NDA2MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6NzIwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjEuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.NIGzbcLdKg82jBzOTKWw-d9wVUhzOuPlY29z3a_adLV4iYZ4i3DomUjjjaGZqg5-x-3pwth3APp96Xko9Icqf0CKOpNWMb-mohX0SibMnvWyzBGuTXn8EPh-D658-NVDX9uRJD1PfzgAIjuyFEGoUCGWtuq7Yxh7H_UZibM1VzH_UqMqK6MWZb7aqEqDx2_2o-T9aKtxXVriCEWxZYyA8-1u8fczYWJBfAREG9rMv_S9sH7taqEaVndA-pK12vf3IxkzbjnmibHAjTII9BhDghdY0CA6ZG9IaCe3u4yjju3mlR0nVwgqTLM-h2rvE-rBA3Xt9omTx6Rs7C_eeFyr6A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDcxMjgyNDA1LCJuYmYiOjE0NzEyODI0MDUsImV4cCI6MTQ3MTI4NjMwNSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6NzIwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjEuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.VGKXsuHHplz2RKW1PolZIRGSsQwxExx9UVzCkSoS1wKER27wwmXNcBM4dFN5SZLsrwRHH7pVmHPCKUEEtFb0Ae1OnsNrOag7yaH9rAqkXlMgmymWHnBWULXKwb1Q8iJJLDfBElavEUwHOIKfJGQAtYdJ_XPon_imVLATcg_dlX0dS4ixyrbvKbo3L17GzyUHsMbgy0_S2LpuC4JK0h__s_Ujl5HYmf9n2rDZzc7LOWA8VuQhAGnsqWkPA4igoyVlc36YeBlkYsd8DSkhhXRTkIOpxogXZuovN6ikUifyHWzB5PNvHs0gHLaoQPQnGS5aa-UdNc19zXfi4Iqw2RiqPQ]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
@@ -12,7 +12,7 @@ interactions:
           msrest_azure/0.4.1 storagemanagementclient/0.30.0rc5 Azure-SDK-For-Python
           AZURECLI/TEST/0.0.1.dev0]
       accept-language: [en-US]
-      x-ms-client-request-id: [edfcffec-5f3e-11e6-ad5b-a0b3ccf7272a]
+      x-ms-client-request-id: [08fb92ae-6315-11e6-840a-a0b3ccf7272a]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_table_scenario_test/providers/Microsoft.Storage/storageAccounts/dummystorage.listKeys?api-version=2016-01-01
   response:
@@ -20,29 +20,29 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR2/z
-        6+ajR9/jX15ki/yjR/ht96PRR6u8XhRNU1RLavDRs3VZ0oeXWblGm9/n7JP89dVPfufl+Ysf/MTv
-        9fC4Plnd3//i2cG9l1fn55PXX7x89hP3fzD96XdP937R9dOTn/5k8Z3lVz+5On178OXvc/r6wXKx
-        +3lbfOcXXbx78xP16ouXZ68u3n756ZfHn3320S8ZdVDZo143ovL87sHdL8uDd9er7/w+l18cX5yW
-        P7V+Pf3y3e+V//T+zu5P/T7vzpuLs+Jy/2391Xd/Ms+uivbb5/nd59nv/Z3dd/fe7i2u3r7+ydXd
-        yfR4983ian7yenXy4MuLnwAq3/8lyf8DIMtEEyEBAAA=
+        6+ajR9/jX15ki/yjR/ht96PRR6u8XhRNU1RLavDRs3VZ0oeXWblGm/Xzdn39yRefvDv56qd/+uTe
+        5Lp5c/5770zaB/Ovnv6i62//Pp88WDx7Or23fDA7Ll/s1MtPPjl48PvsfXH34vXv/dXe711M3v3k
+        D540P/2Ldst7+yffXh3kX05+r+989+qzzz76JaMOKnvU60ZUTicHn95/3iwefP6dq+9U361/sr3/
+        8vPP1/WTV8/eHHz+6dnv8yQ/uNdePH39yS+6/r2e7T396dP9p81s98svP7n3e79a1Tvf3fmpu8++
+        bF7+Pj949fKLp7PT+bN3i5pR+f4vSf4fE616kiEBAAA=
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Wed, 10 Aug 2016 21:10:56 GMT']
+      Date: ['Mon, 15 Aug 2016 18:21:06 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
       eyJUYWJsZU5hbWUiOiAidGFibGUxIn0=
     headers:
       Accept: [application/json;odata=minimalmetadata]
-      Authorization: ['SharedKey vcrstorage674541728147:grW+OzEeqZlFbYJKSE9sTibnz9+v91UaLXQwJK6Gm5I=']
+      Authorization: ['SharedKey vcrstorage213648744859:A3qMLlECUStxR/M2KKDDvIyiXqQkc7SIagIlJ7PWm/I=']
       Connection: [keep-alive]
       Content-Length: ['23']
       Content-Type: [application/json]
@@ -50,8 +50,8 @@ interactions:
       MaxDataServiceVersion: ['3.0']
       Prefer: [return-no-content]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [ee2c80b4-5f3e-11e6-a47c-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:10:56 GMT']
+      x-ms-client-request-id: [0947763a-6315-11e6-a37e-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:08 GMT']
       x-ms-version: ['2015-07-08']
     method: POST
     uri: https://dummystorage.table.core.windows.net/Tables
@@ -60,9 +60,9 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      DataServiceId: ['https://vcrstorage674541728147.table.core.windows.net/Tables(''table1'')']
-      Date: ['Wed, 10 Aug 2016 21:10:55 GMT']
-      Location: ['https://vcrstorage674541728147.table.core.windows.net/Tables(''table1'')']
+      DataServiceId: ['https://vcrstorage213648744859.table.core.windows.net/Tables(''table1'')']
+      Date: ['Mon, 15 Aug 2016 18:21:06 GMT']
+      Location: ['https://vcrstorage213648744859.table.core.windows.net/Tables(''table1'')']
       Preference-Applied: [return-no-content]
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       X-Content-Type-Options: [nosniff]
@@ -72,13 +72,13 @@ interactions:
     body: null
     headers:
       Accept: [application/json;odata=nometadata]
-      Authorization: ['SharedKey vcrstorage674541728147:oc76pG2o5sfV8UJ/jShYjdADaJb0JYpEcGJLdupoOfw=']
+      Authorization: ['SharedKey vcrstorage213648744859:tkYGFrbePzF/Vlw5pPvzDJ5qhl21MlUZHoRdtn9eecQ=']
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [ee70b9f4-5f3e-11e6-87eb-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:10:57 GMT']
+      x-ms-client-request-id: [0981ec46-6315-11e6-99e6-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:08 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/Tables('table1')
@@ -87,7 +87,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json;odata=nometadata;streaming=true;charset=utf-8]
-      Date: ['Wed, 10 Aug 2016 21:10:55 GMT']
+      Date: ['Mon, 15 Aug 2016 18:21:07 GMT']
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       X-Content-Type-Options: [nosniff]
       x-ms-version: ['2015-07-08']
@@ -96,13 +96,13 @@ interactions:
     body: null
     headers:
       Accept: [application/json;odata=nometadata]
-      Authorization: ['SharedKey vcrstorage674541728147:dRoukWng4JBJATBZ70tW8mex+8DCcbskqAIX6m5wh4o=']
+      Authorization: ['SharedKey vcrstorage213648744859:zyq+k507CTo7pHTwGtTtTrE8Oi8WJNwc4lU6SfqrPQs=']
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [ee987798-5f3e-11e6-aa8e-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:10:57 GMT']
+      x-ms-client-request-id: [09a9a41e-6315-11e6-acb1-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:08 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/Tables
@@ -111,7 +111,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json;odata=nometadata;streaming=true;charset=utf-8]
-      Date: ['Wed, 10 Aug 2016 21:10:56 GMT']
+      Date: ['Mon, 15 Aug 2016 18:21:07 GMT']
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       X-Content-Type-Options: [nosniff]
       x-ms-version: ['2015-07-08']
@@ -119,13 +119,13 @@ interactions:
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage674541728147:S+QOIauANa4ZJ4nnnUS796fOwJPokNF/Zxk7xvxA8lE=']
+      Authorization: ['SharedKey vcrstorage213648744859:P0ku9FY+lwRA7mX6dkyY5x++OfMKiSq3ktX8b8i58LM=']
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [eebf3802-5f3e-11e6-ab1d-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:10:57 GMT']
+      x-ms-client-request-id: [09d1f24c-6315-11e6-90a0-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:09 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
@@ -134,20 +134,20 @@ interactions:
         \ />"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Wed, 10 Aug 2016 21:10:56 GMT']
+      Date: ['Mon, 15 Aug 2016 18:21:07 GMT']
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage674541728147:RUbDV+8mjC7VCTZI1V/Ohmqz8XTsV1eZFyVayRpxMtU=']
+      Authorization: ['SharedKey vcrstorage213648744859:P0ku9FY+lwRA7mX6dkyY5x++OfMKiSq3ktX8b8i58LM=']
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [eee804f0-5f3e-11e6-8b65-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:10:58 GMT']
+      x-ms-client-request-id: [09f8929a-6315-11e6-8399-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:09 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
@@ -156,7 +156,7 @@ interactions:
         \ />"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Wed, 10 Aug 2016 21:10:57 GMT']
+      Date: ['Mon, 15 Aug 2016 18:21:08 GMT']
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
@@ -164,17 +164,17 @@ interactions:
     body: !!binary |
       PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0ndXRmLTgnPz4KPFNpZ25lZElkZW50aWZpZXJz
       PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MTwvSWQ+PEFjY2Vzc1BvbGljeT48UGVybWlzc2lv
-      bj5yPC9QZXJtaXNzaW9uPjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRlbnRpZmllcj48L1NpZ25l
+      bj5hPC9QZXJtaXNzaW9uPjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRlbnRpZmllcj48L1NpZ25l
       ZElkZW50aWZpZXJzPg==
     headers:
-      Authorization: ['SharedKey vcrstorage674541728147:2Z0/cLQKoCZkdgRYbaHEzrnvJITgpN4DRykBrYBWizw=']
+      Authorization: ['SharedKey vcrstorage213648744859:7wBvLlayiAQ036nYi4Uc5v8m9TKyfnWnLbKCD4v3h54=']
       Connection: [keep-alive]
       Content-Length: ['184']
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [eefc33d8-5f3e-11e6-a148-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:10:58 GMT']
+      x-ms-client-request-id: [0a0d9d1e-6315-11e6-a9b6-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:09 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
@@ -182,48 +182,48 @@ interactions:
     body: {string: ''}
     headers:
       Content-Length: ['0']
-      Date: ['Wed, 10 Aug 2016 21:10:57 GMT']
+      Date: ['Mon, 15 Aug 2016 18:21:08 GMT']
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 204, message: No Content}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage674541728147:RUbDV+8mjC7VCTZI1V/Ohmqz8XTsV1eZFyVayRpxMtU=']
+      Authorization: ['SharedKey vcrstorage213648744859:P0ku9FY+lwRA7mX6dkyY5x++OfMKiSq3ktX8b8i58LM=']
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [ef11492c-5f3e-11e6-b44b-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:10:58 GMT']
+      x-ms-client-request-id: [0a380998-6315-11e6-b661-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:09 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>r</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Wed, 10 Aug 2016 21:10:57 GMT']
+      Date: ['Mon, 15 Aug 2016 18:21:07 GMT']
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
       PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0ndXRmLTgnPz4KPFNpZ25lZElkZW50aWZpZXJz
-      PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MjwvSWQ+PEFjY2Vzc1BvbGljeT48U3RhcnQ+MjAx
-      Ni0wMS0wMVQwMDowMFo8L1N0YXJ0PjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRlbnRpZmllcj48
-      U2lnbmVkSWRlbnRpZmllcj48SWQ+dGVzdDE8L0lkPjxBY2Nlc3NQb2xpY3k+PFBlcm1pc3Npb24+
-      cjwvUGVybWlzc2lvbj48L0FjY2Vzc1BvbGljeT48L1NpZ25lZElkZW50aWZpZXI+PC9TaWduZWRJ
+      PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MTwvSWQ+PEFjY2Vzc1BvbGljeT48UGVybWlzc2lv
+      bj5hPC9QZXJtaXNzaW9uPjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRlbnRpZmllcj48U2lnbmVk
+      SWRlbnRpZmllcj48SWQ+dGVzdDI8L0lkPjxBY2Nlc3NQb2xpY3k+PFN0YXJ0PjIwMTYtMDEtMDFU
+      MDA6MDBaPC9TdGFydD48L0FjY2Vzc1BvbGljeT48L1NpZ25lZElkZW50aWZpZXI+PC9TaWduZWRJ
       ZGVudGlmaWVycz4=
     headers:
-      Authorization: ['SharedKey vcrstorage674541728147:2Z0/cLQKoCZkdgRYbaHEzrnvJITgpN4DRykBrYBWizw=']
+      Authorization: ['SharedKey vcrstorage213648744859:7wBvLlayiAQ036nYi4Uc5v8m9TKyfnWnLbKCD4v3h54=']
       Connection: [keep-alive]
       Content-Length: ['296']
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [ef26133a-5f3e-11e6-ac18-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:10:58 GMT']
+      x-ms-client-request-id: [0a4c7390-6315-11e6-bf99-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:09 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
@@ -231,50 +231,50 @@ interactions:
     body: {string: ''}
     headers:
       Content-Length: ['0']
-      Date: ['Wed, 10 Aug 2016 21:10:57 GMT']
+      Date: ['Mon, 15 Aug 2016 18:21:08 GMT']
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 204, message: No Content}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage674541728147:RUbDV+8mjC7VCTZI1V/Ohmqz8XTsV1eZFyVayRpxMtU=']
+      Authorization: ['SharedKey vcrstorage213648744859:8JJaLTu6m/SSugkVavZCONLCbmtNrTrjOreWSr4G3JQ=']
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [ef3ad450-5f3e-11e6-b392-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:10:58 GMT']
+      x-ms-client-request-id: [0a638f2e-6315-11e6-883e-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:10 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>r</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Wed, 10 Aug 2016 21:10:57 GMT']
+      Date: ['Mon, 15 Aug 2016 18:21:08 GMT']
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
       PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0ndXRmLTgnPz4KPFNpZ25lZElkZW50aWZpZXJz
-      PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MjwvSWQ+PEFjY2Vzc1BvbGljeT48U3RhcnQ+MjAx
-      Ni0wMS0wMVQwMDowMDowMFo8L1N0YXJ0PjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRlbnRpZmll
-      cj48U2lnbmVkSWRlbnRpZmllcj48SWQ+dGVzdDE8L0lkPjxBY2Nlc3NQb2xpY3k+PFBlcm1pc3Np
-      b24+cjwvUGVybWlzc2lvbj48L0FjY2Vzc1BvbGljeT48L1NpZ25lZElkZW50aWZpZXI+PFNpZ25l
+      PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MTwvSWQ+PEFjY2Vzc1BvbGljeT48UGVybWlzc2lv
+      bj5hPC9QZXJtaXNzaW9uPjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRlbnRpZmllcj48U2lnbmVk
+      SWRlbnRpZmllcj48SWQ+dGVzdDI8L0lkPjxBY2Nlc3NQb2xpY3k+PFN0YXJ0PjIwMTYtMDEtMDFU
+      MDA6MDA6MDBaPC9TdGFydD48L0FjY2Vzc1BvbGljeT48L1NpZ25lZElkZW50aWZpZXI+PFNpZ25l
       ZElkZW50aWZpZXI+PElkPnRlc3QzPC9JZD48QWNjZXNzUG9saWN5PjxFeHBpcnk+MjAxOC0wMS0w
       MVQwMDowMFo8L0V4cGlyeT48L0FjY2Vzc1BvbGljeT48L1NpZ25lZElkZW50aWZpZXI+PC9TaWdu
       ZWRJZGVudGlmaWVycz4=
     headers:
-      Authorization: ['SharedKey vcrstorage674541728147:2Z0/cLQKoCZkdgRYbaHEzrnvJITgpN4DRykBrYBWizw=']
+      Authorization: ['SharedKey vcrstorage213648744859:uOFA1Z8bpL3PjDNb2C2duRXNZhHo0baJrAPuZl0mrFk=']
       Connection: [keep-alive]
       Content-Length: ['413']
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [ef4fe698-5f3e-11e6-83de-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:10:58 GMT']
+      x-ms-client-request-id: [0a773c58-6315-11e6-bbdc-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:10 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
@@ -282,53 +282,53 @@ interactions:
     body: {string: ''}
     headers:
       Content-Length: ['0']
-      Date: ['Wed, 10 Aug 2016 21:10:57 GMT']
+      Date: ['Mon, 15 Aug 2016 18:21:08 GMT']
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 204, message: No Content}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage674541728147:dxYpe983QFVVYqaqwgvPvz0VPJ+xRJmn6x84C4/D7Ac=']
+      Authorization: ['SharedKey vcrstorage213648744859:8JJaLTu6m/SSugkVavZCONLCbmtNrTrjOreWSr4G3JQ=']
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [ef64d1ca-5f3e-11e6-af8c-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:10:59 GMT']
+      x-ms-client-request-id: [0a924422-6315-11e6-bfc0-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:10 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>r</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Wed, 10 Aug 2016 21:10:57 GMT']
+      Date: ['Mon, 15 Aug 2016 18:21:09 GMT']
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
       PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0ndXRmLTgnPz4KPFNpZ25lZElkZW50aWZpZXJz
-      PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MjwvSWQ+PEFjY2Vzc1BvbGljeT48U3RhcnQ+MjAx
-      Ni0wMS0wMVQwMDowMDowMFo8L1N0YXJ0PjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRlbnRpZmll
-      cj48U2lnbmVkSWRlbnRpZmllcj48SWQ+dGVzdDE8L0lkPjxBY2Nlc3NQb2xpY3k+PFBlcm1pc3Np
-      b24+cjwvUGVybWlzc2lvbj48L0FjY2Vzc1BvbGljeT48L1NpZ25lZElkZW50aWZpZXI+PFNpZ25l
-      ZElkZW50aWZpZXI+PElkPnRlc3Q0PC9JZD48QWNjZXNzUG9saWN5PjxTdGFydD4yMDE2LTAxLTAx
-      VDAwOjAwWjwvU3RhcnQ+PEV4cGlyeT4yMDE2LTA1LTAxVDAwOjAwWjwvRXhwaXJ5PjxQZXJtaXNz
-      aW9uPnJhdWQ8L1Blcm1pc3Npb24+PC9BY2Nlc3NQb2xpY3k+PC9TaWduZWRJZGVudGlmaWVyPjxT
+      PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0NDwvSWQ+PEFjY2Vzc1BvbGljeT48U3RhcnQ+MjAx
+      Ni0wMS0wMVQwMDowMFo8L1N0YXJ0PjxFeHBpcnk+MjAxNi0wNS0wMVQwMDowMFo8L0V4cGlyeT48
+      UGVybWlzc2lvbj5yYXVkPC9QZXJtaXNzaW9uPjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRlbnRp
+      Zmllcj48U2lnbmVkSWRlbnRpZmllcj48SWQ+dGVzdDE8L0lkPjxBY2Nlc3NQb2xpY3k+PFBlcm1p
+      c3Npb24+YTwvUGVybWlzc2lvbj48L0FjY2Vzc1BvbGljeT48L1NpZ25lZElkZW50aWZpZXI+PFNp
+      Z25lZElkZW50aWZpZXI+PElkPnRlc3QyPC9JZD48QWNjZXNzUG9saWN5PjxTdGFydD4yMDE2LTAx
+      LTAxVDAwOjAwOjAwWjwvU3RhcnQ+PC9BY2Nlc3NQb2xpY3k+PC9TaWduZWRJZGVudGlmaWVyPjxT
       aWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MzwvSWQ+PEFjY2Vzc1BvbGljeT48RXhwaXJ5PjIwMTgt
       MDEtMDFUMDA6MDA6MDBaPC9FeHBpcnk+PC9BY2Nlc3NQb2xpY3k+PC9TaWduZWRJZGVudGlmaWVy
       PjwvU2lnbmVkSWRlbnRpZmllcnM+
     headers:
-      Authorization: ['SharedKey vcrstorage674541728147:YaS2QNVpb3qKV5R91hTGrN/aK6nAT7EMSYTCJLYe8mY=']
+      Authorization: ['SharedKey vcrstorage213648744859:uOFA1Z8bpL3PjDNb2C2duRXNZhHo0baJrAPuZl0mrFk=']
       Connection: [keep-alive]
       Content-Length: ['591']
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [ef79e426-5f3e-11e6-95bd-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:10:59 GMT']
+      x-ms-client-request-id: [0aa9b1dc-6315-11e6-880b-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:10 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
@@ -336,158 +336,158 @@ interactions:
     body: {string: ''}
     headers:
       Content-Length: ['0']
-      Date: ['Wed, 10 Aug 2016 21:10:57 GMT']
+      Date: ['Mon, 15 Aug 2016 18:21:09 GMT']
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 204, message: No Content}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage674541728147:dxYpe983QFVVYqaqwgvPvz0VPJ+xRJmn6x84C4/D7Ac=']
+      Authorization: ['SharedKey vcrstorage213648744859:8JJaLTu6m/SSugkVavZCONLCbmtNrTrjOreWSr4G3JQ=']
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [ef942766-5f3e-11e6-bcd1-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:10:59 GMT']
+      x-ms-client-request-id: [0ac45c5c-6315-11e6-a8cf-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:10 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>r</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Wed, 10 Aug 2016 21:10:58 GMT']
+      Date: ['Mon, 15 Aug 2016 18:21:09 GMT']
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage674541728147:dxYpe983QFVVYqaqwgvPvz0VPJ+xRJmn6x84C4/D7Ac=']
+      Authorization: ['SharedKey vcrstorage213648744859:v+hoSccrAkirRa/20G5EqAPsMr8wa+jZ1XwcTnPkWcY=']
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [efb9de6c-5f3e-11e6-9951-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:10:59 GMT']
+      x-ms-client-request-id: [0aeba40a-6315-11e6-be13-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:11 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>r</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Wed, 10 Aug 2016 21:10:57 GMT']
+      Date: ['Mon, 15 Aug 2016 18:21:10 GMT']
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage674541728147:dxYpe983QFVVYqaqwgvPvz0VPJ+xRJmn6x84C4/D7Ac=']
+      Authorization: ['SharedKey vcrstorage213648744859:v+hoSccrAkirRa/20G5EqAPsMr8wa+jZ1XwcTnPkWcY=']
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [efe1179c-5f3e-11e6-a29c-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:10:59 GMT']
+      x-ms-client-request-id: [0b13b018-6315-11e6-890a-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:11 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>r</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Wed, 10 Aug 2016 21:10:58 GMT']
+      Date: ['Mon, 15 Aug 2016 18:21:09 GMT']
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage674541728147:F8eSsuJIqGtLuNBQHEiDYlfEJgnaAxsTLFraTyjD5EM=']
+      Authorization: ['SharedKey vcrstorage213648744859:v+hoSccrAkirRa/20G5EqAPsMr8wa+jZ1XwcTnPkWcY=']
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [f008f448-5f3e-11e6-b804-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:11:00 GMT']
+      x-ms-client-request-id: [0b3c0b14-6315-11e6-846c-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:11 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>r</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Wed, 10 Aug 2016 21:10:59 GMT']
+      Date: ['Mon, 15 Aug 2016 18:21:10 GMT']
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage674541728147:F8eSsuJIqGtLuNBQHEiDYlfEJgnaAxsTLFraTyjD5EM=']
+      Authorization: ['SharedKey vcrstorage213648744859:v+hoSccrAkirRa/20G5EqAPsMr8wa+jZ1XwcTnPkWcY=']
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [f0302434-5f3e-11e6-bcf0-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:11:00 GMT']
+      x-ms-client-request-id: [0b652c28-6315-11e6-9f1a-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:11 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>r</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Wed, 10 Aug 2016 21:10:59 GMT']
+      Date: ['Mon, 15 Aug 2016 18:21:10 GMT']
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage674541728147:F8eSsuJIqGtLuNBQHEiDYlfEJgnaAxsTLFraTyjD5EM=']
+      Authorization: ['SharedKey vcrstorage213648744859:fEL/ZfPupcWwph9qTraFZH/xCYNW6v29R9iPen7Hfio=']
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [f0579148-5f3e-11e6-9f33-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:11:00 GMT']
+      x-ms-client-request-id: [0b8e24fa-6315-11e6-99b5-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:12 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>r</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Wed, 10 Aug 2016 21:10:59 GMT']
+      Date: ['Mon, 15 Aug 2016 18:21:10 GMT']
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
       PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0ndXRmLTgnPz4KPFNpZ25lZElkZW50aWZpZXJz
-      PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MjwvSWQ+PEFjY2Vzc1BvbGljeT48U3RhcnQ+MjAx
-      Ni0wMS0wMVQwMDowMDowMFo8L1N0YXJ0PjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRlbnRpZmll
-      cj48U2lnbmVkSWRlbnRpZmllcj48SWQ+dGVzdDE8L0lkPjxBY2Nlc3NQb2xpY3k+PFBlcm1pc3Np
-      b24+cmE8L1Blcm1pc3Npb24+PC9BY2Nlc3NQb2xpY3k+PC9TaWduZWRJZGVudGlmaWVyPjxTaWdu
-      ZWRJZGVudGlmaWVyPjxJZD50ZXN0NDwvSWQ+PEFjY2Vzc1BvbGljeT48U3RhcnQ+MjAxNi0wMS0w
-      MVQwMDowMDowMFo8L1N0YXJ0PjxFeHBpcnk+MjAxNi0wNS0wMVQwMDowMDowMFo8L0V4cGlyeT48
-      UGVybWlzc2lvbj5yYXVkPC9QZXJtaXNzaW9uPjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRlbnRp
+      PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0NDwvSWQ+PEFjY2Vzc1BvbGljeT48U3RhcnQ+MjAx
+      Ni0wMS0wMVQwMDowMDowMFo8L1N0YXJ0PjxFeHBpcnk+MjAxNi0wNS0wMVQwMDowMDowMFo8L0V4
+      cGlyeT48UGVybWlzc2lvbj5yYXVkPC9QZXJtaXNzaW9uPjwvQWNjZXNzUG9saWN5PjwvU2lnbmVk
+      SWRlbnRpZmllcj48U2lnbmVkSWRlbnRpZmllcj48SWQ+dGVzdDE8L0lkPjxBY2Nlc3NQb2xpY3k+
+      PFBlcm1pc3Npb24+YXU8L1Blcm1pc3Npb24+PC9BY2Nlc3NQb2xpY3k+PC9TaWduZWRJZGVudGlm
+      aWVyPjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MjwvSWQ+PEFjY2Vzc1BvbGljeT48U3RhcnQ+
+      MjAxNi0wMS0wMVQwMDowMDowMFo8L1N0YXJ0PjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRlbnRp
       Zmllcj48U2lnbmVkSWRlbnRpZmllcj48SWQ+dGVzdDM8L0lkPjxBY2Nlc3NQb2xpY3k+PEV4cGly
       eT4yMDE4LTAxLTAxVDAwOjAwOjAwWjwvRXhwaXJ5PjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRl
       bnRpZmllcj48L1NpZ25lZElkZW50aWZpZXJzPg==
     headers:
-      Authorization: ['SharedKey vcrstorage674541728147:h3Mb2nHfYkTWu7Aow9n7R4OWHxUs+K7BSNEzB+YuYDE=']
+      Authorization: ['SharedKey vcrstorage213648744859:8WvZ6kpajToCCvH2fQvkjxf1LUO5PXXaptrg/DDxWKg=']
       Connection: [keep-alive]
       Content-Length: ['598']
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [f06d032c-5f3e-11e6-bc8a-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:11:00 GMT']
+      x-ms-client-request-id: [0ba2f8f8-6315-11e6-a055-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:12 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
@@ -495,72 +495,72 @@ interactions:
     body: {string: ''}
     headers:
       Content-Length: ['0']
-      Date: ['Wed, 10 Aug 2016 21:10:59 GMT']
+      Date: ['Mon, 15 Aug 2016 18:21:10 GMT']
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 204, message: No Content}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage674541728147:F8eSsuJIqGtLuNBQHEiDYlfEJgnaAxsTLFraTyjD5EM=']
+      Authorization: ['SharedKey vcrstorage213648744859:fEL/ZfPupcWwph9qTraFZH/xCYNW6v29R9iPen7Hfio=']
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [f08c4f5c-5f3e-11e6-be05-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:11:00 GMT']
+      x-ms-client-request-id: [0bbfafa8-6315-11e6-bfb6-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:12 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>ra</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>au</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Wed, 10 Aug 2016 21:11:01 GMT']
+      Date: ['Mon, 15 Aug 2016 18:21:11 GMT']
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage674541728147:yGZtg9J5XhcvzWj7nlNSSIvsSF/DB2SmWfi3CpyhOH8=']
+      Authorization: ['SharedKey vcrstorage213648744859:fEL/ZfPupcWwph9qTraFZH/xCYNW6v29R9iPen7Hfio=']
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [f1a157a4-5f3e-11e6-8b01-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:11:02 GMT']
+      x-ms-client-request-id: [0be520fe-6315-11e6-870d-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:12 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>ra</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>au</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Wed, 10 Aug 2016 21:11:01 GMT']
+      Date: ['Mon, 15 Aug 2016 18:21:11 GMT']
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
       PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0ndXRmLTgnPz4KPFNpZ25lZElkZW50aWZpZXJz
-      PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0MjwvSWQ+PEFjY2Vzc1BvbGljeT48U3RhcnQ+MjAx
-      Ni0wMS0wMVQwMDowMDowMFo8L1N0YXJ0PjwvQWNjZXNzUG9saWN5PjwvU2lnbmVkSWRlbnRpZmll
-      cj48U2lnbmVkSWRlbnRpZmllcj48SWQ+dGVzdDQ8L0lkPjxBY2Nlc3NQb2xpY3k+PFN0YXJ0PjIw
-      MTYtMDEtMDFUMDA6MDA6MDBaPC9TdGFydD48RXhwaXJ5PjIwMTYtMDUtMDFUMDA6MDA6MDBaPC9F
-      eHBpcnk+PFBlcm1pc3Npb24+cmF1ZDwvUGVybWlzc2lvbj48L0FjY2Vzc1BvbGljeT48L1NpZ25l
+      PjxTaWduZWRJZGVudGlmaWVyPjxJZD50ZXN0NDwvSWQ+PEFjY2Vzc1BvbGljeT48U3RhcnQ+MjAx
+      Ni0wMS0wMVQwMDowMDowMFo8L1N0YXJ0PjxFeHBpcnk+MjAxNi0wNS0wMVQwMDowMDowMFo8L0V4
+      cGlyeT48UGVybWlzc2lvbj5yYXVkPC9QZXJtaXNzaW9uPjwvQWNjZXNzUG9saWN5PjwvU2lnbmVk
+      SWRlbnRpZmllcj48U2lnbmVkSWRlbnRpZmllcj48SWQ+dGVzdDI8L0lkPjxBY2Nlc3NQb2xpY3k+
+      PFN0YXJ0PjIwMTYtMDEtMDFUMDA6MDA6MDBaPC9TdGFydD48L0FjY2Vzc1BvbGljeT48L1NpZ25l
       ZElkZW50aWZpZXI+PFNpZ25lZElkZW50aWZpZXI+PElkPnRlc3QzPC9JZD48QWNjZXNzUG9saWN5
       PjxFeHBpcnk+MjAxOC0wMS0wMVQwMDowMDowMFo8L0V4cGlyeT48L0FjY2Vzc1BvbGljeT48L1Np
       Z25lZElkZW50aWZpZXI+PC9TaWduZWRJZGVudGlmaWVycz4=
     headers:
-      Authorization: ['SharedKey vcrstorage674541728147:aSyCLVjtlzbyVr8mnf1ECmflpin0rQVufJhMFYwbaK8=']
+      Authorization: ['SharedKey vcrstorage213648744859:8WvZ6kpajToCCvH2fQvkjxf1LUO5PXXaptrg/DDxWKg=']
       Connection: [keep-alive]
       Content-Length: ['491']
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [f1b65e14-5f3e-11e6-acd2-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:11:02 GMT']
+      x-ms-client-request-id: [0bfc0f5e-6315-11e6-b501-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:12 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
@@ -568,38 +568,38 @@ interactions:
     body: {string: ''}
     headers:
       Content-Length: ['0']
-      Date: ['Wed, 10 Aug 2016 21:11:01 GMT']
+      Date: ['Mon, 15 Aug 2016 18:21:11 GMT']
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 204, message: No Content}
 - request:
     body: null
     headers:
-      Authorization: ['SharedKey vcrstorage674541728147:tYPVCbDDugafjl0J+W/3pT0TomsqjkPulvuBFWWPJDo=']
+      Authorization: ['SharedKey vcrstorage213648744859:fEL/ZfPupcWwph9qTraFZH/xCYNW6v29R9iPen7Hfio=']
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [f1ccc800-5f3e-11e6-b1d6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:11:03 GMT']
+      x-ms-client-request-id: [0c131048-6315-11e6-b362-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:12 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Wed, 10 Aug 2016 21:11:01 GMT']
+      Date: ['Mon, 15 Aug 2016 18:21:11 GMT']
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJ2YWx1ZSI6ICJzb21ldGhpbmciLCAiUm93S2V5IjogIjAwMSIsICJuYW1lIjogInRlc3QiLCAi
-      UGFydGl0aW9uS2V5IjogIjAwMSJ9
+      eyJuYW1lIjogInRlc3QiLCAidmFsdWUiOiAic29tZXRoaW5nIiwgIlBhcnRpdGlvbktleSI6ICIw
+      MDEiLCAiUm93S2V5IjogIjAwMSJ9
     headers:
       Accept: [application/json;odata=minimalmetadata]
-      Authorization: ['SharedKey vcrstorage674541728147:oYS7rQev63xuxw8Z2qA5VuADcCtuO1FcD97S/TEl3hA=']
+      Authorization: ['SharedKey vcrstorage213648744859:1N+3cvu0A0JcB+nAVnu9G+FaDMC5pVKSlnAbceWYYI4=']
       Connection: [keep-alive]
       Content-Length: ['78']
       Content-Type: [application/json]
@@ -607,8 +607,8 @@ interactions:
       MaxDataServiceVersion: ['3.0']
       Prefer: [return-no-content]
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [f1f161c8-5f3e-11e6-b121-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:11:03 GMT']
+      x-ms-client-request-id: [0c389f6e-6315-11e6-90a9-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:13 GMT']
       x-ms-version: ['2015-07-08']
     method: POST
     uri: https://dummystorage.table.core.windows.net/table1
@@ -617,10 +617,10 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      DataServiceId: ['https://vcrstorage674541728147.table.core.windows.net/table1(PartitionKey=''001'',RowKey=''001'')']
-      Date: ['Wed, 10 Aug 2016 21:11:01 GMT']
-      ETag: [W/"datetime'2016-08-10T21%3A11%3A01.2703238Z'"]
-      Location: ['https://vcrstorage674541728147.table.core.windows.net/table1(PartitionKey=''001'',RowKey=''001'')']
+      DataServiceId: ['https://vcrstorage213648744859.table.core.windows.net/table1(PartitionKey=''001'',RowKey=''001'')']
+      Date: ['Mon, 15 Aug 2016 18:21:11 GMT']
+      ETag: [W/"datetime'2016-08-15T18%3A21%3A12.5234965Z'"]
+      Location: ['https://vcrstorage213648744859.table.core.windows.net/table1(PartitionKey=''001'',RowKey=''001'')']
       Preference-Applied: [return-no-content]
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       X-Content-Type-Options: [nosniff]
@@ -630,23 +630,23 @@ interactions:
     body: null
     headers:
       Accept: [application/json;odata=minimalmetadata]
-      Authorization: ['SharedKey vcrstorage674541728147:6X6XLDHNP31JQuCFQsw6cIdy2+6ztEZHr1rzJWEMgRM=']
+      Authorization: ['SharedKey vcrstorage213648744859:UufjSStb2Kfd0j4nq5UKWhH6V6RsYQUBUh87xHisB9U=']
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [f21b1590-5f3e-11e6-a35b-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:11:03 GMT']
+      x-ms-client-request-id: [0c5f7ce8-6315-11e6-a0b5-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:13 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1(PartitionKey='001',RowKey='001')
   response:
-    body: {string: '{"odata.metadata":"https://vcrstorage674541728147.table.core.windows.net/$metadata#table1/@Element","odata.etag":"W/\"datetime''2016-08-10T21%3A11%3A01.2703238Z''\"","PartitionKey":"001","RowKey":"001","Timestamp":"2016-08-10T21:11:01.2703238Z","value":"something","name":"test"}'}
+    body: {string: '{"odata.metadata":"https://vcrstorage213648744859.table.core.windows.net/$metadata#table1/@Element","odata.etag":"W/\"datetime''2016-08-15T18%3A21%3A12.5234965Z''\"","PartitionKey":"001","RowKey":"001","Timestamp":"2016-08-15T18:21:12.5234965Z","name":"test","value":"something"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
-      Date: ['Wed, 10 Aug 2016 21:11:01 GMT']
-      ETag: [W/"datetime'2016-08-10T21%3A11%3A01.2703238Z'"]
+      Date: ['Mon, 15 Aug 2016 18:21:11 GMT']
+      ETag: [W/"datetime'2016-08-15T18%3A21%3A12.5234965Z'"]
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       X-Content-Type-Options: [nosniff]
       x-ms-version: ['2015-07-08']
@@ -655,34 +655,34 @@ interactions:
     body: null
     headers:
       Accept: [application/json;odata=minimalmetadata]
-      Authorization: ['SharedKey vcrstorage674541728147:6X6XLDHNP31JQuCFQsw6cIdy2+6ztEZHr1rzJWEMgRM=']
+      Authorization: ['SharedKey vcrstorage213648744859:UufjSStb2Kfd0j4nq5UKWhH6V6RsYQUBUh87xHisB9U=']
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [f2419e3e-5f3e-11e6-8734-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:11:03 GMT']
+      x-ms-client-request-id: [0c89bf5c-6315-11e6-95a7-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:13 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1(PartitionKey='001',RowKey='001')?%24select=name
   response:
-    body: {string: '{"odata.metadata":"https://vcrstorage674541728147.table.core.windows.net/$metadata#table1/@Element&$select=name","odata.etag":"W/\"datetime''2016-08-10T21%3A11%3A01.2703238Z''\"","name":"test"}'}
+    body: {string: '{"odata.metadata":"https://vcrstorage213648744859.table.core.windows.net/$metadata#table1/@Element&$select=name","odata.etag":"W/\"datetime''2016-08-15T18%3A21%3A12.5234965Z''\"","name":"test"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
-      Date: ['Wed, 10 Aug 2016 21:11:02 GMT']
-      ETag: [W/"datetime'2016-08-10T21%3A11%3A01.2703238Z'"]
+      Date: ['Mon, 15 Aug 2016 18:21:12 GMT']
+      ETag: [W/"datetime'2016-08-15T18%3A21%3A12.5234965Z'"]
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       X-Content-Type-Options: [nosniff]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJ2YWx1ZSI6ICJuZXd2YWwiLCAiUm93S2V5IjogIjAwMSIsICJuYW1lIjogInRlc3QiLCAiUGFy
-      dGl0aW9uS2V5IjogIjAwMSJ9
+      eyJuYW1lIjogInRlc3QiLCAidmFsdWUiOiAibmV3dmFsIiwgIlBhcnRpdGlvbktleSI6ICIwMDEi
+      LCAiUm93S2V5IjogIjAwMSJ9
     headers:
       Accept: [application/json;odata=minimalmetadata]
-      Authorization: ['SharedKey vcrstorage674541728147:TiuKuUtpOxEQGY0T2V5pks88QZC+lTE0A8PyhR1XHmQ=']
+      Authorization: ['SharedKey vcrstorage213648744859:aF3Jthgnw1Wdg/u87I+pBDoyh3Y4YL8CWjsoSrlf+2U=']
       Connection: [keep-alive]
       Content-Length: ['75']
       Content-Type: [application/json]
@@ -690,8 +690,8 @@ interactions:
       If-Match: ['*']
       MaxDataServiceVersion: ['3.0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [f269a6f6-5f3e-11e6-a843-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:11:04 GMT']
+      x-ms-client-request-id: [0cb0c36c-6315-11e6-96de-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:13 GMT']
       x-ms-version: ['2015-07-08']
     method: MERGE
     uri: https://dummystorage.table.core.windows.net/table1(PartitionKey='001',RowKey='001')
@@ -700,8 +700,8 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Wed, 10 Aug 2016 21:11:02 GMT']
-      ETag: [W/"datetime'2016-08-10T21%3A11%3A02.6113589Z'"]
+      Date: ['Mon, 15 Aug 2016 18:21:12 GMT']
+      ETag: [W/"datetime'2016-08-15T18%3A21%3A13.1149822Z'"]
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       X-Content-Type-Options: [nosniff]
       x-ms-version: ['2015-07-08']
@@ -710,33 +710,33 @@ interactions:
     body: null
     headers:
       Accept: [application/json;odata=minimalmetadata]
-      Authorization: ['SharedKey vcrstorage674541728147:cGO2INWuD1LAkK7snO7O47fsG/DglXmc+RYPkjrEq2k=']
+      Authorization: ['SharedKey vcrstorage213648744859:clp/joyB0916h0+vdlwNPHvHkMVutbZ2nZED1pseoyY=']
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [f28dbe76-5f3e-11e6-8f00-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:11:04 GMT']
+      x-ms-client-request-id: [0ce0fb8c-6315-11e6-aa7f-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:14 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1(PartitionKey='001',RowKey='001')
   response:
-    body: {string: '{"odata.metadata":"https://vcrstorage674541728147.table.core.windows.net/$metadata#table1/@Element","odata.etag":"W/\"datetime''2016-08-10T21%3A11%3A02.6113589Z''\"","PartitionKey":"001","RowKey":"001","Timestamp":"2016-08-10T21:11:02.6113589Z","name":"test","value":"newval"}'}
+    body: {string: '{"odata.metadata":"https://vcrstorage213648744859.table.core.windows.net/$metadata#table1/@Element","odata.etag":"W/\"datetime''2016-08-15T18%3A21%3A13.1149822Z''\"","PartitionKey":"001","RowKey":"001","Timestamp":"2016-08-15T18:21:13.1149822Z","name":"test","value":"newval"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
-      Date: ['Wed, 10 Aug 2016 21:11:03 GMT']
-      ETag: [W/"datetime'2016-08-10T21%3A11%3A02.6113589Z'"]
+      Date: ['Mon, 15 Aug 2016 18:21:13 GMT']
+      ETag: [W/"datetime'2016-08-15T18%3A21%3A13.1149822Z'"]
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       X-Content-Type-Options: [nosniff]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJSb3dLZXkiOiAiMDAxIiwgIlBhcnRpdGlvbktleSI6ICIwMDEiLCAiY2F0IjogImhhdCJ9
+      eyJjYXQiOiAiaGF0IiwgIlJvd0tleSI6ICIwMDEiLCAiUGFydGl0aW9uS2V5IjogIjAwMSJ9
     headers:
       Accept: [application/json;odata=minimalmetadata]
-      Authorization: ['SharedKey vcrstorage674541728147:urk1mVCdtBx/CAesQh+4lkyNfwZpUzVaZ7ULMBL1EBE=']
+      Authorization: ['SharedKey vcrstorage213648744859:18H7rYc/48IvS+a+5cKrIzShN9I36aAJc+dygFVoDdw=']
       Connection: [keep-alive]
       Content-Length: ['54']
       Content-Type: [application/json]
@@ -744,8 +744,8 @@ interactions:
       If-Match: ['*']
       MaxDataServiceVersion: ['3.0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [f2b7d310-5f3e-11e6-98df-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:11:04 GMT']
+      x-ms-client-request-id: [0d0a546c-6315-11e6-98ab-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:14 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.table.core.windows.net/table1(PartitionKey='001',RowKey='001')
@@ -754,8 +754,8 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Wed, 10 Aug 2016 21:11:02 GMT']
-      ETag: [W/"datetime'2016-08-10T21%3A11%3A03.1298372Z'"]
+      Date: ['Mon, 15 Aug 2016 18:21:13 GMT']
+      ETag: [W/"datetime'2016-08-15T18%3A21%3A13.6945522Z'"]
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       X-Content-Type-Options: [nosniff]
       x-ms-version: ['2015-07-08']
@@ -764,23 +764,23 @@ interactions:
     body: null
     headers:
       Accept: [application/json;odata=minimalmetadata]
-      Authorization: ['SharedKey vcrstorage674541728147:cGO2INWuD1LAkK7snO7O47fsG/DglXmc+RYPkjrEq2k=']
+      Authorization: ['SharedKey vcrstorage213648744859:clp/joyB0916h0+vdlwNPHvHkMVutbZ2nZED1pseoyY=']
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [f2e586ac-5f3e-11e6-b5e0-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:11:04 GMT']
+      x-ms-client-request-id: [0d329c0c-6315-11e6-96b7-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:14 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1(PartitionKey='001',RowKey='001')
   response:
-    body: {string: '{"odata.metadata":"https://vcrstorage674541728147.table.core.windows.net/$metadata#table1/@Element","odata.etag":"W/\"datetime''2016-08-10T21%3A11%3A03.1298372Z''\"","PartitionKey":"001","RowKey":"001","Timestamp":"2016-08-10T21:11:03.1298372Z","cat":"hat"}'}
+    body: {string: '{"odata.metadata":"https://vcrstorage213648744859.table.core.windows.net/$metadata#table1/@Element","odata.etag":"W/\"datetime''2016-08-15T18%3A21%3A13.6945522Z''\"","PartitionKey":"001","RowKey":"001","Timestamp":"2016-08-15T18:21:13.6945522Z","cat":"hat"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
-      Date: ['Wed, 10 Aug 2016 21:11:02 GMT']
-      ETag: [W/"datetime'2016-08-10T21%3A11%3A03.1298372Z'"]
+      Date: ['Mon, 15 Aug 2016 18:21:13 GMT']
+      ETag: [W/"datetime'2016-08-15T18%3A21%3A13.6945522Z'"]
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       X-Content-Type-Options: [nosniff]
       x-ms-version: ['2015-07-08']
@@ -789,15 +789,15 @@ interactions:
     body: null
     headers:
       Accept: [application/json;odata=minimalmetadata]
-      Authorization: ['SharedKey vcrstorage674541728147:Kr+e2wcF6d4gQejAsGW9Wdd2pmM20BnRYuJoIaHFTJo=']
+      Authorization: ['SharedKey vcrstorage213648744859:DUR+g20f0p2nHwkdjTUXwv3n8eSn4JVeLW6lxYKhhJs=']
       Connection: [keep-alive]
       Content-Length: ['0']
       DataServiceVersion: [3.0;NetFx]
       If-Match: ['*']
       MaxDataServiceVersion: ['3.0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [f30bea54-5f3e-11e6-abb9-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:11:05 GMT']
+      x-ms-client-request-id: [0d5abd22-6315-11e6-8a4c-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:15 GMT']
       x-ms-version: ['2015-07-08']
     method: DELETE
     uri: https://dummystorage.table.core.windows.net/table1(PartitionKey='001',RowKey='001')
@@ -806,7 +806,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Wed, 10 Aug 2016 21:11:03 GMT']
+      Date: ['Mon, 15 Aug 2016 18:21:13 GMT']
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       X-Content-Type-Options: [nosniff]
       x-ms-version: ['2015-07-08']
@@ -815,23 +815,23 @@ interactions:
     body: null
     headers:
       Accept: [application/json;odata=minimalmetadata]
-      Authorization: ['SharedKey vcrstorage674541728147:WHeBScY0l/KlTrwFeZXh1G4nrWl3ZUpI2JXzT4K9qhI=']
+      Authorization: ['SharedKey vcrstorage213648744859:V9fzNv+TqfddPYuBxkHXCjkdAyYrtbGTUbS0sssME98=']
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [f3312c10-5f3e-11e6-829f-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:11:05 GMT']
+      x-ms-client-request-id: [0d87bcc6-6315-11e6-835a-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:15 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1(PartitionKey='001',RowKey='001')
   response:
     body: {string: '{"odata.error":{"code":"ResourceNotFound","message":{"lang":"en-US","value":"The
-        specified resource does not exist.\nRequestId:661f88ed-0002-00ca-094b-f3a3bb000000\nTime:2016-08-10T21:11:04.5732694Z"}}}'}
+        specified resource does not exist.\nRequestId:a4830fcb-0002-0076-0721-f7b4ca000000\nTime:2016-08-15T18:21:14.4842980Z"}}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
-      Date: ['Wed, 10 Aug 2016 21:11:04 GMT']
+      Date: ['Mon, 15 Aug 2016 18:21:13 GMT']
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       X-Content-Type-Options: [nosniff]
       x-ms-version: ['2015-07-08']
@@ -840,14 +840,14 @@ interactions:
     body: null
     headers:
       Accept: [application/json;odata=minimalmetadata]
-      Authorization: ['SharedKey vcrstorage674541728147:zD34RcebuhOn9Ujtvgxhl7FJE3oNpVg3X7089mAlBSA=']
+      Authorization: ['SharedKey vcrstorage213648744859:Nm+Mbai5+s4kpo+DYqCosT91zM528xJtrcue/EwayKA=']
       Connection: [keep-alive]
       Content-Length: ['0']
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [f35498ae-5f3e-11e6-b8cc-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:11:05 GMT']
+      x-ms-client-request-id: [0daf45b4-6315-11e6-b82f-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:15 GMT']
       x-ms-version: ['2015-07-08']
     method: DELETE
     uri: https://dummystorage.table.core.windows.net/Tables('table1')
@@ -856,7 +856,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Wed, 10 Aug 2016 21:11:04 GMT']
+      Date: ['Mon, 15 Aug 2016 18:21:14 GMT']
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       X-Content-Type-Options: [nosniff]
       x-ms-version: ['2015-07-08']
@@ -865,23 +865,23 @@ interactions:
     body: null
     headers:
       Accept: [application/json;odata=nometadata]
-      Authorization: ['SharedKey vcrstorage674541728147:bQNA2VUA+dJZ2rd9mN3pH1Z1mswr2JedGb5bFOZSnWA=']
+      Authorization: ['SharedKey vcrstorage213648744859:dCOtZNAPXxDY97nRuUhRRr+blnoGfZUBr5sleCSEUxY=']
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       User-Agent: [Azure-Storage/0.32.0 (Python CPython 3.5.1; Windows 10)]
-      x-ms-client-request-id: [f37cc11e-5f3e-11e6-b939-a0b3ccf7272a]
-      x-ms-date: ['Wed, 10 Aug 2016 21:11:05 GMT']
+      x-ms-client-request-id: [0dd86150-6315-11e6-931d-a0b3ccf7272a]
+      x-ms-date: ['Mon, 15 Aug 2016 18:21:15 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/Tables('table1')
   response:
     body: {string: '{"odata.error":{"code":"ResourceNotFound","message":{"lang":"en-US","value":"The
-        specified resource does not exist.\nRequestId:9b93d2d9-0002-0054-3e4b-f3dafc000000\nTime:2016-08-10T21:11:05.1321676Z"}}}'}
+        specified resource does not exist.\nRequestId:9c7db07f-0002-0119-5921-f75a4b000000\nTime:2016-08-15T18:21:15.1362316Z"}}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json;odata=nometadata;streaming=true;charset=utf-8]
-      Date: ['Wed, 10 Aug 2016 21:11:05 GMT']
+      Date: ['Mon, 15 Aug 2016 18:21:14 GMT']
       Server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       X-Content-Type-Options: [nosniff]
       x-ms-version: ['2015-07-08']

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/test_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/test_validators.py
@@ -28,75 +28,73 @@ class Test_storage_validators(unittest.TestCase):
 
     def test_permission_validator(self):
         from azure.storage.blob.models import ContainerPermissions
-        self.assertIsNotNone(get_permission_validator(ContainerPermissions)('rwdl'))
+        from argparse import Namespace
+        
+        ns1 = Namespace(permission='rwdl')
+        ns2 = Namespace(permission='abc')
+        get_permission_validator(ContainerPermissions)(ns1)
+        self.assertTrue(isinstance(ns1.permission, ContainerPermissions))
         with self.assertRaises(ValueError):
-            get_permission_validator(ContainerPermissions)('abc')
+            get_permission_validator(ContainerPermissions)(ns2)
 
-    def test_date_as_string_valid(self):
+    def test_datetime_string_type(self):
         input = "2017-01-01T12:30Z"
-        actual = validate_datetime_as_string(input)
+        actual = datetime_string_type(input)
         expected = "2017-01-01T12:30Z"
         self.assertEqual(actual, expected)
 
-    def test_date_as_string_invalid(self):
         input = "2017-01-01 12:30"
         with self.assertRaises(ValueError):
-            actual = validate_datetime_as_string(input)
+            actual = datetime_string_type(input)
 
-    def test_date_valid(self):
+    def test_datetime_type(self):
         input = "2017-01-01T12:30Z"
-        actual = validate_datetime(input)
+        actual = datetime_type(input)
         expected = datetime(2017, 1, 1, 12, 30, 0)
         self.assertEqual(actual, expected)
 
-    def test_date_invalid(self):
         input = "2017-01-01 12:30"
         with self.assertRaises(ValueError):
-            actual = validate_datetime(input)
+            actual = datetime_type(input)
 
-    def test_ip_address_single(self):
+    def test_ipv4_range_type(self):
         input = "111.22.3.111"
-        actual = validate_ip_range(input)
+        actual = ipv4_range_type(input)
         expected = input
         self.assertEqual(actual, expected)
 
-    def test_ip_address_range(self):
         input = "111.22.3.111-222.11.44.111"
-        actual = validate_ip_range(input)
+        actual = ipv4_range_type(input)
         expected = input
         self.assertEqual(actual, expected)
 
-    def test_ip_address_fail(self):
         input = "111.22"
         with self.assertRaises(ValueError):        
-            actual = validate_ip_range(input)
+            actual = ipv4_range_type(input)
     
-    def test_ip_address_fail2(self):
         input = "111.22.33.44-"
         with self.assertRaises(ValueError):
-            actual = validate_ip_range(input)
+            actual = ipv4_range_type(input)
 
-    def test_resource_types_valid(self):
+    def test_resource_types_type(self):
         input = "sso"
-        actual = str(validate_resource_types(input))
+        actual = str(resource_type_type(input))
         expected = "so"
         self.assertEqual(actual, expected)
 
-    def test_resource_types_invalid(self):
         input = "blob"
         with self.assertRaises(ValueError):
-            actual = validate_resource_types(input)
+            actual = resource_type_type(input)
 
-    def test_services_types_valid(self):
+    def test_services_type(self):
         input = "ttfqbqtf"
-        actual = str(validate_services(input))
+        actual = str(services_type(input))
         expected = "bqtf"
         self.assertEqual(actual, expected)
 
-    def test_services_invalid(self):
         input = "everything"
         with self.assertRaises(ValueError):
-            actual = validate_services(input)
+            actual = services_type(input)
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/test_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/test_validators.py
@@ -76,17 +76,6 @@ class Test_storage_validators(unittest.TestCase):
         with self.assertRaises(ValueError):
             actual = validate_ip_range(input)
 
-    def test_container_permission(self):
-        input = "llwrwd"
-        actual = str(validate_container_permission(input))
-        expected = "rwdl"
-        self.assertEqual(actual, expected)
-
-    def test_container_permission_fail(self):
-        input = "all"
-        with self.assertRaises(ValueError):
-            actual = str(validate_container_permission(input))
-
     def test_resource_types_valid(self):
         input = "sso"
         actual = str(validate_resource_types(input))

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/test_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/test_validators.py
@@ -26,6 +26,12 @@ class Test_storage_validators(unittest.TestCase):
     def tearDown(self):
         self.io.close()
 
+    def test_permission_validator(self):
+        from azure.storage.blob.models import ContainerPermissions
+        self.assertIsNotNone(get_permission_validator(ContainerPermissions)('rwdl'))
+        with self.assertRaises(ValueError):
+            get_permission_validator(ContainerPermissions)('abc')
+
     def test_date_as_string_valid(self):
         input = "2017-01-01T12:30Z"
         actual = validate_datetime_as_string(input)


### PR DESCRIPTION
Addresses issues #421, #640, #641 and #642.
- Enhancements to ACL policy and SAS permissions
- Adds the following storage subcommands: cors, logging, metrics
- Renames `share contents` to `file list`
- Adds support for previously unsupported parameters (`encryption`, `content-settings`)
