### PR TITLE
Change section name from 'default' to 'core'

### DIFF
--- a/src/azure/cli/application.py
+++ b/src/azure/cli/application.py
@@ -166,7 +166,7 @@ class Application(object):
         global_group.add_argument('--subscription', dest='_subscription_id', help=argparse.SUPPRESS)
         global_group.add_argument('--output', '-o', dest='_output_format',
                                   choices=['json', 'tsv', 'list', 'table', 'jsonc'],
-                                  default=az_config.get('default', 'output', fallback='json'),
+                                  default=az_config.get('core', 'output', fallback='json'),
                                   help='Output format',
                                   type=str.lower)
         # The arguments for verbosity don't get parsed by argparse but we add it here for help.

--- a/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/__init__.py
+++ b/src/command_modules/azure-cli-configure/azure/cli/command_modules/configure/__init__.py
@@ -148,13 +148,13 @@ def _handle_global_configuration():
         # no config exists yet so configure global config or user wants to modify global config
         output_index = prompt_choice_list(MSG_PROMPT_GLOBAL_OUTPUT, OUTPUT_LIST,
                                           default=get_default_from_config(global_config, \
-                                          'default', 'output', OUTPUT_LIST))
+                                          'core', 'output', OUTPUT_LIST))
         # save the global config
         try:
-            global_config.add_section('default')
+            global_config.add_section('core')
         except configparser.DuplicateSectionError:
             pass
-        global_config.set('default', 'output', OUTPUT_LIST[output_index]['name'])
+        global_config.set('core', 'output', OUTPUT_LIST[output_index]['name'])
         if not os.path.isdir(GLOBAL_CONFIG_DIR):
             os.makedirs(GLOBAL_CONFIG_DIR)
         with open(GLOBAL_CONFIG_PATH, 'w') as configfile:


### PR DESCRIPTION
- 'core' will correspond to the core module of the CLI. We will have a module called 'core' anyway.
- 'default' is a special section in ConfigParser that operates differently from other sections.

On Python 2.7, we get a `ValueError` using the section name default:
```
root@d662de122eab:/# az configure

Welcome to the Azure CLI! This command will guide you through logging in and setting some default values.

Your global settings can be found at /root/.azure/config

What default output format would you like?
 [1] json - JSON formatted output that most closely matches API responses
 [2] jsonc - Colored JSON formatted output that most closely matches API responses
 [3] table - Human-readable output format
 [4] tsv - Tab and Newline delimited, great for GREP, AWK, etc.
Please enter a choice [1]: 
Invalid section name: default
```