### PR TITLE
cmd: use plurals for list-* command naming

### DIFF
--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/generated.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/generated.py
@@ -182,8 +182,8 @@ factory = lambda _: _network_client_factory().express_route_circuits
 cli_command('network express-route circuit delete', ExpressRouteCircuitsOperations.delete, factory)
 cli_command('network express-route circuit show', ExpressRouteCircuitsOperations.get, factory)
 cli_command('network express-route circuit get-stats', ExpressRouteCircuitsOperations.get_stats, factory)
-cli_command('network express-route circuit list-arp', ExpressRouteCircuitsOperations.list_arp_table, factory)
-cli_command('network express-route circuit list-routes', ExpressRouteCircuitsOperations.list_routes_table, factory)
+cli_command('network express-route circuit list-arp-tables', ExpressRouteCircuitsOperations.list_arp_table, factory)
+cli_command('network express-route circuit list-route-tables', ExpressRouteCircuitsOperations.list_routes_table, factory)
 cli_command('network express-route circuit list', list_express_route_circuits)
 cli_generic_update_command('network express-route circuit update', ExpressRouteCircuitsOperations.get, ExpressRouteCircuitsOperations.create_or_update, factory)
 

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/test_network_commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/test_network_commands.py
@@ -229,9 +229,9 @@ class NetworkExpressRouteCircuitScenarioTest(VCRTestBase):
             rg, ern, pv), allowed_exceptions=allowed_exceptions)
         self.cmd('network express-route circuit-peering show --resource-group {0} --circuit-name {1} --name {2}'.format(
             rg, ern, pv), allowed_exceptions=allowed_exceptions)
-        self.cmd('network express-route circuit list-arp --resource-group {0} --name {1} --peering-name {2} --device-path {2}'.format(
+        self.cmd('network express-route circuit list-arp-tables --resource-group {0} --name {1} --peering-name {2} --device-path {2}'.format(
             rg, ern, pv), allowed_exceptions=allowed_exceptions)
-        self.cmd('network express-route circuit list-routes --resource-group {0} --name {1} --peering-name {2} --device-path {2}'.format(
+        self.cmd('network express-route circuit list-route-tables --resource-group {0} --name {1} --peering-name {2} --device-path {2}'.format(
             rg, ern, pv), allowed_exceptions=allowed_exceptions)
 
 class NetworkLoadBalancerScenarioTest(ResourceGroupVCRTestBase):

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
@@ -67,7 +67,7 @@ def logout(username=None):
         username = profile.get_current_account_user()
     profile.logout(username)
 
-def list_location():
+def list_locations():
     from azure.cli.commands.parameters import get_subscription_locations
     return get_subscription_locations()
 

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/generated.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/generated.py
@@ -9,7 +9,7 @@ from azure.cli.commands import cli_command
 
 from .custom import (login,
                      logout,
-                     list_location,
+                     list_locations,
                      list_subscriptions,
                      set_active_subscription,
                      account_clear)
@@ -20,5 +20,5 @@ cli_command('logout', logout)
 cli_command('account list', list_subscriptions)
 cli_command('account set', set_active_subscription)
 cli_command('account clear', account_clear)
-cli_command('account list-location', list_location)
+cli_command('account list-locations', list_locations)
 


### PR DESCRIPTION
fix #694