### PR TITLE
Clean-up IDs parameters

### DIFF
--- a/scripts/dump_command_table.py
+++ b/scripts/dump_command_table.py
@@ -12,7 +12,7 @@ import re
 import types
 import sys
 
-from azure.cli.application import Application, Configuration
+from azure.cli.application import APPLICATION, Application
 
 class Exporter(json.JSONEncoder):
 
@@ -129,7 +129,6 @@ hide_nulls = args.hide_nulls
 
 PRIMITIVES = (str, int, bool, float)
 IGNORE_ARGS = ['help', 'help_file', 'base_type']
-    
-APPLICATION = Application(Configuration([]))
-APPLICATION.register(Application.COMMAND_TABLE_LOADED, _dump_command_table)
-APPLICATION.execute([''])
+
+APPLICATION.register(Application.COMMAND_PARSER_LOADED, _dump_command_table)
+APPLICATION.execute([])

--- a/src/azure/cli/application.py
+++ b/src/azure/cli/application.py
@@ -60,7 +60,6 @@ class Application(object):
             'query_active': False
             }
 
-
         # Register presence of and handlers for global parameters
         self.register(self.GLOBAL_PARSER_CREATED, Application._register_builtin_arguments)
         self.register(self.COMMAND_PARSER_PARSED, self._handle_builtin_arguments)
@@ -74,8 +73,7 @@ class Application(object):
 
         self.parser = AzCliCommandParser(prog='az', parents=[self.global_parser])
 
-        if config:
-            self.initialize(config)
+        self.initialize(config or Configuration([]))
 
     def initialize(self, configuration):
         self.configuration = configuration

--- a/src/azure/cli/commands/__init__.py
+++ b/src/azure/cli/commands/__init__.py
@@ -147,8 +147,9 @@ class CliCommand(object):
         self.table_transformer = table_transformer
 
     def add_argument(self, param_name, *option_strings, **kwargs):
+        dest = kwargs.pop('dest', None)
         argument = CliCommandArgument(
-            param_name, options_list=option_strings, **kwargs)
+            dest or param_name, options_list=option_strings, **kwargs)
         self.arguments[param_name] = argument
 
     def update_argument(self, param_name, argtype):

--- a/src/azure/cli/commands/arm.py
+++ b/src/azure/cli/commands/arm.py
@@ -145,10 +145,11 @@ def add_id_parameters(command_table):
             if command.arguments[key].id_part:
                 command.arguments[key].arg_group = group_name
 
