### PR TITLE
[VMSS] Temporarily override api-version for 'vmss nic' operations

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/client_factory.py
+++ b/src/azure-cli-core/azure/cli/core/commands/client_factory.py
@@ -14,8 +14,9 @@ logger = _logging.get_az_logger(__name__)
 
 UA_AGENT = "AZURECLI/{}".format(core_version)
 
-def get_mgmt_service_client(client_type, subscription_id=None):
-    client, _ = _get_mgmt_service_client(client_type, subscription_id=subscription_id)
+def get_mgmt_service_client(client_type, subscription_id=None, api_version=None):
+    client, _ = _get_mgmt_service_client(client_type, subscription_id=subscription_id,
+                                         api_version=api_version)
     return client
 
 def get_subscription_service_client(client_type):
@@ -38,14 +39,17 @@ def configure_common_settings(client):
     client.config.generate_client_request_id = \
         'x-ms-client-request-id' not in APPLICATION.session['headers']
 
-def _get_mgmt_service_client(client_type, subscription_bound=True, subscription_id=None):
+def _get_mgmt_service_client(client_type, subscription_bound=True, subscription_id=None,
+                             api_version=None):
     logger.info('Getting management service client client_type=%s', client_type.__name__)
     profile = Profile()
     cred, subscription_id, _ = profile.get_login_credentials(subscription_id=subscription_id)
     if subscription_bound:
-        client = client_type(cred, subscription_id)
+        client = client_type(cred, subscription_id, api_version=api_version) \
+            if api_version else client_type(cred, subscription_id)
     else:
-        client = client_type(cred)
+        client = client_type(cred, api_version=api_version) \
+            if api_version else client_type(cred)
 
     configure_common_settings(client)
 

--- a/src/azure-cli-core/azure/cli/core/utils/vcr_test_base.py
+++ b/src/azure-cli-core/azure/cli/core/utils/vcr_test_base.py
@@ -40,14 +40,17 @@ MOCKED_STORAGE_ACCOUNT = 'dummystorage'
 
 # MOCK METHODS
 
-def _mock_get_mgmt_service_client(client_type, subscription_bound=True, subscription_id=None):
+def _mock_get_mgmt_service_client(client_type, subscription_bound=True, subscription_id=None,
+                                  api_version=None):
     # version of _get_mgmt_service_client to use when recording or playing tests
     profile = Profile()
     cred, subscription_id, _ = profile.get_login_credentials(subscription_id=subscription_id)
     if subscription_bound:
-        client = client_type(cred, subscription_id)
+        client = client_type(cred, subscription_id, api_version=api_version) \
+            if api_version else client_type(cred, subscription_id)
     else:
-        client = client_type(cred)
+        client = client_type(cred, api_version=api_version) \
+            if api_version else client_type(cred)
 
     _debug.allow_debug_connection(client)
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/generated.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/generated.py
@@ -75,10 +75,14 @@ cli_command('vm nic delete', vm_delete_nics)
 cli_command('vm nic update', vm_update_nics)
 
 # VMSS NIC
-factory = lambda _: get_mgmt_service_client(NetworkManagementClient).network_interfaces
-cli_command('vmss nic list-vm-nics', NetworkInterfacesOperations.list_virtual_machine_scale_set_vm_network_interfaces, factory)
+# TODO: Remove hard coded api-version once https://github.com/Azure/azure-rest-api-specs/issues/570
+# is fixed.
+factory = lambda _: get_mgmt_service_client(NetworkManagementClient, api_version='2016-03-30').network_interfaces
 cli_command('vmss nic list', NetworkInterfacesOperations.list_virtual_machine_scale_set_network_interfaces, factory)
+cli_command('vmss nic list-vm-nics', NetworkInterfacesOperations.list_virtual_machine_scale_set_vm_network_interfaces, factory)
 cli_command('vmss nic show', NetworkInterfacesOperations.get_virtual_machine_scale_set_network_interface, factory)
+
+
 
 # VM Access
 cli_command('vm access set-linux-user', set_linux_user)


### PR DESCRIPTION
Fixes #956. This is a workaround only until https://github.com/Azure/azure-rest-api-specs/issues/570 is fixed.