### PR TITLE
Update regular expression to fix issue #147

### DIFF
--- a/src/azure/cli/_output.py
+++ b/src/azure/cli/_output.py
@@ -124,7 +124,7 @@ class OutputProducer(object): #pylint: disable=too-few-public-methods
 class ListOutput(object): #pylint: disable=too-few-public-methods
 
     # Match the capital letters in a camel case string
-    FORMAT_KEYS_PATTERN = re.compile('([A-Z][^A-Z]*)')
+    FORMAT_KEYS_PATTERN = re.compile('([A-Z]+(?![a-z])|[A-Z]{1}[a-z]+)')
 
     def __init__(self):
         self._formatted_keys_cache = {}

--- a/src/azure/cli/tests/test_output.py
+++ b/src/azure/cli/tests/test_output.py
@@ -144,6 +144,16 @@ Id     : 0b1f6472
 
 """))
 
+    def test_out_list_valid_caps(self):
+        output_producer = OutputProducer(formatter=format_list, file=self.io)
+        output_producer.out(CommandResultItem({'active': True, 'TESTStuff': 'blah'}))
+        self.assertEqual(util.normalize_newlines(self.io.getvalue()), util.normalize_newlines(
+"""Test Stuff : blah
+Active     : True
+
+
+"""))
+
     def test_out_list_valid_none_val(self):
         output_producer = OutputProducer(formatter=format_list, file=self.io)
         output_producer.out(CommandResultItem({'active': None, 'id': '0b1f6472'}))
@@ -232,7 +242,7 @@ Myarray :
         lo = ListOutput()
         self.assertEqual(lo._formatted_keys_cache, {})
         lo._get_formatted_key('fooIDS')
-        self.assertEqual(lo._formatted_keys_cache, {'fooIDS': 'Foo I D S'})
+        self.assertEqual(lo._formatted_keys_cache, {'fooIDS': 'Foo Ids'})
 
     def test_out_list_format_key_multiple_words(self):
         lo = ListOutput()


### PR DESCRIPTION
Fixes the issue with caps from issue #147.  Now the output would look like:

```
$ az vm list --out list --query "[].{NAME: name, alsoNAME: name}"

Name : vm1
Also Name  : vm1
```