### PR TITLE
Fixes #883 Telemetry on Ctrl+C

### DIFF
--- a/src/azure-cli/azure/cli/__main__.py
+++ b/src/azure-cli/azure/cli/__main__.py
@@ -9,7 +9,7 @@ import os
 import azure.cli.main
 
 from azure.cli.core.telemetry import (init_telemetry, user_agrees_to_telemetry,
-                                      telemetry_flush)
+                                      telemetry_flush, log_event)
 
 try:
     try:
@@ -29,6 +29,7 @@ try:
 
     sys.exit(azure.cli.main.main(args))
 except KeyboardInterrupt:
+    log_event('keyboard interrupt')
     sys.exit(1)
 finally:
     try:


### PR DESCRIPTION
tested that Ctrl+C is not blocked by the telemetry thread on Windows and Linux