### PR TITLE
Updated capture related commands with examples

### DIFF
--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
@@ -203,3 +203,37 @@ helps['vmss extension image'] = """
     type: group
     short-summary: Find scale-set extensions available for your subscription and region
 """
+helps['vm capture'] = """
+            type: command
+            long-summary: See https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-capture-image/ for an end-to-end tutorial
+            examples:
+                - name: Process to deallocate, generalize, and capture a stopped virtual machine
+                  text: >
+                    az vm deallocate -g my_rg -n my_vm_name\n\r
+                    az vm generalize -g my_rg -n my_vm_name\n\r
+                    az vm capture -g my_rg -n my_vm_name --vhd-name-prefix my_prefix\n\r
+                    """
+
+helps['vm deallocate'] = """
+            type: command
+            long-summary: See https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-capture-image/ for an end-to-end tutorial
+            examples:
+                - name: Process to deallocate, generalize, and capture a stopped virtual machine
+                  text: >
+                    az vm deallocate -g my_rg -n my_vm_name\n\r
+                    az vm generalize -g my_rg -n my_vm_name\n\r
+                    az vm capture -g my_rg -n my_vm_name --vhd-name-prefix my_prefix\n\r
+                    """
+
+helps['vm generalize'] = """
+            type: command
+            long-summary: See https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-capture-image/ for an end-to-end tutorial
+            examples:
+                - name: Process to deallocate, generalize, and capture a stopped virtual machine
+                  text: >
+                    az vm deallocate -g my_rg -n my_vm_name\n\r
+                    az vm generalize -g my_rg -n my_vm_name\n\r
+                    az vm capture -g my_rg -n my_vm_name --vhd-name-prefix my_prefix\n\r
+                    """
+
+


### PR DESCRIPTION
Added examples and links to capture related commands for a demo of the upcoming doc system.

```
$ ./az vm capture -h

Command
    az vm capture: Captures the VM by copying virtual hard disks of the VM and outputs a
    template that can be used to create similar VMs.
        See https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-capture-
        image/ for an end-to-end tutorial.

Arguments
    --vhd-name-prefix [Required]: The VHD name prefix specify for the VM disks.
    --overwrite                 : Overwrite the existing disk file.  Default: True.
    --storage-container         : The storage account container name to save the disks.  Default:
                                  vhds.

Resource Id Arguments
    --ids                       : One or more resource IDs. If provided, no other 'Resource Id'
                                  arguments should be specified.
    --name -n                   : The name of the virtual machine.
    --resource-group -g         : Name of resource group.

Global Arguments
    --debug                     : Increase logging verbosity to show all debug logs.
    --help -h                   : Show this help message and exit.
    --output -o                 : Output format.  Allowed values: json, jsonc, list, table, tsv.
                                  Default: table.
    --query                     : JMESPath query string. See http://jmespath.org/ for more
                                  information and examples.
    --verbose                   : Increase logging verbosity. Use --debug for full debug logs.

Examples
    Process to deallocate, generalize, and capture a stopped virtual machine
        az vm deallocate -g my_rg -n my_vm_name
        az vm generalize -g my_rg -n my_vm_name
        az vm capture -g my_rg -n my_vm_name --vhd-name-prefix my_prefix

(env) jasonsha@JasonShaMBP: ~/code/azure-cli/src/azure-cli $ ./az vm generalize -h

Command
    az vm generalize: Sets the state of the VM as Generalized.
        See https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-capture-
        image/ for an end-to-end tutorial.

Arguments

Resource Id Arguments
    --ids              : One or more resource IDs. If provided, no other 'Resource Id' arguments
                         should be specified.
    --name -n          : The name of the virtual machine.
    --resource-group -g: Name of resource group.

Global Arguments
    --debug            : Increase logging verbosity to show all debug logs.
    --help -h          : Show this help message and exit.
    --output -o        : Output format.  Allowed values: json, jsonc, list, table, tsv.  Default:
                         table.
    --query            : JMESPath query string. See http://jmespath.org/ for more information and
                         examples.
    --verbose          : Increase logging verbosity. Use --debug for full debug logs.

Examples
    Process to deallocate, generalize, and capture a stopped virtual machine
        az vm deallocate -g my_rg -n my_vm_name
        az vm generalize -g my_rg -n my_vm_name
        az vm capture -g my_rg -n my_vm_name --vhd-name-prefix my_prefix

(env) jasonsha@JasonShaMBP: ~/code/azure-cli/src/azure-cli $ ./az vm deallocate -h

Command
    az vm deallocate: Shuts down the Virtual Machine and releases the compute resources.
        See https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-capture-
        image/ for an end-to-end tutorial.

Arguments

Resource Id Arguments
    --ids              : One or more resource IDs. If provided, no other 'Resource Id' arguments
                         should be specified.
    --name -n          : The name of the virtual machine.
    --resource-group -g: Name of resource group.

Global Arguments
    --debug            : Increase logging verbosity to show all debug logs.
    --help -h          : Show this help message and exit.
    --output -o        : Output format.  Allowed values: json, jsonc, list, table, tsv.  Default:
                         table.
    --query            : JMESPath query string. See http://jmespath.org/ for more information and
                         examples.
    --verbose          : Increase logging verbosity. Use --debug for full debug logs.

Examples
    Process to deallocate, generalize, and capture a stopped virtual machine
        az vm deallocate -g my_rg -n my_vm_name
        az vm generalize -g my_rg -n my_vm_name
        az vm capture -g my_rg -n my_vm_name --vhd-name-prefix my_prefix

```