### PR TITLE
[Generic Update] Fixes and Enhancements

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -243,7 +243,7 @@ def cli_generic_update_command(name, getter, setter, factory=None, setter_arg_na
                     add_properties(instance, arg_values)
                 except ValueError:
                     raise CLIError('--add should be of the form:'
-                                   ' --add property.list <key=value, scalar, [], {}>')
+                                   ' --add property.list <key=value, string or JSON string>')
             elif arg_type == '--remove':
                 try:
                     remove_properties(instance, arg_values)
@@ -359,13 +359,13 @@ def add_properties(instance, argument_values):
                 # dictionary.
                 list_to_add_to.append(dict_entry)
                 dict_entry = {}
-            if argument == '[]':
-                list_to_add_to.append([])
-            elif argument == '{}':
-                list_to_add_to.append({})
-            else:
-                # should handle all other kinds of scalars
-                list_to_add_to.append(argument)
+
+            # attempt to convert anything else to JSON and fallback to string if error
+            try:
+                argument = json.loads(argument)
+            except ValueError:
+                pass
+            list_to_add_to.append(argument)
 
     # if only key=value pairs used, must check at the end to append the dictionary
     if dict_entry:
@@ -380,7 +380,7 @@ def remove_properties(instance, argument_values):
     try:
         list_index = argument_values.pop(0)
     except IndexError:
-        pass
+        raise CLIError('invalid syntax: --remove <list> <indices to remove...>')
 
     if not list_index:
         _find_property(instance, list_attribute_path)

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -390,7 +390,7 @@ def remove_properties(instance, argument_values):
         if isinstance(parent_to_remove_from, dict):
             del parent_to_remove_from[list_attribute_path[-1]]
         elif hasattr(parent_to_remove_from, make_snake_case(list_attribute_path[-1])):
-            setattr(parent_to_remove_from, list_attribute_path[-1], None)
+            setattr(parent_to_remove_from, make_snake_case(list_attribute_path[-1]), None)
         else:
             raise ValueError
     else:
@@ -410,10 +410,10 @@ def show_options(instance, part, path):
         options = sorted([make_camel_case(x) for x in options])
         error_message = '{} Available options: {}'.format(error_message, options)
     elif isinstance(options, list):
-        options = 'index into the collection "{}" with [<index>] or [<key=value>]'.format(parent)
+        options = "index into the collection '{}' with [<index>] or [<key=value>]".format(parent)
         error_message = '{} Available options: {}'.format(error_message, options)
     else:
-        error_message = "{} '{}' does not support further indexing.".format(error_message, parent)    
+        error_message = "{} '{}' does not support further indexing.".format(error_message, parent)
     raise CLIError(error_message)
 
 snake_regex_1 = re.compile('(.)([A-Z][a-z]+)')
@@ -451,6 +451,10 @@ def _update_instance(instance, part, path):
     try: # pylint: disable=too-many-nested-blocks
         index = index_or_filter_regex.match(part)
         if index:
+            # indexing on anything but a list is not allowed
+            if not isinstance(instance, list):
+                show_options(instance, part, path)
+
             if '=' in index.group(1):
                 key, value = index.group(1).split('=')
                 matches = []

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -440,7 +440,7 @@ def _get_name_path(path):
     return pathlist.pop(), pathlist
 
 def _update_instance(instance, part, path):
-    try:
+    try: # pylint: disable=too-many-nested-blocks
         index = index_or_filter_regex.match(part)
         if index:
             if '=' in index.group(1):

--- a/src/azure-cli-core/azure/cli/core/tests/test_generic_update.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_generic_update.py
@@ -153,11 +153,7 @@ class GenericUpdateTest(unittest.TestCase):
             try:
                 app.execute(command.split())
             except CLIError as err:
-                try:
-                    self.assertEqual(error in str(err), True, message)
-                except AssertionError:
-                    # give the actual conflicting messages instead of a very non-useful
-                    # False != True.
+                if not error in str(err):
                     raise AssertionError('Expected: {}\nActual: {}'.format(error, str(err)))
             else:
                 raise AssertionError('exception not thrown')

--- a/src/azure-cli-core/azure/cli/core/tests/test_generic_update.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_generic_update.py
@@ -15,6 +15,8 @@ from azure.cli.core._util import CLIError
 
 #pylint:disable=invalid-sequence-index
 #pylint:disable=unsubscriptable-object
