### PR TITLE
Update tags type to be space separated, not semicolon separated

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/parameters.py
+++ b/src/azure-cli-core/azure/cli/core/commands/parameters.py
@@ -110,15 +110,14 @@ quotes = '""' if platform.system() == 'Windows' else "''"
 quote_text = 'Use {} to clear existing tags.'.format(quotes)
 
 tags_type = CliArgumentType(
-    type=validate_tags,
-    help='multiple semicolon separated tags in \'key[=value]\' format.  {}'.format(quote_text),
-    nargs='?',
-    const=''
+    validator=validate_tags,
+    help="space separated tags in 'key[=value]' format. {}".format(quote_text),
+    nargs='*'
 )
 
 tag_type = CliArgumentType(
     type=validate_tag,
-    help='a single tag in \'key[=value]\' format.  {}'.format(quote_text),
+    help="a single tag in 'key[=value]' format. {}".format(quote_text),
     nargs='?',
     const=''
 )

--- a/src/azure-cli-core/azure/cli/core/commands/validators.py
+++ b/src/azure-cli-core/azure/cli/core/commands/validators.py
@@ -7,14 +7,13 @@ import argparse
 import time
 import random
 
-def validate_tags(string):
-    ''' Extracts multiple tags in key[=value] format, separated by semicolons '''
-    result = {}
-    if string:
-        result = validate_key_value_pairs(string)
-        s_list = [x for x in string.split(';') if '=' not in x]  # single values
-        result.update(dict((x, '') for x in s_list))
-    return result
+def validate_tags(ns):
+    ''' Extracts multiple space-separated tags in key[=value] format '''
+    if ns.tags is not None:
+        tags_dict = {}
+        for item in ns.tags:
+            tags_dict.update(validate_tag(item))
+        ns.tags = tags_dict
 
 def validate_tag(string):
     ''' Extracts a single tag in key[=value] format '''

--- a/src/azure-cli-core/azure/cli/core/tests/test_validators.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_validators.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 #---------------------------------------------------------------------------------------------
 
+import argparse
 import unittest
 from six import StringIO
 
@@ -29,16 +30,17 @@ class Test_storage_validators(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     def test_tags_valid(self):
-        the_input = 'a=b;c=d;e'
-        actual = validate_tags(the_input)
+        the_input = argparse.Namespace()
+        the_input.tags = ['a=b', 'c=d', 'e']
+        validate_tags(the_input)
         expected = {'a':'b', 'c':'d', 'e':''}
-        self.assertEqual(actual, expected)
+        self.assertEqual(the_input.tags, expected)
 
     def test_tags_invalid(self):
-        the_input = ''
-        actual = validate_tags(the_input)
-        expected = {}
-        self.assertEqual(actual, expected)
+        the_input = argparse.Namespace()
+        the_input.tags = []
+        validate_tags(the_input)
+        self.assertEqual(the_input.tags, {})
 
     def test_tag(self):
         self.assertEqual(validate_tag('test'), {'test':''})

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/test_storage.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/test_storage.py
@@ -85,7 +85,7 @@ class StorageAccountScenarioTest(ResourceGroupVCRTestBase):
         keys_result = s.cmd('storage account keys renew -g {} -n {} --key secondary'.format(rg, account))
         assert key1 == keys_result['keys'][0]
         assert key2 != keys_result['keys'][1]
-        s.cmd('storage account update -g {} -n {} --tags foo=bar;cat'.format(rg, account),
+        s.cmd('storage account update -g {} -n {} --tags foo=bar cat'.format(rg, account),
             checks=JMESPathCheck('tags', {'cat':'', 'foo':'bar'}))
         s.cmd('storage account update -g {} -n {} --tags'.format(rg, account),
             checks=JMESPathCheck('tags', {}))

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
@@ -313,7 +313,7 @@ class VMCreateAndStateModificationsScenarioTest(ResourceGroupVCRTestBase): #pyli
         self.cmd('vm create --resource-group {0} --location {1} --name {2} --admin-username ubuntu '
                  '--image Canonical:UbuntuServer:14.04.4-LTS:latest --admin-password testPassword0 '
                  '--deployment-name {3} --authentication-type password '
-                 '--tags firsttag=1;secondtag=2;thirdtag --nsg {4} --public-ip-address {5} '
+                 '--tags firsttag=1 secondtag=2 thirdtag --nsg {4} --public-ip-address {5} '
                  '--storage-account {6} --vnet {7}'.format(
                      self.resource_group, self.location, self.vm_name, self.deployment_name,
                      self.nsg_name, self.ip_name, self.storage_name, self.vnet_name))


### PR DESCRIPTION
This was something we did initially because Xplat does this, but we use space-separated lists everywhere else. Figured it would be good to make tags behave the same way before Ignite.