### PR TITLE
rbac: bug fixes on create sp for rbac commands

### DIFF
--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
@@ -28,7 +28,9 @@ sp_name_type = CliArgumentType(
 register_cli_argument('ad sp', 'identifier', options_list=('--id',), help='service principal name, or object id')
 register_cli_argument('ad sp create', 'identifier', options_list=('--id',), help='identifier uri, application id, or object id of the associated application')
 register_cli_argument('ad sp create-for-rbac', 'name', sp_name_type)
+register_cli_argument('ad sp create-for-rbac', 'years', type=int)
 register_cli_argument('ad sp reset-credentials', 'name', sp_name_type)
+register_cli_argument('ad sp reset-credentials', 'years', type=int)
 
 register_cli_argument('ad', 'display_name', help='object\'s display name or its prefix')
 register_cli_argument('ad', 'identifier_uri',


### PR DESCRIPTION
fix #700, fix #703
1. Ensure to parse `years` parameter as integer
2. Avoid referencing guid in the output of `create-for-rbac`  