+#pylint:disable=line-too-long
+#pylint:disable=too-few-public-methods
 
 class ListTestObject(object):
     def __init__(self, val):
@@ -28,7 +30,7 @@ class ObjectTestObject(object):
     def __init__(self, str_val, int_val, bool_val):
         self.my_string = str(str_val)
         self.my_int = int(int_val)
-        self.my_bool = bool(bool_val)    
+        self.my_bool = bool(bool_val)
 
 class TestObject(object):
     def __init__(self):
@@ -75,7 +77,7 @@ class GenericUpdateTest(unittest.TestCase):
         # Test simplest ways of setting properties
         app.execute('update-obj --set myProp=newValue'.split())
         self.assertEqual(my_obj.my_prop, 'newValue', 'set simple property')
-        
+
         app.execute('update-obj --set myProp=val3'.split())
         self.assertEqual(my_obj.my_prop, 'val3', 'set simple property again')
 
@@ -153,8 +155,8 @@ class GenericUpdateTest(unittest.TestCase):
             except CLIError as err:
                 try:
                     self.assertEqual(error in str(err), True, message)
-                except AssertionError as assert_err:
-                    # give the actual conflicting messages instead of a very non-useful 
+                except AssertionError:
+                    # give the actual conflicting messages instead of a very non-useful
                     # False != True.
                     raise AssertionError('Expected: {}\nActual: {}'.format(error, str(err)))
             else:

--- a/src/azure-cli-core/azure/cli/core/tests/test_generic_update.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_generic_update.py
@@ -5,6 +5,7 @@
 
 import logging
 import unittest
+import shlex
 import sys
 
 from azure.cli.core.application import APPLICATION, Application, Configuration
@@ -15,20 +16,50 @@ from azure.cli.core._util import CLIError
 #pylint:disable=invalid-sequence-index
 #pylint:disable=unsubscriptable-object
 
+class ListTestObject(object):
+    def __init__(self, val):
+        self.list_value = list(val)
+
+class DictTestObject(object):
+    def __init__(self, val):
+        self.dict_value = dict(val)
+
+class ObjectTestObject(object):
+    def __init__(self, str_val, int_val, bool_val):
+        self.my_string = str(str_val)
+        self.my_int = int(int_val)
+        self.my_bool = bool(bool_val)    
+
+class TestObject(object):
+    def __init__(self):
+        self.my_prop = 'my_value'
+        self.my_list = [
+            'myValA',
+            ['myValB', 'myValC'],
+            {'myKey': 'valueA'},
+            ObjectTestObject('myString', 0, True)
+        ]
+        self.my_dict = {}
+        self.my_list_of_camel_dicts = [
+            {'myKey': 'value_1'},
+            {'myKey': 'value_2'}
+        ]
+        self.my_list_of_snake_dicts = [
+            {'my_key': 'value1'},
+            {'my_key': 'value2'}
+        ]
+        self.my_list_of_objects = [
+            ObjectTestObject('myKeyA', 25, True),
+            ObjectTestObject('1.2.3.4', 100, False),
+        ]
+
 class GenericUpdateTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         logging.getLogger().setLevel(logging.ERROR)
 
     def test_generic_update(self):
-        my_obj = {
-            'prop': 'val',
-            'list': [
-                'a',
-                'b',
-                ['c', {'d': 'e'}, {'d': 'f'}]
-                ]
-            }
+        my_obj = TestObject()
 
         def my_get():
             return my_obj
@@ -39,69 +70,71 @@ class GenericUpdateTest(unittest.TestCase):
         config = Configuration([])
         app = Application(config)
 
-        cli_generic_update_command('gencommand', my_get, my_set)
+        cli_generic_update_command('update-obj', my_get, my_set)
 
-        app.execute('gencommand --set prop=val2'.split())
-        self.assertEqual(my_obj['prop'], 'val2', 'set simple property')
+        # Test simplest ways of setting properties
+        app.execute('update-obj --set myProp=newValue'.split())
+        self.assertEqual(my_obj.my_prop, 'newValue', 'set simple property')
+        
+        app.execute('update-obj --set myProp=val3'.split())
+        self.assertEqual(my_obj.my_prop, 'val3', 'set simple property again')
 
