### PR TITLE
Case insensitive choice lists

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/parameters.py
+++ b/src/azure-cli-core/azure/cli/core/commands/parameters.py
@@ -75,20 +75,13 @@ def get_generic_completion_list(generic_list):
 
 class CaseInsenstiveList(list): # pylint: disable=too-few-public-methods
     def __contains__(self, other):
-        other_lower = other.lower()
-        for val in self:
-            if other_lower == val.lower():
-                return True
-        return False
+        return next((True for x in self if other.lower() == x.lower()), False)
 
 def enum_choice_list(enum_type):
     """ Creates the argparse choices and type kwargs for a supplied enum type. """
     enum_type_values = [x.value for x in enum_type]
     def _type(value):
-        for val in enum_type_values:
-            if val.lower() == value.lower():
-                return val
-        return value
+        return next((x for x in enum_type_values if x.lower() == value.lower()), value)
     params = {
         'choices': CaseInsenstiveList(enum_type_values),
         'type': _type

--- a/src/azure-cli-core/azure/cli/core/commands/parameters.py
+++ b/src/azure-cli-core/azure/cli/core/commands/parameters.py
@@ -25,7 +25,7 @@ def get_location_completion_list(prefix, **kwargs):#pylint: disable=unused-argum
 def location_name_type(name):
     if ' ' in name:
         # if display name is provided, attempt to convert to short form name
-        name = next((l.name for l in get_subscription_locations() if l.display_name == name), name)
+        name = next((l.name for l in get_subscription_locations() if l.display_name.lower() == name.lower()), name)
     return name
 
 def get_one_of_subscription_locations():

--- a/src/azure-cli-core/azure/cli/core/commands/parameters.py
+++ b/src/azure-cli-core/azure/cli/core/commands/parameters.py
@@ -68,19 +68,32 @@ def get_resource_name_completion_list(resource_type=None):
             return [r.name for r in get_resources_in_subscription(resource_type=resource_type)]
     return completer
 
-def get_enum_type_completion_list(enum_type=None):
-    ENUM_MAPPING_KEY = '_value2member_map_'
-    def completer(prefix, action, parsed_args, **kwargs): # pylint: disable=unused-argument
-        return list(enum_type.__dict__[ENUM_MAPPING_KEY].keys())
-    return completer
-
 def get_generic_completion_list(generic_list):
     def completer(prefix, action, parsed_args, **kwargs): # pylint: disable=unused-argument
         return generic_list
     return completer
 
-def get_enum_choices(enum_type):
-    return [x.value for x in enum_type]
+class CaseInsenstiveList(list): # pylint: disable=too-few-public-methods
+    def __contains__(self, other):
+        other_lower = other.lower()
+        for val in self:
+            if other_lower == val.lower():
+                return True
+        return False
+
+def enum_choice_list(enum_type):
+    """ Creates the argparse choices and type kwargs for a supplied enum type. """
+    enum_type_values = [x.value for x in enum_type]
+    def _type(value):
+        for val in enum_type_values:
+            if val.lower() == value.lower():
+                return val
+        return value
+    params = {
+        'choices': CaseInsenstiveList(enum_type_values),
+        'type': _type
+    }
+    return params
 
 class IgnoreAction(argparse.Action): # pylint: disable=too-few-public-methods
     def __call__(self, parser, namespace, values, option_string=None):

--- a/src/azure-cli-core/azure/cli/core/commands/parameters.py
+++ b/src/azure-cli-core/azure/cli/core/commands/parameters.py
@@ -77,13 +77,17 @@ class CaseInsenstiveList(list): # pylint: disable=too-few-public-methods
     def __contains__(self, other):
         return next((True for x in self if other.lower() == x.lower()), False)
 
-def enum_choice_list(enum_type):
-    """ Creates the argparse choices and type kwargs for a supplied enum type. """
-    enum_type_values = [x.value for x in enum_type]
+def enum_choice_list(data):
+    """ Creates the argparse choices and type kwargs for a supplied enum type or list of strings. """
+    # transform enum types, otherwise assume list of string choices
+    try:
+        choices = [x.value for x in data]
+    except AttributeError:
+        choices = data
     def _type(value):
-        return next((x for x in enum_type_values if x.lower() == value.lower()), value)
+        return next((x for x in choices if x.lower() == value.lower()), value) if value else value
     params = {
-        'choices': CaseInsenstiveList(enum_type_values),
+        'choices': CaseInsenstiveList(choices),
         'type': _type
     }
     return params

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_params.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_params.py
@@ -4,7 +4,8 @@
 #---------------------------------------------------------------------------------------------
 #pylint: disable=line-too-long
 
-from azure.cli.core.commands.parameters import (location_type, get_enum_choices, get_resource_name_completion_list)
+from azure.cli.core.commands.parameters import \
+    (location_type, enum_choice_list, get_resource_name_completion_list)
 from azure.cli.core.commands import register_cli_argument
 from azure.mgmt.iothub.models.iot_hub_client_enums import IotHubSku
 from ._factory import iot_hub_service_factory
@@ -26,10 +27,10 @@ register_cli_argument('iot hub create', 'hub_name', completer=None)
 register_cli_argument('iot hub create', 'location', location_type,
                       help='Location of your IoT Hub. Default is the location of target resource group.')
 register_cli_argument('iot hub create', 'sku',
-                      choices=get_enum_choices(IotHubSku),
                       help='Pricing tier for Azure IoT Hub. Default value is F1, which is free. '
                            'Note that only one free IoT Hub instance is allowed in each subscription. '
-                           'Exception will be thrown if free instances exceed one.')
+                           'Exception will be thrown if free instances exceed one.',
+                      **enum_choice_list(IotHubSku))
 register_cli_argument('iot hub create', 'unit', help='Units in your IoT Hub.', type=int)
 
 # Arguments for 'iot hub show-connection-string'

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
@@ -7,7 +7,7 @@
 from azure.mgmt.keyvault.models.key_vault_management_client_enums import (SkuName)
 from azure.cli.core.commands.parameters import (
     get_resource_name_completion_list,
-    name_type)
+    name_type, enum_choice_list)
 from azure.cli.core.commands import register_cli_argument
 import azure.cli.core.commands.arm # pylint: disable=unused-import
 
@@ -19,7 +19,7 @@ register_cli_argument('keyvault', 'spn', help='name of a service principal that 
 register_cli_argument('keyvault', 'upn', help='name of a user principal that will receive permissions')
 
 register_cli_argument('keyvault create', 'vault_name', completer=None)
-register_cli_argument('keyvault create', 'sku', choices=[e.value for e in SkuName])
+register_cli_argument('keyvault create', 'sku', **enum_choice_list(SkuName))
 register_cli_argument('keyvault create', 'no_self_perms', action='store_true', help="If specified, don't add permissions for the current user in the new vault")
 
 register_cli_argument('keyvault set-policy', 'object_id', validator=process_policy_namespace)

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -11,12 +11,13 @@ from azure.mgmt.network.models.network_management_client_enums import \
     (ApplicationGatewaySkuName, ApplicationGatewayCookieBasedAffinity,
      ApplicationGatewayTier, ApplicationGatewayProtocol,
      ApplicationGatewayRequestRoutingRuleType, ExpressRouteCircuitSkuFamily,
-     ExpressRouteCircuitSkuTier, ExpressRouteCircuitPeeringType, IPVersion)
+     ExpressRouteCircuitSkuTier, ExpressRouteCircuitPeeringType, IPVersion, LoadDistribution,
+     ProbeProtocol, TransportProtocol)
 from azure.mgmt.dns.models.dns_management_client_enums import RecordType
 
 from azure.cli.core.commands import CliArgumentType, register_cli_argument, register_extra_cli_argument
 from azure.cli.core.commands.parameters import (location_type, get_resource_name_completion_list,
-                                                get_enum_type_completion_list, tags_type, get_enum_choices,
+                                                enum_choice_list, tags_type,
                                                 get_generic_completion_list)
 from azure.cli.core.commands.validators import MarkSpecifiedAction
 from azure.cli.core.commands.template_create import register_folded_cli_argument
