### PR TITLE
Fixes #968, #940, #893

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_output.py
+++ b/src/azure-cli-core/azure/cli/core/_output.py
@@ -139,7 +139,11 @@ class TableOutput(object): #pylint: disable=too-few-public-methods
                     new_entry[TableOutput._capitalize_first_char(k)] = item[k]
         except AttributeError:
             # handles odd cases where a string/bool/etc. is returned
-            new_entry['Result'] = item
+            if isinstance(item, list):
+                for col, val in enumerate(item):
+                    new_entry['column{}'.format(col)] = val
+            else:
+                new_entry['Result'] = item
         return new_entry
 
     @staticmethod

--- a/src/azure-cli-core/azure/cli/core/_output.py
+++ b/src/azure-cli-core/azure/cli/core/_output.py
@@ -141,7 +141,7 @@ class TableOutput(object): #pylint: disable=too-few-public-methods
             # handles odd cases where a string/bool/etc. is returned
             if isinstance(item, list):
                 for col, val in enumerate(item):
-                    new_entry['column{}'.format(col)] = val
+                    new_entry['Column{}'.format(col + 1)] = val
             else:
                 new_entry['Result'] = item
         return new_entry

--- a/src/azure-cli-core/azure/cli/core/commands/client_factory.py
+++ b/src/azure-cli-core/azure/cli/core/commands/client_factory.py
@@ -7,6 +7,7 @@ from azure.cli.core import __version__ as core_version
 from azure.cli.core._profile import Profile
 import azure.cli.core._debug as _debug
 import azure.cli.core._logging as _logging
+from azure.cli.core._util import CLIError
 from azure.cli.core.application import APPLICATION
 
 logger = _logging.get_az_logger(__name__)
@@ -53,10 +54,13 @@ def _get_mgmt_service_client(client_type, subscription_bound=True, subscription_
 def get_data_service_client(service_type, account_name, account_key, connection_string=None,
                             sas_token=None):
     logger.info('Getting data service client service_type=%s', service_type.__name__)
-    client = service_type(account_name=account_name,
-                          account_key=account_key,
-                          connection_string=connection_string,
-                          sas_token=sas_token)
+    try:
+        client = service_type(account_name=account_name,
+                              account_key=account_key,
+                              connection_string=connection_string,
+                              sas_token=sas_token)
+    except ValueError:
+        raise CLIError('Unable to obtain data client. Check your connection parameters.')
     # TODO: enable Fiddler
     client.request_callback = _add_headers
     return client

--- a/src/azure-cli-core/azure/cli/core/tests/test_output.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_output.py
@@ -86,8 +86,6 @@ class TestOutput(unittest.TestCase):
         output_producer = OutputProducer(formatter=format_table, file=self.io)
         obj = [['a', 'b'], ['c', 'd']]
         output_producer.out(CommandResultItem(obj))
-        test = self.io.getvalue()
-        print(test)
         self.assertEqual(util.normalize_newlines(self.io.getvalue()), util.normalize_newlines(
 """Column1    Column2
 ---------  ---------

--- a/src/azure-cli-core/azure/cli/core/tests/test_output.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_output.py
@@ -82,6 +82,19 @@ class TestOutput(unittest.TestCase):
        1  0b1f6472
 """))
 
+    def test_out_table_list_of_lists(self):
+        output_producer = OutputProducer(formatter=format_table, file=self.io)
+        obj = [['a', 'b'], ['c', 'd']]
+        output_producer.out(CommandResultItem(obj))
+        test = self.io.getvalue()
+        print(test)
+        self.assertEqual(util.normalize_newlines(self.io.getvalue()), util.normalize_newlines(
+"""Column1    Column2
+---------  ---------
+a          b
+c          d
+"""))
+
     def test_out_table_complex_obj(self):
         output_producer = OutputProducer(formatter=format_table, file=self.io)
         obj = OrderedDict()

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
@@ -4,6 +4,7 @@
 #---------------------------------------------------------------------------------------------
 
 # pylint: disable=line-too-long
+from argcomplete.completers import FilesCompleter
 from six import u as unicode_string
 
 from azure.cli.core._config import az_config
@@ -219,7 +220,7 @@ register_cli_argument('storage blob exists', 'blob_name', required=True)
 register_cli_argument('storage blob list', 'include', help='Specifies additional datasets to include: (c)opy-info, (m)etadata, (s)napshots. Can be combined.', validator=validate_included_datasets)
 
 for item in ['download', 'upload']:
-    register_cli_argument('storage blob {}'.format(item), 'file_path', options_list=('--file', '-f'))
+    register_cli_argument('storage blob {}'.format(item), 'file_path', options_list=('--file', '-f'), completer=FilesCompleter())
     register_cli_argument('storage blob {}'.format(item), 'max_connections', type=int)
     register_cli_argument('storage blob {}'.format(item), 'validate_content', action='store_true')
 
@@ -277,7 +278,7 @@ register_path_argument('storage file copy cancel', options_list=('--destination-
 
 register_path_argument('storage file delete')
 
-register_cli_argument('storage file download', 'file_path', options_list=('--dest',), help='Path of the file to write to. The source filename will be used if not specified.', required=False, validator=process_file_download_namespace)
+register_cli_argument('storage file download', 'file_path', options_list=('--dest',), help='Path of the file to write to. The source filename will be used if not specified.', required=False, validator=process_file_download_namespace, completer=FilesCompleter())
 register_cli_argument('storage file download', 'path', validator=None) # validator called manually from process_file_download_namespace so remove the automatic one
 register_cli_argument('storage file download', 'progress_callback', ignore_type)
 register_path_argument('storage file download')
@@ -303,7 +304,7 @@ for item in ['update', 'upload']:
 register_path_argument('storage file update')
 
 register_cli_argument('storage file upload', 'progress_callback', ignore_type)
-register_cli_argument('storage file upload', 'local_file_path', options_list=('--source',))
+register_cli_argument('storage file upload', 'local_file_path', options_list=('--source',), completer=FilesCompleter())
 register_path_argument('storage file upload', default_file_param='local_file_path')
 
 register_path_argument('storage file url')


### PR DESCRIPTION
Fixes #968, fixes #940, fixes #893 

- Handles table output when using [].[props...] notation instead of [].{key:val..} notation by using generic headers.
- Enables tab completion for `az storage file/blob upload/download`
- Prints a more useful error message when improperly formatted connection parameters prevent creating a storage data client. 