-        app.execute('gencommand --set prop=val3'.split())
-        self.assertEqual(my_obj['prop'], 'val3', 'set simple property again')
+        app.execute('update-obj --set myList[0]=newValA'.split())
+        self.assertEqual(my_obj.my_list[0], 'newValA', 'set simple list element')
 
-        app.execute('gencommand --set list[0]=f'.split())
-        self.assertEqual(my_obj['list'][0], 'f', 'set simple list element')
+        app.execute('update-obj --set myDict.myCamelKey=success'.split())
+        self.assertEqual(my_obj.my_dict['myCamelKey'], 'success', 'set simple dict element with camel case key')
 
-        app.execute('gencommand --set list[2][0]=g'.split())
-        self.assertEqual(my_obj['list'][2][0], 'g', 'set nested list element')
+        app.execute('update-obj --set myDict.my_snake_key=success'.split())
+        self.assertEqual(my_obj.my_dict['my_snake_key'], 'success', 'set simple dict element with snake case key')
 
-        app.execute('gencommand --set list[2][1].d=h'.split())
-        self.assertEqual(my_obj['list'][2][1]['d'], 'h', 'set nested dict element')
+        # Test the different ways of indexing into a list of objects or dictionaries by filter
+        app.execute('update-obj --set myListOfCamelDicts[myKey=value_2].myKey=new_value'.split())
+        self.assertEqual(my_obj.my_list_of_camel_dicts[1]['myKey'], 'new_value', 'index into list of dictionaries by camel-case key')
 
-        app.execute('gencommand --set list[0]={} list[0].foo=bar'.split())
-        self.assertEqual(my_obj['list'][0]['foo'], 'bar', 'replace nested scalar with new dict')
+        app.execute('update-obj --set myListOfSnakeDicts[my_key=value2].my_key=new_value'.split())
+        self.assertEqual(my_obj.my_list_of_snake_dicts[1]['my_key'], 'new_value', 'index into list of dictionaries by snake-case key')
 
-        app.execute('gencommand --set list[1]=[] --add list[1] key1=value1'
-                    ' --set list[1][0].key2=value2'.split())
-        self.assertEqual(my_obj['list'][1][0]['key1'], 'value1',
-                         'replace nested scalar with new list with one value')
-        self.assertEqual(my_obj['list'][1][0]['key2'], 'value2',
-                         'add a second value to the new list')
+        app.execute('update-obj --set myListOfObjects[myString=1.2.3.4].myString=new_value'.split())
+        self.assertEqual(my_obj.my_list_of_objects[1].my_string, 'new_value', 'index into list of objects by key')
 
-        app.execute('gencommand --set list[2][d=f].d=g'.split())
-        self.assertEqual(my_obj['list'][2][2]['d'], 'g',
-                         'index dictionary by unique key=value')
+        # Test setting on elements nested within lists
+        app.execute('update-obj --set myList[1][1]=newValue'.split())
+        self.assertEqual(my_obj.my_list[1][1], 'newValue', 'set nested list element')
 
-        app.execute('gencommand --add list i=j k=l'.split())
-        self.assertEqual(my_obj['list'][-1]['k'], 'l',
-                         'add multiple values to a list at once (verify last element)')
-        self.assertEqual(my_obj['list'][-1]['i'], 'j',
-                         'add multiple values to a list at once (verify first element)')
+        app.execute('update-obj --set myList[2].myKey=newValue'.split())
+        self.assertEqual(my_obj.my_list[2]['myKey'], 'newValue', 'set nested dict element')
 
-        app.execute('gencommand --add list[-2] prop2=val2'.split())
-        self.assertEqual(my_obj['list'][-2][-1]['prop2'], 'val2', 'add to list')
-        app.execute('gencommand --add list[-2] prop3=val3'.split())
-        self.assertEqual(my_obj['list'][-2][-1]['prop3'], 'val3',
-                         'add to list again, should make seperate list elements')
+        app.execute('update-obj --set myList[3].myInt=50'.split())
+        self.assertEqual(my_obj.my_list[3].my_int, 50, 'set nested object element')
 
-        self.assertEqual(len(my_obj['list']), 4, 'pre-verify length of list')
-        app.execute('gencommand --remove list -2'.split())
-        self.assertEqual(len(my_obj['list']), 3, 'verify one item removed')
-        app.execute('gencommand --remove list -1'.split())
-        self.assertEqual(len(my_obj['list']), 2, 'verify another item removed')
+        # Test overwriting and removing values
+        app.execute('update-obj --set myProp={} myProp.foo=bar'.split())
+        self.assertEqual(my_obj.my_prop['foo'], 'bar', 'replace scalar with dict')
 
