### PR TITLE
Table format revisions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,5 @@ pylint==1.5.4
 pyyaml==3.11
 requests==2.9.1
 six==1.10.0
+tabulate==0.7.5
 vcrpy==1.7.4

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ DEPENDENCIES = [
     'pyyaml',
     'requests',
     'six',
+    'tabulate',
 ]
 
 if sys.version_info < (3, 4):

--- a/src/azure/cli/application.py
+++ b/src/azure/cli/application.py
@@ -126,6 +126,8 @@ class Application(object):
         self.raise_event(self.TRANSFORM_RESULT, event_data=event_data)
         self.raise_event(self.FILTER_RESULT, event_data=event_data)
         return CommandResultItem(event_data['result'],
+                                 simple_output_query=
+                                 command_table[args.command].simple_output_query,
                                  is_query_active=self.session['query_active'])
 
     def raise_event(self, name, **kwargs):

--- a/src/azure/cli/application.py
+++ b/src/azure/cli/application.py
@@ -126,8 +126,6 @@ class Application(object):
         self.raise_event(self.TRANSFORM_RESULT, event_data=event_data)
         self.raise_event(self.FILTER_RESULT, event_data=event_data)
         return CommandResultItem(event_data['result'],
-                                 simple_output_query=
-                                 command_table[args.command].simple_output_query,
                                  is_query_active=self.session['query_active'])
 
     def raise_event(self, name, **kwargs):

--- a/src/azure/cli/tests/test_output.py
+++ b/src/azure/cli/tests/test_output.py
@@ -6,6 +6,7 @@
 from __future__ import print_function
  # pylint: disable=protected-access, bad-continuation, too-many-public-methods, trailing-whitespace
 import unittest
