### PR TITLE
webapp: change '--tier' to '--plan'

### DIFF
--- a/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/_params.py
+++ b/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/_params.py
@@ -41,7 +41,7 @@ register_cli_argument('appservice plan', 'resource_group', arg_type=resource_gro
 register_cli_argument('appservice plan', 'location', arg_type=location_type)
 register_cli_argument('appservice plan', 'name', arg_type=existing_plan_name)
 register_cli_argument('appservice plan create', 'name', options_list=('--name', '-n'), help="Name of the new app service plan")
-register_cli_argument('appservice plan', 'tier', type=str.upper, choices=['FREE', 'SHARED', 'B1', 'B2', 'B3', 'S1', 'S2', 'S3', 'P1', 'P2', 'P3'], default='B1',
+register_cli_argument('appservice plan', 'tier', options_list=('--sku',), type=str.upper, choices=['FREE', 'SHARED', 'B1', 'B2', 'B3', 'S1', 'S2', 'S3', 'P1', 'P2', 'P3'], default='B1',
                       help='The pricing tiers, e.g., FREE, SHARED, B1(Basic Small), B2(Basic Medium), B3(Basic Large), S1(Standard Small), P1(Premium Small), etc')
 register_cli_argument('appservice plan', 'number_of_workers', help='Number of workers to be allocated.', type=int, default=1)
 register_cli_argument('appservice plan', 'admin_site_name', help='The name of the admin web app.')

--- a/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/custom.py
+++ b/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/custom.py
@@ -187,7 +187,7 @@ def _get_sku_name(tier):
     elif tier in ['P1', 'P2', 'P3']:
         return 'PREMIUM'
     else:
-        raise CLIError("Invalid pricing tier, please refer to command help for valid values")
+        raise CLIError("Invalid sku(pricing tier), please refer to command help for valid values")
 
 def _get_location_from_resource_group(resource_group):
     from azure.mgmt.resource.resources import ResourceManagementClient

--- a/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/tests/test_webapp_commands.py
+++ b/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/tests/test_webapp_commands.py
@@ -20,7 +20,7 @@ class WebappBasicE2ETest(ResourceGroupVCRTestBase):
     def body(self):
         webapp_name = 'webapp-e2e'
         plan = 'webapp-e2e-plan'
-        result = self.cmd('appservice plan create -g {} -n {} --tier B1'.format(self.resource_group, plan))
+        result = self.cmd('appservice plan create -g {} -n {} --sku B1'.format(self.resource_group, plan))
         self.cmd('appservice plan list -g {}'.format(self.resource_group), checks=[
             JMESPathCheck('length(@)', 1),
             JMESPathCheck('[0].name', plan),
@@ -31,7 +31,7 @@ class WebappBasicE2ETest(ResourceGroupVCRTestBase):
             JMESPathCheck('name', plan)
             ])
         #scale up
-        self.cmd('appservice plan update  -g {} -n {} --tier S1'.format(self.resource_group, plan), checks=[
+        self.cmd('appservice plan update  -g {} -n {} --sku S1'.format(self.resource_group, plan), checks=[
             JMESPathCheck('name', plan),
             JMESPathCheck('sku.tier', 'Standard'),
             JMESPathCheck('sku.name', 'S1')
@@ -93,7 +93,7 @@ class WebappConfigureTest(ResourceGroupVCRTestBase):
     def set_up(self):
         super(WebappConfigureTest, self).set_up()
         plan = 'webapp-config-plan'
-        self.cmd('appservice plan create -g {} -n {} --tier B1'.format(self.resource_group, plan))
+        self.cmd('appservice plan create -g {} -n {} --sku B1'.format(self.resource_group, plan))
         self.cmd('appservice web create -g {} -n {} --plan {}'.format(self.resource_group, self.webapp_name, plan))
 
     def body(self):


### PR DESCRIPTION
The background is webapp team updated it in xplat this week, in order to push the `sku` concept, so azure-cli follow.
Because the sku's naming and type definition are quite confusing in SDK, so in code, i still keep the `tier`, and just do alias at the command layer.