-        self.assertEqual('key1' in my_obj['list'][1][0], True, 'verify dict item')
-        app.execute('gencommand --remove list[1][0].key1'.split())
-        self.assertEqual('key1' not in my_obj['list'][1][0], True,
-                         'verify dict item can be removed')
+        # Test various --add to lists
+        app.execute('update-obj --set myList=[]'.split())
+        app.execute(shlex.split('update-obj --add myList key1=value1 key2=value2 foo "string in quotes" [] {} foo=bar'))
+        self.assertEqual(my_obj.my_list[0]['key1'], 'value1', 'add a value to a dictionary')
+        self.assertEqual(my_obj.my_list[0]['key2'], 'value2', 'add a second value to the dictionary')
+        self.assertEqual(my_obj.my_list[1], 'foo', 'add scalar value to list')
+        self.assertEqual(my_obj.my_list[2], 'string in quotes', 'add scalar value with quotes to list')
+        self.assertEqual(my_obj.my_list[3], [], 'add list to a list')
+        self.assertEqual(my_obj.my_list[4], {}, 'add dict to a list')
+        self.assertEqual(my_obj.my_list[5]['foo'], 'bar', 'add second dict and verify when dict is at the end')
+
+        # Test --remove
+        self.assertEqual(len(my_obj.my_list), 6, 'pre-verify length of list')
+        app.execute('update-obj --remove myList -2'.split())
+        self.assertEqual(len(my_obj.my_list), 5, 'verify one item removed')
+        self.assertEqual(my_obj.my_list[4]['foo'], 'bar', 'verify correct item removed')
+
+        self.assertEqual('key1' in my_obj.my_list[0], True, 'verify dict item exists')
+        app.execute('update-obj --remove myList[0].key1'.split())
+        self.assertEqual('key1' not in my_obj.my_list[0], True, 'verify dict entry can be removed')
 
     def test_generic_update_errors(self):
-        my_obj = {
-            'prop': 'val',
-            'list': [
-                'a',
-                'b',
-                ['c', {'d': 'e'}, {'d': 'e'}]
-                ]
-            }
+        my_obj = TestObject()
 
         def my_get(a1, a2): #pylint: disable=unused-argument
             return my_obj
@@ -118,51 +151,63 @@ class GenericUpdateTest(unittest.TestCase):
             try:
                 app.execute(command.split())
             except CLIError as err:
-                self.assertEqual(error in str(err), True, message)
+                try:
+                    self.assertEqual(error in str(err), True, message)
+                except AssertionError as assert_err:
+                    # give the actual conflicting messages instead of a very non-useful 
+                    # False != True.
+                    raise AssertionError('Expected: {}\nActual: {}'.format(error, str(err)))
             else:
                 raise AssertionError('exception not thrown')
 
         missing_remove_message = """Couldn't find "doesntExist" in "".""" + \
