### PR TITLE
DNS Zone import/export.  

### DIFF
--- a/azure-cli.pyproj
+++ b/azure-cli.pyproj
@@ -358,6 +358,12 @@
     <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_vpn_connection\lib\__init__.py" />
     <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_vpn_connection\__init__.py" />
     <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\tests\test_network_commands.py" />
+    <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\zone_file\configs.py" />
+    <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\zone_file\exceptions.py" />
+    <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\zone_file\make_zone_file.py" />
+    <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\zone_file\parse_zone_file.py" />
+    <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\zone_file\record_processors.py" />
+    <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\zone_file\__init__.py" />
     <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\_factory.py" />
     <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_nsg\lib\credentials.py" />
     <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_nsg\lib\exceptions.py" />
@@ -772,6 +778,7 @@
     <Folder Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_express_route_peering\" />
     <Folder Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_traffic_manager_profile\" />
     <Folder Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_dns_zone\" />
+    <Folder Include="command_modules\azure-cli-network\azure\cli\command_modules\network\zone_file\" />
     <Folder Include="command_modules\azure-cli-redis\" />
     <Folder Include="command_modules\azure-cli-redis\azure\" />
     <Folder Include="command_modules\azure-cli-redis\azure\cli\" />
@@ -916,6 +923,8 @@
     <Content Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_vnet_gateway\swagger_create_vnet_gateway.json" />
     <Content Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_vpn_connection\azuredeploy.json" />
     <Content Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_vpn_connection\swagger_create_vpn_connection.json" />
+    <Content Include="command_modules\azure-cli-network\azure\cli\command_modules\network\tests\TestCert.pfx" />
+    <Content Include="command_modules\azure-cli-network\azure\cli\command_modules\network\tests\zone.txt" />
     <Content Include="command_modules\azure-cli-network\requirements.txt" />
     <Content Include="command_modules\azure-cli-profile\requirements.txt" />
     <Content Include="command_modules\azure-cli-redis\README.rst" />

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -395,3 +395,5 @@ register_cli_argument('network dns', 'record_type', options_list=('--type',), ch
 register_cli_argument('network dns record', 'record_set_name', options_list=('--record-set-name',))
 register_cli_argument('network dns record txt add', 'value', nargs='+')
 register_cli_argument('network dns record txt remove', 'value', nargs='+')
+register_cli_argument('network dns zone import', 'file_name', help='Path to the DNS zone file to import')
+register_cli_argument('network dns zone export', 'file_name', help='Path to the DNS zone file to save')

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/generated.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/generated.py
@@ -115,7 +115,8 @@ from .custom import \
      add_dns_txt_record, add_dns_mx_record,
      remove_dns_aaaa_record, remove_dns_a_record, remove_dns_cname_record,
      remove_dns_ns_record, remove_dns_ptr_record, remove_dns_soa_record, remove_dns_srv_record,
-     remove_dns_txt_record, remove_dns_mx_record, list_traffic_manager_endpoints)
+     remove_dns_txt_record, remove_dns_mx_record, list_traffic_manager_endpoints,
+     export_zone, import_zone)
 from ._factory import _network_client_factory
 
 # pylint: disable=line-too-long
@@ -391,6 +392,8 @@ cli_command('network dns zone show', ZonesOperations.get, factory)
 cli_command('network dns zone delete', ZonesOperations.delete, factory)
 cli_command('network dns zone list', list_dns_zones)
 cli_generic_update_command('network dns zone update', ZonesOperations.get, ZonesOperations.create_or_update, factory)
+cli_command('network dns zone import', import_zone)
+cli_command('network dns zone export', export_zone)
 
 factory = lambda _: get_mgmt_service_client(DnsZoneClient).dns_zone
 cli_command('network dns zone create', DnsZoneOperations.create_or_update, factory, transform=DeploymentOutputLongRunningOperation('Starting network dns zone create'))
