### PR TITLE
Custom Argument Groups

### DIFF
--- a/src/azure/cli/commands/__init__.py
+++ b/src/azure/cli/commands/__init__.py
@@ -49,7 +49,7 @@ class CliArgumentType(object):
 
 class CliCommandArgument(object):
 
-    _NAMED_ARGUMENTS = ('options_list', 'validator', 'completer', 'id_part')
+    _NAMED_ARGUMENTS = ('options_list', 'validator', 'completer', 'id_part', 'arg_group')
 
     def __init__(self, dest=None, argtype=None, **kwargs):
         self.type = CliArgumentType(overrides=argtype, **kwargs)

--- a/src/azure/cli/commands/arm.py
+++ b/src/azure/cli/commands/arm.py
@@ -138,9 +138,10 @@ def add_id_parameters(command_table):
                 missing_required = ' '.join((arg.options_list[0] for arg in errors))
                 raise CLIError('({} | {}) are required'.format(missing_required, '--ids'))
 
+        group_name = 'Resource Id'
         for key, arg in command.arguments.items():
             if command.arguments[key].id_part:
-                command.arguments[key].arg_group = 'ResourceId'
+                command.arguments[key].arg_group = group_name
 
         command.add_argument(argparse.SUPPRESS,
                              '--ids',
@@ -150,7 +151,7 @@ def add_id_parameters(command_table):
                              nargs='+',
                              type=ResourceId,
                              validator=required_values_validator,
-                             arg_group='ResourceId')
+                             arg_group=group_name)
 
     for command in command_table.values():
         command_loaded_handler(command)
@@ -226,18 +227,19 @@ def register_generic_update(name, getter, setter, factory=None, setter_arg_name=
     cmd.arguments.update(set_arguments)
     cmd.arguments.update(get_arguments)
     cmd.arguments.pop(setter_arg_name, None)
+    group_name = 'Generic Update'
     cmd.add_argument('properties_to_set', '--set', nargs='+', action=OrderedArgsAction, default=[],
                      help='Update an object by specifying a property path and value to set.'
                      '  Example: --set property1.property2=value',
-                     metavar='KEY=VALUE', arg_group='GenericUpdate')
+                     metavar='KEY=VALUE', arg_group=group_name)
     cmd.add_argument('properties_to_add', '--add', nargs='+', action=OrderedArgsAction, default=[],
                      help='Add an object to a list of objects by specifying a path and key'
                      ' value pairs.  Example: --add property.list key=<value>',
-                     metavar='LIST KEY=VALUE', arg_group='GenericUpdate')
+                     metavar='LIST KEY=VALUE', arg_group=group_name)
     cmd.add_argument('properties_to_remove', '--remove', nargs='+', action=OrderedArgsAction,
                      default=[], help='Remove a property or an element from a list.  Example: '
                      '--remove property.list <index>', metavar='LIST INDEX',
-                     arg_group='GenericUpdate')
+                     arg_group=group_name)
     main_command_table[name] = cmd
 
 index_regex = re.compile(r'\[(.*)\]')

--- a/src/azure/cli/commands/arm.py
+++ b/src/azure/cli/commands/arm.py
@@ -138,6 +138,10 @@ def add_id_parameters(command_table):
                 missing_required = ' '.join((arg.options_list[0] for arg in errors))
                 raise CLIError('({} | {}) are required'.format(missing_required, '--ids'))
 
+        for key, arg in command.arguments.items():
+            if command.arguments[key].id_part:
+                command.arguments[key].arg_group = 'ResourceId'
+
         command.add_argument(argparse.SUPPRESS,
                              '--ids',
                              metavar='RESOURCE_ID',
@@ -145,7 +149,8 @@ def add_id_parameters(command_table):
                              action=split_action(command.arguments),
                              nargs='+',
                              type=ResourceId,
-                             validator=required_values_validator)
+                             validator=required_values_validator,
+                             arg_group='ResourceId')
 
     for command in command_table.values():
         command_loaded_handler(command)
