### PR TITLE
[Help] Fix UnicodeError When Importing SDK DocStrings

### DIFF
--- a/src/azure/cli/_help.py
+++ b/src/azure/cli/_help.py
@@ -360,7 +360,10 @@ def _print_indent(s, indent=0, subsequent_spaces=-1):
                               width=100)
     paragraphs = s.split('\n')
     for p in paragraphs:
-        print(tw.fill(p), file=sys.stdout)
+        try:
+            print(tw.fill(p), file=sys.stdout)
+        except UnicodeEncodeError:
+            print(tw.fill(p).encode('ascii', 'ignore').decode('utf-8', 'ignore'), file=sys.stdout)
 
 def _get_column_indent(text, max_name_length):
     return ' '*(max_name_length - len(text))


### PR DESCRIPTION
Certain SDK docstrings contain unicode characters that cause the help system to throw an error. This PR handles that case.