@@ -399,8 +402,11 @@ cli_command('network dns zone create', DnsZoneOperations.create_or_update, facto
 factory = lambda _: get_mgmt_service_client(DnsManagementClient).record_sets
 cli_command('network dns record-set show', RecordSetsOperations.get, factory)
 cli_command('network dns record-set delete', RecordSetsOperations.delete, factory)
+cli_command('network dns record-set list', RecordSetsOperations.list_all_in_resource_group, factory)
 cli_command('network dns record-set create', create_dns_record_set)
 cli_generic_update_command('network dns record-set update', RecordSetsOperations.get, RecordSetsOperations.create_or_update, factory)
+
+# DNS RecordOperations
 cli_command('network dns record aaaa add', add_dns_aaaa_record)
 cli_command('network dns record a add', add_dns_a_record)
 cli_command('network dns record cname add', add_dns_cname_record)

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_dns_zone_import_export.yaml
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_dns_zone_import_export.yaml
@@ -1,0 +1,490 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDczMTkxNTU3LCJuYmYiOjE0NzMxOTE1NTcsImV4cCI6MTQ3MzE5NTQ1NywiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJCaWVsaWNraSIsImdpdmVuX25hbWUiOiJCdXJ0IiwiaXBhZGRyIjoiMTY3LjIyMC4wLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.PRVEfn9IoGJzd_bIYstUFfvrQGeg0mZ1xXGz2t5XiUBUxwi30pUwe9QNiLCZ1UmFo3-_wqEoV3C4yw-5jEv6akoGDWPvEA12FKQfGbVsjy0CNp_ZHgcbUC9roV-KSh8g16diKcZ1dnlGkWQzc6Pi9yH0wAUDxzMNxyDPsf2c-n1vqSl3sDexfni3dm3aIImYHorOWFBlqAFYsN_-330FB2oU_u1uuc83OmCSfrmuPoFzKLl2UklbOCD9YTZRfqFJNOejWv2vLOqBjMC5D4DBmb1C-SOj0Ek9UCodv9KfSVhnpsTcSqaQdCScYf32QVg4sBzVW-oGQ3n8HRc8upN0Tw]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 dnsmanagementclient/0.30.0rc5 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bd8219de-7473-11e6-9689-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com?api-version=2016-04-01
+  response:
+    body: {string: !!python/unicode '{"error":{"code":"ResourceNotFound","message":"The
+        Resource ''Microsoft.Network/dnszones/myzone.com'' under resource group ''cli_dns_zone_import_export''
+        was not found."}}'}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['167']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 06 Sep 2016 20:51:53 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-ms-failure-cause: [gateway]
+    status: {code: 404, message: Not Found}
+- request:
+    body: '{"location": "global"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDczMTkxNTU3LCJuYmYiOjE0NzMxOTE1NTcsImV4cCI6MTQ3MzE5NTQ1NywiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJCaWVsaWNraSIsImdpdmVuX25hbWUiOiJCdXJ0IiwiaXBhZGRyIjoiMTY3LjIyMC4wLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.PRVEfn9IoGJzd_bIYstUFfvrQGeg0mZ1xXGz2t5XiUBUxwi30pUwe9QNiLCZ1UmFo3-_wqEoV3C4yw-5jEv6akoGDWPvEA12FKQfGbVsjy0CNp_ZHgcbUC9roV-KSh8g16diKcZ1dnlGkWQzc6Pi9yH0wAUDxzMNxyDPsf2c-n1vqSl3sDexfni3dm3aIImYHorOWFBlqAFYsN_-330FB2oU_u1uuc83OmCSfrmuPoFzKLl2UklbOCD9YTZRfqFJNOejWv2vLOqBjMC5D4DBmb1C-SOj0Ek9UCodv9KfSVhnpsTcSqaQdCScYf32QVg4sBzVW-oGQ3n8HRc8upN0Tw]
+      Connection: [keep-alive]
+      Content-Length: ['22']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 dnsmanagementclient/0.30.0rc5 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bda1d6de-7473-11e6-9fff-001dd8b7c0ad]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com?api-version=2016-04-01
+  response:
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/304e8996-77fb-46e8-bada-557601594be4\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-0396-0f808008d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-09.azure-dns.com.","ns2-09.azure-dns.net.","ns3-09.azure-dns.org.","ns4-09.azure-dns.info."],"numberOfRecordSets":2}}'}
+    headers:
+      cache-control: [private]
+      content-length: ['471']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 06 Sep 2016 20:51:54 GMT']
+      etag: [00000002-0000-0000-0396-0f808008d201]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
+    status: {code: 201, message: Created}
+- request:
+    body: '{"type": "a", "properties": {"ARecords": [{"ipv4Address": "10.0.0.10"}],
+      "TTL": 3600}, "name": "manuala"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDczMTkxNTU3LCJuYmYiOjE0NzMxOTE1NTcsImV4cCI6MTQ3MzE5NTQ1NywiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJCaWVsaWNraSIsImdpdmVuX25hbWUiOiJCdXJ0IiwiaXBhZGRyIjoiMTY3LjIyMC4wLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.PRVEfn9IoGJzd_bIYstUFfvrQGeg0mZ1xXGz2t5XiUBUxwi30pUwe9QNiLCZ1UmFo3-_wqEoV3C4yw-5jEv6akoGDWPvEA12FKQfGbVsjy0CNp_ZHgcbUC9roV-KSh8g16diKcZ1dnlGkWQzc6Pi9yH0wAUDxzMNxyDPsf2c-n1vqSl3sDexfni3dm3aIImYHorOWFBlqAFYsN_-330FB2oU_u1uuc83OmCSfrmuPoFzKLl2UklbOCD9YTZRfqFJNOejWv2vLOqBjMC5D4DBmb1C-SOj0Ek9UCodv9KfSVhnpsTcSqaQdCScYf32QVg4sBzVW-oGQ3n8HRc8upN0Tw]
+      Connection: [keep-alive]
+      Content-Length: ['105']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 dnsmanagementclient/0.30.0rc5 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [be949b4f-7473-11e6-837a-001dd8b7c0ad]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com/A/manuala?api-version=2016-04-01
+  response:
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/304e8996-77fb-46e8-bada-557601594be4\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/manuala","name":"manuala","type":"Microsoft.Network\/dnszones\/A","etag":"8248b442-b4c6-4a42-84ba-fbb344352cba","properties":{"fqdn":"manuala.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
+    headers:
+      cache-control: [private]
+      content-length: ['369']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 06 Sep 2016 20:51:55 GMT']
+      etag: [8248b442-b4c6-4a42-84ba-fbb344352cba]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
+    status: {code: 201, message: Created}
+- request:
+    body: '{"type": "a", "properties": {"ARecords": [{"ipv4Address": "10.0.1.0"},
+      {"ipv4Address": "10.0.1.1"}], "TTL": 0}, "name": "mya"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDczMTkxNTU3LCJuYmYiOjE0NzMxOTE1NTcsImV4cCI6MTQ3MzE5NTQ1NywiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJCaWVsaWNraSIsImdpdmVuX25hbWUiOiJCdXJ0IiwiaXBhZGRyIjoiMTY3LjIyMC4wLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.PRVEfn9IoGJzd_bIYstUFfvrQGeg0mZ1xXGz2t5XiUBUxwi30pUwe9QNiLCZ1UmFo3-_wqEoV3C4yw-5jEv6akoGDWPvEA12FKQfGbVsjy0CNp_ZHgcbUC9roV-KSh8g16diKcZ1dnlGkWQzc6Pi9yH0wAUDxzMNxyDPsf2c-n1vqSl3sDexfni3dm3aIImYHorOWFBlqAFYsN_-330FB2oU_u1uuc83OmCSfrmuPoFzKLl2UklbOCD9YTZRfqFJNOejWv2vLOqBjMC5D4DBmb1C-SOj0Ek9UCodv9KfSVhnpsTcSqaQdCScYf32QVg4sBzVW-oGQ3n8HRc8upN0Tw]
+      Connection: [keep-alive]
+      Content-Length: ['126']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 dnsmanagementclient/0.30.0rc5 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bf131a1e-7473-11e6-a1e7-001dd8b7c0ad]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com/A/mya?api-version=2016-04-01
+  response:
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/304e8996-77fb-46e8-bada-557601594be4\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/mya","name":"mya","type":"Microsoft.Network\/dnszones\/A","etag":"3b54b1c7-2c28-4212-a1c6-abba4a48fcb2","properties":{"fqdn":"mya.myzone.com.","TTL":0,"ARecords":[{"ipv4Address":"10.0.1.0"},{"ipv4Address":"10.0.1.1"}]}}'}
+    headers:
+      cache-control: [private]
+      content-length: ['380']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 06 Sep 2016 20:51:56 GMT']
+      etag: [3b54b1c7-2c28-4212-a1c6-abba4a48fcb2]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
+    status: {code: 201, message: Created}
+- request:
+    body: '{"type": "txt", "properties": {"TXTRecords": [{"value": ["manualtxt"]}],
+      "TTL": 3600}, "name": "myname2"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDczMTkxNTU3LCJuYmYiOjE0NzMxOTE1NTcsImV4cCI6MTQ3MzE5NTQ1NywiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJCaWVsaWNraSIsImdpdmVuX25hbWUiOiJCdXJ0IiwiaXBhZGRyIjoiMTY3LjIyMC4wLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.PRVEfn9IoGJzd_bIYstUFfvrQGeg0mZ1xXGz2t5XiUBUxwi30pUwe9QNiLCZ1UmFo3-_wqEoV3C4yw-5jEv6akoGDWPvEA12FKQfGbVsjy0CNp_ZHgcbUC9roV-KSh8g16diKcZ1dnlGkWQzc6Pi9yH0wAUDxzMNxyDPsf2c-n1vqSl3sDexfni3dm3aIImYHorOWFBlqAFYsN_-330FB2oU_u1uuc83OmCSfrmuPoFzKLl2UklbOCD9YTZRfqFJNOejWv2vLOqBjMC5D4DBmb1C-SOj0Ek9UCodv9KfSVhnpsTcSqaQdCScYf32QVg4sBzVW-oGQ3n8HRc8upN0Tw]
+      Connection: [keep-alive]
+      Content-Length: ['105']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 dnsmanagementclient/0.30.0rc5 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bf83dd51-7473-11e6-9131-001dd8b7c0ad]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com/TXT/myname2?api-version=2016-04-01
+  response:
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/304e8996-77fb-46e8-bada-557601594be4\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myname2","name":"myname2","type":"Microsoft.Network\/dnszones\/TXT","etag":"cfd26765-30dd-4737-9090-e5a82ae4528e","properties":{"fqdn":"myname2.myzone.com.","TTL":3600,"TXTRecords":[{"value":["manualtxt"]}]}}'}
+    headers:
+      cache-control: [private]
+      content-length: ['371']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 06 Sep 2016 20:51:56 GMT']
+      etag: [cfd26765-30dd-4737-9090-e5a82ae4528e]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
+    status: {code: 201, message: Created}
+- request:
+    body: '{"type": "txt", "properties": {"TXTRecords": [{"value": ["abc def"]}, {"value":
+      ["foo bar"]}], "TTL": 7200}, "name": "mytxt2"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDczMTkxNTU3LCJuYmYiOjE0NzMxOTE1NTcsImV4cCI6MTQ3MzE5NTQ1NywiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJCaWVsaWNraSIsImdpdmVuX25hbWUiOiJCdXJ0IiwiaXBhZGRyIjoiMTY3LjIyMC4wLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.PRVEfn9IoGJzd_bIYstUFfvrQGeg0mZ1xXGz2t5XiUBUxwi30pUwe9QNiLCZ1UmFo3-_wqEoV3C4yw-5jEv6akoGDWPvEA12FKQfGbVsjy0CNp_ZHgcbUC9roV-KSh8g16diKcZ1dnlGkWQzc6Pi9yH0wAUDxzMNxyDPsf2c-n1vqSl3sDexfni3dm3aIImYHorOWFBlqAFYsN_-330FB2oU_u1uuc83OmCSfrmuPoFzKLl2UklbOCD9YTZRfqFJNOejWv2vLOqBjMC5D4DBmb1C-SOj0Ek9UCodv9KfSVhnpsTcSqaQdCScYf32QVg4sBzVW-oGQ3n8HRc8upN0Tw]
+      Connection: [keep-alive]
+      Content-Length: ['126']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 dnsmanagementclient/0.30.0rc5 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [c002aa40-7473-11e6-bc5c-001dd8b7c0ad]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com/TXT/mytxt2?api-version=2016-04-01
+  response:
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/304e8996-77fb-46e8-bada-557601594be4\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/mytxt2","name":"mytxt2","type":"Microsoft.Network\/dnszones\/TXT","etag":"b348c94a-48fc-4a46-8324-86442b7db1b2","properties":{"fqdn":"mytxt2.myzone.com.","TTL":7200,"TXTRecords":[{"value":["abc
+        def"]},{"value":["foo bar"]}]}}'}
+    headers:
+      cache-control: [private]
+      content-length: ['388']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 06 Sep 2016 20:51:57 GMT']
+      etag: [b348c94a-48fc-4a46-8324-86442b7db1b2]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
+    status: {code: 201, message: Created}
+- request:
+    body: '{"type": "txt", "properties": {"TXTRecords": [{"value": ["hi"]}], "TTL":
+      3600}, "name": "mytxtrs"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDczMTkxNTU3LCJuYmYiOjE0NzMxOTE1NTcsImV4cCI6MTQ3MzE5NTQ1NywiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJCaWVsaWNraSIsImdpdmVuX25hbWUiOiJCdXJ0IiwiaXBhZGRyIjoiMTY3LjIyMC4wLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.PRVEfn9IoGJzd_bIYstUFfvrQGeg0mZ1xXGz2t5XiUBUxwi30pUwe9QNiLCZ1UmFo3-_wqEoV3C4yw-5jEv6akoGDWPvEA12FKQfGbVsjy0CNp_ZHgcbUC9roV-KSh8g16diKcZ1dnlGkWQzc6Pi9yH0wAUDxzMNxyDPsf2c-n1vqSl3sDexfni3dm3aIImYHorOWFBlqAFYsN_-330FB2oU_u1uuc83OmCSfrmuPoFzKLl2UklbOCD9YTZRfqFJNOejWv2vLOqBjMC5D4DBmb1C-SOj0Ek9UCodv9KfSVhnpsTcSqaQdCScYf32QVg4sBzVW-oGQ3n8HRc8upN0Tw]
+      Connection: [keep-alive]
+      Content-Length: ['98']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 dnsmanagementclient/0.30.0rc5 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [c0837300-7473-11e6-a8c1-001dd8b7c0ad]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com/TXT/mytxtrs?api-version=2016-04-01
+  response:
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/304e8996-77fb-46e8-bada-557601594be4\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/mytxtrs","name":"mytxtrs","type":"Microsoft.Network\/dnszones\/TXT","etag":"bc51fb06-a201-426e-b583-d7ebdc7bf165","properties":{"fqdn":"mytxtrs.myzone.com.","TTL":3600,"TXTRecords":[{"value":["hi"]}]}}'}
+    headers:
+      cache-control: [private]
+      content-length: ['364']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 06 Sep 2016 20:51:58 GMT']
+      etag: [bc51fb06-a201-426e-b583-d7ebdc7bf165]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
+    status: {code: 201, message: Created}
+- request:
+    body: '{"type": "ptr", "properties": {"PTRRecords": [{"ptrdname": "myptrdname"}],
+      "TTL": 3600}, "name": "myname"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDczMTkxNTU3LCJuYmYiOjE0NzMxOTE1NTcsImV4cCI6MTQ3MzE5NTQ1NywiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJCaWVsaWNraSIsImdpdmVuX25hbWUiOiJCdXJ0IiwiaXBhZGRyIjoiMTY3LjIyMC4wLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.PRVEfn9IoGJzd_bIYstUFfvrQGeg0mZ1xXGz2t5XiUBUxwi30pUwe9QNiLCZ1UmFo3-_wqEoV3C4yw-5jEv6akoGDWPvEA12FKQfGbVsjy0CNp_ZHgcbUC9roV-KSh8g16diKcZ1dnlGkWQzc6Pi9yH0wAUDxzMNxyDPsf2c-n1vqSl3sDexfni3dm3aIImYHorOWFBlqAFYsN_-330FB2oU_u1uuc83OmCSfrmuPoFzKLl2UklbOCD9YTZRfqFJNOejWv2vLOqBjMC5D4DBmb1C-SOj0Ek9UCodv9KfSVhnpsTcSqaQdCScYf32QVg4sBzVW-oGQ3n8HRc8upN0Tw]
+      Connection: [keep-alive]
+      Content-Length: ['106']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 dnsmanagementclient/0.30.0rc5 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [c1006b30-7473-11e6-a1c2-001dd8b7c0ad]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com/PTR/myname?api-version=2016-04-01
+  response:
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/304e8996-77fb-46e8-bada-557601594be4\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myname","name":"myname","type":"Microsoft.Network\/dnszones\/PTR","etag":"b632c3f7-28ff-4c4e-adac-050f0bd7266c","properties":{"fqdn":"myname.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"myptrdname"}]}}'}
+    headers:
+      cache-control: [private]
+      content-length: ['370']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 06 Sep 2016 20:51:59 GMT']
+      etag: [b632c3f7-28ff-4c4e-adac-050f0bd7266c]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
+      x-powered-by: [ASP.NET]
+    status: {code: 201, message: Created}
+- request:
+    body: '{"type": "ptr", "properties": {"PTRRecords": [{"ptrdname": "contoso.com"}],
+      "TTL": 3600}, "name": "myptr"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDczMTkxNTU3LCJuYmYiOjE0NzMxOTE1NTcsImV4cCI6MTQ3MzE5NTQ1NywiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJCaWVsaWNraSIsImdpdmVuX25hbWUiOiJCdXJ0IiwiaXBhZGRyIjoiMTY3LjIyMC4wLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.PRVEfn9IoGJzd_bIYstUFfvrQGeg0mZ1xXGz2t5XiUBUxwi30pUwe9QNiLCZ1UmFo3-_wqEoV3C4yw-5jEv6akoGDWPvEA12FKQfGbVsjy0CNp_ZHgcbUC9roV-KSh8g16diKcZ1dnlGkWQzc6Pi9yH0wAUDxzMNxyDPsf2c-n1vqSl3sDexfni3dm3aIImYHorOWFBlqAFYsN_-330FB2oU_u1uuc83OmCSfrmuPoFzKLl2UklbOCD9YTZRfqFJNOejWv2vLOqBjMC5D4DBmb1C-SOj0Ek9UCodv9KfSVhnpsTcSqaQdCScYf32QVg4sBzVW-oGQ3n8HRc8upN0Tw]
+      Connection: [keep-alive]
+      Content-Length: ['106']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 dnsmanagementclient/0.30.0rc5 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [c176d3b0-7473-11e6-8b3e-001dd8b7c0ad]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com/PTR/myptr?api-version=2016-04-01
+  response:
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/304e8996-77fb-46e8-bada-557601594be4\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myptr","name":"myptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"eefb8f5e-657e-42dd-851b-2edf0cf91fba","properties":{"fqdn":"myptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"contoso.com"}]}}'}
+    headers:
+      cache-control: [private]
+      content-length: ['368']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 06 Sep 2016 20:52:00 GMT']
+      etag: [eefb8f5e-657e-42dd-851b-2edf0cf91fba]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-powered-by: [ASP.NET]
+    status: {code: 201, message: Created}
+- request:
+    body: '{"type": "aaaa", "properties": {"AAAARecords": [{"ipv6Address": "2001:4898:e0:99:6dc4:6329:1c99:4e69"}],
+      "TTL": 3600}, "name": "myaaaa"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDczMTkxNTU3LCJuYmYiOjE0NzMxOTE1NTcsImV4cCI6MTQ3MzE5NTQ1NywiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJCaWVsaWNraSIsImdpdmVuX25hbWUiOiJCdXJ0IiwiaXBhZGRyIjoiMTY3LjIyMC4wLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.PRVEfn9IoGJzd_bIYstUFfvrQGeg0mZ1xXGz2t5XiUBUxwi30pUwe9QNiLCZ1UmFo3-_wqEoV3C4yw-5jEv6akoGDWPvEA12FKQfGbVsjy0CNp_ZHgcbUC9roV-KSh8g16diKcZ1dnlGkWQzc6Pi9yH0wAUDxzMNxyDPsf2c-n1vqSl3sDexfni3dm3aIImYHorOWFBlqAFYsN_-330FB2oU_u1uuc83OmCSfrmuPoFzKLl2UklbOCD9YTZRfqFJNOejWv2vLOqBjMC5D4DBmb1C-SOj0Ek9UCodv9KfSVhnpsTcSqaQdCScYf32QVg4sBzVW-oGQ3n8HRc8upN0Tw]
+      Connection: [keep-alive]
+      Content-Length: ['136']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 dnsmanagementclient/0.30.0rc5 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [c1e1f18f-7473-11e6-a865-001dd8b7c0ad]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myaaaa?api-version=2016-04-01
+  response:
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/304e8996-77fb-46e8-bada-557601594be4\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myaaaa","name":"myaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"d4f4fe43-6a3d-4b2e-bf09-7d1e555a264a","properties":{"fqdn":"myaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:4898:e0:99:6dc4:6329:1c99:4e69"}]}}'}
+    headers:
+      cache-control: [private]
+      content-length: ['401']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 06 Sep 2016 20:52:01 GMT']
+      etag: [d4f4fe43-6a3d-4b2e-bf09-7d1e555a264a]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
+    status: {code: 201, message: Created}
+- request:
+    body: '{"type": "cname", "properties": {"CNAMERecord": {"cname": "contoso.com"},
+      "TTL": 3600}, "name": "mycname"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDczMTkxNTU3LCJuYmYiOjE0NzMxOTE1NTcsImV4cCI6MTQ3MzE5NTQ1NywiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJCaWVsaWNraSIsImdpdmVuX25hbWUiOiJCdXJ0IiwiaXBhZGRyIjoiMTY3LjIyMC4wLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.PRVEfn9IoGJzd_bIYstUFfvrQGeg0mZ1xXGz2t5XiUBUxwi30pUwe9QNiLCZ1UmFo3-_wqEoV3C4yw-5jEv6akoGDWPvEA12FKQfGbVsjy0CNp_ZHgcbUC9roV-KSh8g16diKcZ1dnlGkWQzc6Pi9yH0wAUDxzMNxyDPsf2c-n1vqSl3sDexfni3dm3aIImYHorOWFBlqAFYsN_-330FB2oU_u1uuc83OmCSfrmuPoFzKLl2UklbOCD9YTZRfqFJNOejWv2vLOqBjMC5D4DBmb1C-SOj0Ek9UCodv9KfSVhnpsTcSqaQdCScYf32QVg4sBzVW-oGQ3n8HRc8upN0Tw]
+      Connection: [keep-alive]
+      Content-Length: ['106']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 dnsmanagementclient/0.30.0rc5 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [c2a01170-7473-11e6-8dad-001dd8b7c0ad]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com/CNAME/mycname?api-version=2016-04-01
+  response:
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/304e8996-77fb-46e8-bada-557601594be4\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/mycname","name":"mycname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"d3e1e5a4-1d75-49b1-9166-e9bffb60d063","properties":{"fqdn":"mycname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"contoso.com"}}}'}
+    headers:
+      cache-control: [private]
+      content-length: ['374']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 06 Sep 2016 20:52:02 GMT']
+      etag: [d3e1e5a4-1d75-49b1-9166-e9bffb60d063]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
+    status: {code: 201, message: Created}
+- request:
+    body: '{"type": "srv", "properties": {"SRVRecords": [{"priority": 1, "port": 1234,
+      "weight": 2, "target": "target.contoso.com"}], "TTL": 3600}, "name": "mysrv"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDczMTkxNTU3LCJuYmYiOjE0NzMxOTE1NTcsImV4cCI6MTQ3MzE5NTQ1NywiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJCaWVsaWNraSIsImdpdmVuX25hbWUiOiJCdXJ0IiwiaXBhZGRyIjoiMTY3LjIyMC4wLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.PRVEfn9IoGJzd_bIYstUFfvrQGeg0mZ1xXGz2t5XiUBUxwi30pUwe9QNiLCZ1UmFo3-_wqEoV3C4yw-5jEv6akoGDWPvEA12FKQfGbVsjy0CNp_ZHgcbUC9roV-KSh8g16diKcZ1dnlGkWQzc6Pi9yH0wAUDxzMNxyDPsf2c-n1vqSl3sDexfni3dm3aIImYHorOWFBlqAFYsN_-330FB2oU_u1uuc83OmCSfrmuPoFzKLl2UklbOCD9YTZRfqFJNOejWv2vLOqBjMC5D4DBmb1C-SOj0Ek9UCodv9KfSVhnpsTcSqaQdCScYf32QVg4sBzVW-oGQ3n8HRc8upN0Tw]
+      Connection: [keep-alive]
+      Content-Length: ['153']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 dnsmanagementclient/0.30.0rc5 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [c3260a4f-7473-11e6-bd14-001dd8b7c0ad]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com/SRV/mysrv?api-version=2016-04-01
+  response:
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/304e8996-77fb-46e8-bada-557601594be4\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/mysrv","name":"mysrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"f036317c-ed37-4d97-9b25-6f8fd06954af","properties":{"fqdn":"mysrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.contoso.com","weight":2}]}}'}
+    headers:
+      cache-control: [private]
+      content-length: ['409']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 06 Sep 2016 20:52:02 GMT']
+      etag: [f036317c-ed37-4d97-9b25-6f8fd06954af]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
+    status: {code: 201, message: Created}
+- request:
+    body: '{"type": "ns", "properties": {"NSRecords": [{"nsdname": "ns.contoso.com"}],
+      "TTL": 3600}, "name": "myns"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDczMTkxNTU3LCJuYmYiOjE0NzMxOTE1NTcsImV4cCI6MTQ3MzE5NTQ1NywiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJCaWVsaWNraSIsImdpdmVuX25hbWUiOiJCdXJ0IiwiaXBhZGRyIjoiMTY3LjIyMC4wLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.PRVEfn9IoGJzd_bIYstUFfvrQGeg0mZ1xXGz2t5XiUBUxwi30pUwe9QNiLCZ1UmFo3-_wqEoV3C4yw-5jEv6akoGDWPvEA12FKQfGbVsjy0CNp_ZHgcbUC9roV-KSh8g16diKcZ1dnlGkWQzc6Pi9yH0wAUDxzMNxyDPsf2c-n1vqSl3sDexfni3dm3aIImYHorOWFBlqAFYsN_-330FB2oU_u1uuc83OmCSfrmuPoFzKLl2UklbOCD9YTZRfqFJNOejWv2vLOqBjMC5D4DBmb1C-SOj0Ek9UCodv9KfSVhnpsTcSqaQdCScYf32QVg4sBzVW-oGQ3n8HRc8upN0Tw]
+      Connection: [keep-alive]
+      Content-Length: ['105']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 dnsmanagementclient/0.30.0rc5 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [c39b8870-7473-11e6-b4c6-001dd8b7c0ad]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com/NS/myns?api-version=2016-04-01
+  response:
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/304e8996-77fb-46e8-bada-557601594be4\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myns","name":"myns","type":"Microsoft.Network\/dnszones\/NS","etag":"a315f4f1-cfa7-46e8-be07-0868a74acbee","properties":{"fqdn":"myns.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"ns.contoso.com"}]}}'}
+    headers:
+      cache-control: [private]
+      content-length: ['364']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 06 Sep 2016 20:52:04 GMT']
+      etag: [a315f4f1-cfa7-46e8-be07-0868a74acbee]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      x-powered-by: [ASP.NET]
+    status: {code: 201, message: Created}
+- request:
+    body: '{"type": "mx", "properties": {"MXRecords": [{"preference": 1, "exchange":
+      "mail.contoso.com"}], "TTL": 3600}, "name": "mymx"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDczMTkxNTU3LCJuYmYiOjE0NzMxOTE1NTcsImV4cCI6MTQ3MzE5NTQ1NywiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJCaWVsaWNraSIsImdpdmVuX25hbWUiOiJCdXJ0IiwiaXBhZGRyIjoiMTY3LjIyMC4wLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.PRVEfn9IoGJzd_bIYstUFfvrQGeg0mZ1xXGz2t5XiUBUxwi30pUwe9QNiLCZ1UmFo3-_wqEoV3C4yw-5jEv6akoGDWPvEA12FKQfGbVsjy0CNp_ZHgcbUC9roV-KSh8g16diKcZ1dnlGkWQzc6Pi9yH0wAUDxzMNxyDPsf2c-n1vqSl3sDexfni3dm3aIImYHorOWFBlqAFYsN_-330FB2oU_u1uuc83OmCSfrmuPoFzKLl2UklbOCD9YTZRfqFJNOejWv2vLOqBjMC5D4DBmb1C-SOj0Ek9UCodv9KfSVhnpsTcSqaQdCScYf32QVg4sBzVW-oGQ3n8HRc8upN0Tw]
+      Connection: [keep-alive]
+      Content-Length: ['125']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 dnsmanagementclient/0.30.0rc5 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [c3fc6d1e-7473-11e6-991b-001dd8b7c0ad]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com/MX/mymx?api-version=2016-04-01
+  response:
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/304e8996-77fb-46e8-bada-557601594be4\/resourceGroups\/cli_dns_zone_import_export\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/mymx","name":"mymx","type":"Microsoft.Network\/dnszones\/MX","etag":"30cf681e-b958-4cb1-a0bf-6e887f32216b","properties":{"fqdn":"mymx.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"mail.contoso.com","preference":1}]}}'}
+    headers:
+      cache-control: [private]
+      content-length: ['382']
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 06 Sep 2016 20:52:04 GMT']
+      etag: [30cf681e-b958-4cb1-a0bf-6e887f32216b]
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-powered-by: [ASP.NET]
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDczMTkxNTU3LCJuYmYiOjE0NzMxOTE1NTcsImV4cCI6MTQ3MzE5NTQ1NywiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzAzZjFmMWJiLWM4MjYtNGM3Yi1iMzY4LTk0MGMyYWEyNDJkZi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbIndpYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJCaWVsaWNraSIsImdpdmVuX25hbWUiOiJCdXJ0IiwiaXBhZGRyIjoiMTY3LjIyMC4wLjUwIiwibmFtZSI6IkJ1cnQgQmllbGlja2kiLCJvaWQiOiIwM2YxZjFiYi1jODI2LTRjN2ItYjM2OC05NDBjMmFhMjQyZGYiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjEyNzUyMTE4NC0xNjA0MDEyOTIwLTE4ODc5Mjc1MjctNDgxMjgwNiIsInB1aWQiOiIxMDAzQkZGRDgwMUMwOEJDIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoiQ3lCMjhXOU9tRlpGeGw0aGdJRVltdDBHeWpjQ2JFQ21QejVkeFVFUjFsYyIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInVuaXF1ZV9uYW1lIjoiYnVydGJpZWxAbWljcm9zb2Z0LmNvbSIsInVwbiI6ImJ1cnRiaWVsQG1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.PRVEfn9IoGJzd_bIYstUFfvrQGeg0mZ1xXGz2t5XiUBUxwi30pUwe9QNiLCZ1UmFo3-_wqEoV3C4yw-5jEv6akoGDWPvEA12FKQfGbVsjy0CNp_ZHgcbUC9roV-KSh8g16diKcZ1dnlGkWQzc6Pi9yH0wAUDxzMNxyDPsf2c-n1vqSl3sDexfni3dm3aIImYHorOWFBlqAFYsN_-330FB2oU_u1uuc83OmCSfrmuPoFzKLl2UklbOCD9YTZRfqFJNOejWv2vLOqBjMC5D4DBmb1C-SOj0Ek9UCodv9KfSVhnpsTcSqaQdCScYf32QVg4sBzVW-oGQ3n8HRc8upN0Tw]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
+          msrest_azure/0.4.1 dnsmanagementclient/0.30.0rc5 Azure-SDK-For-Python AZURECLI/TEST/0.0.1.dev0]
+      accept-language: [en-US]
+      x-ms-client-request-id: [c48a5540-7473-11e6-bc98-001dd8b7c0ad]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_zone_import_export/providers/Microsoft.Network/dnszones/myzone.com/recordsets?api-version=2016-04-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ue/791mPWmmdbFqi2rZ/L537+3s5wcPH366/eDB+WR7/9P8YHuSzbLt+/cf
+        fLqze//h/iTf/33v1nlTretp/nldrVf01rQsfv/Zsvn9f1At89+/WKyquv3983f48fveXdXVZTHL
+        a2r2RTGtq6Y6b8cv8vaqqt/+vnfpLbxEXy6u8ct4Wi1+37svXv++d3/Pj0YfLbMFIfsRfm2vV/h1
+        I4gXr6lh3mYX1PA8P8j2du/vb+d5vr+9v3uQbWez8xn9cy9/OJk+uH/+4D61JuxWed0WefPRo1/8
+        0fkvmi3pXYfKmJq8efP8o0e7D/YOdnZGH714/SqfVvWMmhMNl81MUVw2u9s7D8fZD9Z1vk0Yycu/
+        ZBS22QvbLPO23+Ze2KaqL/pt9sM2xfK8okbf/yVo9//meX395fHXmlh6j1rqzO4+2J09eHAw3Z5N
+        9u9v7+9kNLP379/bPs/OP935dHfn0/3zCbUm/G41s/c+xbxSDzKxaJwvsqKk1kxhwmJ7XjXtImva
+        vB4vLJ4EhGAQOYo6f1NgPHv7uw/3AA3t6f04U4w+WhTLYrFeSPdoX+fnRPq5QBGE6rytr/UD/N3k
+        dZGVL9aLSV4TO/6S/9fPNc30IluuszKjEet8uw9uM+venB/s7R9M9vf3tif700+39zP67WB/km2f
+        Tyb39vfv3d+bTgCV8IzMuXQ6dshhDoT4TGqdeXqHRLpYXe4fz2ZEHfr7o92dMf7b3fn/gnSB4tcg
+        g6E2//GelL43ub8/2Z0+2N6b7h1s7+/t7m1nu0TzbDLJiO4H59PJHrUm/CKUvo5S+RYk3h0ThUHe
+        2Fe7/58gPj34JKOHBu6mgB76+1azQA811YmY7Z/vn+f797Y/ze7Ntvcne/n25Hzn4faD2W5+//79
+        bO/TfQAmXKMTQU9sLpTj6enMyKeO7KTCdh/tHzw8eJTvPHr48NGns+n+o0/v7T18tDulP/fzTx/+
+        f2FGTl4cf3GKj6Y8Gd6cmA9uMykMhdqaWbmXE/mz/W2yQWR8Hk52tx/ufvrpNvkU5+eTT3dmO5/e
+        o9aEb2xWuOPhaeG+ZF7wGrem96bVsiX88MJH/+/X+1/83vh78Y6GpvjrX7eh9he/NzVUUt/bmZ5/
+        erBLbP/wPmmiKZE625mcb9O4Dh6c39vb2/10g51fvBum8xe/txCZ3iDmz99N59nyArjB7lN7R26A
+        z8/zOl9O6fvd/w9w/cs3r/ABk96bAf7ldnNAEKilTsKE5H5675zMwcH5OU3Cfk4edDbd3rm/c74z
+        mT3Y+/TTKbUmTGOTgF6Hp4E68udh1dbGw11c2z/+P0DyN7/3G3wAdGEa8ZOQdR/chugEg1oq0afn
+        s71PH3x6f/vezoxU/4N7D7Yf7jzc2SbFc7CX5fv39w4wmYTrENH3hqlOPflUNwEh8T7cpPZd+9H3
+        /z9Ac0SINNSGxobxEqL6122I7ceJ2b3d+2Rod7en59kDHU6+82B75+DTg+zBfjad5Jto3QwTejhU
+        pMZOxfx/gNgkqPiAZJJGqKMwf96G3vQ+tVSC5/n55OD8fr796f0HOTmYxOEH93cn23v57Jw0/sPd
+        8w2uPDodpjj145Oc2hqa/3+M4K9f/SQ+aOpLGqAOwfx5G4LT+9RSCX6+c+/Te7sPptv5jBTJ/uwh
+        aZPJ3v3tT88PzsldeXh/Pzun1oRnjODU6TDBqZ+A4DRgspJ79/YBrqjqor2mvwnnrL7I6Sv9hSC5
+        6Rh9dJUXF3P6du//AzND2hMfkJqEZrdTo3/fZm4IArXUuaHo9WD6cD/bRmCFuPbT7YN7e/vbB59S
+        sDt5MJvsboq20Gtsch6QB0+/Dij6bDJNZ/k5qXmitf30vKrSSVbTp/9fmoQaKt+fBf7g/adhep/U
+        zg5FuXs7u6STPiWn8/7Bve3Zg3wymz6YnO9+uiFZyN3G5kGEhHqKzsO8EGJ//5f8P0D7ZYSXFQAA
+    headers:
+      cache-control: [private]
+      content-encoding: [gzip]
+      content-type: [application/json; charset=utf-8]
+      date: ['Tue, 06 Sep 2016 20:52:05 GMT']
+      server: [Microsoft-IIS/8.5]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-content-type-options: [nosniff]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/test_network_commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/test_network_commands.py
@@ -8,6 +8,8 @@
 #pylint: disable=bad-continuation
 #pylint: disable=too-many-lines
 import os
