### PR TITLE
login: capture error caused by expired refresh token

### DIFF
--- a/src/azure-cli-core/azure/cli/core/adal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/adal_authentication.py
@@ -20,6 +20,11 @@ class AdalAuthentication(Authentication):#pylint: disable=too-few-public-methods
         try:
             scheme, token = self._token_retriever()
         except adal.AdalError as err:
+            #pylint: disable=no-member
+            if (hasattr(err, 'error_response') and ('error_description' in err.error_response)
+                    and ('AADSTS70008:' in err.error_response['error_description'])):
+                raise CLIError("Credentials have expired due to inactivity. Please run 'az login'")
+
             raise CLIError(err)
 
         header = "{} {}".format(scheme, token)

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
@@ -23,4 +23,4 @@ register_cli_argument('login', 'tenant', options_list=('--tenant', '-t'), help='
 
 register_cli_argument('logout', 'username', help='account user, if missing, logout the current active account')
 
-register_cli_argument('account', 'subscription_name_or_id', options_list=('--subscription-or-id', '-n'), help='Name or ID of subscription.', completer=get_subscription_id_list)
+register_cli_argument('account', 'subscription_name_or_id', options_list=('--name', '-n'), help='Name or ID of subscription.', completer=get_subscription_id_list)


### PR DESCRIPTION
fix #856
Also simplify the parameter name from `--subscription-or-id` to `--subscription`. The old one is too verbose, and the description in help has called out both id and name can work