### PR TITLE
should not use str.decode because doc CI uses Python 3

### DIFF
--- a/doc/sphinx/azhelpgen/azhelpgen.py
+++ b/doc/sphinx/azhelpgen/azhelpgen.py
@@ -79,7 +79,7 @@ class AzHelpGenDirective(Directive):
         node.document = self.state.document
         result = ViewList()
         for line in self.make_rst():
-            result.append(line.decode('utf-8', 'ignore'), '<azhelpgen>')
+            result.append(line, '<azhelpgen>')
 
         nested_parse_with_titles(self.state, result, node)
         return node.children


### PR DESCRIPTION
fix doc generation error:
`AttributeError: 'str' object has no attribute 'decode'`