### PR TITLE
[Help] Fix argument group ordering.

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_help.py
+++ b/src/azure-cli-core/azure/cli/core/_help.py
@@ -132,9 +132,9 @@ class ArgumentGroupRegistry(object): # pylint: disable=too-few-public-methods
             'Global Arguments': 1000,
             }
         priority = 2
-        # get alphabetical list of groups and ensure they are in the group priority dictionary
-        group_list = sorted(list(set(group_list)))
-        for group in [g for g in group_list if g not in self.priorities]:
+        # any groups not already in the static dictionary should be prioritized alphabetically
+        other_groups = [g for g in sorted(list(set(group_list))) if g not in self.priorities]
+        for group in other_groups:
             self.priorities[group] = priority
             priority += 1
 

--- a/src/azure-cli-core/azure/cli/core/_help.py
+++ b/src/azure-cli-core/azure/cli/core/_help.py
@@ -82,8 +82,12 @@ def print_arguments(help_file):
     max_name_length = max(len(p.name) + (len(required_tag) if p.required else 0)
                           for p in help_file.parameters)
     last_group_name = None
+
+    group_registry = ArgumentGroupRegistry(
+        [p.group_name for p in help_file.parameters if p.group_name])
+
     for p in sorted(help_file.parameters,
-                    key=lambda p: get_group_priority(p.group_name)
+                    key=lambda p: group_registry.get_group_priority(p.group_name)
                     + str(not p.required) + p.name):
         indent = 1
         required_text = required_tag if p.required else ''
@@ -117,15 +121,26 @@ def print_arguments(help_file):
 
     return indent
 
-def get_group_priority(group_name):
-    priorities = {
-        None: 0,
-        'Generic Update Arguments': 5,
-        'Resource Id Arguments': 10,
-        'Global Arguments': 1000,
-        }
-    key = priorities.get(group_name, 1)
-    return "%06d" % key
+class ArgumentGroupRegistry(object): # pylint: disable=too-few-public-methods
+
+    def __init__(self, group_list):
+
+        self.priorities = {
+            None: 0,
+            'Resource Id Arguments': 1,
+            'Generic Update Arguments': 998,
+            'Global Arguments': 1000,
+            }
+        priority = 2
+        # get alphabetical list of groups and ensure they are in the group priority dictionary
+        group_list = sorted(list(set(group_list)))
+        for group in [g for g in group_list if g not in self.priorities]:
+            self.priorities[group] = priority
+            priority += 1
+
+    def get_group_priority(self, group_name):
+        key = self.priorities.get(group_name, 0)
+        return "%06d" % key
 
 def _print_header(help_file):
     indent = 0

--- a/src/azure-cli-core/azure/cli/core/tests/test_help.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_help.py
@@ -14,6 +14,7 @@ from azure.cli.core.application import Application, APPLICATION, Configuration
 from azure.cli.core.commands import CliCommand
 import azure.cli.core.help_files
 import azure.cli.core._help as _help
+from azure.cli.core._help import ArgumentGroupRegistry
 
 io = {}
 def redirect_io(func):
@@ -27,6 +28,25 @@ def redirect_io(func):
         sys.stdout = old_stdout
         sys.stderr = old_stderr
     return wrapper
+
+class HelpArgumentGroupRegistryTest(unittest.TestCase):
+    def test_help_argument_group_registry(self):
+        groups = [
+            'Resource Id Arguments',
+            'Z Arguments',
+            'B Arguments',
+            'Global Arguments',
+            'A Arguments',
+            'Generic Update Arguments',
+            'Resource Id Arguments'
+        ]
+        group_registry = ArgumentGroupRegistry(groups)
+        self.assertEqual(group_registry.get_group_priority('A Arguments'), '000002')
+        self.assertEqual(group_registry.get_group_priority('B Arguments'), '000003')
+        self.assertEqual(group_registry.get_group_priority('Z Arguments'), '000004')
+        self.assertEqual(group_registry.get_group_priority('Resource Id Arguments'), '000001')
+        self.assertEqual(group_registry.get_group_priority('Generic Update Arguments'), '000998')
+        self.assertEqual(group_registry.get_group_priority('Global Arguments'), '001000')
 
 class HelpObjectTest(unittest.TestCase):
     def test_short_summary_no_fullstop(self):


### PR DESCRIPTION
Fixes #976. Previously any group not within the static "priorities" dictionary in the _help.py file was assigned a priority of 1, meaning many groups shared the same priority. When the parameters were then sorted alphabetically, it could result in multiple group labels being printed. This solution ensures argument groups not in the static dictionary (a) don't need to be added and (b) don't have overlapping priorities.