### PR TITLE
webapp: use json when return git url

### DIFF
--- a/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/custom.py
+++ b/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/custom.py
@@ -113,7 +113,7 @@ def enable_local_git(resource_group, name, slot=None):
     else:
         client.sites.create_or_update_site_config_slot(resource_group, name, site_config, slot)
 
-    return _get_git_url(client, resource_group, name, slot)
+    return {'url' : _get_git_url(client, resource_group, name, slot)}
 
 #TODO: logic comes from powershell, cross check with with upcoming xplat styles
 def create_app_service_plan(resource_group, name, tier=None, number_of_workers=None,
@@ -177,7 +177,7 @@ def _get_location_from_app_service_plan(client, resource_group, plan):
 
 def get_git_url(resource_group, name, slot=None):
     client = web_client_factory()
-    return _get_git_url(client, resource_group, name, slot)
+    return {'url' : _get_git_url(client, resource_group, name, slot)}
 
 def _get_git_url(client, resource_group, name, slot=None):
     user = client.provider.get_publishing_user()

--- a/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/tests/test_webapp_commands.py
+++ b/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/tests/test_webapp_commands.py
@@ -55,7 +55,7 @@ class WebappBasicE2ETest(ResourceGroupVCRTestBase):
 
         self.cmd('webapp git enable-local -g {} -n {}'.format(self.resource_group, webapp_name))
         result = self.cmd('webapp git show-url -g {} -n {}'.format(self.resource_group, webapp_name))
-        self.assertTrue(result.endswith(webapp_name + '.git'))
+        self.assertTrue(result['url'].endswith(webapp_name + '.git'))
 
         #turn on diagnostics
         test_cmd = ('webapp log set -g {} -n {} --level verbose'.format(self.resource_group, webapp_name) + ' '


### PR DESCRIPTION
otherwise, the command emit out errors when the output format is `table`