### PR TITLE
'az configure' experience (default output format)

### DIFF
--- a/src/azure/cli/_config.py
+++ b/src/azure/cli/_config.py
@@ -5,9 +5,9 @@
 import os
 from six.moves import configparser
 
-GLOBAL_CONFIG_PATH = os.path.expanduser(os.path.join('~', '.azure', 'az_config'))
+GLOBAL_CONFIG_PATH = os.path.expanduser(os.path.join('~', '.azure', 'config'))
 ACTIVE_ENV_CONFIG_PATH = os.path.expanduser(os.path.join('~', '.azure', 'env_config', 'default'))
-ENV_VAR_PREFIX = 'AZURE_CLI_'
+ENV_VAR_PREFIX = 'AZURE_'
 
 _UNSET = object()
 _ENV_VAR_FORMAT = ENV_VAR_PREFIX+'{section}_{option}'

--- a/src/azure/cli/_config.py
+++ b/src/azure/cli/_config.py
@@ -1,0 +1,54 @@
+#---------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+#---------------------------------------------------------------------------------------------
+import os
+from six.moves import configparser
+
+GLOBAL_CONFIG_PATH = os.path.expanduser(os.path.join('~', '.azure', 'az_config'))
+ACTIVE_ENV_CONFIG_PATH = os.path.expanduser(os.path.join('~', '.azure', 'env_config', 'default'))
+ENV_VAR_PREFIX = 'AZURE_CLI_'
+
+_UNSET = object()
+_ENV_VAR_FORMAT = ENV_VAR_PREFIX+'{section}_{option}'
+
+class AzConfigParser(configparser.SafeConfigParser, object):
+    """A SafeConfigParser that checks environment variables first."""
+    _BOOLEAN_STATES = {'1': True, 'yes': True, 'true': True, 'on': True,
+                       '0': False, 'no': False, 'false': False, 'off': False}
+
+    @staticmethod
+    def env_var_name(section, option):
+        return _ENV_VAR_FORMAT.format(section=section.upper(),
+                                      option=option.upper())
+
+    def has_option(self, section, option):
+        if AzConfigParser.env_var_name(section, option) in os.environ:
+            return True
+        return super(AzConfigParser, self).has_option(section, option)
+
+    def get(self, section, option, fallback=_UNSET): #pylint: disable=W0221
+        try:
+            env = AzConfigParser.env_var_name(section, option)
+            return os.environ[env] if env in os.environ else super(AzConfigParser,
+                                                                   self).get(section, option)
+        except (configparser.NoSectionError, configparser.NoOptionError):
+            if fallback is _UNSET:
+                raise
+            else:
+                return fallback
+
+    def getint(self, section, option, fallback=_UNSET): #pylint: disable=W0221
+        return int(self.get(section, option, fallback))
+
+    def getfloat(self, section, option, fallback=_UNSET): #pylint: disable=W0221
+        return float(self.get(section, option, fallback))
+
+    def getboolean(self, section, option, fallback=_UNSET): #pylint: disable=W0221
+        val = self.get(section, option, fallback)
+        if val.lower() not in AzConfigParser._BOOLEAN_STATES: #pylint: disable=E1101
+            raise ValueError('Not a boolean: {}'.format(val))
+        return AzConfigParser._BOOLEAN_STATES[val.lower()] #pylint: disable=E1101
+
+az_config = AzConfigParser()
+az_config.read([GLOBAL_CONFIG_PATH, ACTIVE_ENV_CONFIG_PATH])

--- a/src/azure/cli/application.py
+++ b/src/azure/cli/application.py
@@ -14,6 +14,7 @@ import azure.cli.extensions
 import azure.cli._help as _help
 import azure.cli._logging as _logging
 from azure.cli._util import todict
+from azure.cli._config import az_config
 
 logger = _logging.get_az_logger(__name__)
 
