### PR TITLE
Exit From LongRunningOperations with Ctrl+C

### DIFF
--- a/src/azure-cli/azure/cli/main.py
+++ b/src/azure-cli/azure/cli/main.py
@@ -37,6 +37,9 @@ def main(args, file=sys.stdout): #pylint: disable=redefined-builtin
         if cmd_result and cmd_result.result:
             formatter = OutputProducer.get_formatter(APPLICATION.configuration.output_format)
             OutputProducer(formatter=formatter, file=file).out(cmd_result)
+    except KeyboardInterrupt:
+        logger.warning('KeyboardInterrupt')
+        sys.exit(1)
     except Exception as ex: # pylint: disable=broad-except
         error_code = handle_exception(ex)
         return error_code

--- a/src/azure/cli/utils/_msrestazure_threading.py
+++ b/src/azure/cli/utils/_msrestazure_threading.py
@@ -1,0 +1,26 @@
+#---------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+#---------------------------------------------------------------------------------------------
+
+# This replaces the existing AzureOperationPoller.__init__ implementation with a custom
+# implemenatation that sets the daemon property on the created thread to True. This
+# allows the program to exit when Ctrl+C is pressed, without having to press it again
+# to kill the running thread.
+from msrestazure.azure_operation import AzureOperationPoller
+
+# pylint: disable=protected-access
+def azureOperationPollerInit(self, send_cmd, output_cmd, update_cmd, timeout=30):
+    import threading
+    self._timeout = timeout
+    self._response = None
+    self._operation = None
+    self._exception = None
+    self._callbacks = []
+    self._done = threading.Event()
+    self._thread = threading.Thread(
+        target=self._start, args=(send_cmd, update_cmd, output_cmd))
+    # Need this set to True so Ctrl+C will simply exit
+    self._thread.daemon = True
+    self._thread.start()
+AzureOperationPoller.__init__ = azureOperationPollerInit


### PR DESCRIPTION
This PR fixes #596, fixes #755. The reason this occurs is because you must press Ctrl+C to exit the CLI, but then must press it again to exit the LongRunningOperation thread. This PR uses a custom implementation of the AzureOperationPoller's __init__ method to set the poller's thread type to a daemon thread. This allows the CLI to exit with a single press of Ctrl+C. It works on bash and CMD (although you still have to answer the Y/N prompt on CMD or press Ctrl+C again).