### PR TITLE
[Help] Fix inherited line breaks in help long summary

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_help.py
+++ b/src/azure-cli-core/azure/cli/core/_help.py
@@ -229,7 +229,8 @@ class HelpFile(HelpObject): #pylint: disable=too-few-public-methods,too-many-ins
         description = getattr(options, 'description', None)
         try:
             self.short_summary = description[:description.index('.')]
-            self.long_summary = description[description.index('.') + 1:].lstrip()
+            long_summary = description[description.index('.') + 1:].lstrip()
+            self.long_summary = ' '.join(long_summary.splitlines())
         except (ValueError, AttributeError):
             self.short_summary = description
 


### PR DESCRIPTION
Fixes #811.