+import re
+import tempfile
 
 from azure.cli.commands.arm import resource_id
 from azure.cli.commands.client_factory import get_subscription_id
@@ -1061,3 +1063,31 @@ class NetworkDnsScenarioTest(ResourceGroupVCRTestBase):
                  .format('a', rg, zone_name))
         self.cmd('network dns record-set show -n myrs{0} -g {1} --type {0} --zone-name {2}'
                  .format('a', rg, zone_name), allowed_exceptions='does not exist in resource group')
+
+class NetworkZoneImportExportTest(ResourceGroupVCRTestBase):
+
+    def __init__(self, test_method):
+        super(NetworkZoneImportExportTest, self).__init__(__file__, test_method)
+        self.resource_group = 'cli_dns_zone_import_export'
+
+    def test_network_dns_zone_import_export(self):
+        self.execute()
+
+    def body(self):
+        zone_name = 'myzone.com'
+        zone_file_path = os.path.join(TEST_DIR, 'zone.txt')
+
+        self.cmd('network dns zone import -n {} -g {} --file-name "{}"'
+                 .format(zone_name, self.resource_group, zone_file_path))
+
+        _, temp_file_path = tempfile.mkstemp()
+        self.cmd('network dns zone export -n {} -g {} --file-name "{}"'
+                 .format(zone_name, self.resource_group, temp_file_path))
+
+        temp_file_text = None
+        with open(temp_file_path, 'r') as f:
+            temp_file_text = f.read()
+        temp_file_text = re.sub('ns..?-..', 'ns0-00', temp_file_text)
+
+        with open(zone_file_path, 'r') as f:
+            self.assertEqual(temp_file_text, f.read(), 'Exported file {} should match imported file'.format(temp_file_path))

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/zone.txt
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/zone.txt
@@ -1,0 +1,20 @@
+$ORIGIN myzone.com.
+@ 3600 IN SOA ns0-00.azure-dns.com. azuredns-hostmaster.microsoft.com. ( 1 3600 300 2419200 300 )
+@ 172800 NS ns0-00.azure-dns.com.
+@ 172800 NS ns0-00.azure-dns.net.
+@ 172800 NS ns0-00.azure-dns.org.
+@ 172800 NS ns0-00.azure-dns.info.
+myns 3600 NS ns.contoso.com
+mymx 3600 MX 1 mail.contoso.com
+manuala 3600 A 10.0.0.10
+mya 0 A 10.0.1.0
+mya 0 A 10.0.1.1
+myaaaa 3600 AAAA 2001:4898:e0:99:6dc4:6329:1c99:4e69
+mycname 3600 CNAME contoso.com
+myname 3600 PTR myptrdname
+myptr 3600 PTR contoso.com
+myname2 3600 TXT "manualtxt"
+mytxt2 7200 TXT "abc def"
+mytxt2 7200 TXT "foo bar"
+mytxtrs 3600 TXT "hi"
+mysrv 3600 SRV 1 2 1234 target.contoso.com

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/zone_file/__init__.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/zone_file/__init__.py
@@ -1,0 +1,30 @@
+#---------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+#---------------------------------------------------------------------------------------------
+#The MIT License (MIT)
+
+#Copyright (c) 2016 Blockstack
+
+#Permission is hereby granted, free of charge, to any person obtaining a copy
+#of this software and associated documentation files (the "Software"), to deal
+#in the Software without restriction, including without limitation the rights
+#to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#copies of the Software, and to permit persons to whom the Software is
+#furnished to do so, subject to the following conditions:
+
+#The above copyright notice and this permission notice shall be included in all
+#copies or substantial portions of the Software.
+
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#SOFTWARE.
+#pylint: skip-file
+
+from azure.cli.command_modules.network.zone_file.parse_zone_file import parse_zone_file
+from azure.cli.command_modules.network.zone_file.make_zone_file import make_zone_file
+from azure.cli.command_modules.network.zone_file.exceptions import InvalidLineException

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/zone_file/configs.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/zone_file/configs.py
@@ -1,0 +1,58 @@
+#---------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+#---------------------------------------------------------------------------------------------
+#The MIT License (MIT)
+
+#Copyright (c) 2016 Blockstack
+
+#Permission is hereby granted, free of charge, to any person obtaining a copy
+#of this software and associated documentation files (the "Software"), to deal
+#in the Software without restriction, including without limitation the rights
+#to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#copies of the Software, and to permit persons to whom the Software is
+#furnished to do so, subject to the following conditions:
+
+#The above copyright notice and this permission notice shall be included in all
+#copies or substantial portions of the Software.
+
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#SOFTWARE.
+#pylint: skip-file
+
+SUPPORTED_RECORDS = [
+    '$ORIGIN', '$TTL', 'SOA', 'NS', 'A', 'AAAA', 'CNAME', 'MX', 'PTR', 'TXT',
+    'SRV', 'SPF', 'URI'
+]
+
+DEFAULT_TEMPLATE = """
+{$origin}\n\
+{$ttl}\n\
+\n\
+{soa}
+\n\
+{ns}\n\
+\n\
+{mx}\n\
+\n\
+{a}\n\
+\n\
+{aaaa}\n\
+\n\
+{cname}\n\
+\n\
+{ptr}\n\
+\n\
+{txt}\n\
+\n\
+{srv}\n\
+\n\
+{spf}\n\
+\n\
+{uri}\n\
+"""

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/zone_file/exceptions.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/zone_file/exceptions.py
@@ -1,0 +1,29 @@
+#---------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+#---------------------------------------------------------------------------------------------
+#The MIT License (MIT)
+
+#Copyright (c) 2016 Blockstack
+
+#Permission is hereby granted, free of charge, to any person obtaining a copy
+#of this software and associated documentation files (the "Software"), to deal
+#in the Software without restriction, including without limitation the rights
+#to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#copies of the Software, and to permit persons to whom the Software is
+#furnished to do so, subject to the following conditions:
+
+#The above copyright notice and this permission notice shall be included in all
+#copies or substantial portions of the Software.
+
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#SOFTWARE.
+#pylint: skip-file
+
+class InvalidLineException(Exception):
+    pass

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/zone_file/make_zone_file.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/zone_file/make_zone_file.py
@@ -1,0 +1,85 @@
+#---------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+#---------------------------------------------------------------------------------------------
+#The MIT License (MIT)
+
+#Copyright (c) 2016 Blockstack
+
+#Permission is hereby granted, free of charge, to any person obtaining a copy
+#of this software and associated documentation files (the "Software"), to deal
+#in the Software without restriction, including without limitation the rights
+#to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#copies of the Software, and to permit persons to whom the Software is
+#furnished to do so, subject to the following conditions:
+
+#The above copyright notice and this permission notice shall be included in all
+#copies or substantial portions of the Software.
+
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#SOFTWARE.
+#pylint: skip-file
+
+from .record_processors import (
+    process_origin, process_ttl, process_soa, process_ns, process_a,
+    process_aaaa, process_cname, process_mx, process_ptr, process_txt,
+    process_srv, process_spf, process_uri
+)
+from .configs import DEFAULT_TEMPLATE
+
+
+def make_zone_file(json_zone_file, template=None):
+    """
+    Generate the DNS zonefile, given a json-encoded description of the
+    zone file (@json_zone_file) and the template to fill in (@template)
+
+    json_zone_file = {
+        "$origin": origin server,
+        "$ttl":    default time-to-live,
+        "soa":     [ soa records ],
+        "ns":      [ ns records ],
+        "a":       [ a records ],
+        "aaaa":    [ aaaa records ]
+        "cname":   [ cname records ]
+        "mx":      [ mx records ]
+        "ptr":     [ ptr records ]
+        "txt":     [ txt records ]
+        "srv":     [ srv records ]
+        "spf":     [ spf records ]
+        "uri":     [ uri records ]
+    }
+    """
+
+    if template is None:
+        template = DEFAULT_TEMPLATE[:]
+
+    soa_records = [json_zone_file.get('soa')] if json_zone_file.get('soa') else None
+
+    zone_file = template
+    zone_file = process_origin(json_zone_file.get('$origin', None), zone_file)
+    zone_file = process_ttl(json_zone_file.get('$ttl', None), zone_file)
+    zone_file = process_soa(soa_records, zone_file)
+    zone_file = process_ns(json_zone_file.get('ns', None), zone_file)
+    zone_file = process_a(json_zone_file.get('a', None), zone_file)
+    zone_file = process_aaaa(json_zone_file.get('aaaa', None), zone_file)
+    zone_file = process_cname(json_zone_file.get('cname', None), zone_file)
+    zone_file = process_mx(json_zone_file.get('mx', None), zone_file)
+    zone_file = process_ptr(json_zone_file.get('ptr', None), zone_file)
+    zone_file = process_txt(json_zone_file.get('txt', None), zone_file)
+    zone_file = process_srv(json_zone_file.get('srv', None), zone_file)
+    zone_file = process_spf(json_zone_file.get('spf', None), zone_file)
+    zone_file = process_uri(json_zone_file.get('uri', None), zone_file)
+
+    # remove newlines, but terminate with one
+    zone_file = "\n".join(
+        filter(
+            lambda l: len(l.strip()) > 0, [tl.strip() for tl in zone_file.split("\n")]
+        )
+    ) + "\n"
+
+    return zone_file

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/zone_file/parse_zone_file.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/zone_file/parse_zone_file.py
@@ -1,0 +1,414 @@
+#!/usr/bin/python 
+#---------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+#---------------------------------------------------------------------------------------------
+
+#The MIT License (MIT)
+
+#Copyright (c) 2016 Blockstack
+
+#Permission is hereby granted, free of charge, to any person obtaining a copy
+#of this software and associated documentation files (the "Software"), to deal
+#in the Software without restriction, including without limitation the rights
+#to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#copies of the Software, and to permit persons to whom the Software is
+#furnished to do so, subject to the following conditions:
+
+#The above copyright notice and this permission notice shall be included in all
+#copies or substantial portions of the Software.
+
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#SOFTWARE.
+#pylint: skip-file
+
+"""
+Known limitations:
+    * only one $ORIGIN and one $TTL are supported
+    * only the IN class is supported
+    * PTR records must have a non-empty name
+    * currently only supports the following:
+    '$ORIGIN', '$TTL', 'SOA', 'NS', 'A', 'AAAA', 'CNAME', 'MX', 'PTR',
+    'TXT', 'SRV', 'SPF', 'URI'
+"""
+
+import copy
+import datetime
+import time
+import argparse
+from collections import defaultdict
+
+from .configs import SUPPORTED_RECORDS, DEFAULT_TEMPLATE
+from .exceptions import InvalidLineException
+
+
+class ZonefileLineParser(argparse.ArgumentParser):
+    def error(self, message):
+        """
+        Silent error message
+        """
+        raise InvalidLineException(message)
+
+
+def make_rr_subparser(subparsers, rec_type, args_and_types):
+    """
+    Make a subparser for a given type of DNS record
+    """
+    sp = subparsers.add_parser(rec_type)
+
+    sp.add_argument("name", type=str)
+    sp.add_argument("ttl", type=int, nargs='?')
+    sp.add_argument(rec_type, type=str)
+
+    for (argname, argtype) in args_and_types:
+        sp.add_argument(argname, type=argtype)
+
+    return sp
+
+
+def make_parser():
+    """
+    Make an ArgumentParser that accepts DNS RRs
+    """
+    line_parser = ZonefileLineParser()
+    subparsers = line_parser.add_subparsers()
+
+    # parse $ORIGIN
+    sp = subparsers.add_parser("$ORIGIN")
+    sp.add_argument("$ORIGIN", type=str)
+
+    # parse $TTL
+    sp = subparsers.add_parser("$TTL")
+    sp.add_argument("$TTL", type=int)
+
+    # parse each RR
+    args_and_types = [
+        ("mname", str), ("rname", str), ("serial", int), ("refresh", int),
+        ("retry", int), ("expire", int), ("minimum", int)
+    ]
+    make_rr_subparser(subparsers, "SOA", args_and_types)
+
+    make_rr_subparser(subparsers, "NS", [("host", str)])
+    make_rr_subparser(subparsers, "A", [("ip", str)])
+    make_rr_subparser(subparsers, "AAAA", [("ip", str)])
+    make_rr_subparser(subparsers, "CNAME", [("alias", str)])
+    make_rr_subparser(subparsers, "MX", [("preference", str), ("host", str)])
+    make_rr_subparser(subparsers, "TXT", [("txt", str)])
+    make_rr_subparser(subparsers, "PTR", [("host", str)])
+    make_rr_subparser(subparsers, "SRV", [("priority", int), ("weight", int), ("port", int), ("target", str)])
+    make_rr_subparser(subparsers, "SPF", [("data", str)])
+    make_rr_subparser(subparsers, "URI", [("priority", int), ("weight", int), ("target", str)])
+
+    return line_parser
+
+
+def tokenize_line(line):
+    """
+    Tokenize a line:
+    * split tokens on whitespace
+    * treat quoted strings as a single token
+    * drop comments
+    * handle escaped spaces and comment delimiters
+    """
+    ret = []
+    escape = False
+    quote = False
+    tokbuf = ""
+    ll = list(line)
+    while len(ll) > 0:
+        c = ll.pop(0)
+        if c.isspace():
+            if not quote and not escape:
+                # end of token
+                if len(tokbuf) > 0:
+                    ret.append(tokbuf)
+
+                tokbuf = ""
+            elif quote:
+                # in quotes
+                tokbuf += c
+            elif escape:
+                # escaped space
+                tokbuf += c
+                escape = False
+            else:
+                tokbuf = ""
+
+            continue
+
+        if c == '\\':
+            escape = True
+            continue
+        elif c == '"':
+            if not escape:
+                if quote:
+                    # end of quote
+                    ret.append(tokbuf)
+                    tokbuf = ""
+                    quote = False
+                    continue
+                else:
+                    # beginning of quote
+                    quote = True
+                    continue
+        elif c == ';':
+            if not escape:
+                # comment 
+                ret.append(tokbuf)
+                tokbuf = ""
+                break
+            
+        # normal character
+        tokbuf += c
+        escape = False
+
+    if len(tokbuf.strip(" ").strip("\n")) > 0:
+        ret.append(tokbuf)
+
+    return ret
+
+
+def serialize(tokens):
+    """
+    Serialize tokens:
+    * quote whitespace-containing tokens
+    * escape semicolons
+    """
+    ret = []
+    for tok in tokens:
+        if " " in tok:
+            tok = '"%s"' % tok
+
+        if ";" in tok:
+            tok = tok.replace(";", "\;")
+
+        ret.append(tok)
+
+    return " ".join(ret)
+
+
+def remove_comments(text):
+    """
+    Remove comments from a zonefile
+    """
+    ret = []
+    lines = text.split("\n")
+    for line in lines:
+        if len(line) == 0:
+            continue 
+
+        line = serialize(tokenize_line(line))
+        ret.append(line)
+
+    return "\n".join(ret)
+
+
+def flatten(text):
+    """
+    Flatten the text:
+    * make sure each record is on one line.
+    * remove parenthesis 
+    """
+    lines = text.split("\n")
+
+    # tokens: sequence of non-whitespace separated by '' where a newline was
+    tokens = []
+    for l in lines:
+        if len(l) == 0:
+            continue 
+
+        l = l.replace("\t", " ")
+        tokens += list(filter(lambda x: len(x) > 0, l.split(" "))) + ['']
+
+    # find (...) and turn it into a single line ("capture" it)
+    capturing = False
+    captured = []
+
+    flattened = []
+    while len(tokens) > 0:
+        tok = tokens.pop(0)
+        if not capturing and len(tok) == 0:
+            # normal end-of-line
+            if len(captured) > 0:
+                flattened.append(" ".join(captured))
+                captured = []
+            continue 
+
+        if tok.startswith("("):
+            # begin grouping
+            tok = tok.lstrip("(")
+            capturing = True
+
+        if capturing and tok.endswith(")"):
+            # end grouping.  next end-of-line will turn this sequence into a flat line
+            tok = tok.rstrip(")")
+            capturing = False 
+
+        captured.append(tok)
+
+    return "\n".join(flattened)
+
+
+def remove_class(text):
+    """
+    Remove the CLASS from each DNS record, if present.
+    The only class that gets used today (for all intents
+    and purposes) is 'IN'.
+    """
+
+    # see RFC 1035 for list of classes
+    lines = text.split("\n")
+    ret = []
+    for line in lines:
+        tokens = tokenize_line(line)
+        tokens_upper = [t.upper() for t in tokens]
+
+        if "IN" in tokens_upper:
+            tokens.remove("IN")
+        elif "CS" in tokens_upper:
+            tokens.remove("CS")
+        elif "CH" in tokens_upper:
+            tokens.remove("CH")
+        elif "HS" in tokens_upper:
+            tokens.remove("HS")
+
+        ret.append(serialize(tokens))
+
+    return "\n".join(ret)
+
+
+def add_record_names(text):
+    """
+    Go through each line of the text and ensure that 
+    a name is defined.  Use previous record name if there is none.
+    """
+    global SUPPORTED_RECORDS
+
+    lines = text.split("\n")
+    ret = []
+    previous_record_name = None
+
+    for line in lines:
+        tokens = tokenize_line(line)
+        
+        if not tokens[0].startswith("$"):
+            is_int = False
+            try:
+                int(tokens[0])
+                is_int = True
+            except ValueError:
+                pass
+            has_name = not is_int and tokens[0] not in SUPPORTED_RECORDS
+
+            if has_name:
+                previous_record_name = tokens[0]
+            else:
+                # add back the name
+                tokens = [previous_record_name] + tokens
+
+        ret.append(serialize(tokens))
+
+    return "\n".join(ret)
+
+def parse_line(parser, record_token, parsed_records):
+    """
+    Given the parser, capitalized list of a line's tokens, and the current set of records 
+    parsed so far, parse it into a dictionary.
+
+    Return the new set of parsed records.
+    Raise an exception on error.
+    """
+
+    global SUPPORTED_RECORDS
+
+    line = " ".join(record_token)
+
+    # match parser to record type
+    if len(record_token) >= 2 and record_token[1] in SUPPORTED_RECORDS:
+        # with no ttl
+        record_token = [record_token[1]] + record_token
+    elif len(record_token) >= 3 and record_token[2] in SUPPORTED_RECORDS:
+        # with ttl
+        record_token = [record_token[2]] + record_token
+
+    try:
+        rr, unmatched = parser.parse_known_args(record_token)
+        assert len(unmatched) == 0, "Unmatched fields: %s" % unmatched
+    except (SystemExit, AssertionError, InvalidLineException):
+        # invalid argument 
+        raise InvalidLineException(line)
+
+    record_dict = rr.__dict__
+
+    # what kind of record? including origin and ttl
+    record_type = None
+    for key in record_dict.keys():
+        if key in SUPPORTED_RECORDS and (key.startswith("$") or record_dict[key] == key):
+            record_type = key
+            if record_dict[key] == key:
+                del record_dict[key]
+            break
+
+    assert record_type is not None, "Unknown record type in %s" % rr
+
+    # clean fields
+    for field in list(record_dict.keys()):
+        if record_dict[field] is None:
+            del record_dict[field]
+
+    current_origin = record_dict.get('$origin', parsed_records.get('$origin', None))
+
+    # special record-specific fix-ups
+    if record_type == 'PTR':
+        record_dict['fullname'] = record_dict['name'] + '.' + current_origin
+      
+    if len(record_dict) > 0:
+        if record_type.startswith("$"):
+            # put the value directly
+            record_dict_key = record_type.lower()
+            parsed_records[record_dict_key] = record_dict[record_type]
+        else:
+            record_dict_key = record_type.lower()
+            parsed_records[record_dict_key].append(record_dict)
+
+    return parsed_records
+
+# LOCAL COPY
+def parse_lines(text, ignore_invalid=False):
+    """
+    Parse a zonefile into a dict.
+    @text must be flattened--each record must be on one line.
+    Also, all comments must be removed.
+    """
+    json_zone_file = defaultdict(list)
+    record_lines = text.split("\n")
+    parser = make_parser()
+
+    for record_line in record_lines:
+        record_token = tokenize_line(record_line)
+        try:
+            json_zone_file = parse_line(parser, record_token, json_zone_file)
+        except InvalidLineException:
+            if ignore_invalid:
+                continue
+            else:
+                raise
+
+    return json_zone_file
+
+
+def parse_zone_file(text, ignore_invalid=False):
+    """
+    Parse a zonefile into a dict
+    """
+    text = remove_comments(text)
+    text = flatten(text)
+    text = remove_class(text)
+    text = add_record_names(text)
+    json_zone_file = parse_lines(text, ignore_invalid=ignore_invalid)
+    return json_zone_file

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/zone_file/record_processors.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/zone_file/record_processors.py
@@ -1,0 +1,224 @@
+#---------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+#---------------------------------------------------------------------------------------------
+#The MIT License (MIT)
+
+#Copyright (c) 2016 Blockstack
+
+#Permission is hereby granted, free of charge, to any person obtaining a copy
+#of this software and associated documentation files (the "Software"), to deal
+#in the Software without restriction, including without limitation the rights
+#to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#copies of the Software, and to permit persons to whom the Software is
+#furnished to do so, subject to the following conditions:
+
+#The above copyright notice and this permission notice shall be included in all
+#copies or substantial portions of the Software.
+
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#SOFTWARE.
+#pylint: skip-file
+
+import copy
+
+def process_origin(data, template):
+    """
+    Replace {$origin} in template with a serialized $ORIGIN record
+    """
+    record = ""
+    if data is not None:
+        record += "$ORIGIN %s" % data
+
+    return template.replace("{$origin}", record)
+
+
+def process_ttl(data, template):
+    """
+    Replace {$ttl} in template with a serialized $TTL record
+    """
+    record = ""
+    if data is not None:
+        record += "$TTL %s" % data
+
+    return template.replace("{$ttl}", record)
+
+
+def process_soa(data, template):
+    """
+    Replace {SOA} in template with a set of serialized SOA records
+    """
+    record = template[:]
+
+    if data is not None:
+    
+        assert len(data) == 1, "Only support one SOA RR at this time"
+        data = data[0]
+
+        soadat = []
+        domain_fields = ['mname', 'rname']
+        param_fields = ['serial', 'refresh', 'retry', 'expire', 'minimum']
+
+        for f in domain_fields + param_fields:
+            assert f in data.keys(), "Missing '%s' (%s)" % (f, data)
+
+        data_name = str(data.get('name', '@'))
+        soadat.append(data_name)
+
+        if data.get('ttl') is not None:
+            soadat.append( str(data['ttl']) )
+  
+        soadat.append("IN")
+        soadat.append("SOA")
+
+        for key in domain_fields:
+            value = str(data[key])
+            soadat.append(value)
+
+        soadat.append("(")
+
+        for key in param_fields:
+            value = str(data[key])
+            soadat.append(value)
+
+        soadat.append(")")
+
+        soa_txt = " ".join(soadat)
+        record = record.replace("{soa}", soa_txt)
+
+    else:
+        # clear all SOA fields 
+        record = record.replace("{soa}", "")
+
+    return record
+
+
+def quote_field(data, field):
+    """
+    Quote a field in a list of DNS records.
+    Return the new data records.
+    """
+    if data is None:
+        return None 
+
+    data_dup = copy.deepcopy(data)
+    for i in range(0, len(data_dup)):
+        data_dup[i][field] = '"%s"' % data_dup[i][field]
+        data_dup[i][field] = data_dup[i][field].replace(";", "\;")
+
+    return data_dup
+
+
+def process_rr(data, record_type, record_keys, field, template):
+    """
+    Meta method:
+    Replace $field in template with the serialized $record_type records,
+    using @record_key from each datum.
+    """
+    if data is None:
+        return template.replace(field, "")
+
+    if type(record_keys) == list:
+        pass
+    elif type(record_keys) == str:
+        record_keys = [record_keys]
+    else:
+        raise ValueError("Invalid record keys")
+
+    assert type(data) == list, "Data must be a list"
+
+    record = ""
+    for i in range(0, len(data)):
+
+        for record_key in record_keys:
+            assert record_key in data[i].keys(), "Missing '%s'" % record_key
+
+        record_data = []
+        record_data.append( str(data[i].get('name', '@')) )
+        if data[i].get('ttl') is not None:
+            record_data.append( str(data[i]['ttl']) )
+
+        record_data.append(record_type)
+        record_data += [str(data[i][record_key]) for record_key in record_keys]
+        record += " ".join(record_data) + "\n"
+
+    return template.replace(field, record)
+
+
+def process_ns(data, template):
+    """
+    Replace {ns} in template with the serialized NS records
+    """
+    return process_rr(data, "NS", "host", "{ns}", template)
+
+
+def process_a(data, template):
+    """
+    Replace {a} in template with the serialized A records
+    """
+    return process_rr(data, "A", "ip", "{a}", template)
+
+
+def process_aaaa(data, template):
+    """
+    Replace {aaaa} in template with the serialized A records
+    """
+    return process_rr(data, "AAAA", "ip", "{aaaa}", template)
+
+
+def process_cname(data, template):
+    """
+    Replace {cname} in template with the serialized CNAME records
+    """
+    return process_rr(data, "CNAME", "alias", "{cname}", template)
+
+
+def process_mx(data, template):
+    """
+    Replace {mx} in template with the serialized MX records
+    """
+    return process_rr(data, "MX", ["preference", "host"], "{mx}", template)
+
+
+def process_ptr(data, template):
+    """
+    Replace {ptr} in template with the serialized PTR records
+    """
+    return process_rr(data, "PTR", "host", "{ptr}", template)
+
+
+def process_txt(data, template):
+    """
+    Replace {txt} in template with the serialized TXT records
+    """
+    # quote txt
+    data_dup = quote_field(data, "txt")
+    return process_rr(data_dup, "TXT", "txt", "{txt}", template)
+
+
+def process_srv(data, template):
+    """
+    Replace {srv} in template with the serialized SRV records
+    """
+    return process_rr(data, "SRV", ["priority", "weight", "port", "target"], "{srv}", template)
+
+
+def process_spf(data, template):
+    """
+    Replace {spf} in template with the serialized SPF records
+    """
+    return process_rr(data, "SPF", "data", "{spf}", template)
+
+
+def process_uri(data, template):
+    """
+    Replace {uri} in templtae with the serialized URI records
+    """
+    # quote target 
+    data_dup = quote_field(data, "target")
+    return process_rr(data_dup, "URI", ["priority", "weight", "target"], "{uri}", template)