@@ -224,14 +229,15 @@ def register_generic_update(name, getter, setter, factory=None, setter_arg_name=
     cmd.add_argument('properties_to_set', '--set', nargs='+', action=OrderedArgsAction, default=[],
                      help='Update an object by specifying a property path and value to set.'
                      '  Example: --set property1.property2=value',
-                     metavar='KEY=VALUE')
+                     metavar='KEY=VALUE', arg_group='GenericUpdate')
     cmd.add_argument('properties_to_add', '--add', nargs='+', action=OrderedArgsAction, default=[],
                      help='Add an object to a list of objects by specifying a path and key'
                      ' value pairs.  Example: --add property.list key=<value>',
-                     metavar='LIST KEY=VALUE')
+                     metavar='LIST KEY=VALUE', arg_group='GenericUpdate')
     cmd.add_argument('properties_to_remove', '--remove', nargs='+', action=OrderedArgsAction,
                      default=[], help='Remove a property or an element from a list.  Example: '
-                     '--remove property.list <index>', metavar='LIST INDEX')
+                     '--remove property.list <index>', metavar='LIST INDEX',
+                     arg_group='GenericUpdate')
     main_command_table[name] = cmd
 
 index_regex = re.compile(r'\[(.*)\]')

--- a/src/azure/cli/parser.py
+++ b/src/azure/cli/parser.py
@@ -4,7 +4,10 @@
 #---------------------------------------------------------------------------------------------
 
 import argparse
+import re
+
 import argcomplete
+
 import azure.cli._help as _help
 from azure.cli._util import CLIError
 
@@ -62,11 +65,24 @@ class AzCliCommandParser(argparse.ArgumentParser):
                                                   help_file=metadata.help)
 
             argument_validators = []
+            argument_groups = {}
             for arg in metadata.arguments.values():
                 if arg.validator:
                     argument_validators.append(arg.validator)
