### PR TITLE
Remove inline CliArgumentType(...) registrations

### DIFF
--- a/src/azure/cli/commands/parameters.py
+++ b/src/azure/cli/commands/parameters.py
@@ -73,6 +73,19 @@ def get_generic_completion_list(generic_list):
 def get_enum_choices(enum_type):
     return [x.value for x in enum_type]
 
+class IgnoreAction(argparse.Action): # pylint: disable=too-few-public-methods
+    def __call__(self, parser, namespace, values, option_string=None):
+        raise argparse.ArgumentError(None, 'unrecognized argument: {} {}'.format(
+            option_string, values or ''))
+
+# CONSTANTS
+
+IGNORE_TYPE = CliArgumentType(
+    help=argparse.SUPPRESS,
+    nargs='?',
+    action=IgnoreAction,
+    required=False)
+
 resource_group_name_type = CliArgumentType(
     options_list=('--resource-group', '-g'),
     completer=get_resource_group_completion_list,

--- a/src/azure/cli/commands/parameters.py
+++ b/src/azure/cli/commands/parameters.py
@@ -78,9 +78,9 @@ class IgnoreAction(argparse.Action): # pylint: disable=too-few-public-methods
         raise argparse.ArgumentError(None, 'unrecognized argument: {} {}'.format(
             option_string, values or ''))
 
-# CONSTANTS
+# GLOBAL ARGUMENT DEFINTIONS
 
-IGNORE_TYPE = CliArgumentType(
+ignore_type = CliArgumentType(
     help=argparse.SUPPRESS,
     nargs='?',
     action=IgnoreAction,

--- a/src/command_modules/azure-cli-component/azure/cli/command_modules/component/_params.py
+++ b/src/command_modules/azure-cli-component/azure/cli/command_modules/component/_params.py
@@ -3,29 +3,13 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 #---------------------------------------------------------------------------------------------
 
-from azure.cli.commands import register_cli_argument, CliArgumentType
+from azure.cli.commands import register_cli_argument
 
 # BASIC PARAMETER CONFIGURATION
 
-register_cli_argument('component', 'component_name', CliArgumentType(
-    options_list=('--name', '-n'),
-    help='Name of component'
-))
-register_cli_argument('component', 'force', CliArgumentType(
-    options_list=('--force', '-f'),
-    help='Supress delete confirmation prompt',
-    action='store_true'
-))
-register_cli_argument('component', 'link', CliArgumentType(
-    options_list=('--link', '-l'),
-    help='If a url or path to an html file, parse for links to archives. If local path or file://'
-         'url that\'s a directory, then look for archives in the directory listing.'
-))
-register_cli_argument('component', 'private', CliArgumentType(
-    options_list=('--private', '-p'),
-    help='Get from the project PyPI server',
-    action='store_true'
-))
-register_cli_argument('component', 'version', CliArgumentType(
-    help='Component version (otherwise latest)'
-))
+# pylint: disable=line-too-long
+register_cli_argument('component', 'component_name', options_list=('--name', '-n'), help='Name of component')
+register_cli_argument('component', 'force', options_list=('--force', '-f'), help='Supress delete confirmation prompt', action='store_true')
+register_cli_argument('component', 'link', options_list=('--link', '-l'), help='If a url or path to an html file, parse for links to archives. If local path or file:// url that\'s a directory, then look for archives in the directory listing.')
+register_cli_argument('component', 'private', options_list=('--private', '-p'), help='Get from the project PyPI server', action='store_true')
+register_cli_argument('component', 'version', help='Component version (otherwise latest)')

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -276,9 +276,9 @@ register_cli_argument('network public-ip', 'public_ip_address_name', name_arg_ty
 register_cli_argument('network public-ip', 'name', name_arg_type, completer=get_resource_name_completion_list('Microsoft.Network/publicIPAddresses'))
 
 register_cli_argument('network public-ip create', 'name', completer=None)
-register_cli_argument('network public-ip create', 'dns_name', CliArgumentType(validator=process_public_ip_create_namespace))
-register_cli_argument('network public-ip create', 'public_ip_address_type', CliArgumentType(help=argparse.SUPPRESS))
-register_cli_argument('network public-ip create', 'allocation_method', CliArgumentType(choices=choices_ip_allocation_method, type=str.lower))
+register_cli_argument('network public-ip create', 'dns_name', validator=process_public_ip_create_namespace)
+register_cli_argument('network public-ip create', 'public_ip_address_type', help=argparse.SUPPRESS)
+register_cli_argument('network public-ip create', 'allocation_method', choices=choices_ip_allocation_method, type=str.lower)
 
 # Route Operation
 register_cli_argument('network route-table route', 'route_name', name_arg_type, id_part='child_name', help='Route name')
@@ -349,7 +349,7 @@ register_cli_argument('network lb rule', 'load_distribution', help='Affinity rul
 register_cli_argument('network nsg create', 'name', name_arg_type)
 
 # VPN gateway
-register_cli_argument('network vpn-gateway', 'virtual_network_gateway_name', CliArgumentType(options_list=('--name', '-n'), completer=get_resource_name_completion_list('Microsoft.Network/virtualNetworkGateways')), id_part='name')
+register_cli_argument('network vpn-gateway', 'virtual_network_gateway_name', options_list=('--name', '-n'), completer=get_resource_name_completion_list('Microsoft.Network/virtualNetworkGateways'), id_part='name')
 register_cli_argument('network vpn-gateway create', 'gateway_type', choices=get_enum_choices(gatewayType))
 register_cli_argument('network vpn-gateway create', 'sku', choices=get_enum_choices(sku))
 register_cli_argument('network vpn-gateway create', 'vpn_type', choices=get_enum_choices(vpnType))
@@ -363,13 +363,13 @@ register_cli_argument('network vpn-gateway root-cert create', 'cert_name', help=
 register_cli_argument('network vpn-gateway root-cert create', 'gateway_name', help='Virtual network gateway name')
 
 # VPN connection
-register_cli_argument('network vpn-connection', 'virtual_network_gateway_connection_name', CliArgumentType(options_list=('--name', '-n'), metavar='NAME', id_part='name'))
+register_cli_argument('network vpn-connection', 'virtual_network_gateway_connection_name', options_list=('--name', '-n'), metavar='NAME', id_part='name')
 register_cli_argument('network vpn-connection create', 'connection_type', help=argparse.SUPPRESS, validator=vnet_gateway_validator, required=False)
 register_cli_argument('network vpn-connection create', 'shared_key', validator=load_cert_file('shared_key'), help='Shared IPSec key, base64 contents of the certificate file or file path.')
 
 # VPN connection shared key
-register_cli_argument('network vpn-connection shared-key', 'connection_shared_key_name', CliArgumentType(options_list=('--name', '-n')), id_part='name')
-register_cli_argument('network vpn-connection shared-key', 'virtual_network_gateway_connection_name', CliArgumentType(options_list=('--connection-name',), metavar='NAME'), id_part='name')
+register_cli_argument('network vpn-connection shared-key', 'connection_shared_key_name', options_list=('--name', '-n'), id_part='name')
+register_cli_argument('network vpn-connection shared-key', 'virtual_network_gateway_connection_name', options_list=('--connection-name',), metavar='NAME', id_part='name')
 
 # Traffic manager profiles
 register_cli_argument('network traffic-manager profile', 'traffic_manager_profile_name', name_arg_type, id_part='name', completer=get_resource_name_completion_list('Microsoft.Network/trafficManagerProfiles'))

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 #---------------------------------------------------------------------------------------------
 
-from azure.cli.commands import CliArgumentType, register_cli_argument
+from azure.cli.commands import register_cli_argument
 from .custom import load_subscriptions
 # BASIC PARAMETER CONFIGURATION
 
@@ -15,39 +15,12 @@ def get_subscription_id_list(prefix, **kwargs):#pylint: disable=unused-argument
         result.append(subscription['name'])
     return result
 
-password_type = CliArgumentType(
-    options_list=('--password', '-p'),
-    help='User password or client secret. Will prompt if not given.'
-)
+# pylint: disable=line-too-long
+register_cli_argument('login', 'password', options_list=('--password', '-p'), help='User password or client secret. Will prompt if not given.')
+register_cli_argument('login', 'service_principal', action='store_true', help='The credential representing a service principal.')
+register_cli_argument('login', 'username', options_list=('--username', '-u'), help='Organization id or service principal')
+register_cli_argument('login', 'tenant', options_list=('--tenant', '-t'), help='The tenant associated with the service principal.')
 
-service_principal_type = CliArgumentType(
-    action='store_true',
-    help='The credential representing a service principal.'
-)
+register_cli_argument('logout', 'username', help='account user, if missing, logout the current active account')
 
-subscription_name_or_id_type = CliArgumentType(
-    options_list=('--subscription-name-or-id', '-n'),
-    metavar='SUBSCRIPTION_NAME_OR_ID',
-    help='Subscription id. Unique name also works.',
-    completer=get_subscription_id_list
-)
-
-tenant_type = CliArgumentType(
-    options_list=('--tenant', '-t'),
-    help='The tenant associated with the service principal.'
-)
-
-username_type = CliArgumentType(
-    options_list=('--username', '-u'),
-    help='Organization id or service principal'
-)
-
-register_cli_argument('login', 'password', password_type)
-register_cli_argument('login', 'service_principal', service_principal_type)
-register_cli_argument('login', 'username', username_type)
-register_cli_argument('login', 'tenant', tenant_type)
-
-register_cli_argument('logout', 'username', username_type,
-                      help='account user, if missing, logout the current active account')
-
-register_cli_argument('account', 'subscription_name_or_id', subscription_name_or_id_type)
+register_cli_argument('account', 'subscription_name_or_id', options_list=('--subscription-or-id', '-n'), help='Name or ID of subscription.', completer=get_subscription_id_list)

--- a/src/command_modules/azure-cli-redis/azure/cli/command_modules/redis/_params.py
+++ b/src/command_modules/azure-cli-redis/azure/cli/command_modules/redis/_params.py
@@ -55,7 +55,6 @@ register_cli_argument('redis import-method', 'files', nargs='+')
 
 register_cli_argument('redis patch-schedule set', 'schedule_entries', type=ScheduleEntryList)
 
-
 register_cli_argument('redis create', 'name', arg_type=name_type, completer=None)
 register_cli_argument('redis create', 'sku_name', choices=[c.lower() for c in get_enum_choices(SkuName)], type=str.lower)
 register_cli_argument('redis create', 'sku_family', choices=[c.lower() for c in get_enum_choices(SkuFamily)], type=str.lower)

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
@@ -21,30 +21,25 @@ from ._validators import validate_resource_type, validate_parent, resolve_resour
 
 choices_deployment_mode = [e.value.lower() for e in DeploymentMode]
 
-resource_type_type = CliArgumentType(
-    help='The resource type in <namespace>/<type> format.',
-    type=validate_resource_type,
-    validator=resolve_resource_parameters
-)
+resource_name_type = CliArgumentType(options_list=('--name', '-n'), help='The resource name.')
 
-resource_name_type = CliArgumentType(options_list=('--name', '-n'))
 register_cli_argument('resource', 'resource_name', resource_name_type)
-register_cli_argument('resource', 'api_version', CliArgumentType(help='The api version of the resource (omit for latest)', required=False))
-register_cli_argument('resource', 'resource_provider_namespace', CliArgumentType(help=argparse.SUPPRESS, required=False))
-register_cli_argument('resource', 'resource_type', resource_type_type)
-register_cli_argument('resource', 'parent_resource_path', CliArgumentType(help='The parent resource type in <type>/<name> format.', type=validate_parent, required=False, options_list=('--parent',)))
+register_cli_argument('resource', 'api_version', help='The api version of the resource (omit for latest)', required=False)
+register_cli_argument('resource', 'resource_provider_namespace', help=argparse.SUPPRESS, required=False)
+register_cli_argument('resource', 'resource_type', help='The resource type in <namespace>/<type> format.', type=validate_resource_type, validator=resolve_resource_parameters)
+register_cli_argument('resource', 'parent_resource_path', help='The parent resource type in <type>/<name> format.', type=validate_parent, required=False, options_list=('--parent',))
 register_cli_argument('resource', 'tag', tag_type)
 register_cli_argument('resource', 'tags', tags_type)
 register_cli_argument('resource list', 'name', resource_name_type)
 register_cli_argument('resource move', 'ids', nargs='+')
 
 _PROVIDER_HELP_TEXT = 'the resource namespace, aka \'provider\''
-register_cli_argument('resource provider', 'top', CliArgumentType(help=argparse.SUPPRESS))
-register_cli_argument('resource provider', 'resource_provider_namespace', CliArgumentType(options_list=('--namespace', '-n'), help=_PROVIDER_HELP_TEXT))
+register_cli_argument('resource provider', 'top', help=argparse.SUPPRESS)
+register_cli_argument('resource provider', 'resource_provider_namespace', options_list=('--namespace', '-n'), help=_PROVIDER_HELP_TEXT)
 
-register_cli_argument('resource feature', 'resource_provider_namespace', CliArgumentType(options_list=('--namespace',), required=True, help=_PROVIDER_HELP_TEXT))
-register_cli_argument('resource feature list', 'resource_provider_namespace', CliArgumentType(options_list=('--namespace',), required=False, help=_PROVIDER_HELP_TEXT))
-register_cli_argument('resource feature', 'feature_name', CliArgumentType(options_list=('--name', '-n'), help='the feature name'))
+register_cli_argument('resource feature', 'resource_provider_namespace', options_list=('--namespace',), required=True, help=_PROVIDER_HELP_TEXT)
+register_cli_argument('resource feature list', 'resource_provider_namespace', options_list=('--namespace',), required=False, help=_PROVIDER_HELP_TEXT)
+register_cli_argument('resource feature', 'feature_name', options_list=('--name', '-n'), help='the feature name')
 
 register_cli_argument('resource policy', 'resource_group_name', arg_type=resource_group_name_type, help='the resource group where the policy will be applied')
 register_cli_argument('resource policy', 'policy_definition_name', options_list=('--name', '-n'), completer=get_policy_completion_list, help='name of policy definition')
@@ -62,16 +57,13 @@ register_cli_argument('resource policy assignment create', 'policy_assignment_na
 
 register_cli_argument('resource group', 'resource_group_name', resource_group_name_type, options_list=('--name', '-n'))
 register_cli_argument('resource group deployment', 'resource_group_name', arg_type=resource_group_name_type, completer=get_resource_group_completion_list)
-register_cli_argument('resource group deployment', 'deployment_name', CliArgumentType(options_list=('--name', '-n'), required=True, help='The deployment name.'))
+register_cli_argument('resource group deployment', 'deployment_name', options_list=('--name', '-n'), required=True, help='The deployment name.')
 register_cli_argument('resource group deployment', 'parameters_file_path', completer=FilesCompleter())
 register_cli_argument('resource group deployment', 'template_file_path', completer=FilesCompleter())
-register_cli_argument('resource group deployment', 'mode', CliArgumentType(
-    choices=choices_deployment_mode, type=str.lower,
-    help='Incremental (only add resources to resource group) or Complete (remove extra resources from resource group)'))
-register_cli_argument('resource group export', 'include_comments', CliArgumentType(action='store_true'))
-register_cli_argument('resource group export', 'include_parameter_default_value', CliArgumentType(action='store_true'))
+register_cli_argument('resource group deployment', 'mode', choices=choices_deployment_mode, type=str.lower, help='Incremental (only add resources to resource group) or Complete (remove extra resources from resource group)')
+register_cli_argument('resource group export', 'include_comments', action='store_true')
+register_cli_argument('resource group export', 'include_parameter_default_value', action='store_true')
 register_cli_argument('resource group create', 'resource_group_name', completer=None)
 
-register_cli_argument('tag', 'tag_name', CliArgumentType(options_list=('--name', '-n')))
-register_cli_argument('tag', 'tag_value', CliArgumentType(options_list=('--value',)))
-
+register_cli_argument('tag', 'tag_name', options_list=('--name', '-n'))
+register_cli_argument('tag', 'tag_value', options_list=('--value',))

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
@@ -4,13 +4,12 @@
 #---------------------------------------------------------------------------------------------
 
 # pylint: disable=line-too-long
-import argparse
 import os
 
 from six import u as unicode_string
 
 from azure.cli.commands.parameters import \
-    (tags_type, get_resource_name_completion_list, get_enum_type_completion_list)
+    (IGNORE_TYPE, tags_type, get_resource_name_completion_list, get_enum_type_completion_list)
 from azure.cli.commands import register_cli_argument, register_extra_cli_argument, CliArgumentType
 from azure.cli.commands.client_factory import get_data_service_client
 
@@ -33,11 +32,7 @@ from ._validators import \
      validate_select,
      get_content_setting_validator, validate_encryption,
      process_file_download_namespace, process_logging_update_namespace,
-     process_metric_update_namespace, IgnoreAction)
-
-# CONSTANTS
-
-IGNORE_TYPE = CliArgumentType(help=argparse.SUPPRESS, nargs='?', action=IgnoreAction, required=False)
+     process_metric_update_namespace)
 
 # COMPLETERS
 

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
@@ -9,7 +9,7 @@ import os
 from six import u as unicode_string
 
 from azure.cli.commands.parameters import \
-    (IGNORE_TYPE, tags_type, get_resource_name_completion_list, get_enum_type_completion_list)
+    (ignore_type, tags_type, get_resource_name_completion_list, get_enum_type_completion_list)
 from azure.cli.commands import register_cli_argument, register_extra_cli_argument, CliArgumentType
 from azure.cli.commands.client_factory import get_data_service_client
 
@@ -106,13 +106,13 @@ def register_path_argument(scope, default_file_param=None, options_list=None):
     if default_file_param:
         path_help = '{} If the file name is omitted, the source file name will be used.'.format(path_help)
     register_extra_cli_argument(scope, 'path', options_list=options_list or ('--path', '-p'), required=default_file_param is None, help=path_help, validator=get_file_path_validator(default_file_param=default_file_param), completer=file_path_completer)
-    register_cli_argument(scope, 'file_name', IGNORE_TYPE)
-    register_cli_argument(scope, 'directory_name', IGNORE_TYPE)
+    register_cli_argument(scope, 'file_name', ignore_type)
+    register_cli_argument(scope, 'directory_name', ignore_type)
 
 # CONTENT SETTINGS REGISTRATION
 
 def register_content_settings_argument(scope, settings_class):
-    register_cli_argument(scope, 'content_settings', IGNORE_TYPE, validator=get_content_setting_validator(settings_class))
+    register_cli_argument(scope, 'content_settings', ignore_type, validator=get_content_setting_validator(settings_class))
     register_extra_cli_argument(scope, 'content_type', default=None, help='The content MIME type.')
     register_extra_cli_argument(scope, 'content_encoding', default=None, help='The content encoding type.')
     register_extra_cli_argument(scope, 'content_language', default=None, help='The content language.')
@@ -206,15 +206,15 @@ register_cli_argument('storage container create', 'public_access', choices=list(
 
 register_cli_argument('storage container delete', 'fail_not_exist', help='Throw an exception if the container does not exist.')
 
-register_cli_argument('storage container exists', 'blob_name', IGNORE_TYPE)
+register_cli_argument('storage container exists', 'blob_name', ignore_type)
 
 register_cli_argument('storage container policy', 'container_name', container_name_type)
 register_cli_argument('storage container policy', 'policy_name', options_list=('--name', '-n'), help='The stored access policy name.', completer=get_storage_acl_name_completion_list(BaseBlobService, 'container_name', 'get_container_acl'))
 
 register_cli_argument('storage share', 'share_name', share_name_type, options_list=('--name', '-n'))
 
-register_cli_argument('storage share exists', 'directory_name', IGNORE_TYPE)
-register_cli_argument('storage share exists', 'file_name', IGNORE_TYPE)
+register_cli_argument('storage share exists', 'directory_name', ignore_type)
+register_cli_argument('storage share exists', 'file_name', ignore_type)
 
 register_cli_argument('storage share policy', 'container_name', share_name_type)
 register_cli_argument('storage share policy', 'policy_name', options_list=('--name', '-n'), help='The stored access policy name.', completer=get_storage_acl_name_completion_list(FileService, 'container_name', 'get_share_acl'))
@@ -222,7 +222,7 @@ register_cli_argument('storage share policy', 'policy_name', options_list=('--na
 register_cli_argument('storage directory', 'directory_name', directory_type, options_list=('--name', '-n'))
 
 register_cli_argument('storage directory exists', 'directory_name', required=True)
-register_cli_argument('storage directory exists', 'file_name', IGNORE_TYPE)
+register_cli_argument('storage directory exists', 'file_name', ignore_type)
 
 register_cli_argument('storage file', 'file_name', file_name_type, options_list=('--name', '-n'))
 register_cli_argument('storage file', 'directory_name', directory_type, required=False)
@@ -235,7 +235,7 @@ register_path_argument('storage file delete')
 
 register_cli_argument('storage file download', 'file_path', options_list=('--dest',), help='Path of the file to write to. The source filename will be used if not specified.', required=False, validator=process_file_download_namespace)
 register_cli_argument('storage file download', 'path', validator=None) # validator called manually from process_file_download_namespace so remove the automatic one
-register_cli_argument('storage file download', 'progress_callback', IGNORE_TYPE)
+register_cli_argument('storage file download', 'progress_callback', ignore_type)
 register_path_argument('storage file download')
 
 register_cli_argument('storage file exists', 'file_name', required=True)
@@ -257,7 +257,7 @@ for item in ['update', 'upload']:
 
 register_path_argument('storage file update')
 
-register_cli_argument('storage file upload', 'progress_callback', IGNORE_TYPE)
+register_cli_argument('storage file upload', 'progress_callback', ignore_type)
 register_cli_argument('storage file upload', 'local_file_path', options_list=('--source',))
 register_path_argument('storage file upload', default_file_param='local_file_path')
 
@@ -278,7 +278,7 @@ register_cli_argument('storage table policy', 'container_name', table_name_type)
 register_cli_argument('storage table policy', 'policy_name', options_list=('--name', '-n'), help='The stored access policy name.', completer=get_storage_acl_name_completion_list(TableService, 'container_name', 'get_table_acl'))
 
 register_cli_argument('storage entity', 'entity', options_list=('--entity', '-e'), validator=validate_entity, nargs='+')
-register_cli_argument('storage entity', 'property_resolver', IGNORE_TYPE)
+register_cli_argument('storage entity', 'property_resolver', ignore_type)
 register_cli_argument('storage entity', 'select', nargs='+', validator=validate_select)
 
 register_cli_argument('storage entity insert', 'if_exists', choices=['fail', 'merge', 'replace'])

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
@@ -16,15 +16,6 @@ from azure.mgmt.storage import StorageManagementClient
 from azure.storage.models import ResourceTypes, Services
 from azure.storage.table import TablePermissions
 
-# region ACTIONS
-
-class IgnoreAction(argparse.Action): # pylint: disable=too-few-public-methods
-    def __call__(self, parser, namespace, values, option_string=None):
-        raise argparse.ArgumentError(None, 'unrecognized argument: {} {}'.format(
-            option_string, values or ''))
-
-# endregion
-
 # region PARAMETER VALIDATORS
 
 def validate_client_parameters(namespace):

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -48,21 +48,24 @@ def get_vm_size_completion_list(prefix, action, parsed_args, **kwargs):#pylint: 
     result = get_vm_sizes(location)
     return [r.name for r in result]
 
-# BASIC PARAMETER CONFIGURATION
+# CHOICE LISTS
+
 choices_caching_types = [e.value for e in CachingTypes]
 choices_container_service_orchestrator_types = [e.value for e in ContainerServiceOchestratorTypes]
 choices_upgrade_mode = [e.value.lower() for e in UpgradeMode]
 choices_ip_allocation_method = [e.value.lower() for e in IPAllocationMethod]
 
-name_arg_type = CliArgumentType(options_list=('--name', '-n'), metavar='NAME')
-multi_ids_type = CliArgumentType(
-    nargs='+'
-)
+# REUSABLE ARGUMENT DEFINITIONS
 
+name_arg_type = CliArgumentType(options_list=('--name', '-n'), metavar='NAME')
+multi_ids_type = CliArgumentType(nargs='+')
 admin_username_type = CliArgumentType(options_list=('--admin-username',), default=getpass.getuser(), required=False)
 existing_vm_name = CliArgumentType(overrides=name_arg_type, help='The name of the virtual machine', completer=get_resource_name_completion_list('Microsoft.Compute/virtualMachines'), id_part='name')
+
+# ARGUMENT REGISTRATION
+
 register_cli_argument('vm', 'vm_name', existing_vm_name)
-register_cli_argument('vm', 'size', CliArgumentType(completer=get_vm_size_completion_list))
+register_cli_argument('vm', 'size', completer=get_vm_size_completion_list)
 register_cli_argument('vm', 'tags', tags_type)
 register_cli_argument('vm', 'name', arg_type=name_arg_type)
 
@@ -72,32 +75,24 @@ register_cli_argument('vmss', 'instance_ids', multi_ids_type)
 register_cli_argument('vmss', 'tags', tags_type)
 register_cli_argument('vmss', 'name', arg_type=name_arg_type)
 register_cli_argument('vm disk', 'vm_name', arg_type=existing_vm_name, options_list=('--vm-name',))
-register_cli_argument('vm disk', 'disk_name', CliArgumentType(options_list=('--name', '-n'), help='The data disk name. If missing, will retrieve from vhd uri'))
-register_cli_argument('vm disk', 'disk_size', CliArgumentType(help='Size of disk (GiB)', default=1023, type=int))
-register_cli_argument('vm disk', 'lun', CliArgumentType(
-    type=int, help='0-based logical unit number (LUN). Max value depends on the Virutal Machine size.'))
-register_cli_argument('vm disk', 'vhd', CliArgumentType(type=VirtualHardDisk, help='virtual hard disk\'s uri. For example:https://mystorage.blob.core.windows.net/vhds/d1.vhd'))
-register_cli_argument('vm disk', 'caching', CliArgumentType(help='Host caching policy', default=CachingTypes.none.value, choices=choices_caching_types))
+register_cli_argument('vm disk', 'disk_name', options_list=('--name', '-n'), help='The data disk name. If missing, will retrieve from vhd uri')
+register_cli_argument('vm disk', 'disk_size', help='Size of disk (GiB)', default=1023, type=int)
+register_cli_argument('vm disk', 'lun', type=int, help='0-based logical unit number (LUN). Max value depends on the Virutal Machine size.')
+register_cli_argument('vm disk', 'vhd', type=VirtualHardDisk, help='virtual hard disk\'s uri. For example:https://mystorage.blob.core.windows.net/vhds/d1.vhd')
+register_cli_argument('vm disk', 'caching', help='Host caching policy', default=CachingTypes.none.value, choices=choices_caching_types)
 
 register_cli_argument('vm availability-set', 'availability_set_name', name_arg_type, completer=get_resource_name_completion_list('Microsoft.Compute/availabilitySets'), help='Name of the availability set')
 
-register_cli_argument('vm access', 'username', CliArgumentType(options_list=('--username', '-u'), help='The user name'))
-register_cli_argument('vm access', 'password', CliArgumentType(options_list=('--password', '-p'), help='The user password'))
+register_cli_argument('vm access', 'username', options_list=('--username', '-u'), help='The user name')
+register_cli_argument('vm access', 'password', options_list=('--password', '-p'), help='The user password')
 
-register_cli_argument('vm container', 'orchestrator_type', CliArgumentType(choices=choices_container_service_orchestrator_types))
+register_cli_argument('vm container', 'orchestrator_type', choices=choices_container_service_orchestrator_types)
 register_cli_argument('vm container', 'admin_username', admin_username_type)
-register_cli_argument(
-    'vm container', 'ssh_key_value', CliArgumentType(
-        required=False,
-        help='SSH key file value or key file path.',
-        default=os.path.join(os.path.expanduser('~'), '.ssh', 'id_rsa.pub'),
-        completer=FilesCompleter()
-    )
-)
-register_cli_argument('vm container', 'container_service_name', CliArgumentType(overrides=name_arg_type, help='The name of the container service', completer=get_resource_name_completion_list('Microsoft.ContainerService/ContainerServices')))
-register_cli_argument('vm container create', 'agent_vm_size', CliArgumentType(completer=get_vm_size_completion_list))
+register_cli_argument('vm container', 'ssh_key_value', required=False, help='SSH key file value or key file path.', default=os.path.join(os.path.expanduser('~'), '.ssh', 'id_rsa.pub'), completer=FilesCompleter())
+register_cli_argument('vm container', 'container_service_name', options_list=('--name', '-n'), help='The name of the container service', completer=get_resource_name_completion_list('Microsoft.ContainerService/ContainerServices'))
+register_cli_argument('vm container create', 'agent_vm_size', completer=get_vm_size_completion_list)
 
-register_cli_argument('vm capture', 'overwrite', CliArgumentType(action='store_true'))
+register_cli_argument('vm capture', 'overwrite', action='store_true')
 register_cli_argument('vm nic', 'nic_ids', multi_ids_type)
 register_cli_argument('vm nic', 'nic_names', multi_ids_type)
 register_cli_argument('vm diagnostics', 'vm_name', arg_type=existing_vm_name, options_list=('--vm-name',))
@@ -105,20 +100,20 @@ register_cli_argument('vm diagnostics set', 'storage_account', completer=get_res
 
 register_cli_argument('vm extension', 'vm_extension_name', name_arg_type, completer=get_resource_name_completion_list('Microsoft.Compute/virtualMachines/extensions'))
 register_cli_argument('vm extension', 'vm_name', arg_type=existing_vm_name, options_list=('--vm-name',))
-register_cli_argument('vm extension', 'auto_upgrade_minor_version', CliArgumentType(action='store_true'))
+register_cli_argument('vm extension', 'auto_upgrade_minor_version', action='store_true')
 
-register_cli_argument('vm extension image', 'image_location', CliArgumentType(options_list=('--location', '-l')))
-register_cli_argument('vm extension image', 'publisher_name', CliArgumentType(options_list=('--publisher',)))
-register_cli_argument('vm extension image', 'type', CliArgumentType(options_list=('--name', '-n')))
-register_cli_argument('vm extension image', 'latest', CliArgumentType(action='store_true'))
+register_cli_argument('vm extension image', 'image_location', options_list=('--location', '-l'))
+register_cli_argument('vm extension image', 'publisher_name', options_list=('--publisher',))
+register_cli_argument('vm extension image', 'type', options_list=('--name', '-n'))
+register_cli_argument('vm extension image', 'latest', action='store_true')
 
 register_cli_argument('vmss extension', 'extension_name', name_arg_type, id_part='name', help='Name of extension')
 register_cli_argument('vmss extension', 'vmss_name', help='Scale set name')
-register_cli_argument('vmss extension', 'auto_upgrade_minor_version', CliArgumentType(action='store_true'))
+register_cli_argument('vmss extension', 'auto_upgrade_minor_version', action='store_true')
 
-register_cli_argument('vmss extension image', 'publisher_name', CliArgumentType(options_list=('--publisher',), help='Image publisher name'))
-register_cli_argument('vmss extension image', 'type', CliArgumentType(options_list=('--name', '-n'), help='Extension name'))
-register_cli_argument('vmss extension image', 'latest', CliArgumentType(action='store_true'))
+register_cli_argument('vmss extension image', 'publisher_name', options_list=('--publisher',), help='Image publisher name')
+register_cli_argument('vmss extension image', 'type', options_list=('--name', '-n'), help='Extension name')
+register_cli_argument('vmss extension image', 'latest', action='store_true')
 register_cli_argument('vmss extension image', 'image_name', help='Image name')
 register_cli_argument('vmss extension image', 'orderby', help='The sort to apply on the operation')
 register_cli_argument('vmss extension image', 'top', help='Return top number of records')
@@ -145,45 +140,41 @@ nsg_rule_type = CliArgumentType(
 )
 
 register_cli_argument('vm create', 'network_interface_type', help=argparse.SUPPRESS)
-register_cli_argument('vm create', 'network_interface_ids', options_list=('--nics',), nargs='+',
-                      help='Names or IDs of existing NICs to reference.  The first NIC will be the primary NIC.',
-                      type=lambda val: val if (not '/' in val or is_valid_resource_id(val, ValueError)) else '',
-                      validator=_handle_vm_nics)
+register_cli_argument('vm create', 'network_interface_ids', options_list=('--nics',), nargs='+', help='Names or IDs of existing NICs to reference.  The first NIC will be the primary NIC.', type=lambda val: val if (not '/' in val or is_valid_resource_id(val, ValueError)) else '', validator=_handle_vm_nics)
 
 register_cli_argument('vm create', 'name', name_arg_type, validator=_resource_not_exists('Microsoft.Compute/virtualMachines'))
 register_cli_argument('vmss create', 'name', name_arg_type, validator=_resource_not_exists('Microsoft.Compute/virtualMachineScaleSets'))
 register_cli_argument('vmss', 'vm_scale_set_name', name_arg_type, help='scale set name')
-register_cli_argument('vmss', 'instance_ids',
-                      help='Space separated ids such as "0 2 3", or use "*" for all instances')
+register_cli_argument('vmss', 'instance_ids', help='Space separated ids such as "0 2 3", or use "*" for all instances')
 
 for scope in ['vm create', 'vmss create']:
-    register_cli_argument(scope, 'location', CliArgumentType(completer=get_location_completion_list))
-    register_cli_argument(scope, 'custom_os_disk_uri', CliArgumentType(help=argparse.SUPPRESS))
-    register_cli_argument(scope, 'os_disk_type', CliArgumentType(help=argparse.SUPPRESS))
-    register_cli_argument(scope, 'os_disk_name', CliArgumentType(validator=_os_disk_default))
-    register_cli_argument(scope, 'overprovision', CliArgumentType(action='store_false', default=None, options_list=('--disable-overprovision',)))
-    register_cli_argument(scope, 'upgrade_policy_mode', CliArgumentType(choices=choices_upgrade_mode, help=None, type=str.lower))
-    register_cli_argument(scope, 'os_disk_uri', CliArgumentType(help=argparse.SUPPRESS))
-    register_cli_argument(scope, 'os_offer', CliArgumentType(help=argparse.SUPPRESS))
-    register_cli_argument(scope, 'os_publisher', CliArgumentType(help=argparse.SUPPRESS))
-    register_cli_argument(scope, 'os_sku', CliArgumentType(help=argparse.SUPPRESS))
-    register_cli_argument(scope, 'os_type', CliArgumentType(help=argparse.SUPPRESS))
-    register_cli_argument(scope, 'os_version', CliArgumentType(help=argparse.SUPPRESS))
-    register_cli_argument(scope, 'dns_name_type', CliArgumentType(help=argparse.SUPPRESS))
+    register_cli_argument(scope, 'location', completer=get_location_completion_list)
+    register_cli_argument(scope, 'custom_os_disk_uri', help=argparse.SUPPRESS)
+    register_cli_argument(scope, 'os_disk_type', help=argparse.SUPPRESS)
+    register_cli_argument(scope, 'os_disk_name', validator=_os_disk_default)
+    register_cli_argument(scope, 'overprovision', action='store_false', default=None, options_list=('--disable-overprovision',))
+    register_cli_argument(scope, 'upgrade_policy_mode', choices=choices_upgrade_mode, help=None, type=str.lower)
+    register_cli_argument(scope, 'os_disk_uri', help=argparse.SUPPRESS)
+    register_cli_argument(scope, 'os_offer', help=argparse.SUPPRESS)
+    register_cli_argument(scope, 'os_publisher', help=argparse.SUPPRESS)
+    register_cli_argument(scope, 'os_sku', help=argparse.SUPPRESS)
+    register_cli_argument(scope, 'os_type', help=argparse.SUPPRESS)
+    register_cli_argument(scope, 'os_version', help=argparse.SUPPRESS)
+    register_cli_argument(scope, 'dns_name_type', help=argparse.SUPPRESS)
     register_cli_argument(scope, 'admin_username', admin_username_type)
     register_cli_argument(scope, 'storage_type', help='The VM storage type.')
     register_cli_argument(scope, 'subnet_name', help='The subnet name.  Creates if creating a new VNet, references if referencing an existing VNet.')
     register_cli_argument(scope, 'admin_password', help='Password for the Virtual Machine if Authentication Type is Password.')
-    register_cli_argument(scope, 'ssh_key_value', CliArgumentType(action=VMSSHFieldAction))
+    register_cli_argument(scope, 'ssh_key_value', action=VMSSHFieldAction)
     register_cli_argument(scope, 'ssh_dest_key_path', completer=FilesCompleter())
-    register_cli_argument(scope, 'dns_name_for_public_ip', CliArgumentType(action=VMDNSNameAction), options_list=('--public-ip-address-dns-name',), help='Globally unique DNS Name for the Public IP.')
+    register_cli_argument(scope, 'dns_name_for_public_ip', action=VMDNSNameAction, options_list=('--public-ip-address-dns-name',), help='Globally unique DNS Name for the Public IP.')
     register_cli_argument(scope, 'authentication_type', authentication_type)
     register_folded_cli_argument(scope, 'availability_set', 'Microsoft.Compute/availabilitySets', default_value_flag='none')
     register_cli_argument(scope, 'private_ip_address_allocation', help=argparse.SUPPRESS)
     register_cli_argument(scope, 'virtual_network_ip_address_prefix', options_list=('--vnet-ip-address-prefix',))
     register_cli_argument(scope, 'subnet_ip_address_prefix', options_list=('--subnet-ip-address-prefix',))
     register_cli_argument(scope, 'private_ip_address', help='Static private IP address (e.g. 10.0.0.5).', options_list=('--private-ip-address',), action=PrivateIpAction)
-    register_cli_argument(scope, 'public_ip_address_allocation', CliArgumentType(choices=['dynamic', 'static'], help='', default='dynamic', type=str.lower))
+    register_cli_argument(scope, 'public_ip_address_allocation', choices=['dynamic', 'static'], help='', default='dynamic', type=str.lower)
     register_folded_cli_argument(scope, 'public_ip_address', 'Microsoft.Network/publicIPAddresses')
     register_folded_cli_argument(scope, 'storage_account', 'Microsoft.Storage/storageAccounts', validator=_find_default_storage_account, allow_none=False, default_value_flag='existingId')
     register_folded_cli_argument(scope, 'virtual_network', 'Microsoft.Network/virtualNetworks', options_list=('--vnet',), validator=_find_default_vnet, allow_none=False, default_value_flag='existingId')

--- a/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/_params.py
+++ b/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/_params.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 #---------------------------------------------------------------------------------------------
 
-from azure.cli.commands import CliArgumentType, register_cli_argument
+from azure.cli.commands import register_cli_argument
 from azure.cli.commands.parameters import tags_type
 
 from azure.mgmt.web import WebSiteManagementClient
@@ -17,7 +17,7 @@ def _web_client_factory(**_):
 
 # PARAMETER REGISTRATION
 
-register_cli_argument('webapp', 'name', CliArgumentType(options_list=('--name', '-n')))
+register_cli_argument('webapp', 'name', options_list=('--name', '-n'))
 register_cli_argument('webapp', 'tags', tags_type)
 
 register_folded_cli_argument('webapp create', 'hosting_plan', 'Microsoft.Web/serverfarms')


### PR DESCRIPTION
Removes all instances of the old anti-pattern and replaces them with the current best-practices.

```Python
register_cli_argument('scope', 'dest', CliArgumentType(a=b, c=d))  # anti-pattern!

register_cli_argument('scope', 'dest', a=b, c=d) # do it this way

myarg = CliArgumentType(x=y, m=n) # only do this if you will reuse the definition
register_cli_argument('scope1', 'dest', myarg) # direct reuse
register_cli_argument('scope2', 'dest', myarg, m=p) # reuse with modification
```
Addresses issue #742.