### PR TITLE
Able to create role assignments under other subscriptions

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/client_factory.py
+++ b/src/azure-cli-core/azure/cli/core/commands/client_factory.py
@@ -13,8 +13,8 @@ logger = _logging.get_az_logger(__name__)
 
 UA_AGENT = "AZURECLI/{}".format(core_version)
 
-def get_mgmt_service_client(client_type):
-    client, _ = _get_mgmt_service_client(client_type)
+def get_mgmt_service_client(client_type, subscription_id=None):
+    client, _ = _get_mgmt_service_client(client_type, subscription_id=subscription_id)
     return client
 
 def get_subscription_service_client(client_type):
@@ -37,10 +37,10 @@ def configure_common_settings(client):
     client.config.generate_client_request_id = \
         'x-ms-client-request-id' not in APPLICATION.session['headers']
 
-def _get_mgmt_service_client(client_type, subscription_bound=True):
+def _get_mgmt_service_client(client_type, subscription_bound=True, subscription_id=None):
     logger.info('Getting management service client client_type=%s', client_type.__name__)
     profile = Profile()
-    cred, subscription_id, _ = profile.get_login_credentials()
+    cred, subscription_id, _ = profile.get_login_credentials(subscription_id=subscription_id)
     if subscription_bound:
         client = client_type(cred, subscription_id)
     else:

--- a/src/azure-cli-core/azure/cli/core/utils/vcr_test_base.py
+++ b/src/azure-cli-core/azure/cli/core/utils/vcr_test_base.py
@@ -40,10 +40,10 @@ MOCKED_STORAGE_ACCOUNT = 'dummystorage'
 
 # MOCK METHODS
 
-def _mock_get_mgmt_service_client(client_type, subscription_bound=True):
+def _mock_get_mgmt_service_client(client_type, subscription_bound=True, subscription_id=None):
     # version of _get_mgmt_service_client to use when recording or playing tests
     profile = Profile()
-    cred, subscription_id, _ = profile.get_login_credentials()
+    cred, subscription_id, _ = profile.get_login_credentials(subscription_id=subscription_id)
     if subscription_bound:
         client = client_type(cred, subscription_id)
     else:

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/custom.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/custom.py
@@ -83,7 +83,7 @@ def create_keyvault(client, resource_group_name, vault_name, location, #pylint:d
     profile = Profile()
     cred, _, tenant_id = profile.get_login_credentials(for_graph_client=True)
     graph_client = GraphRbacManagementClient(cred, tenant_id)
-    subscription = profile.get_default_subscription()
+    subscription = profile.get_subscription()
     if no_self_perms:
         access_policies = []
     else:

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
@@ -29,7 +29,7 @@ register_cli_argument('ad sp', 'identifier', options_list=('--id',), help='servi
 register_cli_argument('ad sp create', 'identifier', options_list=('--id',), help='identifier uri, application id, or object id of the associated application')
 register_cli_argument('ad sp create-for-rbac', 'name', sp_name_type)
 register_cli_argument('ad sp create-for-rbac', 'years', type=int)
-register_cli_argument('ad sp create-for-rbac', 'resource_ids', nargs='+')
+register_cli_argument('ad sp create-for-rbac', 'scopes', nargs='+')
 register_cli_argument('ad sp reset-credentials', 'name', sp_name_type)
 register_cli_argument('ad sp reset-credentials', 'years', type=int)
 
@@ -55,7 +55,7 @@ register_cli_argument('role assignment', 'ids', nargs='+', help='space separated
 register_cli_argument('role', 'role_id', help='the role id')
 register_cli_argument('role', 'resource_group_name', options_list=('--resource-group', '-g'),
                       help='use it only if the role or assignment was added at the level of a resource group')
-register_cli_argument('role', 'resource_id', help='use it only if the role or assignment was added at the level of a resource')
+register_cli_argument('role', 'scope', help='scope at which this role assignment applies to, e.g., /subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333, /subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup, or /subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup/providers/Microsoft.Compute/virtualMachines/myVM')
 register_cli_argument('role', 'custom_role_only', action='store_true', help='custom roles only(vs. build-in ones)')
 register_cli_argument('role', 'role_definition', help="json formatted content which defines the new role. run 'show-create-template' to get samples")
 register_cli_argument('role', 'name', options_list=('--name', '-n'), help="the role's logical name")

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/test_role.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/test_role.py
@@ -99,11 +99,11 @@ class RoleAssignmentScenarioTest(ResourceGroupVCRTestBase):
         self.cmd('role assignment list -g {}'.format(self.resource_group), checks=NoneCheck())
 
         #test role assignments on a resource
-        self.cmd('role assignment create --assignee {} --role contributor --resource-id {}'.format(self.user, resource_id), None)
-        self.cmd('role assignment list --assignee {} --role contributor --resource-id {}'.format(self.user, resource_id),
+        self.cmd('role assignment create --assignee {} --role contributor --scope {}'.format(self.user, resource_id), None)
+        self.cmd('role assignment list --assignee {} --role contributor --scope {}'.format(self.user, resource_id),
                  checks=[JMESPathCheck("length([])", 1)])
-        self.cmd('role assignment delete --assignee {} --role contributor --resource-id {}'.format(self.user, resource_id), None)
-        self.cmd('role assignment list --resource-id {}'.format(resource_id), checks=NoneCheck())
+        self.cmd('role assignment delete --assignee {} --role contributor --scope {}'.format(self.user, resource_id), None)
+        self.cmd('role assignment list --scope {}'.format(resource_id), checks=NoneCheck())
 
         #test role assignment on subscription level
         self.cmd('role assignment create --assignee {} --role reader'.format(self.user), None)


### PR DESCRIPTION
It is a pretty useful under RBAC context. The resource id could come from another subscriptions
Also, the change inside core will be used in near future when we introduce the global flag `--subscription` #807. 