--- a/src/command_modules/azure-cli-network/setup.py
+++ b/src/command_modules/azure-cli-network/setup.py
@@ -112,7 +112,8 @@ setup(
         'azure.cli.command_modules.network.mgmt_dns_zone',
         'azure.cli.command_modules.network.mgmt_dns_zone.lib',
         'azure.cli.command_modules.network.mgmt_dns_zone.lib.models',
-        'azure.cli.command_modules.network.mgmt_dns_zone.lib.operations'
+        'azure.cli.command_modules.network.mgmt_dns_zone.lib.operations',
+        'azure.cli.command_modules.network.zone_file'
     ],
     install_requires=DEPENDENCIES,
 )


### PR DESCRIPTION
List record sets (one line change), dns zone import and dns zone export.  Fixes #721 

Export Data flow: load all record sets from the zone, for each record set and each record set’s records, create a dict of the fields that conforms to the zone_file format (most of our changes), then zone_file converts the dict to the canonical zone file format.

The import data flow is the reverse of export.  We don't allow import over the top of existing zones; this is a difference compared to xplat, which has a “force” option.  Given that the force option implementation would essentially be deleting and re-creating the record sets, I left it to the user to delete their record set if they run into a situation where they want to create it from scratch again.

Zone_file: the zone_file library lives at https://github.com/blockstack/dns-zone-file-py.  While we wait for my PRs on it and a PR for Python3 support to go through, I have snapped the library and added their license to each file’s header.  Those files aren't part of this review.

```
Command
    az network dns zone import

Arguments
    --file-name         [Required]
    --name -n           [Required]: The name of the zone without a terminating dot.
    --resource-group -g [Required]: Name of resource group.
    --location -l                 : Location.  Default: global.
```

```
Command
    az network dns zone export

Arguments
    --file-name         [Required]
    --name -n           [Required]: The name of the zone without a terminating dot.
    --resource-group -g [Required]: Name of resource group.
```