-        command.add_argument(argparse.SUPPRESS,
+        command.add_argument('ids',
                              '--ids',
                              metavar='RESOURCE_ID',
                              help='ID of resource',
+                             dest=argparse.SUPPRESS,
                              action=split_action(command.arguments),
                              nargs='+',
                              type=ResourceId,

--- a/src/azure/cli/commands/arm.py
+++ b/src/azure/cli/commands/arm.py
@@ -96,6 +96,23 @@ def resource_exists(resource_group, name, namespace, type, **_): # pylint: disab
 
 def add_id_parameters(command_table):
 
+    def _extract_ids_help(command):
+        # TODO for performance don't bother with this unless -h or --help is specified
+        # if not help_requested:
+        #   return
+
+        from azure.cli.commands import _cli_argument_registry as aliases
+        components = command.name.split()
+        alias = {}
+        while components:
+            target = ' '.join(components)
+            try:
+                alias = aliases.arguments[target]['ids'].settings['help']
+                break
+            except KeyError:
+                components.pop()
+        return alias or None
+
     def split_action(arguments):
         class SplitAction(argparse.Action): #pylint: disable=too-few-public-methods
 
@@ -129,6 +146,10 @@ def add_id_parameters(command_table):
             # parameter
             return
 
+        ids_help = _extract_ids_help(command) or 'One or more resource IDs.'
+        ids_help = '{} If provided, no other \'Resource Id\' arguments '.format(ids_help) + \
+                   'should be specified.'
+
         required_arguments = []
         optional_arguments = []
         for arg in [argument for argument in command.arguments.values() if argument.id_part]:
@@ -154,8 +175,8 @@ def add_id_parameters(command_table):
         command.add_argument('ids',
                              '--ids',
                              metavar='RESOURCE_ID',
-                             help='ID of resource',
                              dest=argparse.SUPPRESS,
+                             help=ids_help,
                              action=split_action(command.arguments),
                              nargs='+',
                              type=ResourceId,

--- a/src/azure/cli/commands/arm.py
+++ b/src/azure/cli/commands/arm.py
@@ -20,7 +20,8 @@ logger = _logging.get_az_logger(__name__)
 
 regex = re.compile('/subscriptions/(?P<subscription>[^/]*)/resourceGroups/(?P<resource_group>[^/]*)'
                    '/providers/(?P<namespace>[^/]*)/(?P<type>[^/]*)/(?P<name>[^/]*)'
-                   '(/(?P<child_type>[^/]*)/(?P<child_name>[^/]*))?')
+                   '(/(?P<child_type>[^/]*)/(?P<child_name>[^/]*))?'
+                   '(/(?P<grandchild_type>[^/]*)/(?P<grandchild_name>[^/]*))?')
 
 def resource_id(**kwargs):
     '''Create a valid resource id string from the given parts
@@ -32,6 +33,8 @@ def resource_id(**kwargs):
         - name              Name of the resource (or parent if child_name is also specified)
         - child_type        Type of the child resource
         - child_name        Name of the child resource
+        - grandchild_type   Type of the grandchild resource
+        - grandchild_name   Name of the grandchild resource
     '''
     rid = '/subscriptions/{subscription}'.format(**kwargs)
     try:
@@ -39,6 +42,7 @@ def resource_id(**kwargs):
         rid = '/'.join((rid, 'providers/{namespace}'.format(**kwargs)))
         rid = '/'.join((rid, '{type}/{name}'.format(**kwargs)))
         rid = '/'.join((rid, '{child_type}/{child_name}'.format(**kwargs)))
+        rid = '/'.join((rid, '{grandchild_type}/{grandchild_name}'.format(**kwargs)))
     except KeyError:
         pass
     return rid
@@ -53,6 +57,8 @@ def parse_resource_id(rid):
         - name              Name of the resource (or parent if child_name is also specified)
         - child_type        Type of the child resource
         - child_name        Name of the child resource
+        - grandchild_type   Type of the grandchild resource
+        - grandchild_name   Name of the grandchild resource
     '''
     m = regex.match(rid)
     if m:

--- a/src/azure/cli/commands/arm.py
+++ b/src/azure/cli/commands/arm.py
@@ -96,23 +96,6 @@ def resource_exists(resource_group, name, namespace, type, **_): # pylint: disab
 
 def add_id_parameters(command_table):
 
-    def _extract_ids_help(command):
-        # TODO for performance don't bother with this unless -h or --help is specified
-        # if not help_requested:
-        #   return
-
-        from azure.cli.commands import _cli_argument_registry as aliases
-        components = command.name.split()
-        alias = {}
-        while components:
-            target = ' '.join(components)
-            try:
-                alias = aliases.arguments[target]['ids'].settings['help']
-                break
-            except KeyError:
-                components.pop()
-        return alias or None
-
     def split_action(arguments):
         class SplitAction(argparse.Action): #pylint: disable=too-few-public-methods
 
@@ -146,10 +129,6 @@ def add_id_parameters(command_table):
             # parameter
             return
 
-        ids_help = _extract_ids_help(command) or 'One or more resource IDs.'
-        ids_help = '{} If provided, no other \'Resource Id\' arguments '.format(ids_help) + \
-                   'should be specified.'
-
         required_arguments = []
         optional_arguments = []
         for arg in [argument for argument in command.arguments.values() if argument.id_part]:
@@ -176,7 +155,8 @@ def add_id_parameters(command_table):
                              '--ids',
                              metavar='RESOURCE_ID',
                              dest=argparse.SUPPRESS,
-                             help=ids_help,
+                             help="One or more resource IDs. If provided, no other 'Resource Id' "
+                                  "arguments should be specified.",
                              action=split_action(command.arguments),
                              nargs='+',
                              type=ResourceId,

--- a/src/azure/cli/tests/test_resource_id.py
+++ b/src/azure/cli/tests/test_resource_id.py
@@ -28,7 +28,21 @@ class TestApplication(unittest.TestCase):
         self.assertTrue(is_valid_resource_id(result))
         self.assertEqual(result, expected)
 
-    def test_resource_id_complex(self):
+    def test_resource_id_with_child(self):
+        rg = 'lbrg'
+        lb = 'mylb'
+        namespace = 'Microsoft.Network'
+        rtype = 'loadBalancers'
+        bep = 'mybep'
+        bep_type = 'backendAddressPools'
+        sub = '00000000-0000-0000-0000-000000000000'
+        result = resource_id(name=lb, resource_group=rg, namespace=namespace, type=rtype, subscription=sub, child_type=bep_type, child_name=bep)
+        expected = '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbrg/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mybep'
+        self.assertTrue(is_valid_resource_id(expected))
+        self.assertTrue(is_valid_resource_id(result))
+        self.assertEqual(result, expected)
+
+    def test_resource_id_with_grandchild(self):
         rg = 'lbrg'
         lb = 'mylb'
         namespace = 'Microsoft.Network'

--- a/src/azure/cli/tests/test_resource_id.py
+++ b/src/azure/cli/tests/test_resource_id.py
@@ -35,15 +35,17 @@ class TestApplication(unittest.TestCase):
         rtype = 'loadBalancers'
         bep = 'mybep'
         bep_type = 'backendAddressPools'
+        grandchild = 'grandchild'
+        gc_type = 'grandchildType'
         sub = '00000000-0000-0000-0000-000000000000'
-        result = resource_id(name=lb, resource_group=rg, namespace=namespace, type=rtype, subscription=sub, child_type=bep_type, child_name=bep)
-        expected = '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbrg/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mybep'
+        result = resource_id(name=lb, resource_group=rg, namespace=namespace, type=rtype, subscription=sub, child_type=bep_type, child_name=bep, grandchild_name=grandchild, grandchild_type=gc_type)
+        expected = '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbrg/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mybep/grandchildType/grandchild'
         self.assertTrue(is_valid_resource_id(expected))
         self.assertTrue(is_valid_resource_id(result))
         self.assertEqual(result, expected)
 
     def test_resource_id_with_id(self):
-        rid = '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbrg/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mybep'
+        rid = '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbrg/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mybep/grandchildType/grandchild'
         result = resource_id(**parse_resource_id(rid))
         self.assertEqual(result, rid)
 

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
@@ -13,7 +13,7 @@ import azure.cli.commands.arm # pylint: disable=unused-import
 
 from azure.cli.command_modules.keyvault._validators import (process_policy_namespace, process_set_policy_perms_namespace)
 
-register_cli_argument('keyvault', 'vault_name', arg_type=name_type, completer=get_resource_name_completion_list('Microsoft.KeyVault/vaults'), id_part='name')
+register_cli_argument('keyvault', 'vault_name', arg_type=name_type, help='Name of the key vault', completer=get_resource_name_completion_list('Microsoft.KeyVault/vaults'), id_part='name')
 register_cli_argument('keyvault', 'object_id', help='a GUID that identifies the principal that will receive permissions')
 register_cli_argument('keyvault', 'spn', help='name of a service principal that will receive permissions')
 register_cli_argument('keyvault', 'upn', help='name of a user principal that will receive permissions')

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -97,6 +97,7 @@ def get_tm_endpoint_completion_list():
 # BASIC PARAMETER CONFIGURATION
 
 name_arg_type = CliArgumentType(options_list=('--name', '-n'), metavar='NAME')
+nic_type = CliArgumentType(options_list=('--nic-name',), metavar='NIC_NAME', help='The network interface (NIC).', id_part='name', completer=get_resource_name_completion_list('Microsoft.Network/networkInterfaces'))
 nsg_name_type = CliArgumentType(options_list=('--nsg-name',), metavar='NSG', help='Name of the network security group.')
 virtual_network_name_type = CliArgumentType(options_list=('--vnet-name',), metavar='VNET_NAME', help='The virtual network (VNET) name.', completer=get_resource_name_completion_list('Microsoft.Network/virtualNetworks'))
 subnet_name_type = CliArgumentType(options_list=('--subnet-name',), metavar='SUBNET_NAME', help='The subnet name.')
@@ -221,13 +222,13 @@ register_cli_argument('network express-route circuit', 'sku_tier', completer=get
 register_cli_argument('network local-gateway', 'local_network_gateway_name', name_arg_type, completer=get_resource_name_completion_list('Microsoft.Network/localNetworkGateways'), id_part='name')
 
 # NIC
-register_cli_argument('network nic', 'network_interface_name', name_arg_type, id_part='name', completer=get_resource_name_completion_list('Microsoft.Network/networkInterfaces'))
+register_cli_argument('network nic', 'network_interface_name', nic_type, options_list=('--name', '-n'))
 register_cli_argument('network nic', 'private_ip_address_allocation', help=argparse.SUPPRESS)
 register_cli_argument('network nic', 'network_security_group_type', help=argparse.SUPPRESS)
 register_cli_argument('network nic', 'public_ip_address_type', help=argparse.SUPPRESS)
 register_cli_argument('network nic', 'internal_dns_name_label', options_list=('--internal-dns-name',))
 
-register_cli_argument('network nic create', 'network_interface_name', name_arg_type, validator=process_nic_create_namespace)
+register_cli_argument('network nic create', 'network_interface_name', nic_type, options_list=('--name', '-n'), validator=process_nic_create_namespace, id_part=None)
 register_cli_argument('network nic create', 'enable_ip_forwarding', options_list=('--ip-forwarding',), action='store_true')
 register_cli_argument('network nic create', 'use_dns_settings', help=argparse.SUPPRESS)
 register_folded_cli_argument('network nic create', 'public_ip_address', 'Microsoft.Network/publicIPAddresses', new_flag_value=None, default_value_flag='none', completer=get_resource_name_completion_list('Microsoft.Network/publicIPAddresses'))
@@ -249,7 +250,10 @@ register_cli_argument('network nic ip-config', 'item_name', options_list=('--nam
 
 for item in ['address-pool', 'inbound-nat-rule']:
     register_cli_argument('network nic ip-config {}'.format(item), 'ip_config_name', options_list=('--ip-config-name', '-n'), metavar='IP_CONFIG_NAME', help='The name of the IP configuration.', id_part='child_name')
-    register_cli_argument('network nic ip-config {}'.format(item), 'network_interface_name', options_list=('--nic-name',), metavar='NIC_NAME', help='The network interface (NIC).', id_part='name', completer=get_resource_name_completion_list('Microsoft.Network/networkInterfaces'))
+    register_cli_argument('network nic ip-config {}'.format(item), 'network_interface_name', nic_type)
+
+register_cli_argument('network nic ip-config address-pool remove', 'network_interface_name', nic_type, id_part=None)
+register_cli_argument('network nic ip-config inbound-nat-rule remove', 'network_interface_name', nic_type, id_part=None)
 
 register_cli_argument('network nic ip-config address-pool', 'load_balancer_name', options_list=('--lb-name',), help='The name of the load balancer associated with the address pool (Omit if suppying an address pool ID).', completer=get_resource_name_completion_list('Microsoft.Network/loadBalancers'))
 register_cli_argument('network nic ip-config inbound-nat-rule', 'load_balancer_name', options_list=('--lb-name',), help='The name of the load balancer associated with the NAT rule (Omit if suppying a NAT rule ID).', completer=get_resource_name_completion_list('Microsoft.Network/loadBalancers'))
@@ -375,9 +379,9 @@ register_cli_argument('network traffic-manager profile check-dns', 'type', help=
 
 # Traffic manager endpoints
 endpoint_types = ['azureEndpoints', 'externalEndpoints', 'nestedEndpoints']
-register_cli_argument('network traffic-manager endpoint', 'endpoint_name', name_arg_type, id_part='name', help='Endpoint name.', completer=get_tm_endpoint_completion_list())
+register_cli_argument('network traffic-manager endpoint', 'endpoint_name', name_arg_type, id_part='child_name', help='Endpoint name.', completer=get_tm_endpoint_completion_list())
 register_cli_argument('network traffic-manager endpoint', 'endpoint_type', options_list=('--type',), help='Endpoint type.  Values include: {}.'.format(', '.join(endpoint_types)), completer=get_generic_completion_list(endpoint_types))
-register_cli_argument('network traffic-manager endpoint', 'profile_name', help='Name of parent profile.', completer=get_resource_name_completion_list('Microsoft.Network/trafficManagerProfiles'))
+register_cli_argument('network traffic-manager endpoint', 'profile_name', help='Name of parent profile.', completer=get_resource_name_completion_list('Microsoft.Network/trafficManagerProfiles'), id_part='name')
 
 # DNS
 register_cli_argument('network dns zone', 'zone_name', name_arg_type)

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -196,9 +196,9 @@ register_cli_argument('network application-gateway url-path-map', 'address_pool'
 register_cli_argument('network application-gateway url-path-map', 'http_settings', help='The name or ID of the HTTP settings to use with the created rule.', completer=get_ag_subresource_completion_list('backend_http_settings_collection'))
 
 
-register_cli_argument('network application-gateway url-path-map rule', 'item_name', options_list=('--name', '-n'), help='The name of the url-path-map rule.', completer=get_ag_url_map_rule_completion_list())
+register_cli_argument('network application-gateway url-path-map rule', 'item_name', options_list=('--name', '-n'), help='The name of the url-path-map rule.', completer=get_ag_url_map_rule_completion_list(), id_part='grandchild_name')
 register_cli_argument('network application-gateway url-path-map rule create', 'item_name', options_list=('--name', '-n'), help='The name of the url-path-map rule.', completer=None)
-register_cli_argument('network application-gateway url-path-map rule', 'url_path_map_name', options_list=('--path-map-name',), help='The name of the URL path map.', completer=get_ag_subresource_completion_list('url_path_maps'))
+register_cli_argument('network application-gateway url-path-map rule', 'url_path_map_name', options_list=('--path-map-name',), help='The name of the URL path map.', completer=get_ag_subresource_completion_list('url_path_maps'), id_part='child_name')
 register_cli_argument('network application-gateway url-path-map rule', 'address_pool', help='The name or ID of the backend address pool. If not specified, the default for the map will be used.', validator=process_ag_url_path_map_rule_create_namespace, completer=get_ag_subresource_completion_list('backend_address_pools'))
 register_cli_argument('network application-gateway url-path-map rule', 'http_settings', help='The name or ID of the HTTP settings. If not specified, the default for the map will be used.', completer=get_ag_subresource_completion_list('backend_http_settings_collection'))
 

--- a/src/command_modules/azure-cli-redis/azure/cli/command_modules/redis/_params.py
+++ b/src/command_modules/azure-cli-redis/azure/cli/command_modules/redis/_params.py
@@ -46,7 +46,7 @@ class ScheduleEntryList(list):
             row.get('maintenanceWindow', None))
                      for row in dictval])
 
-register_cli_argument('redis', 'name', arg_type=name_type, completer=get_resource_name_completion_list('Microsoft.Cache/redis'), id_part='name')
+register_cli_argument('redis', 'name', arg_type=name_type, help='Name of the redis cache.', completer=get_resource_name_completion_list('Microsoft.Cache/redis'), id_part='name')
 register_cli_argument('redis', 'redis_configuration', type=JsonString)
 register_cli_argument('redis', 'reboot_type', completer=get_enum_type_completion_list(RebootType))
 register_cli_argument('redis', 'key_type', choices=[e.value for e in RedisKeyType])

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
@@ -156,7 +156,7 @@ for item in ['check-name', 'delete', 'list', 'show', 'show-usage', 'update', 'ke
 register_cli_argument('storage account connection-string', 'account_name', account_name_type, options_list=('--name', '-n'))
 register_cli_argument('storage account connection-string', 'protocol', help='The default endpoint protocol.', choices=['http', 'https'], type=str.lower)
 
-register_cli_argument('storage account create', 'account_name', account_name_type, options_list=('--name', '-n'), completer=None, id_part=None)
+register_cli_argument('storage account create', 'account_name', account_name_type, options_list=('--name', '-n'), completer=None)
 register_cli_argument('storage account create', 'kind', help='Indicates the type of storage account. (Storage, BlobStorage)', completer=get_enum_type_completion_list(Kind))
 register_cli_argument('storage account create', 'tags', tags_type)
 

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
@@ -11,6 +11,7 @@ from six import u as unicode_string
 from azure.cli.commands.parameters import \
     (ignore_type, tags_type, get_resource_name_completion_list, get_enum_type_completion_list)
 from azure.cli.commands import register_cli_argument, register_extra_cli_argument, CliArgumentType
+import azure.cli.commands.arm # pylint: disable=unused-import
 from azure.cli.commands.client_factory import get_data_service_client
 
 from azure.common import AzureMissingResourceHttpError
@@ -149,12 +150,13 @@ register_cli_argument('storage', 'metadata', nargs='+', help='Metadata in space-
 register_cli_argument('storage', 'timeout', help='Request timeout in seconds. Applies to each call to the service.', type=int)
 register_cli_argument('storage', 'container_name', container_name_type)
 
-register_cli_argument('storage account', 'account_name', account_name_type, options_list=('--name', '-n'))
+for item in ['check-name', 'delete', 'list', 'show', 'show-usage', 'update', 'keys']:
+    register_cli_argument('storage account {}'.format(item), 'account_name', account_name_type, options_list=('--name', '-n'))
 
 register_cli_argument('storage account connection-string', 'account_name', account_name_type, options_list=('--name', '-n'))
 register_cli_argument('storage account connection-string', 'protocol', help='The default endpoint protocol.', choices=['http', 'https'], type=str.lower)
 
-register_cli_argument('storage account create', 'account_name', account_name_type, options_list=('--name', '-n'), completer=None)
+register_cli_argument('storage account create', 'account_name', account_name_type, options_list=('--name', '-n'), completer=None, id_part=None)
 register_cli_argument('storage account create', 'kind', help='Indicates the type of storage account. (Storage, BlobStorage)', completer=get_enum_type_completion_list(Kind))
 register_cli_argument('storage account create', 'tags', tags_type)
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
@@ -116,3 +116,24 @@ helps['vm update'] = """
                 - name: Remove fourth NIC
                   text: az <command> -n name -g group --remove networkProfile.networkInterfaces 3
             """.format(generic_update_help)
+
+helps['vmss get-instance-view'] = """
+    type: command
+    parameters: 
+        - name: --ids
+          short-summary: "One or more scale set or specific VM instance IDs. If provided, no other 'Resource Id' arguments should be specified."
+"""
+
+helps['vmss reimage'] = """
+    type: command
+    parameters: 
+        - name: --ids
+          short-summary: "One or more scale set or specific VM instance IDs. If provided, no other 'Resource Id' arguments should be specified."
+"""
+
+helps['vmss show'] = """
+    type: command
+    parameters: 
+        - name: --ids
+          short-summary: "One or more scale set or specific VM instance IDs. If provided, no other 'Resource Id' arguments should be specified."
+"""

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -81,6 +81,9 @@ register_cli_argument('vm disk', 'lun', type=int, help='0-based logical unit num
 register_cli_argument('vm disk', 'vhd', type=VirtualHardDisk, help='virtual hard disk\'s uri. For example:https://mystorage.blob.core.windows.net/vhds/d1.vhd')
 register_cli_argument('vm disk', 'caching', help='Host caching policy', default=CachingTypes.none.value, choices=choices_caching_types)
 
+for item in ['attach-existing', 'attach-new', 'detach']:
+    register_cli_argument('vm disk {}'.format(item), 'vm_name', arg_type=existing_vm_name, options_list=('--vm-name',), id_part=None)
+
 register_cli_argument('vm availability-set', 'availability_set_name', name_arg_type, completer=get_resource_name_completion_list('Microsoft.Compute/availabilitySets'), help='Name of the availability set')
 
 register_cli_argument('vm access', 'username', options_list=('--username', '-u'), help='The user name')
@@ -97,8 +100,8 @@ register_cli_argument('vm capture', 'overwrite', action='store_true')
 register_cli_argument('vm diagnostics', 'vm_name', arg_type=existing_vm_name, options_list=('--vm-name',))
 register_cli_argument('vm diagnostics set', 'storage_account', completer=get_resource_name_completion_list('Microsoft.Storage/storageAccounts'))
 
-register_cli_argument('vm extension', 'vm_extension_name', name_arg_type, completer=get_resource_name_completion_list('Microsoft.Compute/virtualMachines/extensions'))
-register_cli_argument('vm extension', 'vm_name', arg_type=existing_vm_name, options_list=('--vm-name',))
+register_cli_argument('vm extension', 'vm_extension_name', name_arg_type, completer=get_resource_name_completion_list('Microsoft.Compute/virtualMachines/extensions'), id_part='child_name')
+register_cli_argument('vm extension', 'vm_name', arg_type=existing_vm_name, options_list=('--vm-name',), id_part='name')
 register_cli_argument('vm extension', 'no_auto_upgrade', action='store_true')
 
 register_cli_argument('vm extension image', 'image_location', options_list=('--location', '-l'))
@@ -106,8 +109,8 @@ register_cli_argument('vm extension image', 'publisher_name', options_list=('--p
 register_cli_argument('vm extension image', 'type', options_list=('--name', '-n'))
 register_cli_argument('vm extension image', 'latest', action='store_true')
 
-register_cli_argument('vmss extension', 'extension_name', name_arg_type, id_part='name', help='Name of extension')
-register_cli_argument('vmss extension', 'vmss_name', help='Scale set name')
+register_cli_argument('vmss extension', 'extension_name', name_arg_type, help='Name of the extension.')
+register_cli_argument('vmss extension', 'vmss_name', help='Scale set name', id_part=None)
 register_cli_argument('vmss extension', 'no_auto_upgrade', action='store_true')
 
 register_cli_argument('vmss extension image', 'publisher_name', options_list=('--publisher',), help='Image publisher name')
@@ -124,12 +127,15 @@ register_cli_argument('vm open-port', 'vm_name', name_arg_type, help='The name o
 register_cli_argument('vm open-port', 'network_security_group_name', options_list=('--nsg-name',), help='The name of the network security group to create if one does not exist. Ignored if an NSG already exists.', validator=nsg_name_validator)
 register_cli_argument('vm open-port', 'apply_to_subnet', help='Allow inbound traffic on the subnet instead of the NIC', action='store_true')
 
+register_cli_argument('vm nic', 'vm_name', existing_vm_name, id_part=None)
 register_cli_argument('vm nic', 'nic_ids', multi_ids_type)
 register_cli_argument('vm nic', 'nic_names', multi_ids_type)
 
-register_cli_argument('vmss nic', 'virtual_machine_scale_set_name', options_list=('--vmss-name',), help='Scale set name.', completer=get_resource_name_completion_list('Microsoft.Compute/virtualMachineScaleSets'), id_part='name')
+register_cli_argument('vmss nic', 'virtual_machine_scale_set_name', options_list=('--vmss-name',), help='Scale set name.', completer=get_resource_name_completion_list('Microsoft.Compute/virtualMachineScaleSets'), id_part=None)
 register_cli_argument('vmss nic', 'virtualmachine_index', options_list=('--instance-id',))
-register_cli_argument('vmss nic', 'network_interface_name', options_list=('--name', '-n'), id_part='child_name')
+register_cli_argument('vmss nic', 'network_interface_name', nic_type, id_part=None)
+
+register_cli_argument('network nic scale-set list', 'virtual_machine_scale_set_name', options_list=('--vmss-name',), completer=get_resource_name_completion_list('Microsoft.Compute/virtualMachineScaleSets'), id_part='name')
 
 # VM CREATE PARAMETER CONFIGURATION
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -118,7 +118,6 @@ register_cli_argument('vmss', 'instance_id', id_part='child_name')
 register_cli_argument('vmss', 'instance_ids', multi_ids_type)
 register_cli_argument('vmss', 'tags', tags_type)
 register_cli_argument('vmss', 'instance_ids', help='Space separated ids such as "0 2 3", or use "*" for all instances')
-register_cli_argument('vmss', 'ids', help='One or more scale set or specific VM instance IDs.')
 
 register_cli_argument('vmss extension', 'extension_name', name_arg_type, help='Name of the extension.')
 register_cli_argument('vmss extension', 'vmss_name', id_part=None)
@@ -142,9 +141,9 @@ register_cli_argument('vm nic', 'vm_name', existing_vm_name, id_part=None)
 register_cli_argument('vm nic', 'nic_ids', multi_ids_type)
 register_cli_argument('vm nic', 'nic_names', multi_ids_type)
 
-register_cli_argument('vmss nic', 'virtual_machine_scale_set_name', options_list=('--vmss-name',), help='Scale set name.', completer=get_resource_name_completion_list('Microsoft.Compute/virtualMachineScaleSets'), id_part=None)
-register_cli_argument('vmss nic', 'virtualmachine_index', options_list=('--instance-id',))
-register_cli_argument('vmss nic', 'network_interface_name', nic_type, id_part=None)
+register_cli_argument('vmss nic', 'virtual_machine_scale_set_name', options_list=('--vmss-name',), help='Scale set name.', completer=get_resource_name_completion_list('Microsoft.Compute/virtualMachineScaleSets'), id_part='name')
+register_cli_argument('vmss nic', 'virtualmachine_index', options_list=('--instance-id',), id_part='child_name')
+register_cli_argument('vmss nic', 'network_interface_name', options_list=('--nic-name',), metavar='NIC_NAME', help='The network interface (NIC).', completer=get_resource_name_completion_list('Microsoft.Network/networkInterfaces'), id_part='grandchild_name')
 
 register_cli_argument('network nic scale-set list', 'virtual_machine_scale_set_name', options_list=('--vmss-name',), completer=get_resource_name_completion_list('Microsoft.Compute/virtualMachineScaleSets'), id_part='name')
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -118,6 +118,7 @@ register_cli_argument('vmss', 'instance_id', id_part='child_name')
 register_cli_argument('vmss', 'instance_ids', multi_ids_type)
 register_cli_argument('vmss', 'tags', tags_type)
 register_cli_argument('vmss', 'instance_ids', help='Space separated ids such as "0 2 3", or use "*" for all instances')
+register_cli_argument('vmss', 'ids', help='One or more scale set or specific VM instance IDs.')
 
 register_cli_argument('vmss extension', 'extension_name', name_arg_type, help='Name of the extension.')
 register_cli_argument('vmss extension', 'vmss_name', id_part=None)

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -143,7 +143,7 @@ register_cli_argument('vm nic', 'nic_names', multi_ids_type)
 
 register_cli_argument('vmss nic', 'virtual_machine_scale_set_name', options_list=('--vmss-name',), help='Scale set name.', completer=get_resource_name_completion_list('Microsoft.Compute/virtualMachineScaleSets'), id_part='name')
 register_cli_argument('vmss nic', 'virtualmachine_index', options_list=('--instance-id',), id_part='child_name')
-register_cli_argument('vmss nic', 'network_interface_name', options_list=('--nic-name',), metavar='NIC_NAME', help='The network interface (NIC).', completer=get_resource_name_completion_list('Microsoft.Network/networkInterfaces'), id_part='grandchild_name')
+register_cli_argument('vmss nic', 'network_interface_name', options_list=('--name', '-n'), metavar='NIC_NAME', help='The network interface (NIC).', completer=get_resource_name_completion_list('Microsoft.Network/networkInterfaces'), id_part='grandchild_name')
 
 register_cli_argument('network nic scale-set list', 'virtual_machine_scale_set_name', options_list=('--vmss-name',), completer=get_resource_name_completion_list('Microsoft.Compute/virtualMachineScaleSets'), id_part='name')
 


### PR DESCRIPTION
Fixes #732, fixes #656. Follows the guidance that if we cannot directly access the object of interest with `--ids`, we do not expose `--ids` at all. 

Makes updates so that `--ids` correctly appears in the command table when using the `dump_command_table.py` script.

Adds common language to the IDs parameter help text "If provides, no other 'Resource Id' arguments should be specified."