@@ -25,7 +26,7 @@ class Configuration(object): # pylint: disable=too-few-public-methods
     """
     def __init__(self, argv):
         self.argv = argv or sys.argv[1:]
-        self.output_format = 'list'
+        self.output_format = None
 
     def get_command_table(self):
         import azure.cli.commands as commands
@@ -166,7 +167,7 @@ class Application(object):
         global_group.add_argument('--subscription', dest='_subscription_id', help=argparse.SUPPRESS)
         global_group.add_argument('--output', '-o', dest='_output_format',
                                   choices=['json', 'tsv', 'list', 'table', 'jsonc'],
-                                  default='json',
+                                  default=az_config.get('core', 'output', fallback='json'),
                                   help='Output format',
                                   type=str.lower)
         # The arguments for verbosity don't get parsed by argparse but we add it here for help.

--- a/src/azure/cli/tests/test_config.py
+++ b/src/azure/cli/tests/test_config.py
@@ -1,3 +1,8 @@
+#---------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+#---------------------------------------------------------------------------------------------
+
 import os
 import unittest
 import mock
@@ -34,14 +39,14 @@ class TestAzConfigParser(unittest.TestCase):
         value = 'myvalue'
         self.config.add_section(section)
         self.config.set(section, option, value)
-        self.assertEquals(self.config.get(section, option), value)
+        self.assertEqual(self.config.get(section, option), value)
 
     @mock.patch.dict(os.environ, {AzConfigParser.env_var_name('MySection', 'myoption'): 'myvalue'})
     def test_get_env(self):
         section = 'MySection'
         option = 'myoption'
         value = 'myvalue'
-        self.assertEquals(self.config.get(section, option), value)
+        self.assertEqual(self.config.get(section, option), value)
 
     def test_get_not_found_section(self):
         section = 'MySection'
@@ -59,7 +64,7 @@ class TestAzConfigParser(unittest.TestCase):
     def test_get_fallback(self):
         section = 'MySection'
         option = 'myoption'
-        self.assertEquals(self.config.get(section, option, fallback='fallback'), 'fallback')
+        self.assertEqual(self.config.get(section, option, fallback='fallback'), 'fallback')
 
     def test_getint(self):
         section = 'MySection'
@@ -67,7 +72,7 @@ class TestAzConfigParser(unittest.TestCase):
         value = '123'
         self.config.add_section(section)
         self.config.set(section, option, value)
-        self.assertEquals(self.config.getint(section, option), int(value))
+        self.assertEqual(self.config.getint(section, option), int(value))
 
     def test_getint_error(self):
         section = 'MySection'
@@ -84,7 +89,7 @@ class TestAzConfigParser(unittest.TestCase):
         value = '123.456'
         self.config.add_section(section)
         self.config.set(section, option, value)
-        self.assertEquals(self.config.getfloat(section, option), float(value))
+        self.assertEqual(self.config.getfloat(section, option), float(value))
 
     def test_getfloat_error(self):
         section = 'MySection'
@@ -101,7 +106,7 @@ class TestAzConfigParser(unittest.TestCase):
         value = 'true'
         self.config.add_section(section)
         self.config.set(section, option, value)
-        self.assertEquals(self.config.getboolean(section, option), True)
+        self.assertEqual(self.config.getboolean(section, option), True)
 
     def test_getboolean_error(self):
         section = 'MySection'

--- a/src/azure/cli/tests/test_config.py
+++ b/src/azure/cli/tests/test_config.py
@@ -1,0 +1,116 @@
+import os
+import unittest
+import mock
+from six.moves import configparser
+from azure.cli._config import AzConfigParser
+
+class TestAzConfigParser(unittest.TestCase):
+
+    def setUp(self):
+        self.config = AzConfigParser()
+
+    def test_has_option(self):
+        section = 'MySection'
+        option = 'myoption'
+        value = 'myvalue'
+        self.config.add_section(section)
+        self.config.set(section, option, value)
+        self.assertTrue(self.config.has_option(section, option))
+
+    @mock.patch.dict(os.environ, {AzConfigParser.env_var_name('MySection', 'myoption'): 'myvalue'})
+    def test_has_option_env(self):
+        section = 'MySection'
+        option = 'myoption'
+        self.assertTrue(self.config.has_option(section, option))
+
+    def test_has_option_env_no(self):
+        section = 'MySection'
+        option = 'myoption'
+        self.assertFalse(self.config.has_option(section, option))
+
+    def test_get(self):
+        section = 'MySection'
+        option = 'myoption'
+        value = 'myvalue'
+        self.config.add_section(section)
+        self.config.set(section, option, value)
+        self.assertEquals(self.config.get(section, option), value)
+
+    @mock.patch.dict(os.environ, {AzConfigParser.env_var_name('MySection', 'myoption'): 'myvalue'})
+    def test_get_env(self):
+        section = 'MySection'
+        option = 'myoption'
+        value = 'myvalue'
+        self.assertEquals(self.config.get(section, option), value)
+
+    def test_get_not_found_section(self):
+        section = 'MySection'
+        option = 'myoption'
+        with self.assertRaises(configparser.NoSectionError):
+            self.config.get(section, option)
+
+    def test_get_not_found_option(self):
+        section = 'MySection'
+        option = 'myoption'
+        self.config.add_section(section)
+        with self.assertRaises(configparser.NoOptionError):
+            self.config.get(section, option)
+
+    def test_get_fallback(self):
+        section = 'MySection'
+        option = 'myoption'
+        self.assertEquals(self.config.get(section, option, fallback='fallback'), 'fallback')
+
+    def test_getint(self):
+        section = 'MySection'
+        option = 'myoption'
+        value = '123'
+        self.config.add_section(section)
+        self.config.set(section, option, value)
+        self.assertEquals(self.config.getint(section, option), int(value))
+
+    def test_getint_error(self):
+        section = 'MySection'
+        option = 'myoption'
+        value = 'not_an_int'
+        self.config.add_section(section)
+        self.config.set(section, option, value)
+        with self.assertRaises(ValueError):
+            self.config.getint(section, option)
+
+    def test_getfloat(self):
+        section = 'MySection'
+        option = 'myoption'
+        value = '123.456'
+        self.config.add_section(section)
+        self.config.set(section, option, value)
+        self.assertEquals(self.config.getfloat(section, option), float(value))
+
+    def test_getfloat_error(self):
+        section = 'MySection'
+        option = 'myoption'
+        value = 'not_a_float'
+        self.config.add_section(section)
+        self.config.set(section, option, value)
+        with self.assertRaises(ValueError):
+            self.config.getfloat(section, option)
+
+    def test_getboolean(self):
+        section = 'MySection'
+        option = 'myoption'
+        value = 'true'
+        self.config.add_section(section)
+        self.config.set(section, option, value)
+        self.assertEquals(self.config.getboolean(section, option), True)
+
+    def test_getboolean_error(self):
+        section = 'MySection'
+        option = 'myoption'
+        value = 'not_a_boolean'
+        self.config.add_section(section)
+        self.config.set(section, option, value)
+        with self.assertRaises(ValueError):
+            self.config.getboolean(section, option)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/azure/cli/tests/test_config.py
+++ b/src/azure/cli/tests/test_config.py
@@ -7,115 +7,115 @@ import os
 import unittest
 import mock
 from six.moves import configparser
-from azure.cli._config import AzConfigParser
+from azure.cli._config import AzConfig
 
-class TestAzConfigParser(unittest.TestCase):
+class TestAzConfig(unittest.TestCase):
 
     def setUp(self):
-        self.config = AzConfigParser()
+        self.az_config = AzConfig()
 
     def test_has_option(self):
         section = 'MySection'
         option = 'myoption'
         value = 'myvalue'
-        self.config.add_section(section)
-        self.config.set(section, option, value)
-        self.assertTrue(self.config.has_option(section, option))
+        self.az_config.config_parser.add_section(section)
+        self.az_config.config_parser.set(section, option, value)
+        self.assertTrue(self.az_config.has_option(section, option))
 
-    @mock.patch.dict(os.environ, {AzConfigParser.env_var_name('MySection', 'myoption'): 'myvalue'})
+    @mock.patch.dict(os.environ, {AzConfig.env_var_name('MySection', 'myoption'): 'myvalue'})
     def test_has_option_env(self):
         section = 'MySection'
         option = 'myoption'
-        self.assertTrue(self.config.has_option(section, option))
+        self.assertTrue(self.az_config.has_option(section, option))
 
     def test_has_option_env_no(self):
         section = 'MySection'
         option = 'myoption'
-        self.assertFalse(self.config.has_option(section, option))
+        self.assertFalse(self.az_config.has_option(section, option))
 
     def test_get(self):
         section = 'MySection'
         option = 'myoption'
         value = 'myvalue'
-        self.config.add_section(section)
-        self.config.set(section, option, value)
-        self.assertEqual(self.config.get(section, option), value)
+        self.az_config.config_parser.add_section(section)
+        self.az_config.config_parser.set(section, option, value)
+        self.assertEqual(self.az_config.get(section, option), value)
 
-    @mock.patch.dict(os.environ, {AzConfigParser.env_var_name('MySection', 'myoption'): 'myvalue'})
+    @mock.patch.dict(os.environ, {AzConfig.env_var_name('MySection', 'myoption'): 'myvalue'})
     def test_get_env(self):
         section = 'MySection'
         option = 'myoption'
         value = 'myvalue'
-        self.assertEqual(self.config.get(section, option), value)
+        self.assertEqual(self.az_config.get(section, option), value)
 
     def test_get_not_found_section(self):
         section = 'MySection'
         option = 'myoption'
         with self.assertRaises(configparser.NoSectionError):
-            self.config.get(section, option)
+            self.az_config.get(section, option)
 
     def test_get_not_found_option(self):
         section = 'MySection'
         option = 'myoption'
-        self.config.add_section(section)
+        self.az_config.config_parser.add_section(section)
         with self.assertRaises(configparser.NoOptionError):
-            self.config.get(section, option)
+            self.az_config.get(section, option)
 
     def test_get_fallback(self):
         section = 'MySection'
         option = 'myoption'
-        self.assertEqual(self.config.get(section, option, fallback='fallback'), 'fallback')
+        self.assertEqual(self.az_config.get(section, option, fallback='fallback'), 'fallback')
 
     def test_getint(self):
         section = 'MySection'
         option = 'myoption'
         value = '123'
-        self.config.add_section(section)
-        self.config.set(section, option, value)
-        self.assertEqual(self.config.getint(section, option), int(value))
+        self.az_config.config_parser.add_section(section)
+        self.az_config.config_parser.set(section, option, value)
+        self.assertEqual(self.az_config.getint(section, option), int(value))
 
     def test_getint_error(self):
         section = 'MySection'
         option = 'myoption'
         value = 'not_an_int'
-        self.config.add_section(section)
-        self.config.set(section, option, value)
+        self.az_config.config_parser.add_section(section)
+        self.az_config.config_parser.set(section, option, value)
         with self.assertRaises(ValueError):
-            self.config.getint(section, option)
+            self.az_config.getint(section, option)
 
     def test_getfloat(self):
         section = 'MySection'
         option = 'myoption'
         value = '123.456'
-        self.config.add_section(section)
-        self.config.set(section, option, value)
-        self.assertEqual(self.config.getfloat(section, option), float(value))
+        self.az_config.config_parser.add_section(section)
+        self.az_config.config_parser.set(section, option, value)
+        self.assertEqual(self.az_config.getfloat(section, option), float(value))
 
     def test_getfloat_error(self):
         section = 'MySection'
         option = 'myoption'
         value = 'not_a_float'
-        self.config.add_section(section)
-        self.config.set(section, option, value)
+        self.az_config.config_parser.add_section(section)
+        self.az_config.config_parser.set(section, option, value)
         with self.assertRaises(ValueError):
-            self.config.getfloat(section, option)
+            self.az_config.getfloat(section, option)
 
     def test_getboolean(self):
         section = 'MySection'
         option = 'myoption'
         value = 'true'
-        self.config.add_section(section)
-        self.config.set(section, option, value)
-        self.assertEqual(self.config.getboolean(section, option), True)
+        self.az_config.config_parser.add_section(section)
+        self.az_config.config_parser.set(section, option, value)
+        self.assertEqual(self.az_config.getboolean(section, option), True)
 
     def test_getboolean_error(self):
         section = 'MySection'
         option = 'myoption'
         value = 'not_a_boolean'
-        self.config.add_section(section)
-        self.config.set(section, option, value)
+        self.az_config.config_parser.add_section(section)
+        self.az_config.config_parser.set(section, option, value)
         with self.assertRaises(ValueError):
-            self.config.getboolean(section, option)
+            self.az_config.getboolean(section, option)
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/command_modules/azure-cli-configure/README.rst
+++ b/src/command_modules/azure-cli-configure/README.rst
@@ -1,0 +1,7 @@
+Microsoft Azure CLI 'configure' Command Module
+==================================
+
+This package is for the 'configure' module.
+i.e. 'az configure'
+
+This package has [not] been tested [much] with Python 2.7, 3.4 and 3.5.

--- a/src/command_modules/azure-cli-configure/README.rst
+++ b/src/command_modules/azure-cli-configure/README.rst
@@ -3,5 +3,3 @@ Microsoft Azure CLI 'configure' Command Module
 
 This package is for the 'configure' module.
 i.e. 'az configure'
-
-This package has [not] been tested [much] with Python 2.7, 3.4 and 3.5.

--- a/src/command_modules/azure-cli-configure/azure/__init__.py
+++ b/src/command_modules/azure-cli-configure/azure/__init__.py
@@ -1,0 +1,6 @@
+#---------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+#---------------------------------------------------------------------------------------------
+import pkg_resources
+pkg_resources.declare_namespace(__name__)

--- a/src/command_modules/azure-cli-configure/azure/cli/__init__.py
+++ b/src/command_modules/azure-cli-configure/azure/cli/__init__.py
@@ -1,0 +1,6 @@
+#---------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+#---------------------------------------------------------------------------------------------
+import pkg_resources
+pkg_resources.declare_namespace(__name__)

--- a/src/command_modules/azure-cli-configure/azure/cli/command_modules/__init__.py
+++ b/src/command_modules/azure-cli-configure/azure/cli/command_modules/__init__.py
@@ -1,0 +1,6 @@
+#---------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+#---------------------------------------------------------------------------------------------
+import pkg_resources
+pkg_resources.declare_namespace(__name__)

--- a/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/__init__.py
+++ b/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/__init__.py
@@ -79,7 +79,7 @@ def _print_cur_configuration(file_config):
 def _handle_global_configuration():
     print(MESSAGES['global_settings_loc'].format(GLOBAL_CONFIG_PATH))
     print(MESSAGES['active_env_settings_loc'].format(ACTIVE_ENV_CONFIG_PATH))
-    # We don't want to use AzConfigParser as we don't want to use get values set by env vars.
+    # We don't want to use AzConfig as we don't want to use get values set by env vars.
     file_config = configparser.SafeConfigParser()
     config_exists = file_config.read([GLOBAL_CONFIG_PATH, ACTIVE_ENV_CONFIG_PATH])
     global_config = configparser.SafeConfigParser()

--- a/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/__init__.py
+++ b/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/__init__.py
@@ -1,0 +1,111 @@
+#---------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+#---------------------------------------------------------------------------------------------
+
+from __future__ import print_function
+import os
+from six.moves import input, configparser #pylint: disable=redefined-builtin
+from azure.cli.commands import cli_command
+import azure.cli._logging as _logging
+from azure.cli._config import GLOBAL_CONFIG_PATH, ACTIVE_ENV_CONFIG_PATH, ENV_VAR_PREFIX
+import azure.cli.command_modules.configure._help # pylint: disable=unused-import
+
+logger = _logging.get_az_logger(__name__)
+
+OUTPUT_LIST = [
+    {'name': 'json', 'desc': 'JSON formatted output that most closely matches API responses'},
+    {'name': 'jsonc', 'desc': 'Colored JSON formatted output that most closely matches API responses'}, #pylint: disable=line-too-long
+    {'name': 'table', 'desc': 'Human-readable output format that focuses on clarity'},
+    {'name': 'tsv', 'desc': 'Tab and Newline delimited, great for GREP, AWK, etc.'}
+]
+
+MESSAGES = {
+    'intro': '\nWelcome to the Azure CLI! This command will guide you through logging in and '\
+             'setting some default values.\n',
+    'global_settings_loc': 'Your global settings can be found at {}',
+    'active_env_settings_loc': 'Your current environment settings can be found at {}',
+    'current_config_info': 'Your current configuration is as follows:\n',
+    'env_vars_heading': 'Environment variables:',
+    'global_settings_exists': 'Do you wish to change your global settings? (y/N): ',
+    'prompt_global_output': 'What default output format would you like?\n'\
+                            '{}\n'\
+                            'Please enter a choice [{}]: ',
+    'closing': '\nYou\'re all set! Here are some commands to try:\n'\
+               ' $ az vm create --help\n'\
+               ' $ az feedback\n',
+}
+
+def _prompt_global_output(global_config):
+    try:
+        config_output = global_config.get('core', 'output')
+        default_output = [i for i, x in enumerate(OUTPUT_LIST) if x['name'] == config_output][0]+1
+    except (IndexError, configparser.NoSectionError, configparser.NoOptionError):
+        default_output = 1
+    options = '\n'.join([' [{}] {} - {}'.format(i+1, x['name'], x['desc']) \
+                        for i, x in enumerate(OUTPUT_LIST)])
+    allowed_vals = list(range(1, len(OUTPUT_LIST)+1))
+    while True:
+        try:
+            ans = int(input(MESSAGES['prompt_global_output'].format(options, default_output)) \
+                            or default_output)
+            if ans in allowed_vals:
+                # array index is 0-based, user input is 1-based
+                return ans-1
+            raise ValueError
+        except ValueError:
+            logger.warning('Valid values are %s', allowed_vals)
+
+def _prompt_global_settings_exist():
+    while True:
+        ans = input(MESSAGES['global_settings_exists'])
+        if not ans or ans.lower() == 'n':
+            return False
+        if ans.lower() == 'y':
+            return True
+
+def _print_cur_configuration(file_config):
+    for section in file_config.sections():
+        print('[{}]'.format(section))
+        for option in file_config.options(section):
+            print('{} = {}'.format(option, file_config.get(section, option)))
+        print()
+    env_vars = [ev for ev in os.environ if ev.startswith(ENV_VAR_PREFIX)]
+    if env_vars:
+        print(MESSAGES['env_vars_heading'])
+        print('\n'.join(['{} = {}'.format(ev, os.environ[ev]) for ev in env_vars]))
+        print()
+
+def _handle_global_configuration():
+    print(MESSAGES['global_settings_loc'].format(GLOBAL_CONFIG_PATH))
+    print(MESSAGES['active_env_settings_loc'].format(ACTIVE_ENV_CONFIG_PATH))
+    # We don't want to use AzConfigParser as we don't want to use get values set by env vars.
+    file_config = configparser.SafeConfigParser()
+    config_exists = file_config.read([GLOBAL_CONFIG_PATH, ACTIVE_ENV_CONFIG_PATH])
+    global_config = configparser.SafeConfigParser()
+    global_config.read(GLOBAL_CONFIG_PATH)
+    change_global_settings = None
+    if config_exists:
+        print(MESSAGES['current_config_info'])
+        _print_cur_configuration(file_config)
+        change_global_settings = _prompt_global_settings_exist()
+    if not config_exists or change_global_settings:
+        output_index = _prompt_global_output(global_config)
+        try:
+            global_config.add_section('core')
+        except configparser.DuplicateSectionError:
+            pass
+        global_config.set('core', 'output', OUTPUT_LIST[output_index]['name'])
+        with open(GLOBAL_CONFIG_PATH, 'wb') as configfile:
+            global_config.write(configfile)
+
+def handle_configure():
+    try:
+        print(MESSAGES['intro'])
+        _handle_global_configuration()
+        print(MESSAGES['closing'])
+    except KeyboardInterrupt:
+        # Catch to prevent stacktrace and print newline
+        print()
+
+cli_command('configure', handle_configure)

--- a/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/__init__.py
+++ b/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/__init__.py
@@ -20,21 +20,19 @@ OUTPUT_LIST = [
     {'name': 'tsv', 'desc': 'Tab and Newline delimited, great for GREP, AWK, etc.'}
 ]
 
-MESSAGES = {
-    'intro': '\nWelcome to the Azure CLI! This command will guide you through logging in and '\
-             'setting some default values.\n',
-    'global_settings_loc': 'Your global settings can be found at {}',
-    'active_env_settings_loc': 'Your current environment settings can be found at {}',
-    'current_config_info': 'Your current configuration is as follows:\n',
-    'env_vars_heading': 'Environment variables:',
-    'global_settings_exists': 'Do you wish to change your global settings? (y/N): ',
-    'prompt_global_output': 'What default output format would you like?\n'\
+MESSAGES_INTRO = '\nWelcome to the Azure CLI! This command will guide you through logging in and '\
+             'setting some default values.\n'
+MESSAGES_GLOBAL_SETTINGS_LOCATION = 'Your global settings can be found at {}'
+MESSAGES_ACTIVE_ENV_SETTINGS_LOCATION = 'Your current environment settings can be found at {}'
+MESSAGES_CURRENT_CONFIG_INFO = 'Your current configuration is as follows:\n'
+MESSAGES_ENV_VARS_HEADING = 'Environment variables:'
+MESSAGES_GLOBAL_SETTINGS_EXISTS = 'Do you wish to change your global settings? (y/N): '
+MESSAGES_PROMPT_GLOBAL_OUTPUT = 'What default output format would you like?\n'\
                             '{}\n'\
-                            'Please enter a choice [{}]: ',
-    'closing': '\nYou\'re all set! Here are some commands to try:\n'\
+                            'Please enter a choice [{}]: '
+MESSAGES_CLOSING = '\nYou\'re all set! Here are some commands to try:\n'\
                ' $ az vm create --help\n'\
-               ' $ az feedback\n',
-}
+               ' $ az feedback\n'
 
 def _prompt_global_output(global_config):
     try:
@@ -47,7 +45,7 @@ def _prompt_global_output(global_config):
     allowed_vals = list(range(1, len(OUTPUT_LIST)+1))
     while True:
         try:
-            ans = int(input(MESSAGES['prompt_global_output'].format(options, default_output)) \
+            ans = int(input(MESSAGES_PROMPT_GLOBAL_OUTPUT.format(options, default_output)) \
                             or default_output)
             if ans in allowed_vals:
                 # array index is 0-based, user input is 1-based
@@ -58,7 +56,7 @@ def _prompt_global_output(global_config):
 
 def _prompt_global_settings_exist():
     while True:
-        ans = input(MESSAGES['global_settings_exists'])
+        ans = input(MESSAGES_GLOBAL_SETTINGS_EXISTS)
         if not ans or ans.lower() == 'n':
             return False
         if ans.lower() == 'y':
@@ -72,21 +70,21 @@ def _print_cur_configuration(file_config):
         print()
     env_vars = [ev for ev in os.environ if ev.startswith(ENV_VAR_PREFIX)]
     if env_vars:
-        print(MESSAGES['env_vars_heading'])
+        print(MESSAGES_ENV_VARS_HEADING)
         print('\n'.join(['{} = {}'.format(ev, os.environ[ev]) for ev in env_vars]))
         print()
 
 def _handle_global_configuration():
-    print(MESSAGES['global_settings_loc'].format(GLOBAL_CONFIG_PATH))
-    print(MESSAGES['active_env_settings_loc'].format(ACTIVE_ENV_CONFIG_PATH))
-    # We don't want to use AzConfig as we don't want to use get values set by env vars.
+    print(MESSAGES_GLOBAL_SETTINGS_LOCATION.format(GLOBAL_CONFIG_PATH))
+    print(MESSAGES_ACTIVE_ENV_SETTINGS_LOCATION.format(ACTIVE_ENV_CONFIG_PATH))
+    # We don't want to use AzConfig as we don't want to use values set by env vars.
     file_config = configparser.SafeConfigParser()
     config_exists = file_config.read([GLOBAL_CONFIG_PATH, ACTIVE_ENV_CONFIG_PATH])
     global_config = configparser.SafeConfigParser()
     global_config.read(GLOBAL_CONFIG_PATH)
     change_global_settings = None
     if config_exists:
-        print(MESSAGES['current_config_info'])
+        print(MESSAGES_CURRENT_CONFIG_INFO)
         _print_cur_configuration(file_config)
         change_global_settings = _prompt_global_settings_exist()
     if not config_exists or change_global_settings:
@@ -96,14 +94,14 @@ def _handle_global_configuration():
         except configparser.DuplicateSectionError:
             pass
         global_config.set('core', 'output', OUTPUT_LIST[output_index]['name'])
-        with open(GLOBAL_CONFIG_PATH, 'wb') as configfile:
+        with open(GLOBAL_CONFIG_PATH, 'w') as configfile:
             global_config.write(configfile)
 
 def handle_configure():
     try:
-        print(MESSAGES['intro'])
+        print(MESSAGES_INTRO)
         _handle_global_configuration()
-        print(MESSAGES['closing'])
+        print(MESSAGES_CLOSING)
     except KeyboardInterrupt:
         # Catch to prevent stacktrace and print newline
         print()

--- a/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/_help.py
+++ b/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/_help.py
@@ -1,0 +1,8 @@
+#---------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+#---------------------------------------------------------------------------------------------
+
+from azure.cli.help_files import helps #pylint: disable=unused-import
+
+#pylint: disable=line-too-long

--- a/src/command_modules/azure-cli-configure/setup.py
+++ b/src/command_modules/azure-cli-configure/setup.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+#---------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+#---------------------------------------------------------------------------------------------
+
+from codecs import open
+from setuptools import setup
+
+VERSION = '0.0.1'
+
+CLASSIFIERS = [
+    'Development Status :: 3 - Alpha',
+    'Intended Audience :: Developers',
+    'Intended Audience :: System Administrators',
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 2',
+    'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
+    'License :: OSI Approved :: MIT License',
+]
+
+DEPENDENCIES = [
+]
+
+with open('README.rst', 'r', encoding='utf-8') as f:
+    README = f.read()
+
+setup(
+    name='azure-cli-configure',
+    version=VERSION,
+    description='Microsoft Azure Command-Line Tools Configure Command Module',
+    long_description=README,
+    license='MIT',
+    author='Microsoft Corporation',
+    author_email='azpycli@microsoft.com',
+    url='https://github.com/Azure/azure-cli',
+    classifiers=CLASSIFIERS,
+    namespace_packages = [
+        'azure',
+        'azure.cli',
+        'azure.cli.command_modules',
+    ],
+    packages=[
+        'azure.cli.command_modules.configure',
+    ],
+    install_requires=DEPENDENCIES,
+)


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-cli/issues/657
- Allows user to set default output type.
- Infrastructure for CLI configurations also implemented.

```
$ az configure

Welcome to the Azure CLI! This command will guide you through logging in and setting some default values.

Your global settings can be found at /Users/derek/.azure/config
Your current environment settings can be found at /Users/derek/.azure/env_config/default
Your current configuration is as follows:

[core]
output = json

Environment variables:
AZURE_STORAGE_ACCOUNT = derekstorageaccount

Do you wish to change your global settings? (y/N): y
What default output format would you like?
 [1] json - JSON formatted output that most closely matches API responses
 [2] jsonc - Colored JSON formatted output that most closely matches API responses
 [3] table - Human-readable output format that focuses on clarity
 [4] tsv - Tab and Newline delimited, great for GREP, AWK, etc.
Please enter a choice [1]: 2

You're all set! Here are some commands to try:
 $ az vm create --help
 $ az feedback


```