-                                 """  Available options: ['list', 'prop']"""
-        _execute_with_error('gencommand --a1 1 --a2 2 --remove doesnt_exist',
+                                """  Available options: ['myDict', 'myList', """ + \
+                                """'myListOfCamelDicts', 'myListOfObjects', """ + \
+                                """'myListOfSnakeDicts', 'myProp']"""
+        _execute_with_error('gencommand --a1 1 --a2 2 --remove doesntExist',
                             missing_remove_message,
                             'remove non-existent property by name')
         _execute_with_error('gencommand --a1 1 --a2 2 --remove doesntExist 2',
                             missing_remove_message,
                             'remove non-existent property by index')
 
-        remove_prop_message = """Couldn't find "doesntExist" in "list.doesntExist".""" + \
-                              """  Available options: index into the """ + \
-                              """collection "list.doesntExist" with [<index>] or [<key=value>]"""
-        _execute_with_error('gencommand --a1 1 --a2 2 --remove list.doesnt_exist.missing 2',
+        remove_prop_message = """Couldn't find "doesntExist" in "myList.doesntExist".""" + \
+                            """  Available options: index into the """ + \
+                            """collection "myList.doesntExist" with [<index>] or [<key=value>]"""
+        _execute_with_error('gencommand --a1 1 --a2 2 --remove myList.doesntExist.missing 2',
                             remove_prop_message,
                             'remove non-existent sub-property by index')
 
-        _execute_with_error('gencommand --a1 1 --a2 2 --remove list 20',
-                            "index 20 doesn't exist on list",
+        _execute_with_error('gencommand --a1 1 --a2 2 --remove myList 20',
+                            "index 20 doesn't exist on myList",
                             'remove out-of-range index')
 
-        set_on_list_message = """Couldn't find "doesntExist" in "list".""" + \
-                              """  Available options: index into the collection "list" with""" + \
-                              """ [<index>] or [<key=value>]"""
-        _execute_with_error('gencommand --a1 1 --a2 2 --set list.doesnt_exist=foo',
+        set_on_list_message = """Couldn't find "doesnt_exist" in "myList".""" + \
+                            """  Available options: index into the collection "myList" with""" + \
+                            """ [<index>] or [<key=value>]"""
+        _execute_with_error('gencommand --a1 1 --a2 2 --set myList.doesnt_exist=foo',
                             set_on_list_message,
                             'set shouldn\'t work on a list')
-        _execute_with_error('gencommand --a1 1 --a2 2 --set list.doesnt_exist.doesnt_exist2=foo',
+        _execute_with_error('gencommand --a1 1 --a2 2 --set myList.doesnt_exist.doesnt_exist2=foo',
                             set_on_list_message,
                             'set shouldn\'t work on a list')
 
-        _execute_with_error('gencommand --a1 1 --a2 2 --set list[2][3].doesnt_exist=foo',
-                            "index 3 doesn't exist on [2]",
+        _execute_with_error('gencommand --a1 1 --a2 2 --set myList[5].doesnt_exist=foo',
+                            "index 5 doesn't exist on myList",
                             'index out of range in path')
 
-        _execute_with_error('gencommand --a1 1 --a2 2 --set list[2][d=e].doesnt_exist=foo',
-                            "non-unique key 'd' found multiple matches on [2]. Key must be unique.",
-                            'indexing by key must be unique')
+        # add an entry which makes 'myKey' no longer unique
+        app.execute('gencommand --a1 1 --a2 2 --add myListOfCamelDicts myKey=value_2'.split())
+        _execute_with_error(
+            'gencommand --a1 1 --a2 2 --set myListOfCamelDicts[myKey=value_2].myKey=foo',
+            "non-unique key 'myKey' found multiple matches on myListOfCamelDicts. "
+            "Key must be unique.",
+            'indexing by key must be unique')
 
-        _execute_with_error('gencommand --a1 1 --a2 2 --set list[2][f=a].doesnt_exist=foo',
-                            "item with value 'a' doesn\'t exist for key 'f' on [2]",
-                            'no match found when indexing by key and value')
+        _execute_with_error(
+            'gencommand --a1 1 --a2 2 --set myListOfCamelDicts[myKey=foo].myKey=foo',
+            "item with value 'foo' doesn\'t exist for key 'myKey' on myListOfCamelDicts",
+            'no match found when indexing by key and value')
 
     def test_generic_update_ids(self):
         my_objs = [

--- a/src/azure-cli-core/azure/cli/core/tests/test_generic_update.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_generic_update.py
@@ -60,7 +60,7 @@ class GenericUpdateTest(unittest.TestCase):
     def setUpClass(cls):
         logging.getLogger().setLevel(logging.ERROR)
 
-    def test_generic_update(self):
+    def test_generic_update(self): # pylint: disable=too-many-statements
         my_obj = TestObject()
 
         def my_get():
@@ -83,6 +83,9 @@ class GenericUpdateTest(unittest.TestCase):
 
         app.execute('update-obj --set myList[0]=newValA'.split())
         self.assertEqual(my_obj.my_list[0], 'newValA', 'set simple list element')
+
+        app.execute('update-obj --set myList[-4]=newValB'.split())
+        self.assertEqual(my_obj.my_list[0], 'newValB', 'set simple list element')
 
         app.execute('update-obj --set myDict.myCamelKey=success'.split())
         self.assertEqual(my_obj.my_dict['myCamelKey'], 'success', 'set simple dict element with camel case key')


### PR DESCRIPTION
This PR:

- Fixes #824
- Fixes #851
- Adds the ability to add scalars to a list as well as empty lists and dictionaries. Consecutive key=value entries are grouped into a single dict entry. Non-consecutive key=value entries get placed into separate dicts.