### PR TITLE
Updated command name parsing

### DIFF
--- a/src/azure-cli-core/azure/cli/core/tests/test_help.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_help.py
@@ -534,7 +534,7 @@ def _is_group(parser):
     return getattr(parser, 'choices', None) is not None
 
 def _get_parser_name(parser):
-    return (parser._prog_prefix if hasattr(parser, '_prog_prefix') else parser.prog).lstrip('az ') #pylint:disable=protected-access
+    return (parser._prog_prefix if hasattr(parser, '_prog_prefix') else parser.prog)[len('az '):] #pylint:disable=protected-access
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Python lstrip removes any of the provided characters from the left end of the string.
```
'aaaaaaaabbbbbbbc'.lstrip('ab') => 'c'
'az account list'.lstrip('az ') => 'ccount list'

'az account list'[len('az '):] => 'account list'
```