### PR TITLE
Use APT repository instead of Azure Storage blob container & update docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,10 +32,10 @@ A Debian package is also available. Install as follows:
 
 .. code-block:: console
 
-   $ echo "deb https://azurecliprod.blob.core.windows.net/repos/apt/debian wheezy main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
-   $ curl https://azurecliprod.blob.core.windows.net/azure-cli-preview.gpg.key | sudo apt-key add -
-   $ sudo apt-get update && sudo apt-get install azure-cli
-
+    $ echo "deb https://apt-mo.trafficmanager.net/repos/azure-cli/ wheezy main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
+    $ sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893
+    $ sudo apt-get install apt-transport-https
+    $ sudo apt-get update && sudo apt-get install azure-cli
 
 We also maintain a docker image preconfigured with the Azure CLI.
 

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ For those familiar with pip, use the following:
 
    $ pip install azure-cli
 
-A Debian package is also available. Install as follows:
+A Debian/Ubuntu package is also available. Install as follows:
 
 .. code-block:: console
 


### PR DESCRIPTION
- Also, I've added the '$ sudo apt-get install apt-transport-https' though on Ubuntu it should come already installed and you'd just get 'apt-transport-https is already the newest version.'.