+from collections import OrderedDict
 from six import StringIO
 
 from azure.cli._output import (OutputProducer, format_json, format_table, format_list,
@@ -71,7 +72,10 @@ class TestOutput(unittest.TestCase):
 
     def test_out_table(self):
         output_producer = OutputProducer(formatter=format_table, file=self.io)
-        output_producer.out(CommandResultItem({'active': True, 'val': '0b1f6472'}))
+        obj = OrderedDict()
+        obj['active'] = True
+        obj['val'] = '0b1f6472'
+        output_producer.out(CommandResultItem(obj))
         self.assertEqual(util.normalize_newlines(self.io.getvalue()), util.normalize_newlines(
 """  Active  Val
 --------  --------
@@ -80,7 +84,11 @@ class TestOutput(unittest.TestCase):
 
     def test_out_table_complex_obj(self):
         output_producer = OutputProducer(formatter=format_table, file=self.io)
-        result_item = CommandResultItem([{'name': 'qwerty', 'val': '0b1f6472qwerty', 'sub': {'1'}}])
+        obj = OrderedDict()
+        obj['name'] = 'qwerty'
+        obj['val'] = '0b1f6472qwerty'
+        obj['sub'] = {'1'}
+        result_item = CommandResultItem(obj)
         output_producer.out(result_item)
         self.assertEqual(util.normalize_newlines(self.io.getvalue()), util.normalize_newlines(
 """Name    Val
@@ -222,7 +230,6 @@ Myarray :
         self.assertEqual(result, '2\t1\n')
 
     def test_output_format_ordereddict_not_sorted(self):
-        from collections import OrderedDict
         obj = OrderedDict()
         obj['B'] = 1
         obj['A'] = 2
@@ -230,7 +237,6 @@ Myarray :
         self.assertEqual(result, '1\t2\n')
 
     def test_output_format_ordereddict_list_not_sorted(self):
-        from collections import OrderedDict
         obj1 = OrderedDict()
         obj1['B'] = 1
         obj1['A'] = 2

--- a/src/azure/cli/tests/test_output.py
+++ b/src/azure/cli/tests/test_output.py
@@ -69,68 +69,24 @@ class TestOutput(unittest.TestCase):
 
     # TABLE output tests
 
-    def test_out_table_valid_query1(self):
+    def test_out_table(self):
         output_producer = OutputProducer(formatter=format_table, file=self.io)
-        result_item = CommandResultItem([{'name': 'qwerty', 'id': '0b1f6472qwerty'},
-                                         {'name': 'asdf', 'id': '0b1f6472asdf'}],
-                                              simple_output_query='[*].{Name:name, Id:id}')
-        output_producer.out(result_item)
+        output_producer.out(CommandResultItem({'active': True, 'val': '0b1f6472'}))
         self.assertEqual(util.normalize_newlines(self.io.getvalue()), util.normalize_newlines(
-""" Name  |       Id      
--------|---------------
-qwerty | 0b1f6472qwerty
-asdf   | 0b1f6472asdf  
+"""  Active  Val
+--------  --------
+       1  0b1f6472
 """))
-
-    def test_out_table_no_query(self):
-        output_producer = OutputProducer(formatter=format_table, file=self.io)
-        with self.assertRaises(util.CLIError):
-            output_producer.out(CommandResultItem({'active': True, 'id': '0b1f6472'}))
-
-    def test_out_table_valid_query2(self):
-        output_producer = OutputProducer(formatter=format_table, file=self.io)
-        result_item = CommandResultItem([{'name': 'qwerty', 'id': '0b1f6472qwerty'},
-                                         {'name': 'asdf', 'id': '0b1f6472asdf'}],
-                                              simple_output_query='[*].{Name:name}')
-        output_producer.out(result_item)
-        self.assertEqual(util.normalize_newlines(self.io.getvalue()), util.normalize_newlines(
-""" Name 
-------
-qwerty
-asdf  
-"""))
-
-    def test_out_table_bad_query(self):
-        output_producer = OutputProducer(formatter=format_table, file=self.io)
-        result_item = CommandResultItem([{'name': 'qwerty', 'id': '0b1f6472qwerty'},
-                                         {'name': 'asdf', 'id': '0b1f6472asdf'}],
-                                              simple_output_query='[*].{Name:name')
-        with self.assertRaises(util.CLIError):
-            output_producer.out(result_item)
 
     def test_out_table_complex_obj(self):
         output_producer = OutputProducer(formatter=format_table, file=self.io)
-        result_item = CommandResultItem([{'name': 'qwerty', 'id': '0b1f6472qwerty', 'sub': {'1'}}])
-        with self.assertRaises(util.CLIError):
-            output_producer.out(result_item)
-
-    def test_out_table_complex_obj_with_query_ok(self):
-        output_producer = OutputProducer(formatter=format_table, file=self.io)
-        result_item = CommandResultItem([{'name': 'qwerty', 'id': '0b1f6472qwerty', 'sub': {'1'}}],
-                                        simple_output_query='[*].{Name:name}')
+        result_item = CommandResultItem([{'name': 'qwerty', 'val': '0b1f6472qwerty', 'sub': {'1'}}])
         output_producer.out(result_item)
         self.assertEqual(util.normalize_newlines(self.io.getvalue()), util.normalize_newlines(
-""" Name 
-------
-qwerty
+"""Name    Val
+------  --------------
+qwerty  0b1f6472qwerty
 """))
-
-    def test_out_table_complex_obj_with_query_still_complex(self):
-        output_producer = OutputProducer(formatter=format_table, file=self.io)
-        result_item = CommandResultItem([{'name': 'qwerty', 'id': '0b1f6472qwerty', 'sub': {'1'}}],
-                                        simple_output_query='[*].{Name:name, Sub:sub}')
-        with self.assertRaises(util.CLIError):
-            output_producer.out(result_item)
 
     # LIST output tests
 

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
@@ -325,7 +325,7 @@ def transform_metrics_list_output(result):
             new_entry['Interval'] = interval
             new_entry['Enabled'] = item['enabled']
             new_entry['IncludeApis'] = item['includeApis']
-            new_entry['RetentionPolicy)'] = item['retentionPolicy']['days']
+            new_entry['RetentionPolicy'] = item['retentionPolicy']['days']
             new_result.append(new_entry)
     return new_result
 


### PR DESCRIPTION
Fixes #705, fixes #704, fixes #652

- Table output is generic and automatically extracts fields from the result.
- No longer use simple_output_query as it was specific for commands and as packages will support multiple API versions, this solution is no longer feasible.