### PR TITLE
Help polish, unblock doc generation

### DIFF
--- a/doc/sphinx/azhelpgen/azhelpgen.py
+++ b/doc/sphinx/azhelpgen/azhelpgen.py
@@ -10,10 +10,10 @@ from docutils.statemachine import ViewList
 from sphinx.util.compat import Directive
 from sphinx.util.nodes import nested_parse_with_titles
 
-from azure.cli.application import Application, Configuration
+from azure.cli.application import APPLICATION, Configuration
 import azure.cli._help as _help
 
-app = Application(Configuration([]))
+app = APPLICATION
 try:
     app.execute(['-h'])
 except:
@@ -79,7 +79,8 @@ class AzHelpGenDirective(Directive):
         node.document = self.state.document
         result = ViewList()
         for line in self.make_rst():
-            result.append(line, '<azhelpgen>')
+            result.append(line.decode('utf-8', 'ignore'), '<azhelpgen>')
+
         nested_parse_with_titles(self.state, result, node)
         return node.children
 

--- a/src/azure/cli/_help.py
+++ b/src/azure/cli/_help.py
@@ -82,7 +82,7 @@ def print_arguments(help_file):
                           for p in help_file.parameters)
     last_group_name = None
     for p in sorted(help_file.parameters,
-                    key=lambda p: str(p.group_name or 'A')
+                    key=lambda p: _get_group_priority(p.group_name)
                     + str(not p.required) + p.name):
         indent = 1
         required_text = required_tag if p.required else ''
@@ -385,6 +385,14 @@ def _load_help_file_from_string(text):
 def _get_single_metadata(cmd_table):
     assert len(cmd_table) == 1
     return next(metadata for _, metadata in cmd_table.items())
+
+def _get_group_priority(group_name):
+    priorities = {
+        'Resource Id Arguments': 10,
+        'Global Arguments': 1000,
+        }
+    key = priorities.get(group_name, 0)
+    return "%06d" % key
 
 class HelpAuthoringException(Exception):
     pass


### PR DESCRIPTION
Add group ordering system so Global Arguments is at the bottom again.  Unblock doc generation script so --ids show in the output and unicode characters don't fail the sphinx build.