-                param = command_parser.add_argument(
-                    *arg.options_list, **arg.options)
+                if arg.arg_group:
+                    try:
+                        group = argument_groups[arg.arg_group]
+                    except KeyError:
+                        # group not found so create
+                        name_comps = re.findall('[A-Z][^A-Z]*', arg.arg_group)
+                        group_name = '{} Arguments'.format(' '.join(name_comps))
+                        group = command_parser.add_argument_group(arg.arg_group, group_name)
+                        argument_groups[arg.arg_group] = group
+                    param = group.add_argument(
+                        *arg.options_list, **arg.options)
+                else:
+                    param = command_parser.add_argument(
+                        *arg.options_list, **arg.options)
                 param.completer = arg.completer
 
             command_parser.set_defaults(func=metadata.handler,
@@ -103,9 +119,7 @@ class AzCliCommandParser(argparse.ArgumentParser):
     def format_help(self):
         is_group = self.is_group()
         _help.show_help(self.prog.split()[1:],
-                        (self._actions[-1]
-                         if is_group
-                         else self),
+                        self._actions[-1] if is_group else self,
                         is_group)
         self.exit()
 

--- a/src/azure/cli/parser.py
+++ b/src/azure/cli/parser.py
@@ -4,7 +4,6 @@
 #---------------------------------------------------------------------------------------------
 
 import argparse
-import re
 
 import argcomplete
 
@@ -74,8 +73,7 @@ class AzCliCommandParser(argparse.ArgumentParser):
                         group = argument_groups[arg.arg_group]
                     except KeyError:
                         # group not found so create
-                        name_comps = re.findall('[A-Z][^A-Z]*', arg.arg_group)
-                        group_name = '{} Arguments'.format(' '.join(name_comps))
+                        group_name = '{} Arguments'.format(arg.arg_group)
                         group = command_parser.add_argument_group(arg.arg_group, group_name)
                         argument_groups[arg.arg_group] = group
                     param = group.add_argument(

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_command_type.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_command_type.py
@@ -15,10 +15,20 @@ def cli_storage_data_plane_command(name, operation, client_factory,
     command = create_command(name, operation, transform, simple_output_query, client_factory)
 
     # add parameters required to create a storage client
-    command.add_argument('account_name', '--account-name', required=False, default=None)
-    command.add_argument('account_key', '--account-key', required=False, default=None)
-    command.add_argument('connection_string', '--connection-string', required=False,
-                         default=None, validator=validate_client_parameters)
-    command.add_argument('sas_token', '--sas-token', required=False, default=None)
-
+    command.add_argument('account_name', '--account-name', required=False, default=None,
+                         arg_group='StorageAccount',
+                         help='Storage account name. Must be used in conjunction with either '
+                         'storage account key or a SAS token. Var: AZURE_STORAGE_ACCOUNT')
+    command.add_argument('account_key', '--account-key', required=False, default=None,
+                         arg_group='StorageAccount',
+                         help='Storage account key. Must be used in conjunction with storage '
+                         'account name. Var: AZURE_STORAGE_KEY')
+    command.add_argument('connection_string', '--connection-string', required=False, default=None,
+                         validator=validate_client_parameters, arg_group='StorageAccount',
+                         help='Storage account connection string. Var: '
+                         'AZURE_STORAGE_CONNECTION_STRING')
+    command.add_argument('sas_token', '--sas-token', required=False, default=None,
+                         arg_group='StorageAccount',
+                         help='A Shared Access Signature (SAS). Must be used in conjunction with '
+                         'storage account name. Var: AZURE_SAS_TOKEN')
     command_table[command.name] = command

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_command_type.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_command_type.py
@@ -15,20 +15,21 @@ def cli_storage_data_plane_command(name, operation, client_factory,
     command = create_command(name, operation, transform, simple_output_query, client_factory)
 
     # add parameters required to create a storage client
+    group_name = 'Storage Account'
     command.add_argument('account_name', '--account-name', required=False, default=None,
-                         arg_group='StorageAccount',
+                         arg_group=group_name,
                          help='Storage account name. Must be used in conjunction with either '
                          'storage account key or a SAS token. Var: AZURE_STORAGE_ACCOUNT')
     command.add_argument('account_key', '--account-key', required=False, default=None,
-                         arg_group='StorageAccount',
+                         arg_group=group_name,
                          help='Storage account key. Must be used in conjunction with storage '
                          'account name. Var: AZURE_STORAGE_KEY')
     command.add_argument('connection_string', '--connection-string', required=False, default=None,
-                         validator=validate_client_parameters, arg_group='StorageAccount',
+                         validator=validate_client_parameters, arg_group=group_name,
                          help='Storage account connection string. Var: '
                          'AZURE_STORAGE_CONNECTION_STRING')
     command.add_argument('sas_token', '--sas-token', required=False, default=None,
-                         arg_group='StorageAccount',
+                         arg_group=group_name,
                          help='A Shared Access Signature (SAS). Must be used in conjunction with '
                          'storage account name. Var: AZURE_SAS_TOKEN')
     command_table[command.name] = command


### PR DESCRIPTION
After our discussion today, and after experimenting with a more complex mechanism, I believe this simple implementation is sufficient to cover items #656, #676 and #677. Some things to point out:

- The ordering in --help is not ideal. Global args should be at the bottom. However, this would necessitate changes to the help formatter that can be addressed in a separate PR.
- I removed any "dynamic help" so that the help output is consistent from one invocation to the next.
- Having help text for the group (either a paragraph or usage string) is not advisable for a few reasons. (1) it would necessitate changes to the help file format (which currently doesn't allow argument group help), (2) text does not wrap well and (3) all groups are backed by a validator which will give a useful error if the group is used incorrectly.