@@ -103,19 +104,15 @@ virtual_network_name_type = CliArgumentType(options_list=('--vnet-name',), metav
 subnet_name_type = CliArgumentType(options_list=('--subnet-name',), metavar='SUBNET_NAME', help='The subnet name.')
 load_balancer_name_type = CliArgumentType(options_list=('--lb-name',), metavar='LB_NAME', help='The load balancer name.', completer=get_resource_name_completion_list('Microsoft.Network/loadBalancers'), id_part='name')
 private_ip_address_type = CliArgumentType(help='Static private IP address to use.', validator=validate_private_ip_address)
-cookie_based_affinity_type = CliArgumentType(type=str.lower, completer=get_enum_type_completion_list(ApplicationGatewayCookieBasedAffinity))
-http_protocol_type = CliArgumentType(type=str.lower, completer=get_enum_type_completion_list(ApplicationGatewayProtocol))
-
-choices_ip_allocation_method = [e.value.lower() for e in IPAllocationMethod]
-choices_private_ip_address_version = [e.value.lower() for e in privateIpAddressVersion]
-choices_ip_address_version = [e.value.lower() for e in IPVersion]
+cookie_based_affinity_type = CliArgumentType(**enum_choice_list(ApplicationGatewayCookieBasedAffinity))
+http_protocol_type = CliArgumentType(**enum_choice_list(ApplicationGatewayProtocol))
 
 register_cli_argument('network', 'subnet_name', subnet_name_type)
 register_cli_argument('network', 'virtual_network_name', virtual_network_name_type, id_part='name')
 register_cli_argument('network', 'network_security_group_name', nsg_name_type, id_part='name')
 register_cli_argument('network', 'private_ip_address', private_ip_address_type)
 register_cli_argument('network', 'private_ip_address_allocation', help=argparse.SUPPRESS)
-register_cli_argument('network', 'private_ip_address_version', choices=choices_private_ip_address_version, type=str.lower)
+register_cli_argument('network', 'private_ip_address_version', **enum_choice_list(privateIpAddressVersion))
 register_cli_argument('network', 'tags', tags_type)
 
 for item in ['lb', 'nic']:
@@ -124,9 +121,9 @@ for item in ['lb', 'nic']:
     register_cli_argument('network {}'.format(item), 'public_ip_address', validator=validate_public_ip_name_or_id)
 
 register_cli_argument('network application-gateway', 'application_gateway_name', name_arg_type, completer=get_resource_name_completion_list('Microsoft.Network/applicationGateways'), id_part='name')
-register_cli_argument('network application-gateway', 'sku_name', completer=get_enum_type_completion_list(ApplicationGatewaySkuName))
-register_cli_argument('network application-gateway', 'sku_tier', completer=get_enum_type_completion_list(ApplicationGatewayTier))
-register_cli_argument('network application-gateway', 'routing_rule_type', completer=get_enum_type_completion_list(ApplicationGatewayRequestRoutingRuleType))
+register_cli_argument('network application-gateway', 'sku_name', **enum_choice_list(ApplicationGatewaySkuName))
+register_cli_argument('network application-gateway', 'sku_tier', **enum_choice_list(ApplicationGatewayTier))
+register_cli_argument('network application-gateway', 'routing_rule_type', **enum_choice_list(ApplicationGatewayRequestRoutingRuleType))
 register_cli_argument('network application-gateway', 'virtual_network_name', virtual_network_name_type)
 register_folded_cli_argument('network application-gateway', 'subnet', 'subnets', parent_name='virtual_network_name', parent_type='Microsoft.Network/virtualNetworks', none_flag_value=None, validator=validate_address_prefixes, completer=get_subnet_completion_list())
 register_folded_cli_argument('network application-gateway', 'public_ip', 'Microsoft.Network/publicIPAddresses', completer=get_resource_name_completion_list('Microsoft.Network/publicIPAddresses'))
@@ -210,14 +207,14 @@ register_cli_argument('network express-route circuit-auth', 'authorization_key',
 
 # Express Route Circuit Peering
 register_cli_argument('network express-route circuit-peering', 'peering_name', name_arg_type, id_part='child_name')
-register_cli_argument('network express-route circuit-peering', 'peering_type', completer=get_enum_type_completion_list(ExpressRouteCircuitPeeringType))
-register_cli_argument('network express-route circuit-peering', 'sku_family', completer=get_enum_type_completion_list(ExpressRouteCircuitSkuFamily))
-register_cli_argument('network express-route circuit-peering', 'sku_tier', completer=get_enum_type_completion_list(ExpressRouteCircuitSkuTier))
+register_cli_argument('network express-route circuit-peering', 'peering_type', **enum_choice_list(ExpressRouteCircuitPeeringType))
+register_cli_argument('network express-route circuit-peering', 'sku_family', **enum_choice_list(ExpressRouteCircuitSkuFamily))
+register_cli_argument('network express-route circuit-peering', 'sku_tier', **enum_choice_list(ExpressRouteCircuitSkuTier))
 
 # Express Route Circuit
 register_cli_argument('network express-route circuit', 'circuit_name', name_arg_type, completer=get_resource_name_completion_list('Microsoft.Network/expressRouteCircuits'), id_part='name')
-register_cli_argument('network express-route circuit', 'sku_family', completer=get_enum_type_completion_list(ExpressRouteCircuitSkuFamily))
-register_cli_argument('network express-route circuit', 'sku_tier', completer=get_enum_type_completion_list(ExpressRouteCircuitSkuTier))
+register_cli_argument('network express-route circuit', 'sku_family', **enum_choice_list(ExpressRouteCircuitSkuFamily))
+register_cli_argument('network express-route circuit', 'sku_tier', **enum_choice_list(ExpressRouteCircuitSkuTier))
 
 # Local Gateway
 register_cli_argument('network local-gateway', 'local_network_gateway_name', name_arg_type, completer=get_resource_name_completion_list('Microsoft.Network/localNetworkGateways'), id_part='name')
@@ -236,7 +233,7 @@ register_folded_cli_argument('network nic create', 'public_ip_address', 'Microso
 register_folded_cli_argument('network nic create', 'subnet', 'subnets', none_flag_value=None, new_flag_value=None, default_value_flag='existingId', parent_name='virtual_network_name', parent_type='Microsoft.Network/virtualNetworks', completer=get_subnet_completion_list())
 register_folded_cli_argument('network nic create', 'network_security_group', 'Microsoft.Network/networkSecurityGroups', new_flag_value=None, default_value_flag='none', completer=get_resource_name_completion_list('Microsoft.Network/networkSecurityGroups'))
 
-register_cli_argument('network nic update', 'enable_ip_forwarding', options_list=('--ip-forwarding',), choices=['true', 'false'])
+register_cli_argument('network nic update', 'enable_ip_forwarding', options_list=('--ip-forwarding',), choices=['true', 'false'], type=str.lower)
 register_cli_argument('network nic update', 'network_security_group', validator=validate_nsg_name_or_id, completer=get_resource_name_completion_list('Microsoft.Network/networkSecurityGroups'))
 
 for item in ['create', 'ip-config update', 'ip-config create']:
@@ -278,13 +275,13 @@ register_cli_argument('network public-ip', 'name', name_arg_type, completer=get_
 register_cli_argument('network public-ip create', 'name', completer=None)
 register_cli_argument('network public-ip create', 'dns_name', validator=process_public_ip_create_namespace)
 register_cli_argument('network public-ip create', 'dns_name_type', help=argparse.SUPPRESS)
-register_cli_argument('network public-ip create', 'allocation_method', choices=choices_ip_allocation_method, type=str.lower)
-register_cli_argument('network public-ip create', 'version', choices=choices_ip_address_version, type=str.lower)
+register_cli_argument('network public-ip create', 'allocation_method', **enum_choice_list(IPAllocationMethod))
+register_cli_argument('network public-ip create', 'version', **enum_choice_list(IPVersion))
 
 # Route Operation
 register_cli_argument('network route-table route', 'route_name', name_arg_type, id_part='child_name', help='Route name')
 register_cli_argument('network route-table route', 'route_table_name', options_list=('--route-table-name',), help='Route table name')
-register_cli_argument('network route-table route', 'next_hop_type', choices=get_enum_choices(RouteNextHopType))
+register_cli_argument('network route-table route', 'next_hop_type', **enum_choice_list(RouteNextHopType))
 
 # Route table
 register_cli_argument('network route-table', 'route_table_name', name_arg_type, completer=get_resource_name_completion_list('Microsoft.Network/routeTables'), id_part='name')
@@ -337,11 +334,11 @@ register_cli_argument('network lb', 'backend_address_pool_name', options_list=('
 register_cli_argument('network lb', 'frontend_ip_name', help='The name of the frontend IP configuration.', completer=get_lb_subresource_completion_list('frontend_ip_configurations'))
 register_cli_argument('network lb', 'floating_ip', help='Enable floating IP.', choices=['true', 'false'], type=str.lower)
 register_cli_argument('network lb', 'idle_timeout', help='Idle timeout in minutes.')
-register_cli_argument('network lb', 'protocol', help='', choices=['udp', 'tcp'], type=str.lower)
+register_cli_argument('network lb', 'protocol', help='', **enum_choice_list(TransportProtocol))
 
 register_cli_argument('network lb create', 'public_ip_dns_name', validator=process_lb_create_namespace)
 register_cli_argument('network lb create', 'dns_name_type', help=argparse.SUPPRESS)
-register_cli_argument('network lb create', 'public_ip_address_allocation', choices=choices_ip_allocation_method, default='dynamic', type=str.lower)
+register_cli_argument('network lb create', 'public_ip_address_allocation', default='dynamic', **enum_choice_list(IPAllocationMethod))
 register_folded_cli_argument('network lb create', 'public_ip_address', 'Microsoft.Network/publicIPAddresses', validator=validate_public_ip_type)
 register_folded_cli_argument('network lb create', 'subnet', 'subnets', parent_name='virtual_network_name', parent_type='Microsoft.Network/virtualNetworks', default_value_flag='none')
 
@@ -352,18 +349,18 @@ register_cli_argument('network lb frontend-ip', 'virtual_network_name', arg_type
 register_cli_argument('network lb probe', 'interval', help='Probing time interval in seconds.')
 register_cli_argument('network lb probe', 'path', help='The endpoint to interrogate (http only).')
 register_cli_argument('network lb probe', 'port', help='The port to interrogate.')
-register_cli_argument('network lb probe', 'protocol', help='The protocol to probe.', choices=['http', 'tcp'], type=str.lower)
+register_cli_argument('network lb probe', 'protocol', help='The protocol to probe.', **enum_choice_list(ProbeProtocol))
 register_cli_argument('network lb probe', 'threshold', help='The number of consecutive probe failures before an instance is deemed unhealthy.')
 
-register_cli_argument('network lb rule', 'load_distribution', help='Affinity rule settings.', choices=['default', 'sourceip', 'sourceipprotocol'], type=str.lower)
+register_cli_argument('network lb rule', 'load_distribution', help='Affinity rule settings.', **enum_choice_list(LoadDistribution))
 
 register_cli_argument('network nsg create', 'name', name_arg_type)
 
 # VPN gateway
 register_cli_argument('network vpn-gateway', 'virtual_network_gateway_name', options_list=('--name', '-n'), completer=get_resource_name_completion_list('Microsoft.Network/virtualNetworkGateways'), id_part='name')
-register_cli_argument('network vpn-gateway create', 'gateway_type', choices=get_enum_choices(gatewayType))
-register_cli_argument('network vpn-gateway create', 'sku', choices=get_enum_choices(sku))
-register_cli_argument('network vpn-gateway create', 'vpn_type', choices=get_enum_choices(vpnType))
+register_cli_argument('network vpn-gateway create', 'gateway_type', **enum_choice_list(gatewayType))
+register_cli_argument('network vpn-gateway create', 'sku', **enum_choice_list(sku))
+register_cli_argument('network vpn-gateway create', 'vpn_type', **enum_choice_list(vpnType))
 register_folded_cli_argument('network vpn-gateway create', 'public_ip_address', 'Microsoft.Network/publicIPAddresses', default_value_flag='existingId', none_flag_value=None, new_flag_value=None, required=True)
 register_cli_argument('network vpn-gateway', 'cert_name', help='Root certificate name', options_list=('--name', '-n'))
 register_cli_argument('network vpn-gateway', 'gateway_name', help='Virtual network gateway name')
@@ -385,7 +382,7 @@ register_cli_argument('network vpn-connection shared-key', 'virtual_network_gate
 # Traffic manager profiles
 register_cli_argument('network traffic-manager profile', 'traffic_manager_profile_name', name_arg_type, id_part='name', completer=get_resource_name_completion_list('Microsoft.Network/trafficManagerProfiles'))
 register_cli_argument('network traffic-manager profile', 'profile_name', name_arg_type, id_part='name', completer=get_resource_name_completion_list('Microsoft.Network/trafficManagerProfiles'))
-register_cli_argument('network traffic-manager profile create', 'routing_method', choices=get_enum_choices(routingMethod), completer=get_enum_type_completion_list(routingMethod))
+register_cli_argument('network traffic-manager profile create', 'routing_method', **enum_choice_list(routingMethod))
 register_cli_argument('network traffic-manager profile check-dns', 'name', name_arg_type, help='DNS prefix to verify availability for.', required=True)
 register_cli_argument('network traffic-manager profile check-dns', 'type', help=argparse.SUPPRESS, default='Microsoft.Network/trafficManagerProfiles')
 
@@ -400,9 +397,9 @@ register_cli_argument('network dns zone', 'zone_name', name_arg_type)
 register_cli_argument('network dns', 'record_set_name', name_arg_type, help='The name of the RecordSet, relative to the name of the zone.')
 register_cli_argument('network dns', 'relative_record_set_name', name_arg_type, help='The name of the RecordSet, relative to the name of the zone.')
 register_cli_argument('network dns', 'zone_name', help='The name of the zone without a terminating dot.')
-register_cli_argument('network dns record-set create', 'record_set_type', options_list=('--type',), choices=get_enum_choices(RecordType), type=str.upper)
+register_cli_argument('network dns record-set create', 'record_set_type', options_list=('--type',), **enum_choice_list(RecordType))
 register_cli_argument('network dns record-set create', 'ttl', default=3600)
-register_cli_argument('network dns', 'record_type', options_list=('--type',), choices=get_enum_choices(RecordType), type=str.upper)
+register_cli_argument('network dns', 'record_type', options_list=('--type',), **enum_choice_list(RecordType))
 register_cli_argument('network dns record', 'record_set_name', options_list=('--record-set-name',))
 register_cli_argument('network dns record txt add', 'value', nargs='+')
 register_cli_argument('network dns record txt remove', 'value', nargs='+')

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -233,7 +233,7 @@ register_folded_cli_argument('network nic create', 'public_ip_address', 'Microso
 register_folded_cli_argument('network nic create', 'subnet', 'subnets', none_flag_value=None, new_flag_value=None, default_value_flag='existingId', parent_name='virtual_network_name', parent_type='Microsoft.Network/virtualNetworks', completer=get_subnet_completion_list())
 register_folded_cli_argument('network nic create', 'network_security_group', 'Microsoft.Network/networkSecurityGroups', new_flag_value=None, default_value_flag='none', completer=get_resource_name_completion_list('Microsoft.Network/networkSecurityGroups'))
 
-register_cli_argument('network nic update', 'enable_ip_forwarding', options_list=('--ip-forwarding',), choices=['true', 'false'], type=str.lower)
+register_cli_argument('network nic update', 'enable_ip_forwarding', options_list=('--ip-forwarding',), **enum_choice_list(['true', 'false']))
 register_cli_argument('network nic update', 'network_security_group', validator=validate_nsg_name_or_id, completer=get_resource_name_completion_list('Microsoft.Network/networkSecurityGroups'))
 
 for item in ['create', 'ip-config update', 'ip-config create']:
@@ -332,7 +332,7 @@ register_cli_argument('network lb', 'frontend_port_range_end', help='Port number
 register_cli_argument('network lb', 'backend_port', help='Port number')
 register_cli_argument('network lb', 'backend_address_pool_name', options_list=('--backend-pool-name',), help='The name of the backend address pool.', completer=get_lb_subresource_completion_list('backend_address_pools'))
 register_cli_argument('network lb', 'frontend_ip_name', help='The name of the frontend IP configuration.', completer=get_lb_subresource_completion_list('frontend_ip_configurations'))
-register_cli_argument('network lb', 'floating_ip', help='Enable floating IP.', choices=['true', 'false'], type=str.lower)
+register_cli_argument('network lb', 'floating_ip', help='Enable floating IP.', **enum_choice_list(['true', 'false']))
 register_cli_argument('network lb', 'idle_timeout', help='Idle timeout in minutes.')
 register_cli_argument('network lb', 'protocol', help='', **enum_choice_list(TransportProtocol))
 

--- a/src/command_modules/azure-cli-redis/azure/cli/command_modules/redis/_params.py
+++ b/src/command_modules/azure-cli-redis/azure/cli/command_modules/redis/_params.py
@@ -6,8 +6,7 @@
 # pylint: disable=line-too-long
 from azure.cli.core.commands.parameters import (
     get_resource_name_completion_list,
-    get_enum_choices,
-    get_enum_type_completion_list,
+    enum_choice_list,
     name_type)
 from azure.cli.core.commands import register_cli_argument
 import azure.cli.core.commands.arm # pylint: disable=unused-import
@@ -48,16 +47,16 @@ class ScheduleEntryList(list):
 
 register_cli_argument('redis', 'name', arg_type=name_type, help='Name of the redis cache.', completer=get_resource_name_completion_list('Microsoft.Cache/redis'), id_part='name')
 register_cli_argument('redis', 'redis_configuration', type=JsonString)
-register_cli_argument('redis', 'reboot_type', completer=get_enum_type_completion_list(RebootType))
-register_cli_argument('redis', 'key_type', choices=[e.value for e in RedisKeyType])
+register_cli_argument('redis', 'reboot_type', **enum_choice_list(RebootType))
+register_cli_argument('redis', 'key_type', **enum_choice_list(RedisKeyType))
 register_cli_argument('redis', 'shard_id', type=int)
 register_cli_argument('redis import-method', 'files', nargs='+')
 
 register_cli_argument('redis patch-schedule set', 'schedule_entries', type=ScheduleEntryList)
 
 register_cli_argument('redis create', 'name', arg_type=name_type, completer=None)
-register_cli_argument('redis create', 'sku_name', choices=[c.lower() for c in get_enum_choices(SkuName)], type=str.lower)
-register_cli_argument('redis create', 'sku_family', choices=[c.lower() for c in get_enum_choices(SkuFamily)], type=str.lower)
+register_cli_argument('redis create', 'sku_name', **enum_choice_list(SkuName))
+register_cli_argument('redis create', 'sku_family', **enum_choice_list(SkuFamily))
 register_cli_argument('redis create', 'sku_capacity', choices=[str(n) for n in range(0, 7)])
 register_cli_argument('redis create', 'enable_non_ssl_port', action='store_true')
 register_cli_argument('redis create', 'tenant_settings', type=JsonString)

--- a/src/command_modules/azure-cli-redis/azure/cli/command_modules/redis/tests/test_redis_params.py
+++ b/src/command_modules/azure-cli-redis/azure/cli/command_modules/redis/tests/test_redis_params.py
@@ -30,9 +30,9 @@ class Test_RedisCache(unittest.TestCase):
         args = mock_echo_args('redis create',
                               '--tenant-settings {\"hello\":1} -g wombat -n asldkj --sku-family c -l westus  --sku-capacity 1  --sku-name basic') # pylint: disable=line-too-long
         subset = set(dict(
-            sku_family='c',
+            sku_family='C',
             sku_capacity='1',
-            sku_name='basic',
+            sku_name='Basic',
             name='asldkj'
             ).items())
 

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
@@ -9,13 +9,12 @@ from argcomplete.completers import FilesCompleter
 from azure.mgmt.resource.resources.models import DeploymentMode
 from azure.cli.core.commands import register_cli_argument, CliArgumentType
 from azure.cli.core.commands.parameters import (ignore_type, resource_group_name_type, tag_type,
-                                                tags_type, get_resource_group_completion_list)
+                                                tags_type, get_resource_group_completion_list,
+                                                enum_choice_list)
 from .custom import get_policy_completion_list, get_policy_assignment_completion_list
 from ._validators import validate_resource_type, validate_parent, resolve_resource_parameters
 
 # BASIC PARAMETER CONFIGURATION
-
-choices_deployment_mode = [e.value.lower() for e in DeploymentMode]
 
 resource_name_type = CliArgumentType(options_list=('--name', '-n'), help='The resource name.')
 
@@ -59,7 +58,7 @@ register_cli_argument('resource group deployment', 'resource_group_name', arg_ty
 register_cli_argument('resource group deployment', 'deployment_name', options_list=('--name', '-n'), required=True, help='The deployment name.')
 register_cli_argument('resource group deployment', 'parameters_file_path', completer=FilesCompleter())
 register_cli_argument('resource group deployment', 'template_file_path', completer=FilesCompleter())
-register_cli_argument('resource group deployment', 'mode', choices=choices_deployment_mode, type=str.lower, help='Incremental (only add resources to resource group) or Complete (remove extra resources from resource group)')
+register_cli_argument('resource group deployment', 'mode', help='Incremental (only add resources to resource group) or Complete (remove extra resources from resource group)', **enum_choice_list(DeploymentMode))
 register_cli_argument('resource group export', 'include_comments', action='store_true')
 register_cli_argument('resource group export', 'include_parameter_default_value', action='store_true')
 register_cli_argument('resource group create', 'resource_group_name', completer=None)

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
@@ -17,6 +17,7 @@ register_cli_argument('ad app', 'reply_urls', nargs='+',
 register_cli_argument('ad app', 'start_date', help='the start date after which password or key would be valid. Default value is current time')
 register_cli_argument('ad app', 'end_date', help='the end date till which password or key is valid. Default value is one year after current time')
 register_cli_argument('ad app', 'key_value', help='the value for the key credentials associated with the application')
+# TODO: Update these with **enum_choice_list(...) when SDK supports proper enums
 register_cli_argument('ad app', 'key_type', choices=['AsymmetricX509Cert', 'Password', 'Symmetric'], default='AsymmetricX509Cert',
                       help='the type of the key credentials associated with the application')
 register_cli_argument('ad app', 'key_usage', choices=['Sign', 'Verify'], default='Verify',

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
@@ -6,6 +6,7 @@
 import azure.cli.core.commands.parameters #pylint: disable=unused-import
 from azure.cli.core.commands import CliArgumentType
 from azure.cli.core.commands import register_cli_argument
+from azure.cli.core.commands.parameters import enum_choice_list
 
 register_cli_argument('ad app', 'application_object_id', options_list=('--object-id',))
 register_cli_argument('ad app', 'display_name', help=' the display name of the application')
@@ -18,10 +19,12 @@ register_cli_argument('ad app', 'start_date', help='the start date after which p
 register_cli_argument('ad app', 'end_date', help='the end date till which password or key is valid. Default value is one year after current time')
 register_cli_argument('ad app', 'key_value', help='the value for the key credentials associated with the application')
 # TODO: Update these with **enum_choice_list(...) when SDK supports proper enums
-register_cli_argument('ad app', 'key_type', choices=['AsymmetricX509Cert', 'Password', 'Symmetric'], default='AsymmetricX509Cert',
-                      help='the type of the key credentials associated with the application')
-register_cli_argument('ad app', 'key_usage', choices=['Sign', 'Verify'], default='Verify',
-                      help='the usage of the key credentials associated with the application.')
+register_cli_argument('ad app', 'key_type', default='AsymmetricX509Cert',
+                      help='the type of the key credentials associated with the application',
+                      **enum_choice_list(['AsymmetricX509Cert', 'Password', 'Symmetric']))
+register_cli_argument('ad app', 'key_usage', default='Verify',
+                      help='the usage of the key credentials associated with the application.',
+                      **enum_choice_list(['Sign', 'Verify']))
 
 sp_name_type = CliArgumentType(
     options_list=('--name', '-n')

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
@@ -170,8 +170,8 @@ for item in ['check-name', 'delete', 'list', 'show', 'show-usage', 'update', 'ke
     register_cli_argument('storage account {}'.format(item), 'account_name', account_name_type, options_list=('--name', '-n'))
 
 register_cli_argument('storage account show-connection-string', 'account_name', account_name_type, options_list=('--name', '-n'))
-register_cli_argument('storage account show-connection-string', 'protocol', help='The default endpoint protocol.', choices=['http', 'https'], type=str.lower)
-register_cli_argument('storage account show-connection-string', 'key_name', options_list=('--key',), help='The key to use.', choices=list(storage_account_key_options.keys()), type=str.lower)
+register_cli_argument('storage account show-connection-string', 'protocol', help='The default endpoint protocol.', **enum_choice_list(['http', 'https']))
+register_cli_argument('storage account show-connection-string', 'key_name', options_list=('--key',), help='The key to use.', **enum_choice_list(list(storage_account_key_options.keys())))
 for item in ['blob', 'file', 'queue', 'table']:
     register_cli_argument('storage account show-connection-string', '{}_endpoint'.format(item), help='Custom endpoint for {}s.'.format(item))
 
@@ -182,18 +182,18 @@ register_cli_argument('storage account create', 'tags', tags_type)
 
 for item in ['create', 'update']:
     register_cli_argument('storage account {}'.format(item), 'sku', help='The storage account SKU.', **enum_choice_list(SkuName))
-    register_cli_argument('storage account {}'.format(item), 'encryption', nargs='+', help='Specifies which service(s) to encrypt.', choices=list(EncryptionServices._attribute_map.keys()), validator=validate_encryption) # pylint: disable=protected-access
+    register_cli_argument('storage account {}'.format(item), 'encryption', nargs='+', help='Specifies which service(s) to encrypt.', validator=validate_encryption, **enum_choice_list(list(EncryptionServices._attribute_map.keys()))) # pylint: disable=protected-access
 
 register_cli_argument('storage account create', 'access_tier', help='Required for StandardBlob accounts. The access tier used for billing. Cannot be set for StandardLRS, StandardGRS, StandardRAGRS, or PremiumLRS account types.', **enum_choice_list(AccessTier))
 register_cli_argument('storage account update', 'access_tier', help='The access tier used for billing StandardBlob accounts. Cannot be set for StandardLRS, StandardGRS, StandardRAGRS, or PremiumLRS account types.', **enum_choice_list(AccessTier))
 register_cli_argument('storage account create', 'custom_domain', help='User domain assigned to the storage account. Name is the CNAME source.', validator=validate_custom_domain)
 register_cli_argument('storage account update', 'custom_domain', help='User domain assigned to the storage account. Name is the CNAME source. Use "" to clear existing value.', validator=validate_custom_domain)
 register_extra_cli_argument('storage account create', 'subdomain', options_list=('--use-subdomain',), help='Specify to enable indirect CNAME validation.', action='store_true')
-register_extra_cli_argument('storage account update', 'subdomain', options_list=('--use-subdomain',), help='Specify whether to use indirect CNAME validation.', choices=['true', 'false'], default=None)
+register_extra_cli_argument('storage account update', 'subdomain', options_list=('--use-subdomain',), help='Specify whether to use indirect CNAME validation.', default=None, **enum_choice_list(['true', 'false']))
 
 register_cli_argument('storage account update', 'tags', tags_type, default=None)
 
-register_cli_argument('storage account keys renew', 'key_name', options_list=('--key',), help='The key to regenerate.', choices=list(storage_account_key_options.keys()), validator=validate_key, type=str.lower)
+register_cli_argument('storage account keys renew', 'key_name', options_list=('--key',), help='The key to regenerate.', validator=validate_key, **enum_choice_list(list(storage_account_key_options.keys())))
 register_cli_argument('storage account keys renew', 'account_name', account_name_type, id_part=None)
 
 register_cli_argument('storage blob', 'blob_name', blob_name_type, options_list=('--name', '-n'))
@@ -213,7 +213,7 @@ register_cli_argument('storage blob copy', 'container_name', container_name_type
 register_cli_argument('storage blob copy', 'blob_name', blob_name_type, options_list=('--destination-blob', '-b'), help='Name of the destination blob. If the exists, it will be overwritten.')
 register_cli_argument('storage blob copy', 'source_lease_id', arg_group='Copy Source')
 
-register_cli_argument('storage blob delete', 'delete_snapshots', choices=list(delete_snapshot_types.keys()), type=str.lower)
+register_cli_argument('storage blob delete', 'delete_snapshots', **enum_choice_list(list(delete_snapshot_types.keys())))
 
 register_cli_argument('storage blob exists', 'blob_name', required=True)
 
@@ -227,16 +227,16 @@ for item in ['download', 'upload']:
 for item in ['update', 'upload']:
     register_content_settings_argument('storage blob {}'.format(item), BlobContentSettings, item == 'update')
 
-register_cli_argument('storage blob upload', 'blob_type', help="Defaults to 'page' for *.vhd files, or 'block' otherwise.", options_list=('--type', '-t'), choices=list(blob_types.keys()), type=str.lower, validator=validate_blob_type)
+register_cli_argument('storage blob upload', 'blob_type', help="Defaults to 'page' for *.vhd files, or 'block' otherwise.", options_list=('--type', '-t'), validator=validate_blob_type, **enum_choice_list(blob_types.keys()))
 register_cli_argument('storage blob upload', 'maxsize_condition', help='The max length in bytes permitted for an append blob.')
 register_cli_argument('storage blob upload', 'validate_content', help='Specifies that an MD5 hash shall be calculated for each chunk of the blob and verified by the service when the chunk has arrived.')
 
 for item in ['file', 'blob']:
-    register_cli_argument('storage {} url'.format(item), 'protocol', help='Protocol to use.', choices=['http', 'https'], default='https', type=str.lower)
+    register_cli_argument('storage {} url'.format(item), 'protocol', help='Protocol to use.', default='https', **enum_choice_list(['http', 'https']))
     register_source_uri_arguments('storage {} copy start'.format(item))
 
 register_cli_argument('storage container', 'container_name', container_name_type, options_list=('--name', '-n'))
-register_cli_argument('storage container', 'public_access', choices=list(public_access_types.keys()), validator=validate_public_access, help='Specifies whether data in the container may be accessed publically. By default, container data is private ("off") to the account owner. Use "blob" to allow public read access for blobs. Use "container" to allow public read and list access to the entire container.')
+register_cli_argument('storage container', 'public_access', validator=validate_public_access, help='Specifies whether data in the container may be accessed publically. By default, container data is private ("off") to the account owner. Use "blob" to allow public read access for blobs. Use "container" to allow public read and list access to the entire container.', **enum_choice_list(public_access_types.keys()))
 
 register_cli_argument('storage container create', 'container_name', container_name_type, options_list=('--name', '-n'), completer=None)
 register_cli_argument('storage container create', 'fail_on_exist', help='Throw an exception if the container already exists.')
@@ -327,9 +327,9 @@ register_cli_argument('storage entity', 'entity', options_list=('--entity', '-e'
 register_cli_argument('storage entity', 'property_resolver', ignore_type)
 register_cli_argument('storage entity', 'select', nargs='+', help='Space separated list of properties to return for each entity.', validator=validate_select)
 
-register_cli_argument('storage entity insert', 'if_exists', choices=['fail', 'merge', 'replace'])
+register_cli_argument('storage entity insert', 'if_exists', **enum_choice_list(['fail', 'merge', 'replace']))
 
-register_cli_argument('storage entity query', 'accept', help='Specifies how much metadata to include in the response payload.', choices=table_payload_formats.keys(), default='minimal', validator=validate_accept)
+register_cli_argument('storage entity query', 'accept', help='Specifies how much metadata to include in the response payload.', default='minimal', validator=validate_accept, **enum_choice_list(table_payload_formats.keys()))
 
 register_cli_argument('storage queue', 'queue_name', queue_name_type, options_list=('--name', '-n'))
 
@@ -377,17 +377,17 @@ register_cli_argument('storage logging update', 'log', help='The operations for 
 register_cli_argument('storage logging update', 'retention', type=int, help='Number of days for which to retain logs. 0 to disable.')
 
 register_cli_argument('storage metrics show', 'services', help='The storage services from which to retrieve metrics info: (b)lob (f)ile (q)ueue (t)able. Can be combined.')
-register_cli_argument('storage metrics show', 'interval', help='Filter the set of metrics to retrieve by time interval.', choices=['hour', 'minute', 'both'])
+register_cli_argument('storage metrics show', 'interval', help='Filter the set of metrics to retrieve by time interval.', **enum_choice_list(['hour', 'minute', 'both']))
 
 register_cli_argument('storage metrics update', 'services', help='The storage service(s) for which to update metrics info: (b)lob (f)ile (q)ueue (t)able. Can be combined.')
-register_cli_argument('storage metrics update', 'hour', help='Update the hourly metrics.', choices=['enable', 'disable'], validator=process_metric_update_namespace)
-register_cli_argument('storage metrics update', 'minute', help='Update the by-minute metrics.', choices=['enable', 'disable'])
-register_cli_argument('storage metrics update', 'api', help='Specify whether to include API in metrics. Applies to both hour and minute metrics if both are specified. Must be specified if hour or minute metrics are enabled and being updated.', choices=['enable', 'disable'])
+register_cli_argument('storage metrics update', 'hour', help='Update the hourly metrics.', validator=process_metric_update_namespace, **enum_choice_list(['true', 'false']))
+register_cli_argument('storage metrics update', 'minute', help='Update the by-minute metrics.', **enum_choice_list(['true', 'false']))
+register_cli_argument('storage metrics update', 'api', help='Specify whether to include API in metrics. Applies to both hour and minute metrics if both are specified. Must be specified if hour or minute metrics are enabled and being updated.', **enum_choice_list(['true', 'false']))
 register_cli_argument('storage metrics update', 'retention', type=int, help='Number of days for which to retain metrics. 0 to disable. Applies to both hour and minute metrics if both are specified.')
 
 register_cli_argument('storage cors', 'max_age', type=int, help='The number of seconds the client/browser should cache a preflight response.', default="0")
 register_cli_argument('storage cors', 'origins', nargs='+', help='List of origin domains that will be allowed via CORS, or "*" to allow all domains.')
-register_cli_argument('storage cors', 'methods', nargs='+', help='List of HTTP methods allowed to be executed by the origin.', choices=['DELETE', 'GET', 'HEAD', 'MERGE', 'POST', 'OPTIONS', 'PUT'], type=str.upper)
+register_cli_argument('storage cors', 'methods', nargs='+', help='List of HTTP methods allowed to be executed by the origin.', **enum_choice_list(['DELETE', 'GET', 'HEAD', 'MERGE', 'POST', 'OPTIONS', 'PUT']))
 register_cli_argument('storage cors', 'allowed_headers', nargs='+', help='List of response headers allowed to be part of the cross-origin request.')
 register_cli_argument('storage cors', 'exposed_headers', nargs='+', help='List of response headers to expose to CORS clients.')
 

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
@@ -9,7 +9,7 @@ from six import u as unicode_string
 
 from azure.cli.core._config import az_config
 from azure.cli.core.commands.parameters import \
-    (ignore_type, tags_type, get_resource_name_completion_list, get_enum_type_completion_list)
+    (ignore_type, tags_type, get_resource_name_completion_list, enum_choice_list)
 import azure.cli.core.commands.arm # pylint: disable=unused-import
 from azure.cli.core.commands import register_cli_argument, register_extra_cli_argument, CliArgumentType
 from azure.cli.core.commands.client_factory import get_data_service_client
@@ -177,15 +177,15 @@ for item in ['blob', 'file', 'queue', 'table']:
 
 register_cli_argument('storage account create', 'account_name', account_name_type, options_list=('--name', '-n'), completer=None)
 
-register_cli_argument('storage account create', 'kind', help='Indicates the type of storage account. (Storage, BlobStorage)', completer=get_enum_type_completion_list(Kind))
+register_cli_argument('storage account create', 'kind', help='Indicates the type of storage account.', **enum_choice_list(Kind))
 register_cli_argument('storage account create', 'tags', tags_type)
 
 for item in ['create', 'update']:
-    register_cli_argument('storage account {}'.format(item), 'sku', help='The storage account SKU. (Standard_LRS, Standard_GRS, Standard_RAGRS, Standard_ZRS, Premium_LRS)', completer=get_enum_type_completion_list(SkuName))
+    register_cli_argument('storage account {}'.format(item), 'sku', help='The storage account SKU.', **enum_choice_list(SkuName))
     register_cli_argument('storage account {}'.format(item), 'encryption', nargs='+', help='Specifies which service(s) to encrypt.', choices=list(EncryptionServices._attribute_map.keys()), validator=validate_encryption) # pylint: disable=protected-access
 
-register_cli_argument('storage account create', 'access_tier', help='Required for StandardBlob accounts. The access tier used for billing. Cannot be set for StandardLRS, StandardGRS, StandardRAGRS, or PremiumLRS account types. (Hot, Cool)', completer=get_enum_type_completion_list(AccessTier))
-register_cli_argument('storage account update', 'access_tier', help='The access tier used for billing StandardBlob accounts. Cannot be set for StandardLRS, StandardGRS, StandardRAGRS, or PremiumLRS account types. (Hot, Cool)', completer=get_enum_type_completion_list(AccessTier))
+register_cli_argument('storage account create', 'access_tier', help='Required for StandardBlob accounts. The access tier used for billing. Cannot be set for StandardLRS, StandardGRS, StandardRAGRS, or PremiumLRS account types.', **enum_choice_list(AccessTier))
+register_cli_argument('storage account update', 'access_tier', help='The access tier used for billing StandardBlob accounts. Cannot be set for StandardLRS, StandardGRS, StandardRAGRS, or PremiumLRS account types.', **enum_choice_list(AccessTier))
 register_cli_argument('storage account create', 'custom_domain', help='User domain assigned to the storage account. Name is the CNAME source.', validator=validate_custom_domain)
 register_cli_argument('storage account update', 'custom_domain', help='User domain assigned to the storage account. Name is the CNAME source. Use "" to clear existing value.', validator=validate_custom_domain)
 register_extra_cli_argument('storage account create', 'subdomain', options_list=('--use-subdomain',), help='Specify to enable indirect CNAME validation.', action='store_true')

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -14,14 +14,13 @@ from azure.mgmt.compute.models import (VirtualHardDisk,
                                        CachingTypes,
                                        ContainerServiceOchestratorTypes,
                                        UpgradeMode)
-from azure.mgmt.network.models import IPAllocationMethod
 from azure.mgmt.storage.models import SkuName
 from azure.cli.core.commands import register_cli_argument, CliArgumentType, register_extra_cli_argument
 from azure.cli.core.commands.arm import is_valid_resource_id
 from azure.cli.core.commands.template_create import register_folded_cli_argument
 from azure.cli.core.commands.parameters import \
     (location_type, get_location_completion_list, get_one_of_subscription_locations,
-     get_resource_name_completion_list, tags_type)
+     get_resource_name_completion_list, tags_type, enum_choice_list)
 from azure.cli.command_modules.vm._actions import \
     (VMImageFieldAction, VMSSHFieldAction, VMDNSNameAction, load_images_from_aliases_doc,
      get_vm_sizes, PrivateIpAction, _resource_not_exists)
@@ -39,13 +38,6 @@ def get_vm_size_completion_list(prefix, action, parsed_args, **kwargs):#pylint: 
         location = get_one_of_subscription_locations()
     result = get_vm_sizes(location)
     return [r.name for r in result]
-
-# CHOICE LISTS
-
-choices_caching_types = [e.value for e in CachingTypes]
-choices_container_service_orchestrator_types = [e.value for e in ContainerServiceOchestratorTypes]
-choices_upgrade_mode = [e.value.lower() for e in UpgradeMode]
-choices_ip_allocation_method = [e.value.lower() for e in IPAllocationMethod]
 
 # REUSABLE ARGUMENT DEFINITIONS
 
@@ -67,7 +59,7 @@ register_cli_argument('vm disk', 'disk_name', options_list=('--name', '-n'), hel
 register_cli_argument('vm disk', 'disk_size', help='Size of disk (GiB)', default=1023, type=int)
 register_cli_argument('vm disk', 'lun', type=int, help='0-based logical unit number (LUN). Max value depends on the Virutal Machine size.')
 register_cli_argument('vm disk', 'vhd', type=VirtualHardDisk, help='virtual hard disk\'s uri. For example:https://mystorage.blob.core.windows.net/vhds/d1.vhd')
-register_cli_argument('vm disk', 'caching', help='Host caching policy', default=CachingTypes.none.value, choices=choices_caching_types)
+register_cli_argument('vm disk', 'caching', help='Host caching policy', default=CachingTypes.none.value, **enum_choice_list(CachingTypes))
 
 for item in ['attach-existing', 'attach-new', 'detach']:
     register_cli_argument('vm disk {}'.format(item), 'vm_name', arg_type=existing_vm_name, options_list=('--vm-name',), id_part=None)
@@ -77,7 +69,7 @@ register_cli_argument('vm availability-set', 'availability_set_name', name_arg_t
 register_cli_argument('vm access', 'username', options_list=('--username', '-u'), help='The user name')
 register_cli_argument('vm access', 'password', options_list=('--password', '-p'), help='The user password')
 
-register_cli_argument('vm container', 'orchestrator_type', choices=choices_container_service_orchestrator_types)
+register_cli_argument('vm container', 'orchestrator_type', **enum_choice_list(ContainerServiceOchestratorTypes))
 register_cli_argument('vm container', 'admin_username', admin_username_type)
 register_cli_argument('vm container', 'ssh_key_value', required=False, help='SSH key file value or key file path.', default=os.path.join(os.path.expanduser('~'), '.ssh', 'id_rsa.pub'), completer=FilesCompleter())
 register_cli_argument('vm container', 'container_service_name', options_list=('--name', '-n'), help='The name of the container service', completer=get_resource_name_completion_list('Microsoft.ContainerService/ContainerServices'))
@@ -173,7 +165,7 @@ for scope in ['vm create', 'vmss create']:
     register_cli_argument(scope, 'os_disk_type', help=argparse.SUPPRESS)
     register_cli_argument(scope, 'os_disk_name', validator=validate_default_os_disk)
     register_cli_argument(scope, 'overprovision', action='store_false', default=None, options_list=('--disable-overprovision',))
-    register_cli_argument(scope, 'upgrade_policy_mode', choices=choices_upgrade_mode, help=None, type=str.lower)
+    register_cli_argument(scope, 'upgrade_policy_mode', help=None, **enum_choice_list(UpgradeMode))
     register_cli_argument(scope, 'os_disk_uri', help=argparse.SUPPRESS)
     register_cli_argument(scope, 'os_offer', help=argparse.SUPPRESS)
     register_cli_argument(scope, 'os_publisher', help=argparse.SUPPRESS)
@@ -182,7 +174,7 @@ for scope in ['vm create', 'vmss create']:
     register_cli_argument(scope, 'os_version', help=argparse.SUPPRESS)
     register_cli_argument(scope, 'dns_name_type', help=argparse.SUPPRESS)
     register_cli_argument(scope, 'admin_username', admin_username_type)
-    register_cli_argument(scope, 'storage_type', help='The VM storage type.', choices=[x.value for x in SkuName])
+    register_cli_argument(scope, 'storage_type', help='The VM storage type.', **enum_choice_list(SkuName))
     register_cli_argument(scope, 'subnet_name', help='The subnet name.  Creates if creating a new VNet, references if referencing an existing VNet.')
     register_cli_argument(scope, 'admin_password', help='Password for the Virtual Machine if Authentication Type is Password.')
     register_cli_argument(scope, 'ssh_key_value', action=VMSSHFieldAction)

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -141,15 +141,15 @@ register_cli_argument('network nic scale-set list', 'virtual_machine_scale_set_n
 # VM CREATE PARAMETER CONFIGURATION
 
 authentication_type = CliArgumentType(
-    choices=['ssh', 'password'], default=None,
+    default=None,
     help='Password or SSH public key authentication. Defaults to password for Windows and SSH public key for Linux.',
-    type=str.lower
+    **enum_choice_list(['ssh', 'password'])
 )
 
 nsg_rule_type = CliArgumentType(
-    choices=['RDP', 'SSH'], default=None,
+    default=None,
     help='Network security group rule to create. Defaults open ports for allowing RDP on Windows and allowing SSH on Linux.',
-    type=str.upper
+    **enum_choice_list(['RDP', 'SSH'])
 )
 
 register_cli_argument('vm create', 'network_interface_type', help=argparse.SUPPRESS)
@@ -186,7 +186,7 @@ for scope in ['vm create', 'vmss create']:
     register_cli_argument(scope, 'virtual_network_ip_address_prefix', options_list=('--vnet-ip-address-prefix',))
     register_cli_argument(scope, 'subnet_ip_address_prefix', options_list=('--subnet-ip-address-prefix',))
     register_cli_argument(scope, 'private_ip_address', help='Static private IP address (e.g. 10.0.0.5).', options_list=('--private-ip-address',), action=PrivateIpAction)
-    register_cli_argument(scope, 'public_ip_address_allocation', choices=['dynamic', 'static'], help='', default='dynamic', type=str.lower)
+    register_cli_argument(scope, 'public_ip_address_allocation', help='', default='dynamic', **enum_choice_list(['dynamic', 'static']))
     register_folded_cli_argument(scope, 'public_ip_address', 'Microsoft.Network/publicIPAddresses')
     register_folded_cli_argument(scope, 'storage_account', 'Microsoft.Storage/storageAccounts', validator=validate_default_storage_account, none_flag_value=None, default_value_flag='existingId')
     register_folded_cli_argument(scope, 'virtual_network', 'Microsoft.Network/virtualNetworks', options_list=('--vnet',), validator=validate_default_vnet, none_flag_value=None, default_value_flag='existingId')

--- a/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/_params.py
+++ b/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/_params.py
@@ -8,7 +8,7 @@ from azure.mgmt.web import WebSiteManagementClient
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.commands.parameters import (resource_group_name_type, location_type,
                                                 get_resource_name_completion_list,
-                                                CliArgumentType, ignore_type)
+                                                CliArgumentType, ignore_type, enum_choice_list)
 
 # FACTORIES
 def web_client_factory(**_):
@@ -38,9 +38,8 @@ def get_hostname_completion_list(prefix, action, parsed_args, **kwargs): # pylin
 #pylint: disable=line-too-long
 # PARAMETER REGISTRATION
 name_arg_type = CliArgumentType(options_list=('--name', '-n'), metavar='NAME')
-sku_arg_type = CliArgumentType(type=str.upper,
-                               choices=['F1', 'FREE', 'D1', 'SHARED', 'B1', 'B2', 'B3', 'S1', 'S2', 'S3', 'P1', 'P2', 'P3'],
-                               help='The pricing tiers, e.g., F1(Free), D1(Shared), B1(Basic Small), B2(Basic Medium), B3(Basic Large), S1(Standard Small), P1(Premium Small), etc')
+sku_arg_type = CliArgumentType(help='The pricing tiers, e.g., F1(Free), D1(Shared), B1(Basic Small), B2(Basic Medium), B3(Basic Large), S1(Standard Small), P1(Premium Small), etc',
+                               **enum_choice_list(['F1', 'FREE', 'D1', 'SHARED', 'B1', 'B2', 'B3', 'S1', 'S2', 'S3', 'P1', 'P2', 'P3']))
 
 register_cli_argument('appservice', 'resource_group_name', arg_type=resource_group_name_type)
 register_cli_argument('appservice', 'location', arg_type=location_type)
@@ -67,20 +66,14 @@ register_cli_argument('appservice web deployment slot', 'webapp', help='Name of 
 register_cli_argument('appservice web deployment slot', 'auto_swap_slot', help='target slot to swap', default='production')
 register_cli_argument('appservice web deployment slot', 'disable', help='disable auto swap', action='store_true')
 
-two_states_switch = [True, False]
-def two_states_switch_type(value=None):
-    if value is None:
-        return None
-    if value.lower() in ['true', 'false']:
-        return value.lower() == 'true'
-    return value
+two_states_switch = ['true', 'false']
 
-register_cli_argument('appservice web log set', 'application_logging', choices=two_states_switch, type=two_states_switch_type, help='configure application logging to file system')
-register_cli_argument('appservice web log set', 'detailed_error_messages', choices=two_states_switch, type=two_states_switch_type, help='configure detailed error messages')
-register_cli_argument('appservice web log set', 'failed_request_tracing', choices=two_states_switch, type=two_states_switch_type, help='configure failed request tracing')
-register_cli_argument('appservice web log set', 'level', choices=['error', 'warning', 'information', 'verbose'], type=str.lower, help='logging level')
+register_cli_argument('appservice web log set', 'application_logging', help='configure application logging to file system', **enum_choice_list(two_states_switch))
+register_cli_argument('appservice web log set', 'detailed_error_messages', help='configure detailed error messages', **enum_choice_list(two_states_switch))
+register_cli_argument('appservice web log set', 'failed_request_tracing', help='configure failed request tracing', **enum_choice_list(two_states_switch))
+register_cli_argument('appservice web log set', 'level', help='logging level', **enum_choice_list(['error', 'warning', 'information', 'verbose']))
 server_log_switch_options = ['off', 'storage', 'filesystem']
-register_cli_argument('appservice web log set', 'web_server_logging', choices=server_log_switch_options, type=str.lower, help='configure Web server logging')
+register_cli_argument('appservice web log set', 'web_server_logging', help='configure Web server logging', **enum_choice_list(server_log_switch_options))
 
 register_cli_argument('appservice web log tail', 'provider', help="scope the live traces to certain providers/folders, for example:'application', 'http' for server log, 'kudu/trace', etc")
 register_cli_argument('appservice web log download', 'log_file', default='webapp_logs.zip', help='the downloaded zipped log file path')
@@ -88,11 +81,11 @@ register_cli_argument('appservice web log download', 'log_file', default='webapp
 register_cli_argument('appservice web config appsettings', 'settings', nargs='+', help="space separated app settings in a format of <name>=<value>")
 register_cli_argument('appservice web config appsettings', 'setting_names', nargs='+', help="space separated app setting names")
 
-register_cli_argument('appservice web config update', 'remote_debugging_enabled', choices=two_states_switch, type=two_states_switch_type, help='enable or disable remote debugging')
-register_cli_argument('appservice web config update', 'web_sockets_enabled', choices=two_states_switch, type=two_states_switch_type, help='enable or disable web sockets')
-register_cli_argument('appservice web config update', 'always_on', choices=two_states_switch, type=two_states_switch_type, help='ensure webapp gets loaded all the time, rather unloaded after been idle. Recommended when you have continuous web jobs running')
-register_cli_argument('appservice web config update', 'auto_heal_enabled', choices=two_states_switch, type=two_states_switch_type, help='enable or disable auto heal')
-register_cli_argument('appservice web config update', 'use32_bit_worker_process', options_list=('--use-32bit-worker-process',), choices=two_states_switch, type=two_states_switch_type, help='use 32 bits worker process or not')
+register_cli_argument('appservice web config update', 'remote_debugging_enabled', help='enable or disable remote debugging', **enum_choice_list(two_states_switch))
+register_cli_argument('appservice web config update', 'web_sockets_enabled', help='enable or disable web sockets', **enum_choice_list(two_states_switch))
+register_cli_argument('appservice web config update', 'always_on', help='ensure webapp gets loaded all the time, rather unloaded after been idle. Recommended when you have continuous web jobs running', **enum_choice_list(two_states_switch))
+register_cli_argument('appservice web config update', 'auto_heal_enabled', help='enable or disable auto heal', **enum_choice_list(two_states_switch))
+register_cli_argument('appservice web config update', 'use32_bit_worker_process', options_list=('--use-32bit-worker-process',), help='use 32 bits worker process or not', **enum_choice_list(two_states_switch))
 register_cli_argument('appservice web config update', 'php_version', help='The version used to run your web app if using PHP, e.g., 5.5, 5.6, 7.0')
 register_cli_argument('appservice web config update', 'python_version', help='The version used to run your web app if using Python, e.g., 2.7, 3.4')
 register_cli_argument('appservice web config update', 'net_framework_version', help="The version used to run your web app if using .NET Framework, e.g., 'v4.0' for .NET 4.6 and 'v3.0' for .NET 3.5")


### PR DESCRIPTION
Fixes #829.  We had a lot of wonkiness centered around choice lists within the CLI. Due to confusion on the meaning of "modelAsString" some enums were exposed as completers, others had a choice list without the 'str.lower' component to make them case insensitve, etc. Also, that approach generally destroyed the case information when displayed in help so an enum value that was `MixedCasedForReadabilty` would appear as `mixedcaseforreadability`.

This PR creates a simple way of exposing SDK-style enums.
```Python
from azure.cli.core.commands.parameters import enum_choice_list
register_cli_argument('scope', 'dest', **enum_choice_list(MyEnum))
```

This essentially adds a consistent `choices` entry that does a case insensitive comparison of the value against the enum values, as well as a standard `type` that returns the correct-case string from the enum when matched. This ensures that:

1. matching is purely case-insensitve
2. help retains the proper mixed casing format from the SDK
3. parameters which are case sensitive on the server receive values with the correct casing