### PR TITLE
[Feedback] Catch EOFError during 'az feedback'

### DIFF
--- a/src/command_modules/azure-cli-feedback/azure/cli/command_modules/feedback/__init__.py
+++ b/src/command_modules/azure-cli-feedback/azure/cli/command_modules/feedback/__init__.py
@@ -81,8 +81,7 @@ def handle_feedback():
         email_address = input(MESSAGES['prompt_email_addr'])
         _send_feedback(score, response_what_changes, response_do_well, email_address)
         print(MESSAGES['thanks'])
-    except KeyboardInterrupt:
-        # Catch to prevent stacktrace and print newline
+    except (EOFError, KeyboardInterrupt):
         print()
 
 cli_command('feedback', handle_feedback)


### PR DESCRIPTION
Fixes #594. Note that depending on what threads are running when you press Ctrl+C you may get a stack trace for other reasons.