### PR TITLE
webapp: support hostname

### DIFF
--- a/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/_help.py
+++ b/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/_help.py
@@ -26,3 +26,18 @@ helps['appservice plan create'] = """
     type: command
     short-summary: create a new plan
 """
+
+helps['appservice web config hostname add'] = """
+    type: command
+    short-summary: bind a hostname(custom domain) to the app
+"""
+
+helps['appservice web config hostname delete'] = """
+    type: command
+    short-summary: unbind a hostname(custom domain) from the app
+"""
+
+helps['appservice web config hostname list'] = """
+    type: command
+    short-summary: list all hostname bindings
+"""

--- a/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/_params.py
+++ b/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/_params.py
@@ -35,7 +35,7 @@ register_cli_argument('appservice plan', 'admin_site_name', help='The name of th
 register_cli_argument('appservice web', 'slot', help="the name of the slot. Default to the productions slot if not specified")
 register_cli_argument('appservice web', 'name', arg_type=name_arg_type, completer=get_resource_name_completion_list('Microsoft.Web/sites'), id_part='name')
 register_cli_argument('appservice web create', 'name', options_list=('--name', '-n'), help='name of the new webapp')
-register_cli_argument('appservice web create', 'plan',  options_list=('--plan',), completer=get_resource_name_completion_list('Microsoft.Web/serverFarms'),
+register_cli_argument('appservice web create', 'plan', options_list=('--plan',), completer=get_resource_name_completion_list('Microsoft.Web/serverFarms'),
                       help="name or resource id of the app service plan. Use 'appservice plan create' to get one")
 
 register_cli_argument('appservice web deployment user', 'user_name', help='user name')

--- a/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/_params.py
+++ b/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/_params.py
@@ -14,36 +14,17 @@ from azure.cli.core.commands.parameters import (resource_group_name_type, locati
 def web_client_factory(**_):
     return get_mgmt_service_client(WebSiteManagementClient)
 
-def list_webapp_names(prefix, action, parsed_args, **kwargs):#pylint: disable=unused-argument
-    if parsed_args.resource_group_name:
-        client = web_client_factory()
-        #pylint: disable=no-member
-        result = client.sites.get_sites(parsed_args.resource_group_name).value
-        return [x.name for x in result]
-
-def list_app_service_plan_names(prefix, action, parsed_args, **kwargs):#pylint: disable=unused-argument
-    if parsed_args.resource_group_name:
-        client = web_client_factory()
-        #pylint: disable=no-member
-        result = client.server_farms.get_server_farms(parsed_args.resource_group_name).value
-        return [x.name for x in result]
-
 #pylint: disable=line-too-long
 # PARAMETER REGISTRATION
 name_arg_type = CliArgumentType(options_list=('--name', '-n'), metavar='NAME')
-existing_plan_name = CliArgumentType(overrides=name_arg_type, help='The name of the app service plan', completer=get_resource_name_completion_list('Microsoft.Web/serverFarms'), id_part='name')
-existing_webapp_name = CliArgumentType(overrides=name_arg_type, help='The name of the web app', completer=get_resource_name_completion_list('Microsoft.Web/sites'), id_part='name')
 sku_arg_type = CliArgumentType(type=str.upper,
                                choices=['F1', 'FREE', 'D1', 'SHARED', 'B1', 'B2', 'B3', 'S1', 'S2', 'S3', 'P1', 'P2', 'P3'],
                                help='The pricing tiers, e.g., F1(Free), D1(Shared), B1(Basic Small), B2(Basic Medium), B3(Basic Large), S1(Standard Small), P1(Premium Small), etc')
 
-register_cli_argument('appservice web', 'resource_group', arg_type=resource_group_name_type)
-register_cli_argument('appservice web', 'location', arg_type=location_type)
-register_cli_argument('appservice web', 'slot', help="the name of the slot. Default to the productions slot if not specified")
+register_cli_argument('appservice', 'resource_group_name', arg_type=resource_group_name_type)
+register_cli_argument('appservice', 'location', arg_type=location_type)
 
-register_cli_argument('appservice plan', 'resource_group', arg_type=resource_group_name_type)
-register_cli_argument('appservice plan', 'location', arg_type=location_type)
-register_cli_argument('appservice plan', 'name', arg_type=existing_plan_name)
+register_cli_argument('appservice plan', 'name', arg_type=name_arg_type, help='The name of the app service plan', completer=get_resource_name_completion_list('Microsoft.Web/serverFarms'), id_part='name')
 register_cli_argument('appservice plan create', 'name', options_list=('--name', '-n'), help="Name of the new app service plan")
 register_cli_argument('appservice plan create', 'sku', arg_type=sku_arg_type, default='B1')
 register_cli_argument('appservice plan update', 'sku', arg_type=sku_arg_type)
@@ -51,9 +32,10 @@ register_cli_argument('appservice plan update', 'allow_pending_state', ignore_ty
 register_cli_argument('appservice plan', 'number_of_workers', help='Number of workers to be allocated.', type=int, default=1)
 register_cli_argument('appservice plan', 'admin_site_name', help='The name of the admin web app.')
 
-register_cli_argument('appservice web', 'name', arg_type=existing_webapp_name)
+register_cli_argument('appservice web', 'slot', help="the name of the slot. Default to the productions slot if not specified")
+register_cli_argument('appservice web', 'name', arg_type=name_arg_type, completer=get_resource_name_completion_list('Microsoft.Web/sites'), id_part='name')
 register_cli_argument('appservice web create', 'name', options_list=('--name', '-n'), help='name of the new webapp')
-register_cli_argument('appservice web create', 'plan', arg_type=existing_plan_name, options_list=('--plan',),
+register_cli_argument('appservice web create', 'plan',  options_list=('--plan',), completer=get_resource_name_completion_list('Microsoft.Web/serverFarms'),
                       help="name or resource id of the app service plan. Use 'appservice plan create' to get one")
 
 register_cli_argument('appservice web deployment user', 'user_name', help='user name')

--- a/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/_params.py
+++ b/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/_params.py
@@ -26,17 +26,14 @@ def _generic_site_operation(resource_group_name, name, operation_name, slot=None
         return (m(resource_group_name, name, slot)
                 if extra_parameter is None else m(resource_group_name, name, extra_parameter, slot))
 
-def get_hostname_completion_list():
-    def completer(prefix, action, parsed_args, **kwargs): # pylint: disable=unused-argument
-        if parsed_args.resource_group_name and parsed_args.webapp:
-            rg = parsed_args.resource_group_name
-            webapp = parsed_args.webapp
-            slot = getattr(parsed_args, 'slot', None)
-            result = _generic_site_operation(rg, webapp, 'get_site_host_name_bindings', slot)
-            #workaround an api defect, that 'name' is '<webapp>/<hostname>' 
-            return [r.name.split('/', 1)[1] for r in result]
-    return completer
-
+def get_hostname_completion_list(prefix, action, parsed_args, **kwargs): # pylint: disable=unused-argument
+    if parsed_args.resource_group_name and parsed_args.webapp:
+        rg = parsed_args.resource_group_name
+        webapp = parsed_args.webapp
+        slot = getattr(parsed_args, 'slot', None)
+        result = _generic_site_operation(rg, webapp, 'get_site_host_name_bindings', slot)
+        #workaround an api defect, that 'name' is '<webapp>/<hostname>'
+        return [r.name.split('/', 1)[1] for r in result]
 
 #pylint: disable=line-too-long
 # PARAMETER REGISTRATION
@@ -104,4 +101,4 @@ register_cli_argument('appservice web config update', 'java_container', help="Th
 register_cli_argument('appservice web config update', 'java_container_version', help="The version of the java container, e.g., '8.0.23' for Tomcat")
 
 register_cli_argument('appservice web config hostname', 'webapp', help="webapp name", completer=get_resource_name_completion_list('Microsoft.Web/sites'), id_part='name')
-register_cli_argument('appservice web config hostname', 'name', arg_type=name_arg_type, completer=get_hostname_completion_list(), help="hostname assigned to the site, such as custom domains", id_part='child_name')
+register_cli_argument('appservice web config hostname', 'name', arg_type=name_arg_type, completer=get_hostname_completion_list, help="hostname assigned to the site, such as custom domains", id_part='child_name')

--- a/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/_params.py
+++ b/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/_params.py
@@ -7,6 +7,7 @@ from azure.cli.core.commands import register_cli_argument
 from azure.mgmt.web import WebSiteManagementClient
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.commands.parameters import (resource_group_name_type, location_type,
+                                                get_resource_name_completion_list,
                                                 CliArgumentType, ignore_type)
 
 # FACTORIES
@@ -30,8 +31,8 @@ def list_app_service_plan_names(prefix, action, parsed_args, **kwargs):#pylint: 
 #pylint: disable=line-too-long
 # PARAMETER REGISTRATION
 name_arg_type = CliArgumentType(options_list=('--name', '-n'), metavar='NAME')
-existing_plan_name = CliArgumentType(overrides=name_arg_type, help='The name of the app service plan', completer=list_app_service_plan_names, id_part='name')
-existing_webapp_name = CliArgumentType(overrides=name_arg_type, help='The name of the web app', completer=list_webapp_names, id_part='name')
+existing_plan_name = CliArgumentType(overrides=name_arg_type, help='The name of the app service plan', completer=get_resource_name_completion_list('Microsoft.Web/serverFarms'), id_part='name')
+existing_webapp_name = CliArgumentType(overrides=name_arg_type, help='The name of the web app', completer=get_resource_name_completion_list('Microsoft.Web/sites'), id_part='name')
 sku_arg_type = CliArgumentType(type=str.upper,
                                choices=['F1', 'FREE', 'D1', 'SHARED', 'B1', 'B2', 'B3', 'S1', 'S2', 'S3', 'P1', 'P2', 'P3'],
                                help='The pricing tiers, e.g., F1(Free), D1(Shared), B1(Basic Small), B2(Basic Medium), B3(Basic Large), S1(Standard Small), P1(Premium Small), etc')
@@ -52,7 +53,8 @@ register_cli_argument('appservice plan', 'admin_site_name', help='The name of th
 
 register_cli_argument('appservice web', 'name', arg_type=existing_webapp_name)
 register_cli_argument('appservice web create', 'name', options_list=('--name', '-n'), help='name of the new webapp')
-register_cli_argument('appservice web create', 'plan', help="name or resource id of the app service plan. Use 'appservice plan create' to get one")
+register_cli_argument('appservice web create', 'plan', arg_type=existing_plan_name, options_list=('--plan',),
+                      help="name or resource id of the app service plan. Use 'appservice plan create' to get one")
 
 register_cli_argument('appservice web deployment user', 'user_name', help='user name')
 register_cli_argument('appservice web deployment user', 'password', help='password, will prompt if not specified')
@@ -88,10 +90,11 @@ register_cli_argument('appservice web config update', 'web_sockets_enabled', cho
 register_cli_argument('appservice web config update', 'always_on', choices=two_states_switch, type=two_states_switch_type, help='ensure webapp gets loaded all the time, rather unloaded after been idle. Recommended when you have continuous web jobs running')
 register_cli_argument('appservice web config update', 'auto_heal_enabled', choices=two_states_switch, type=two_states_switch_type, help='enable or disable auto heal')
 register_cli_argument('appservice web config update', 'use32_bit_worker_process', options_list=('--use-32bit-worker-process',), choices=two_states_switch, type=two_states_switch_type, help='use 32 bits worker process or not')
-
 register_cli_argument('appservice web config update', 'php_version', help='The version used to run your web app if using PHP, e.g., 5.5, 5.6, 7.0')
 register_cli_argument('appservice web config update', 'python_version', help='The version used to run your web app if using Python, e.g., 2.7, 3.4')
 register_cli_argument('appservice web config update', 'net_framework_version', help="The version used to run your web app if using .NET Framework, e.g., 'v4.0' for .NET 4.6 and 'v3.0' for .NET 3.5")
 register_cli_argument('appservice web config update', 'java_version', help="The version used to run your web app if using Java, e.g., '1.7' for Java 7, '1.8' for Java 8")
 register_cli_argument('appservice web config update', 'java_container', help="The java container, e.g., Tomcat, Jetty")
 register_cli_argument('appservice web config update', 'java_container_version', help="The version of the java container, e.g., '8.0.23' for Tomcat")
+
+register_cli_argument('appservice web config hostname', 'hostname', help="hostname assigned to the site, such as custom domains")

--- a/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/custom.py
+++ b/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/custom.py
@@ -99,7 +99,8 @@ def update_site_configs(resource_group_name, name, slot=None,
     return _generic_site_operation(resource_group_name, name, 'update_site_config', slot, configs)
 
 def update_app_settings(resource_group_name, name, settings, slot=None):
-    app_settings = _generic_site_operation(resource_group_name, name, 'list_site_app_settings', slot)
+    app_settings = _generic_site_operation(resource_group_name, name,
+                                           'list_site_app_settings', slot)
     for name_value in settings:
         #split at the first '=', appsetting should not have '=' in the name
         settings_name, value = name_value.split('=', 1)
@@ -110,7 +111,8 @@ def update_app_settings(resource_group_name, name, settings, slot=None):
     return result.properties
 
 def delete_app_settings(resource_group_name, name, setting_names, slot=None):
-    app_settings = _generic_site_operation(resource_group_name, name, 'list_site_app_settings', slot)
+    app_settings = _generic_site_operation(resource_group_name, name,
+                                           'list_site_app_settings', slot)
     for setting_name in setting_names:
         app_settings.properties.pop(setting_name, None)
 
@@ -120,8 +122,6 @@ def delete_app_settings(resource_group_name, name, setting_names, slot=None):
 def add_hostname(resource_group_name, name, hostname, slot=None):
     client = web_client_factory()
     webapp = client.sites.get_site(resource_group_name, name)
-    bindings = _generic_site_operation(resource_group_name, name, 'get_site_host_name_bindings',
-                                   slot)
     binding = HostNameBinding(webapp.location, host_name_binding_name=hostname, site_name=name)
     if slot is None:
         return client.sites.create_or_update_site_host_name_binding(resource_group_name, name,
@@ -135,7 +135,8 @@ def delete_hostname(resource_group_name, name, hostname, slot=None):
     if slot is None:
         return client.sites.delete_site_host_name_binding(resource_group_name, name, hostname)
     else:
-        return client.sites.delete_site_host_name_binding_slot(resource_group_name, name, slot, hostname)
+        return client.sites.delete_site_host_name_binding_slot(resource_group_name,
+                                                               name, slot, hostname)
 
 def list_hostnames(resource_group_name, name, slot=None):
     return _generic_site_operation(resource_group_name, name, 'get_site_host_name_bindings',

--- a/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/custom.py
+++ b/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/custom.py
@@ -24,33 +24,33 @@ logger = _logging.get_az_logger(__name__)
 
 #pylint:disable=no-member
 
-def create_webapp(resource_group, name, plan):
+def create_webapp(resource_group_name, name, plan):
     client = web_client_factory()
     if is_valid_resource_id(plan):
         plan = parse_resource_id(plan)['name']
-    location = _get_location_from_app_service_plan(client, resource_group, plan)
+    location = _get_location_from_app_service_plan(client, resource_group_name, plan)
     webapp_def = Site(server_farm_id=plan, location=location)
-    return client.sites.create_or_update_site(resource_group, name, webapp_def)
+    return client.sites.create_or_update_site(resource_group_name, name, webapp_def)
 
-def _generic_site_operation(resource_group, name, operation_name, slot=None,
+def _generic_site_operation(resource_group_name, name, operation_name, slot=None,
                             extra_parameter=None, client=None):
     client = client or web_client_factory()
     m = getattr(client.sites,
                 operation_name if slot is None else operation_name + '_slot')
     if slot is None:
-        return (m(resource_group, name)
-                if extra_parameter is None else m(resource_group, name, extra_parameter))
+        return (m(resource_group_name, name)
+                if extra_parameter is None else m(resource_group_name, name, extra_parameter))
     else:
-        return (m(resource_group, name, slot)
-                if extra_parameter is None else m(resource_group, name, extra_parameter, slot))
+        return (m(resource_group_name, name, slot)
+                if extra_parameter is None else m(resource_group_name, name, extra_parameter, slot))
 
-def show_webapp(resource_group, name, slot=None):
-    webapp = _generic_site_operation(resource_group, name, 'get_site', slot)
+def show_webapp(resource_group_name, name, slot=None):
+    webapp = _generic_site_operation(resource_group_name, name, 'get_site', slot)
     return _rename_server_farm_props(webapp)
 
-def list_webapp(resource_group):
+def list_webapp(resource_group_name):
     client = web_client_factory()
-    result = client.sites.get_sites(resource_group)
+    result = client.sites.get_sites(resource_group_name)
     for webapp in result:
         _rename_server_farm_props(webapp)
     return result
@@ -61,32 +61,32 @@ def _rename_server_farm_props(webapp):
     del webapp.server_farm_id
     return webapp
 
-def delete_webapp(resource_group, name, slot=None):
-    return _generic_site_operation(resource_group, name, 'delete_site', slot)
+def delete_webapp(resource_group_name, name, slot=None):
+    return _generic_site_operation(resource_group_name, name, 'delete_site', slot)
 
-def stop_webapp(resource_group, name, slot=None):
-    return _generic_site_operation(resource_group, name, 'stop_site', slot)
+def stop_webapp(resource_group_name, name, slot=None):
+    return _generic_site_operation(resource_group_name, name, 'stop_site', slot)
 
-def restart_webapp(resource_group, name, slot=None):
-    return _generic_site_operation(resource_group, name, 'restart_site', slot)
+def restart_webapp(resource_group_name, name, slot=None):
+    return _generic_site_operation(resource_group_name, name, 'restart_site', slot)
 
-def get_site_configs(resource_group, name, slot=None):
-    return _generic_site_operation(resource_group, name, 'get_site_config', slot)
+def get_site_configs(resource_group_name, name, slot=None):
+    return _generic_site_operation(resource_group_name, name, 'get_site_config', slot)
 
-def get_app_settings(resource_group, name, slot=None):
-    result = _generic_site_operation(resource_group, name, 'list_site_app_settings', slot)
+def get_app_settings(resource_group_name, name, slot=None):
+    result = _generic_site_operation(resource_group_name, name, 'list_site_app_settings', slot)
     return result.properties
 
 #for any modifications to the non-optional parameters, adjust the reflection logic accordingly
 #in the method
-def update_site_configs(resource_group, name, slot=None,
+def update_site_configs(resource_group_name, name, slot=None,
                         php_version=None, python_version=None,#pylint: disable=unused-argument
                         net_framework_version=None, #pylint: disable=unused-argument
                         java_version=None, java_container=None, java_container_version=None,#pylint: disable=unused-argument
                         remote_debugging_enabled=None, web_sockets_enabled=None,#pylint: disable=unused-argument
                         always_on=None, auto_heal_enabled=None,#pylint: disable=unused-argument
                         use32_bit_worker_process=None):#pylint: disable=unused-argument
-    configs = get_site_configs(resource_group, name, slot)
+    configs = get_site_configs(resource_group_name, name, slot)
     import inspect
     frame = inspect.currentframe()
     #note: getargvalues is used already in azure.cli.core.commands.
@@ -96,88 +96,88 @@ def update_site_configs(resource_group, name, slot=None,
         if arg is not None:
             setattr(configs, arg, values[arg])
 
-    return _generic_site_operation(resource_group, name, 'update_site_config', slot, configs)
+    return _generic_site_operation(resource_group_name, name, 'update_site_config', slot, configs)
 
-def update_app_settings(resource_group, name, settings, slot=None):
-    app_settings = _generic_site_operation(resource_group, name, 'list_site_app_settings', slot)
+def update_app_settings(resource_group_name, name, settings, slot=None):
+    app_settings = _generic_site_operation(resource_group_name, name, 'list_site_app_settings', slot)
     for name_value in settings:
         #split at the first '=', appsetting should not have '=' in the name
         settings_name, value = name_value.split('=', 1)
         app_settings.properties[settings_name] = value
 
-    result = _generic_site_operation(resource_group, name, 'update_site_app_settings',
+    result = _generic_site_operation(resource_group_name, name, 'update_site_app_settings',
                                      slot, app_settings)
     return result.properties
 
-def delete_app_settings(resource_group, name, setting_names, slot=None):
-    app_settings = _generic_site_operation(resource_group, name, 'list_site_app_settings', slot)
+def delete_app_settings(resource_group_name, name, setting_names, slot=None):
+    app_settings = _generic_site_operation(resource_group_name, name, 'list_site_app_settings', slot)
     for setting_name in setting_names:
         app_settings.properties.pop(setting_name, None)
 
-    return _generic_site_operation(resource_group, name, 'update_site_app_settings',
+    return _generic_site_operation(resource_group_name, name, 'update_site_app_settings',
                                    slot, app_settings)
 
-def add_hostname(resource_group, name, hostname, slot=None):
+def add_hostname(resource_group_name, name, hostname, slot=None):
     client = web_client_factory()
-    webapp = client.sites.get_site(resource_group, name)
-    bindings = _generic_site_operation(resource_group, name, 'get_site_host_name_bindings',
+    webapp = client.sites.get_site(resource_group_name, name)
+    bindings = _generic_site_operation(resource_group_name, name, 'get_site_host_name_bindings',
                                    slot)
     binding = HostNameBinding(webapp.location, host_name_binding_name=hostname, site_name=name)
     if slot is None:
-        return client.sites.create_or_update_site_host_name_binding(resource_group, name,
+        return client.sites.create_or_update_site_host_name_binding(resource_group_name, name,
                                                                     hostname, binding)
     else:
-        return client.sites.create_or_update_site_host_name_binding_slot(resource_group, name,
+        return client.sites.create_or_update_site_host_name_binding_slot(resource_group_name, name,
                                                                          hostname, binding, slot)
 
-def delete_hostname(resource_group, name, hostname, slot=None):
+def delete_hostname(resource_group_name, name, hostname, slot=None):
     client = web_client_factory()
     if slot is None:
-        return client.sites.delete_site_host_name_binding(resource_group, name, hostname)
+        return client.sites.delete_site_host_name_binding(resource_group_name, name, hostname)
     else:
-        return client.sites.delete_site_host_name_binding_slot(resource_group, name, slot, hostname)
+        return client.sites.delete_site_host_name_binding_slot(resource_group_name, name, slot, hostname)
 
-def list_hostnames(resource_group, name, slot=None):
-    return _generic_site_operation(resource_group, name, 'get_site_host_name_bindings',
+def list_hostnames(resource_group_name, name, slot=None):
+    return _generic_site_operation(resource_group_name, name, 'get_site_host_name_bindings',
                                    slot)
 
 #TODO: figure out the 'configuration_source' and add related param descriptions
-def create_webapp_slot(resource_group, webapp, slot, configuration_source=None):
+def create_webapp_slot(resource_group_name, webapp, slot, configuration_source=None):
     client = web_client_factory()
-    site = client.sites.get_site(resource_group, webapp)
+    site = client.sites.get_site(resource_group_name, webapp)
     location = site.location
     if configuration_source is None:
         slot_def = Site(server_farm_id=site.server_farm_id, location=location)
     elif configuration_source.lower() == webapp.lower(): #clone from production
         slot_def = site #pylint: disable=redefined-variable-type
     else: # from other slot
-        slot_def = client.sites.get_site_slot(resource_group, webapp, slot)
+        slot_def = client.sites.get_site_slot(resource_group_name, webapp, slot)
 
-    return client.sites.create_or_update_site_slot(resource_group, webapp, slot_def, slot)
+    return client.sites.create_or_update_site_slot(resource_group_name, webapp, slot_def, slot)
 
-def enable_local_git(resource_group, name, slot=None):
+def enable_local_git(resource_group_name, name, slot=None):
     client = web_client_factory()
-    location = _get_location_from_webapp(client, resource_group, name)
+    location = _get_location_from_webapp(client, resource_group_name, name)
     site_config = SiteConfig(location)
     site_config.scm_type = 'LocalGit'
     if slot is None:
-        client.sites.create_or_update_site_config(resource_group, name, site_config)
+        client.sites.create_or_update_site_config(resource_group_name, name, site_config)
     else:
-        client.sites.create_or_update_site_config_slot(resource_group, name, site_config, slot)
+        client.sites.create_or_update_site_config_slot(resource_group_name, name, site_config, slot)
 
-    return {'url' : _get_git_url(client, resource_group, name, slot)}
+    return {'url' : _get_git_url(client, resource_group_name, name, slot)}
 
-def create_app_service_plan(resource_group, name, sku, number_of_workers=None,
+def create_app_service_plan(resource_group_name, name, sku, number_of_workers=None,
                             location=None):
     client = web_client_factory()
     sku = _normalize_sku(sku)
     if location is None:
-        location = _get_location_from_resource_group(resource_group)
+        location = _get_location_from_resource_group(resource_group_name)
 
     #the api is odd on parameter naming, have to live with it for now
     sku_def = SkuDescription(tier=_get_sku_name(sku), name=sku, capacity=number_of_workers)
     plan_def = ServerFarmWithRichSku(location, server_farm_with_rich_sku_name=name, sku=sku_def)
-    return client.server_farms.create_or_update_server_farm(resource_group, name, plan_def)
+    return client.server_farms.create_or_update_server_farm(resource_group_name, name, plan_def)
 
 def update_app_service_plan(instance, sku=None, number_of_workers=None,
                             admin_site_name=None):
@@ -219,34 +219,34 @@ def _get_sku_name(tier):
     else:
         raise CLIError("Invalid sku(pricing tier), please refer to command help for valid values")
 
-def _get_location_from_resource_group(resource_group):
+def _get_location_from_resource_group(resource_group_name):
     from azure.mgmt.resource.resources import ResourceManagementClient
     client = get_mgmt_service_client(ResourceManagementClient)
-    group = client.resource_groups.get(resource_group)
+    group = client.resource_groups.get(resource_group_name)
     return group.location
 
-def _get_location_from_webapp(client, resource_group, webapp):
-    webapp = client.sites.get_site(resource_group, webapp)
+def _get_location_from_webapp(client, resource_group_name, webapp):
+    webapp = client.sites.get_site(resource_group_name, webapp)
     return webapp.location
 
-def _get_location_from_app_service_plan(client, resource_group, plan):
-    plan = client.server_farms.get_server_farm(resource_group, plan)
+def _get_location_from_app_service_plan(client, resource_group_name, plan):
+    plan = client.server_farms.get_server_farm(resource_group_name, plan)
     return plan.location
 
-def get_git_url(resource_group, name, slot=None):
+def get_git_url(resource_group_name, name, slot=None):
     client = web_client_factory()
-    return {'url' : _get_git_url(client, resource_group, name, slot)}
+    return {'url' : _get_git_url(client, resource_group_name, name, slot)}
 
-def _get_git_url(client, resource_group, name, slot=None):
+def _get_git_url(client, resource_group_name, name, slot=None):
     user = client.provider.get_publishing_user()
-    repo_url = _get_repo_url(client, resource_group, name, slot)
+    repo_url = _get_repo_url(client, resource_group_name, name, slot)
     parsed = urlparse(repo_url)
     git_url = '{}://{}@{}/{}.git'.format(parsed.scheme, user.publishing_user_name,
                                          parsed.netloc, name)
     return git_url
 
-def _get_repo_url(client, resource_group, name, slot=None):
-    scc = _generic_site_operation(resource_group, name, 'get_site_source_control',
+def _get_repo_url(client, resource_group_name, name, slot=None):
+    scc = _generic_site_operation(resource_group_name, name, 'get_site_source_control',
                                   slot, client=client)
     if scc.repo_url is None:
         raise CLIError("Please enable Git deployment, say, run 'webapp git enable-local'")
@@ -267,9 +267,9 @@ def set_deployment_user(user_name, password=None):
     result = client.provider.update_publishing_user(user)
     return result
 
-def view_in_browser(resource_group, name, slot=None):
+def view_in_browser(resource_group_name, name, slot=None):
     import webbrowser
-    site = _generic_site_operation(resource_group, name, 'get_site', slot)
+    site = _generic_site_operation(resource_group_name, name, 'get_site', slot)
     url = site.default_host_name
     ssl_host = next((h for h in site.host_name_ssl_states
                      if h.ssl_state != SslState.disabled), None)
@@ -277,7 +277,7 @@ def view_in_browser(resource_group, name, slot=None):
     webbrowser.open(url, new=2) # 2 means: open in a new tab, if possible
 
 #TODO: expose new blob suport
-def config_diagnostics(resource_group, name, level=None,
+def config_diagnostics(resource_group_name, name, level=None,
                        application_logging=None, web_server_logging=None,
                        detailed_error_messages=None, failed_request_tracing=None,
                        slot=None):
@@ -286,7 +286,7 @@ def config_diagnostics(resource_group, name, level=None,
                                        FileSystemHttpLogsConfig, EnabledConfig)
     client = web_client_factory()
     #TODO: ensure we call get_site only once
-    site = client.sites.get_site(resource_group, name)
+    site = client.sites.get_site(resource_group_name, name)
     location = site.location
 
     application_logs = None
@@ -315,25 +315,25 @@ def config_diagnostics(resource_group, name, level=None,
                                      failed_requests_tracing=failed_request_tracing_logs,
                                      detailed_error_messages=detailed_error_messages_logs)
 
-    return _generic_site_operation(resource_group, name, 'update_site_logs_config',
+    return _generic_site_operation(resource_group_name, name, 'update_site_logs_config',
                                    slot, site_log_config)
 
 
-def config_slot_auto_swap(resource_group, webapp, slot, auto_swap_slot=None, disable=None):
+def config_slot_auto_swap(resource_group_name, webapp, slot, auto_swap_slot=None, disable=None):
     client = web_client_factory()
-    site_config = client.sites.get_site_config_slot(resource_group, webapp, slot)
+    site_config = client.sites.get_site_config_slot(resource_group_name, webapp, slot)
     site_config.auto_swap_slot_name = '' if disable else (auto_swap_slot or 'production')
-    return client.sites.update_site_config_slot(resource_group, webapp, site_config, slot)
+    return client.sites.update_site_config_slot(resource_group_name, webapp, site_config, slot)
 
-def get_streaming_log(resource_group, name, provider=None, slot=None):
+def get_streaming_log(resource_group_name, name, provider=None, slot=None):
     client = web_client_factory()
-    repo_url = _get_repo_url(client, resource_group, name, slot)
+    repo_url = _get_repo_url(client, resource_group_name, name, slot)
     streaming_url = repo_url + '/logstream'
     import time
     if provider:
         streaming_url += ('/' + provider.lstrip('/'))
 
-    user, password = _get_site_credential(client, resource_group, name)
+    user, password = _get_site_credential(client, resource_group_name, name)
     t = threading.Thread(target=_stream_trace, args=(streaming_url, user, password))
     t.daemon = True
     t.start()
@@ -341,13 +341,13 @@ def get_streaming_log(resource_group, name, provider=None, slot=None):
     while True:
         time.sleep(100) #so that ctrl+c can stop the command
 
-def download_historical_logs(resource_group, name, log_file=None, slot=None):
+def download_historical_logs(resource_group_name, name, log_file=None, slot=None):
     '''
     Download historical logs as a zip file
     '''
     client = web_client_factory()
-    user, password = _get_site_credential(client, resource_group, name)
-    repo_url = _get_repo_url(client, resource_group, name, slot)
+    user, password = _get_site_credential(client, resource_group_name, name)
+    repo_url = _get_repo_url(client, resource_group_name, name, slot)
     host = urlparse(repo_url).netloc
     url = "https://{}:{}@{}/dump".format(user, password, host)
     import requests
@@ -358,8 +358,8 @@ def download_historical_logs(resource_group, name, log_file=None, slot=None):
                 f.write(chunk)
     logger.warning('Downloaded logs to %s', log_file)
 
-def _get_site_credential(client, resource_group, name):
-    creds = client.sites.list_site_publishing_credentials(resource_group, name)
+def _get_site_credential(client, resource_group_name, name):
+    creds = client.sites.list_site_publishing_credentials(resource_group_name, name)
     creds = creds.result()
     return (creds.publishing_user_name, creds.publishing_password)
 

--- a/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/generated.py
+++ b/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/generated.py
@@ -17,7 +17,8 @@ from .custom import (create_webapp, show_webapp, list_webapp,
                      get_streaming_log, download_historical_logs,
                      create_webapp_slot, config_slot_auto_swap,
                      get_site_configs, update_site_configs,
-                     get_app_settings, update_app_settings, delete_app_settings)
+                     get_app_settings, update_app_settings, delete_app_settings,
+                     add_hostname, list_hostnames, delete_hostname)
 
 cli_command('appservice web create', create_webapp)
 cli_command('appservice web list', list_webapp)
@@ -31,6 +32,9 @@ cli_command('appservice web config show', get_site_configs)
 cli_command('appservice web config appsettings show', get_app_settings)
 cli_command('appservice web config appsettings update', update_app_settings)
 cli_command('appservice web config appsettings delete', delete_app_settings)
+cli_command('appservice web config hostname add', add_hostname)
+cli_command('appservice web config hostname list', list_hostnames)
+cli_command('appservice web config hostname delete', delete_hostname)
 
 factory = lambda _: web_client_factory().sites
 cli_command('appservice web show-publish-profile',

--- a/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/tests/recordings/test_webapp_config.yaml
+++ b/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/tests/recordings/test_webapp_config.yaml
@@ -4,13 +4,13 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc0MzEyNDQyLCJuYmYiOjE0NzQzMTI0NDIsImV4cCI6MTQ3NDMxNjM0MiwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoic2RrIiwiZ2l2ZW5fbmFtZSI6ImFkbWluMyIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4wLjEzMCIsIm5hbWUiOiJhZG1pbjMiLCJvaWQiOiJlN2UxNThkMy03Y2RjLTQ3Y2QtODgyNS01ODU5ZDdhYjJiNTUiLCJwdWlkIjoiMTAwMzNGRkY5NUQ0NEU4NCIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6ImhRenl3b3FTLUEtRzAySTl6ZE5TRmtGd3R2MGVwZ2lWY1Vsdm1PZEZHaFEiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluM0BBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4zQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAiLCJ3aWRzIjpbIjYyZTkwMzk0LTY5ZjUtNDIzNy05MTkwLTAxMjE3NzE0NWUxMCJdfQ.VhR3i26A_Ll2bGifjgEprzJ-C1gAUd9vqck9YmBO8QPIGvW5pNmIep5eYrFkgX5CjSn0QFxRVcF-V9biOH-4XbxuG3LqqWh0q1JvQH0b0fUaxPHQ4NZ-Cx497bPfhlpCa9DyYXsgiaJ4IQQ5nVN1imbX_Z3ybzLehV1rXeizWiJjwrD6zTvovhhqZ00WfbWm_Mj9aDliSNuIHH3KCBTKiotX4WAM4pqMBI8vhs5oE18bqHiuzEdebObzPyluxmQBDIleSr_fDqZhMSgP7xR7jpNrm-nTlVyeyonct_DyFFYNMVuzHaEXy7KoCvS6WfmohwJ2pie54BC09CBg18Gr2w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc1MTkyMTE3LCJuYmYiOjE0NzUxOTIxMTcsImV4cCI6MTQ3NTE5NjAxNywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA3OTksImZhbWlseV9uYW1lIjoic2RrIiwiZ2l2ZW5fbmFtZSI6ImFkbWluMyIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4wLjEzMCIsIm5hbWUiOiJhZG1pbjMiLCJvaWQiOiJlN2UxNThkMy03Y2RjLTQ3Y2QtODgyNS01ODU5ZDdhYjJiNTUiLCJwdWlkIjoiMTAwMzNGRkY5NUQ0NEU4NCIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6ImhRenl3b3FTLUEtRzAySTl6ZE5TRmtGd3R2MGVwZ2lWY1Vsdm1PZEZHaFEiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluM0BBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4zQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAiLCJ3aWRzIjpbIjYyZTkwMzk0LTY5ZjUtNDIzNy05MTkwLTAxMjE3NzE0NWUxMCJdfQ.g84028HOdopYMPs073rrNbx5z1ZAqarJ57bWWaLaoxNGDXZ6bLCGhGwSCBIbyu3x-H8dyhtzlfPe8kcMjbcrphuUwuTkwaWkTDw4fw2u23KvndH7EPI_9fK-9q7G4NXmvDLjPxerDZ9hIRlPgh55aC5MyF6kPmd_x1PbF0ASKBXoVWMR2tXDHkmkIvH7HofO6sbzusth2jUb4jGXdpQWjhdISvaozruej1n--8x98LRCgwPLOU5TgAmpkWEJQ5dSrsxXepe_eUEeVSaZhgQUDHcD05ggqN5-m3LRQTic7_5ViM-KwdJ-xb2qMF7gim9kRQlCZZj8wpexZYHvURqe2Q]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.0.1]
+          websitemanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
       accept-language: [en-US]
-      x-ms-client-request-id: [ff73cbdc-7e9d-11e6-9ea1-64510658e3b3]
+      x-ms-client-request-id: [28ea6f6e-869f-11e6-943f-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/web?api-version=2015-08-01
   response:
@@ -42,7 +42,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Mon, 19 Sep 2016 19:19:35 GMT']
+      Date: ['Thu, 29 Sep 2016 23:48:02 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -56,13 +56,13 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc0MzEyNDQyLCJuYmYiOjE0NzQzMTI0NDIsImV4cCI6MTQ3NDMxNjM0MiwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoic2RrIiwiZ2l2ZW5fbmFtZSI6ImFkbWluMyIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4wLjEzMCIsIm5hbWUiOiJhZG1pbjMiLCJvaWQiOiJlN2UxNThkMy03Y2RjLTQ3Y2QtODgyNS01ODU5ZDdhYjJiNTUiLCJwdWlkIjoiMTAwMzNGRkY5NUQ0NEU4NCIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6ImhRenl3b3FTLUEtRzAySTl6ZE5TRmtGd3R2MGVwZ2lWY1Vsdm1PZEZHaFEiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluM0BBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4zQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAiLCJ3aWRzIjpbIjYyZTkwMzk0LTY5ZjUtNDIzNy05MTkwLTAxMjE3NzE0NWUxMCJdfQ.VhR3i26A_Ll2bGifjgEprzJ-C1gAUd9vqck9YmBO8QPIGvW5pNmIep5eYrFkgX5CjSn0QFxRVcF-V9biOH-4XbxuG3LqqWh0q1JvQH0b0fUaxPHQ4NZ-Cx497bPfhlpCa9DyYXsgiaJ4IQQ5nVN1imbX_Z3ybzLehV1rXeizWiJjwrD6zTvovhhqZ00WfbWm_Mj9aDliSNuIHH3KCBTKiotX4WAM4pqMBI8vhs5oE18bqHiuzEdebObzPyluxmQBDIleSr_fDqZhMSgP7xR7jpNrm-nTlVyeyonct_DyFFYNMVuzHaEXy7KoCvS6WfmohwJ2pie54BC09CBg18Gr2w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc1MTkyMTE3LCJuYmYiOjE0NzUxOTIxMTcsImV4cCI6MTQ3NTE5NjAxNywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA3OTksImZhbWlseV9uYW1lIjoic2RrIiwiZ2l2ZW5fbmFtZSI6ImFkbWluMyIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4wLjEzMCIsIm5hbWUiOiJhZG1pbjMiLCJvaWQiOiJlN2UxNThkMy03Y2RjLTQ3Y2QtODgyNS01ODU5ZDdhYjJiNTUiLCJwdWlkIjoiMTAwMzNGRkY5NUQ0NEU4NCIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6ImhRenl3b3FTLUEtRzAySTl6ZE5TRmtGd3R2MGVwZ2lWY1Vsdm1PZEZHaFEiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluM0BBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4zQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAiLCJ3aWRzIjpbIjYyZTkwMzk0LTY5ZjUtNDIzNy05MTkwLTAxMjE3NzE0NWUxMCJdfQ.g84028HOdopYMPs073rrNbx5z1ZAqarJ57bWWaLaoxNGDXZ6bLCGhGwSCBIbyu3x-H8dyhtzlfPe8kcMjbcrphuUwuTkwaWkTDw4fw2u23KvndH7EPI_9fK-9q7G4NXmvDLjPxerDZ9hIRlPgh55aC5MyF6kPmd_x1PbF0ASKBXoVWMR2tXDHkmkIvH7HofO6sbzusth2jUb4jGXdpQWjhdISvaozruej1n--8x98LRCgwPLOU5TgAmpkWEJQ5dSrsxXepe_eUEeVSaZhgQUDHcD05ggqN5-m3LRQTic7_5ViM-KwdJ-xb2qMF7gim9kRQlCZZj8wpexZYHvURqe2Q]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.0.1]
+          websitemanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
       accept-language: [en-US]
-      x-ms-client-request-id: [02a7c6c6-7e9e-11e6-9a79-64510658e3b3]
+      x-ms-client-request-id: [2956c04c-869f-11e6-a8b7-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/web?api-version=2015-08-01
   response:
@@ -94,7 +94,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Mon, 19 Sep 2016 19:19:39 GMT']
+      Date: ['Thu, 29 Sep 2016 23:48:03 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -105,37 +105,36 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJsb2NhdGlvbiI6ICJXZXN0IFVTIiwgIm5hbWUiOiAid2ViYXBwLWNvbmZpZy10ZXN0IiwgInBy
-      b3BlcnRpZXMiOiB7ImFsd2F5c09uIjogdHJ1ZSwgIm51bWJlck9mV29ya2VycyI6IDEsICJodHRw
-      TG9nZ2luZ0VuYWJsZWQiOiBmYWxzZSwgInNjbVR5cGUiOiAiTm9uZSIsICJ3ZWJTb2NrZXRzRW5h
-      YmxlZCI6IHRydWUsICJwdWJsaXNoaW5nVXNlcm5hbWUiOiAiJHdlYmFwcC1jb25maWctdGVzdCIs
-      ICJsb2dzRGlyZWN0b3J5U2l6ZUxpbWl0IjogMzUsICJ2bmV0TmFtZSI6ICIiLCAidXNlMzJCaXRX
-      b3JrZXJQcm9jZXNzIjogZmFsc2UsICJweXRob25WZXJzaW9uIjogIjMuNCIsICJwaHBWZXJzaW9u
-      IjogIjUuNSIsICJhdXRvSGVhbEVuYWJsZWQiOiB0cnVlLCAiZGVmYXVsdERvY3VtZW50cyI6IFsi
-      RGVmYXVsdC5odG0iLCAiRGVmYXVsdC5odG1sIiwgIkRlZmF1bHQuYXNwIiwgImluZGV4Lmh0bSIs
-      ICJpbmRleC5odG1sIiwgImlpc3N0YXJ0Lmh0bSIsICJkZWZhdWx0LmFzcHgiLCAiaW5kZXgucGhw
-      IiwgImhvc3RpbmdzdGFydC5odG1sIl0sICJyZW1vdGVEZWJ1Z2dpbmdFbmFibGVkIjogZmFsc2Us
-      ICJtYW5hZ2VkUGlwZWxpbmVNb2RlIjogIkludGVncmF0ZWQiLCAibmV0RnJhbWV3b3JrVmVyc2lv
-      biI6ICJ2My41IiwgImxvY2FsTXlTcWxFbmFibGVkIjogZmFsc2UsICJyZXF1ZXN0VHJhY2luZ0Vu
-      YWJsZWQiOiBmYWxzZSwgImRldGFpbGVkRXJyb3JMb2dnaW5nRW5hYmxlZCI6IGZhbHNlLCAidmly
-      dHVhbEFwcGxpY2F0aW9ucyI6IFt7InZpcnR1YWxQYXRoIjogIi8iLCAicHJlbG9hZEVuYWJsZWQi
-      OiBmYWxzZSwgInBoeXNpY2FsUGF0aCI6ICJzaXRlXFx3d3dyb290In1dLCAibG9hZEJhbGFuY2lu
-      ZyI6ICJMZWFzdFJlcXVlc3RzIiwgImV4cGVyaW1lbnRzIjogeyJyYW1wVXBSdWxlcyI6IFtdfX0s
-      ICJ0eXBlIjogIk1pY3Jvc29mdC5XZWIvc2l0ZXMvY29uZmlnIiwgImlkIjogIi9zdWJzY3JpcHRp
-      b25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9h
-      enVyZWNsaS13ZWJhcHAtY29uZmlnL3Byb3ZpZGVycy9NaWNyb3NvZnQuV2ViL3NpdGVzL3dlYmFw
-      cC1jb25maWctdGVzdC9jb25maWcvd2ViIn0=
+      eyJwcm9wZXJ0aWVzIjogeyJyZXF1ZXN0VHJhY2luZ0VuYWJsZWQiOiBmYWxzZSwgImV4cGVyaW1l
+      bnRzIjogeyJyYW1wVXBSdWxlcyI6IFtdfSwgIm51bWJlck9mV29ya2VycyI6IDEsICJweXRob25W
+      ZXJzaW9uIjogIjMuNCIsICJkZXRhaWxlZEVycm9yTG9nZ2luZ0VuYWJsZWQiOiBmYWxzZSwgInZp
+      cnR1YWxBcHBsaWNhdGlvbnMiOiBbeyJwcmVsb2FkRW5hYmxlZCI6IGZhbHNlLCAidmlydHVhbFBh
+      dGgiOiAiLyIsICJwaHlzaWNhbFBhdGgiOiAic2l0ZVxcd3d3cm9vdCJ9XSwgInNjbVR5cGUiOiAi
+      Tm9uZSIsICJ1c2UzMkJpdFdvcmtlclByb2Nlc3MiOiBmYWxzZSwgImxvYWRCYWxhbmNpbmciOiAi
+      TGVhc3RSZXF1ZXN0cyIsICJ2bmV0TmFtZSI6ICIiLCAicGhwVmVyc2lvbiI6ICI1LjUiLCAibG9n
+      c0RpcmVjdG9yeVNpemVMaW1pdCI6IDM1LCAid2ViU29ja2V0c0VuYWJsZWQiOiB0cnVlLCAibmV0
+      RnJhbWV3b3JrVmVyc2lvbiI6ICJ2My41IiwgImF1dG9IZWFsRW5hYmxlZCI6IHRydWUsICJodHRw
+      TG9nZ2luZ0VuYWJsZWQiOiBmYWxzZSwgImFsd2F5c09uIjogdHJ1ZSwgInB1Ymxpc2hpbmdVc2Vy
+      bmFtZSI6ICIkd2ViYXBwLWNvbmZpZy10ZXN0IiwgImxvY2FsTXlTcWxFbmFibGVkIjogZmFsc2Us
+      ICJkZWZhdWx0RG9jdW1lbnRzIjogWyJEZWZhdWx0Lmh0bSIsICJEZWZhdWx0Lmh0bWwiLCAiRGVm
+      YXVsdC5hc3AiLCAiaW5kZXguaHRtIiwgImluZGV4Lmh0bWwiLCAiaWlzc3RhcnQuaHRtIiwgImRl
+      ZmF1bHQuYXNweCIsICJpbmRleC5waHAiLCAiaG9zdGluZ3N0YXJ0Lmh0bWwiXSwgIm1hbmFnZWRQ
+      aXBlbGluZU1vZGUiOiAiSW50ZWdyYXRlZCJ9LCAibmFtZSI6ICJ3ZWJhcHAtY29uZmlnLXRlc3Qi
+      LCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5
+      NTkwL3Jlc291cmNlR3JvdXBzL2F6dXJlY2xpLXdlYmFwcC1jb25maWcvcHJvdmlkZXJzL01pY3Jv
+      c29mdC5XZWIvc2l0ZXMvd2ViYXBwLWNvbmZpZy10ZXN0L2NvbmZpZy93ZWIiLCAibG9jYXRpb24i
+      OiAiV2VzdCBVUyIsICJ0eXBlIjogIk1pY3Jvc29mdC5XZWIvc2l0ZXMvY29uZmlnIn0=
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc0MzEyNDQyLCJuYmYiOjE0NzQzMTI0NDIsImV4cCI6MTQ3NDMxNjM0MiwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoic2RrIiwiZ2l2ZW5fbmFtZSI6ImFkbWluMyIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4wLjEzMCIsIm5hbWUiOiJhZG1pbjMiLCJvaWQiOiJlN2UxNThkMy03Y2RjLTQ3Y2QtODgyNS01ODU5ZDdhYjJiNTUiLCJwdWlkIjoiMTAwMzNGRkY5NUQ0NEU4NCIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6ImhRenl3b3FTLUEtRzAySTl6ZE5TRmtGd3R2MGVwZ2lWY1Vsdm1PZEZHaFEiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluM0BBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4zQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAiLCJ3aWRzIjpbIjYyZTkwMzk0LTY5ZjUtNDIzNy05MTkwLTAxMjE3NzE0NWUxMCJdfQ.VhR3i26A_Ll2bGifjgEprzJ-C1gAUd9vqck9YmBO8QPIGvW5pNmIep5eYrFkgX5CjSn0QFxRVcF-V9biOH-4XbxuG3LqqWh0q1JvQH0b0fUaxPHQ4NZ-Cx497bPfhlpCa9DyYXsgiaJ4IQQ5nVN1imbX_Z3ybzLehV1rXeizWiJjwrD6zTvovhhqZ00WfbWm_Mj9aDliSNuIHH3KCBTKiotX4WAM4pqMBI8vhs5oE18bqHiuzEdebObzPyluxmQBDIleSr_fDqZhMSgP7xR7jpNrm-nTlVyeyonct_DyFFYNMVuzHaEXy7KoCvS6WfmohwJ2pie54BC09CBg18Gr2w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc1MTkyMTE3LCJuYmYiOjE0NzUxOTIxMTcsImV4cCI6MTQ3NTE5NjAxNywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA3OTksImZhbWlseV9uYW1lIjoic2RrIiwiZ2l2ZW5fbmFtZSI6ImFkbWluMyIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4wLjEzMCIsIm5hbWUiOiJhZG1pbjMiLCJvaWQiOiJlN2UxNThkMy03Y2RjLTQ3Y2QtODgyNS01ODU5ZDdhYjJiNTUiLCJwdWlkIjoiMTAwMzNGRkY5NUQ0NEU4NCIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6ImhRenl3b3FTLUEtRzAySTl6ZE5TRmtGd3R2MGVwZ2lWY1Vsdm1PZEZHaFEiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluM0BBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4zQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAiLCJ3aWRzIjpbIjYyZTkwMzk0LTY5ZjUtNDIzNy05MTkwLTAxMjE3NzE0NWUxMCJdfQ.g84028HOdopYMPs073rrNbx5z1ZAqarJ57bWWaLaoxNGDXZ6bLCGhGwSCBIbyu3x-H8dyhtzlfPe8kcMjbcrphuUwuTkwaWkTDw4fw2u23KvndH7EPI_9fK-9q7G4NXmvDLjPxerDZ9hIRlPgh55aC5MyF6kPmd_x1PbF0ASKBXoVWMR2tXDHkmkIvH7HofO6sbzusth2jUb4jGXdpQWjhdISvaozruej1n--8x98LRCgwPLOU5TgAmpkWEJQ5dSrsxXepe_eUEeVSaZhgQUDHcD05ggqN5-m3LRQTic7_5ViM-KwdJ-xb2qMF7gim9kRQlCZZj8wpexZYHvURqe2Q]
       Connection: [keep-alive]
-      Content-Length: ['1109']
+      Content-Length: ['1076']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.0.1]
+          websitemanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
       accept-language: [en-US]
-      x-ms-client-request-id: [0349b35a-7e9e-11e6-8b38-64510658e3b3]
+      x-ms-client-request-id: [29b3c3fe-869f-11e6-a0ff-64510658e3b3]
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/web?api-version=2015-08-01
   response:
@@ -149,25 +148,25 @@ interactions:
         o+V6McnrL8+/W9VvCcGPHu2OPprl59m6bJ9W0/UiX7b04fc+eiqfjeftguB5f5Xen1mzor+K5Sx/
         h6/839GsKJqmzWp+jf7UbvDWO/pTmq7mADGvmrZYXtjW5UffJ5Lk7bOayHJFqP4k4SqDvLw33qE3
         6D332f3xfXx03c6rpfv03nifPl1Ws9x9Rh/U+S9aE6He1NmUujxdZpMyJ3Y4z8omx7eLqs2f5pP1
-        xcXNXzvAP/l6b2d3j8DP23b1vOJvuy+X1UXztCCGaav6+nXxg/x5sSjajx7duw/itFlBjU/ruqoH
-        3l+tJ2XRzOmbr5q8Vo753aIs45q+zJqGKEhQhB2o7eu8ZWqbjxbU9yxrM/M3gVoSkjSw120dNMym
-        BDL/vfJr88k8W87KvP6CoPoNZ8pKr6qKxiefNdPFG2HkF9UyJxzXTX5v70nRCiu+rKtp3hAEHSwN
-        63U1fZu3jSVDW6/pi6y8yq6bL4no8vdPZ5eZnQfpCh+dVEui6DKvox92XiD0T6rFggbznL4lFAk9
-        +iu7yGcvi1Ve0odfEB999Ghn9NFlUbfrrDxercpCRI+Q/t4vNp+/zNo5AbhLEFbz64aamI8gsb/v
-        73t1dVWDKvR1nZdVNusMT8EYPmGxBZK/hCTiqlger9v58WxR0NRkrSCkn77Jl9mydR9P101bLQjN
-        l1VVns1oNor22n9VCR1tFwDThvWavlrkx0/BfYJU58Mur2F4T7IyW0LSWNWQ2gTrvVqXGNf3aEz5
-        O9JOBIH1zi/+iAR+9dXKfv9LCAiEhP4QkNm6rb6dZ2WHauZjfVHatiLiX4qCN59ekl55IbJDk4BJ
-        AfUsPB2s+dzJyi/+iGgibQQQJP14Vbys8/PincyxfLFeEjpzGhFNfpvPTsqCfj9mgTJN2uptTvNQ
-        1bntWL7IyrK6IjXwroWEl6/yGTPCV3VJKEgT1aMkMGxkzMdkhqibMwtJ/n6dT+vcyiAp5LV7Q/s6
-        Xs+oJQmf/Xw2K4BsVpIiKpYvM5oU+2XRHGf0Sltx/xAiIK9Uu6iqizKXATtM/E9DfOSbLwnc/PWU
-        zJTt5Tyb5pOqekts6eB4H4ZgzBcRQO1V0RIpSfAb0ki1p7o634QQF8bWHk+nFbG4IO9QiX+/GUYP
-        O2LuaQUbjD9IH6wby0LZqiAjWyx5HuyHRPXXV9nqdVkpB8vncAHKL65f/yInFTofBQi1rkmgX5Fd
-        qAvmQe3wl/yS/wdVyrp5CAkAAA==
+        xcXNX1vAQup5266eV/xN98WyumieFsQsbVVfvy5+kD8vFkX70aN790GYNiuo8WldV/XA+6v1pCya
+        OX3zVZPXyi2/W5RdXNOXWdMQ9QiK4EdtX+ctU9p8tKC+Z1mbmb8J1JKQpEG9buugYTYlkPnvlV+b
+        T+bZclbm9RcE1W84UzZ6VVU0PvmsmS7eCBO/qJY54bhu8nt7T4pW2PBlXU3zhiDoYGlYr6vp27xt
+        LBnaek1fZOVVdt18SQSXv386u8w6c4CPTqolUXSZ19EPOy8Q+ifVYkGDeU7fEoqEHv2VXeSzl8Uq
+        L+nDL4iHPnq0M/rosqjbdVYer1ZlIWJHSH/vF5vPX2btnADcJQir+XVDTcxHkNbf9/e9urqqQRX6
+        us7LKpt1hqdgDJ+wyALJX0LScFUsj9ft/Hi2KGhqslYQ0k/f5Mts2bqPp+umrRaE5suqKs9mNBtF
+        e+2/qoSOtguAacN6TV8t8uOn4D5BqvNhl9cwvCdZmS0hZaxmSGWC9V6tS4zrezSm/B1pJoLAOucX
+        f0TCvvpqZb//JQQEQkJ/CMhs3VbfzrOyQzXzsb4obVsR7y9FuZtPL0mnvBDZoUnApIB6Fp4O1nzu
+        ZOUXf0Q0kTYCCJJ+vCpe1vl58U7mWL5YLwmdOY2IJr/NZydlQb8fs0CZJm31Nqd5qOrcdixfZGVZ
+        XZEaeNdCwstX+YwZ4au6JBSkiepQEhg2MOZjMkHUzZmFJH+/zqd1bmWQlPHavaF9Ha9n1JKEz34+
+        mxVANitJERXLlxlNiv2yaI4zeqWtuH8IEZBXql1U1UWZy4AdJv6nIT7yzZcEbv56SibK9nKeTfNJ
+        Vb0ltnRwvA9DMOaLCKD2qmiJlCT4DWmk2lNdnW9CiAtjZ4+n04pYXJB3qMS/3wyjhx0x97SC/cUf
+        pA/WjWWhbFWQgS2WPA/2Q6L666ts9bqslIPlc5j/8ovr17/ISYXORwFCrWsS6FdkF+qCeVA7/CW/
+        5P8BmS1I+AQJAAA=
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Mon, 19 Sep 2016 19:19:41 GMT']
+      Date: ['Thu, 29 Sep 2016 23:48:04 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -175,20 +174,20 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc0MzEyNDQyLCJuYmYiOjE0NzQzMTI0NDIsImV4cCI6MTQ3NDMxNjM0MiwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoic2RrIiwiZ2l2ZW5fbmFtZSI6ImFkbWluMyIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4wLjEzMCIsIm5hbWUiOiJhZG1pbjMiLCJvaWQiOiJlN2UxNThkMy03Y2RjLTQ3Y2QtODgyNS01ODU5ZDdhYjJiNTUiLCJwdWlkIjoiMTAwMzNGRkY5NUQ0NEU4NCIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6ImhRenl3b3FTLUEtRzAySTl6ZE5TRmtGd3R2MGVwZ2lWY1Vsdm1PZEZHaFEiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluM0BBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4zQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAiLCJ3aWRzIjpbIjYyZTkwMzk0LTY5ZjUtNDIzNy05MTkwLTAxMjE3NzE0NWUxMCJdfQ.VhR3i26A_Ll2bGifjgEprzJ-C1gAUd9vqck9YmBO8QPIGvW5pNmIep5eYrFkgX5CjSn0QFxRVcF-V9biOH-4XbxuG3LqqWh0q1JvQH0b0fUaxPHQ4NZ-Cx497bPfhlpCa9DyYXsgiaJ4IQQ5nVN1imbX_Z3ybzLehV1rXeizWiJjwrD6zTvovhhqZ00WfbWm_Mj9aDliSNuIHH3KCBTKiotX4WAM4pqMBI8vhs5oE18bqHiuzEdebObzPyluxmQBDIleSr_fDqZhMSgP7xR7jpNrm-nTlVyeyonct_DyFFYNMVuzHaEXy7KoCvS6WfmohwJ2pie54BC09CBg18Gr2w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc1MTkyMTE3LCJuYmYiOjE0NzUxOTIxMTcsImV4cCI6MTQ3NTE5NjAxNywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA3OTksImZhbWlseV9uYW1lIjoic2RrIiwiZ2l2ZW5fbmFtZSI6ImFkbWluMyIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4wLjEzMCIsIm5hbWUiOiJhZG1pbjMiLCJvaWQiOiJlN2UxNThkMy03Y2RjLTQ3Y2QtODgyNS01ODU5ZDdhYjJiNTUiLCJwdWlkIjoiMTAwMzNGRkY5NUQ0NEU4NCIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6ImhRenl3b3FTLUEtRzAySTl6ZE5TRmtGd3R2MGVwZ2lWY1Vsdm1PZEZHaFEiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluM0BBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4zQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAiLCJ3aWRzIjpbIjYyZTkwMzk0LTY5ZjUtNDIzNy05MTkwLTAxMjE3NzE0NWUxMCJdfQ.g84028HOdopYMPs073rrNbx5z1ZAqarJ57bWWaLaoxNGDXZ6bLCGhGwSCBIbyu3x-H8dyhtzlfPe8kcMjbcrphuUwuTkwaWkTDw4fw2u23KvndH7EPI_9fK-9q7G4NXmvDLjPxerDZ9hIRlPgh55aC5MyF6kPmd_x1PbF0ASKBXoVWMR2tXDHkmkIvH7HofO6sbzusth2jUb4jGXdpQWjhdISvaozruej1n--8x98LRCgwPLOU5TgAmpkWEJQ5dSrsxXepe_eUEeVSaZhgQUDHcD05ggqN5-m3LRQTic7_5ViM-KwdJ-xb2qMF7gim9kRQlCZZj8wpexZYHvURqe2Q]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.0.1]
+          websitemanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
       accept-language: [en-US]
-      x-ms-client-request-id: [04a5a9dc-7e9e-11e6-84c7-64510658e3b3]
+      x-ms-client-request-id: [2aec4646-869f-11e6-9647-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/web?api-version=2015-08-01
   response:
@@ -202,25 +201,25 @@ interactions:
         vVVet0VOn/zij5brxSSvvzz/blW/JZQ/erQ7+miWn2frsn1aTdeLfNnSh9/76Kl8Np63C4Ln/VV6
         f2bNiv4qlrP8Hb7yf0ezomiaNqv5NfpTu8Fb7+hPabqaA8S8atpieWFblx99nyiTt89qos4VofqT
         hKsM8vLeeIfeoPfcZ/fH9/HRdTuvlu7Te+N9+nRZzXL3GX1Q579oTYR6U2dT6vJ0mU3KnBjkPCub
-        HN8uqjZ/mk/WFxc3f+0A/+TrvZ3dPQI/b9vV84q/7b5cVhfN04JYqK3q69fFD/LnxaJoP3p07z6I
-        02YFNT6t66oeeH+1npRFM6dvvmryWhnnd4tyjmv6MmsaoiBBEXagtq/zlqltPlpQ37OszczfBGpJ
-        SNLAXrd10DCbEsj898qvzSfzbDkr8/oLguo3nCkrvaoqGp981kwXb4SfX1TLnHBcN/m9vSdFK6z4
-        sq6meUMQdLA0rNfV9G3eNpYMbb2mL7LyKrtuviSiy98/nV1mdh6kK3x0Ui2Josu8jn7YeYHQP6kW
-        CxrMc/qWUCT06K/sIp+9LFZ5SR9+QXz00aOd0UeXRd2us/J4tSoLET1C+nu/2Hz+MmvnBOAuQVjN
-        rxtqYj6C4P6+v+/V1VUNqtDXdV5W2awzPAVj+ITFFkj+EpKIq2J5vG7nx7NFQVOTtYKQfvomX2bL
-        1n08XTdttSA0X1ZVeTaj2Sjaa/9VJXS0XQBMG9Zr+mqRHz8F9wlSnQ+7vIbhPcnKbAlJY1VDihSs
-        92pdYlzfozHl70g7EQTWO7/4IxL41Vcr+/0vISAQEvpDQGbrtvp2npUdqpmP9UVp24qIfykq33x6
-        SXrlhcgOTQImBdSz8HSw5nMnK7/4I6KJtBFAkPTjVfGyzs+LdzLH8sV6SejMaUQ0+W0+OykL+v2Y
-        Bco0aau3Oc1DVee2Y/kiK8vqitTAuxYSXr7KZ8wIX9UloSBNVI+SwLDZMR+TYaJuziwk+ft1Pq1z
-        K4OkkNfuDe3reD2jliR89vPZrACyWUmKqFi+zGhS7JdFc5zRK23F/UOIgLxS7aKqLspcBuww8T8N
-        8ZFvviRw89dTMlO2l/Nsmk+q6i2xpYPjfRiCMV9EALVXRUukJMFvSCPVnurqfBNCXBiTezydVsTi
-        grxDJf79Zhg97Ii5pxVsMP4gfbBuLAtlq4KMbLHkebAfEtVfX2Wr12WlHCyfwwUov7h+/YucVOh8
-        FCDUuiaBfkV2oS6YB7XDX/JL/h+kCPzrGgkAAA==
+        HN8uqjZ/mk/WFxc3f20BC6nnbbt6XvE33RfL6qJ5WhD7tFV9/br4Qf68WBTtR4/u3Qdh2qygxqd1
+        XdUD76/Wk7Jo5vTNV01eK9P8blGucU1fZk1D1CMogh+1fZ23TGnz0YL6nmVtZv4mUEtCkgb1uq2D
+        htmUQOa/V35tPplny1mZ118QVL/hTNnoVVXR+OSzZrp4I7z8olrmhOO6ye/tPSlaYcOXdTXNG4Kg
+        g6Vhva6mb/O2sWRo6zV9kZVX2XXzJRFc/v7p7DLrzAE+OqmWRNFlXkc/7LxA6J9UiwUN5jl9SygS
+        evRXdpHPXharvKQPvyAe+ujRzuijy6Ju11l5vFqVhYgdIf29X2w+f5m1cwJwlyCs5tcNNTEfQWh/
+        39/36uqqBlXo6zovq2zWGZ6CMXzCIgskfwlJw1WxPF638+PZoqCpyVpBSD99ky+zZes+nq6btloQ
+        mi+rqjyb0WwU7bX/qhI62i4Apg3rNX21yI+fgvsEqc6HXV7D8J5kZbaElLGaISUK1nu1LjGu79GY
+        8nekmQgC65xf/BEJ++qrlf3+lxAQCAn9ISCzdVt9O8/KDtXMx/qitG1FvL8UdW8+vSSd8kJkhyYB
+        kwLqWXg6WPO5k5Vf/BHRRNoIIEj68ap4WefnxTuZY/livSR05jQimvw2n52UBf1+zAJlmrTV25zm
+        oapz27F8kZVldUVq4F0LCS9f5TNmhK/qklCQJqpDSWDY5JiPyShRN2cWkvz9Op/WuZVBUsZr94b2
+        dbyeUUsSPvv5bFYA2awkRVQsX2Y0KfbLojnO6JW24v4hREBeqXZRVRdlLgN2mPifhvjIN18SuPnr
+        KZko28t5Ns0nVfWW2NLB8T4MwZgvIoDaq6IlUpLgN6SRak91db4JIS6MuT2eTiticUHeoRL/fjOM
+        HnbE3NMK9hd/kD5YN5aFslVBBrZY8jzYD4nqr6+y1euyUg6Wz2H+yy+uX/8iJxU6HwUIta5JoF+R
+        XagL5kHt8Jf8kv8HayXMuxYJAAA=
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Mon, 19 Sep 2016 19:19:42 GMT']
+      Date: ['Thu, 29 Sep 2016 23:48:05 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -234,14 +233,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc0MzEyNDQyLCJuYmYiOjE0NzQzMTI0NDIsImV4cCI6MTQ3NDMxNjM0MiwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoic2RrIiwiZ2l2ZW5fbmFtZSI6ImFkbWluMyIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4wLjEzMCIsIm5hbWUiOiJhZG1pbjMiLCJvaWQiOiJlN2UxNThkMy03Y2RjLTQ3Y2QtODgyNS01ODU5ZDdhYjJiNTUiLCJwdWlkIjoiMTAwMzNGRkY5NUQ0NEU4NCIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6ImhRenl3b3FTLUEtRzAySTl6ZE5TRmtGd3R2MGVwZ2lWY1Vsdm1PZEZHaFEiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluM0BBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4zQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAiLCJ3aWRzIjpbIjYyZTkwMzk0LTY5ZjUtNDIzNy05MTkwLTAxMjE3NzE0NWUxMCJdfQ.VhR3i26A_Ll2bGifjgEprzJ-C1gAUd9vqck9YmBO8QPIGvW5pNmIep5eYrFkgX5CjSn0QFxRVcF-V9biOH-4XbxuG3LqqWh0q1JvQH0b0fUaxPHQ4NZ-Cx497bPfhlpCa9DyYXsgiaJ4IQQ5nVN1imbX_Z3ybzLehV1rXeizWiJjwrD6zTvovhhqZ00WfbWm_Mj9aDliSNuIHH3KCBTKiotX4WAM4pqMBI8vhs5oE18bqHiuzEdebObzPyluxmQBDIleSr_fDqZhMSgP7xR7jpNrm-nTlVyeyonct_DyFFYNMVuzHaEXy7KoCvS6WfmohwJ2pie54BC09CBg18Gr2w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc1MTkyMTE3LCJuYmYiOjE0NzUxOTIxMTcsImV4cCI6MTQ3NTE5NjAxNywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA3OTksImZhbWlseV9uYW1lIjoic2RrIiwiZ2l2ZW5fbmFtZSI6ImFkbWluMyIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4wLjEzMCIsIm5hbWUiOiJhZG1pbjMiLCJvaWQiOiJlN2UxNThkMy03Y2RjLTQ3Y2QtODgyNS01ODU5ZDdhYjJiNTUiLCJwdWlkIjoiMTAwMzNGRkY5NUQ0NEU4NCIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6ImhRenl3b3FTLUEtRzAySTl6ZE5TRmtGd3R2MGVwZ2lWY1Vsdm1PZEZHaFEiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluM0BBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4zQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAiLCJ3aWRzIjpbIjYyZTkwMzk0LTY5ZjUtNDIzNy05MTkwLTAxMjE3NzE0NWUxMCJdfQ.g84028HOdopYMPs073rrNbx5z1ZAqarJ57bWWaLaoxNGDXZ6bLCGhGwSCBIbyu3x-H8dyhtzlfPe8kcMjbcrphuUwuTkwaWkTDw4fw2u23KvndH7EPI_9fK-9q7G4NXmvDLjPxerDZ9hIRlPgh55aC5MyF6kPmd_x1PbF0ASKBXoVWMR2tXDHkmkIvH7HofO6sbzusth2jUb4jGXdpQWjhdISvaozruej1n--8x98LRCgwPLOU5TgAmpkWEJQ5dSrsxXepe_eUEeVSaZhgQUDHcD05ggqN5-m3LRQTic7_5ViM-KwdJ-xb2qMF7gim9kRQlCZZj8wpexZYHvURqe2Q]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.0.1]
+          websitemanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
       accept-language: [en-US]
-      x-ms-client-request-id: [05342a92-7e9e-11e6-aff6-64510658e3b3]
+      x-ms-client-request-id: [2b64eb9e-869f-11e6-b748-64510658e3b3]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/appsettings/list?api-version=2015-08-01
   response:
@@ -258,7 +257,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Mon, 19 Sep 2016 19:19:43 GMT']
+      Date: ['Thu, 29 Sep 2016 23:48:06 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -266,28 +265,28 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11940']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJsb2NhdGlvbiI6ICJXZXN0IFVTIiwgIm5hbWUiOiAiYXBwc2V0dGluZ3MiLCAicHJvcGVydGll
-      cyI6IHsiczEiOiAiZm9vIiwgInMyIjogImJhciIsICJzMyI6ICJiYXIyIiwgIldFQlNJVEVfTk9E
-      RV9ERUZBVUxUX1ZFUlNJT04iOiAiNC40LjcifSwgInR5cGUiOiAiTWljcm9zb2Z0LldlYi9zaXRl
-      cy9jb25maWciLCAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEtMWJmMC00ZGRhLWFlYzMt
-      Y2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2F6dXJlY2xpLXdlYmFwcC1jb25maWcvcHJvdmlk
-      ZXJzL01pY3Jvc29mdC5XZWIvc2l0ZXMvd2ViYXBwLWNvbmZpZy10ZXN0L2NvbmZpZy9hcHBzZXR0
-      aW5ncyJ9
+      eyJwcm9wZXJ0aWVzIjogeyJzMSI6ICJmb28iLCAiV0VCU0lURV9OT0RFX0RFRkFVTFRfVkVSU0lP
+      TiI6ICI0LjQuNyIsICJzMiI6ICJiYXIiLCAiczMiOiAiYmFyMiJ9LCAibmFtZSI6ICJhcHBzZXR0
+      aW5ncyIsICJsb2NhdGlvbiI6ICJXZXN0IFVTIiwgImlkIjogIi9zdWJzY3JpcHRpb25zLzBiMWY2
+      NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vwcy9henVyZWNsaS13
+      ZWJhcHAtY29uZmlnL3Byb3ZpZGVycy9NaWNyb3NvZnQuV2ViL3NpdGVzL3dlYmFwcC1jb25maWct
+      dGVzdC9jb25maWcvYXBwc2V0dGluZ3MiLCAidHlwZSI6ICJNaWNyb3NvZnQuV2ViL3NpdGVzL2Nv
+      bmZpZyJ9
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc0MzEyNDQyLCJuYmYiOjE0NzQzMTI0NDIsImV4cCI6MTQ3NDMxNjM0MiwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoic2RrIiwiZ2l2ZW5fbmFtZSI6ImFkbWluMyIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4wLjEzMCIsIm5hbWUiOiJhZG1pbjMiLCJvaWQiOiJlN2UxNThkMy03Y2RjLTQ3Y2QtODgyNS01ODU5ZDdhYjJiNTUiLCJwdWlkIjoiMTAwMzNGRkY5NUQ0NEU4NCIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6ImhRenl3b3FTLUEtRzAySTl6ZE5TRmtGd3R2MGVwZ2lWY1Vsdm1PZEZHaFEiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluM0BBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4zQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAiLCJ3aWRzIjpbIjYyZTkwMzk0LTY5ZjUtNDIzNy05MTkwLTAxMjE3NzE0NWUxMCJdfQ.VhR3i26A_Ll2bGifjgEprzJ-C1gAUd9vqck9YmBO8QPIGvW5pNmIep5eYrFkgX5CjSn0QFxRVcF-V9biOH-4XbxuG3LqqWh0q1JvQH0b0fUaxPHQ4NZ-Cx497bPfhlpCa9DyYXsgiaJ4IQQ5nVN1imbX_Z3ybzLehV1rXeizWiJjwrD6zTvovhhqZ00WfbWm_Mj9aDliSNuIHH3KCBTKiotX4WAM4pqMBI8vhs5oE18bqHiuzEdebObzPyluxmQBDIleSr_fDqZhMSgP7xR7jpNrm-nTlVyeyonct_DyFFYNMVuzHaEXy7KoCvS6WfmohwJ2pie54BC09CBg18Gr2w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc1MTkyMTE3LCJuYmYiOjE0NzUxOTIxMTcsImV4cCI6MTQ3NTE5NjAxNywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA3OTksImZhbWlseV9uYW1lIjoic2RrIiwiZ2l2ZW5fbmFtZSI6ImFkbWluMyIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4wLjEzMCIsIm5hbWUiOiJhZG1pbjMiLCJvaWQiOiJlN2UxNThkMy03Y2RjLTQ3Y2QtODgyNS01ODU5ZDdhYjJiNTUiLCJwdWlkIjoiMTAwMzNGRkY5NUQ0NEU4NCIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6ImhRenl3b3FTLUEtRzAySTl6ZE5TRmtGd3R2MGVwZ2lWY1Vsdm1PZEZHaFEiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluM0BBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4zQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAiLCJ3aWRzIjpbIjYyZTkwMzk0LTY5ZjUtNDIzNy05MTkwLTAxMjE3NzE0NWUxMCJdfQ.g84028HOdopYMPs073rrNbx5z1ZAqarJ57bWWaLaoxNGDXZ6bLCGhGwSCBIbyu3x-H8dyhtzlfPe8kcMjbcrphuUwuTkwaWkTDw4fw2u23KvndH7EPI_9fK-9q7G4NXmvDLjPxerDZ9hIRlPgh55aC5MyF6kPmd_x1PbF0ASKBXoVWMR2tXDHkmkIvH7HofO6sbzusth2jUb4jGXdpQWjhdISvaozruej1n--8x98LRCgwPLOU5TgAmpkWEJQ5dSrsxXepe_eUEeVSaZhgQUDHcD05ggqN5-m3LRQTic7_5ViM-KwdJ-xb2qMF7gim9kRQlCZZj8wpexZYHvURqe2Q]
       Connection: [keep-alive]
       Content-Length: ['348']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.0.1]
+          websitemanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
       accept-language: [en-US]
-      x-ms-client-request-id: [0ba52376-7e9e-11e6-acfd-64510658e3b3]
+      x-ms-client-request-id: [2be28a14-869f-11e6-bdc1-64510658e3b3]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/appsettings?api-version=2015-08-01
   response:
@@ -298,13 +297,13 @@ interactions:
         o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
         p/nndbVeNXezH6zrfFoW21f5JFuttqfV8ry4uLuqq8tiltfN3S+KaV011Xk7/m4+udsUbd7cDdpu
         0yftXfn9Ln3c5G1bLC+aj0YfLbNFTmiGH7bXK3wYgytAqE1ZTTOMidp9l6CnX72mD9uM3n+0XJfl
-        6CPCb5XXbZHTJ7/4o2aXGp5XFTVq9ujXSVbj13vy6x79/t3TJ6/P3pz+/i++fHr6+z89fXb81fM3
-        v/9Pnr56ffblC2q1P94fP/jol/yS/wcwPVXhWAEAAA==
+        6CPCb5XXbZHTJ7/4o2aXGp5XFTX67umT12dvTn//F18+Pf39n54+O/7q+Zvf/ydPX70++/IFNdof
+        748fULNmj/6YZDV+vSe/7n30S37J/wPhAmMKWAEAAA==
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Mon, 19 Sep 2016 19:19:55 GMT']
+      Date: ['Thu, 29 Sep 2016 23:48:08 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -319,14 +318,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc0MzEyNDQyLCJuYmYiOjE0NzQzMTI0NDIsImV4cCI6MTQ3NDMxNjM0MiwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoic2RrIiwiZ2l2ZW5fbmFtZSI6ImFkbWluMyIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4wLjEzMCIsIm5hbWUiOiJhZG1pbjMiLCJvaWQiOiJlN2UxNThkMy03Y2RjLTQ3Y2QtODgyNS01ODU5ZDdhYjJiNTUiLCJwdWlkIjoiMTAwMzNGRkY5NUQ0NEU4NCIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6ImhRenl3b3FTLUEtRzAySTl6ZE5TRmtGd3R2MGVwZ2lWY1Vsdm1PZEZHaFEiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluM0BBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4zQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAiLCJ3aWRzIjpbIjYyZTkwMzk0LTY5ZjUtNDIzNy05MTkwLTAxMjE3NzE0NWUxMCJdfQ.VhR3i26A_Ll2bGifjgEprzJ-C1gAUd9vqck9YmBO8QPIGvW5pNmIep5eYrFkgX5CjSn0QFxRVcF-V9biOH-4XbxuG3LqqWh0q1JvQH0b0fUaxPHQ4NZ-Cx497bPfhlpCa9DyYXsgiaJ4IQQ5nVN1imbX_Z3ybzLehV1rXeizWiJjwrD6zTvovhhqZ00WfbWm_Mj9aDliSNuIHH3KCBTKiotX4WAM4pqMBI8vhs5oE18bqHiuzEdebObzPyluxmQBDIleSr_fDqZhMSgP7xR7jpNrm-nTlVyeyonct_DyFFYNMVuzHaEXy7KoCvS6WfmohwJ2pie54BC09CBg18Gr2w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc1MTkyMTE3LCJuYmYiOjE0NzUxOTIxMTcsImV4cCI6MTQ3NTE5NjAxNywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA3OTksImZhbWlseV9uYW1lIjoic2RrIiwiZ2l2ZW5fbmFtZSI6ImFkbWluMyIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4wLjEzMCIsIm5hbWUiOiJhZG1pbjMiLCJvaWQiOiJlN2UxNThkMy03Y2RjLTQ3Y2QtODgyNS01ODU5ZDdhYjJiNTUiLCJwdWlkIjoiMTAwMzNGRkY5NUQ0NEU4NCIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6ImhRenl3b3FTLUEtRzAySTl6ZE5TRmtGd3R2MGVwZ2lWY1Vsdm1PZEZHaFEiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluM0BBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4zQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAiLCJ3aWRzIjpbIjYyZTkwMzk0LTY5ZjUtNDIzNy05MTkwLTAxMjE3NzE0NWUxMCJdfQ.g84028HOdopYMPs073rrNbx5z1ZAqarJ57bWWaLaoxNGDXZ6bLCGhGwSCBIbyu3x-H8dyhtzlfPe8kcMjbcrphuUwuTkwaWkTDw4fw2u23KvndH7EPI_9fK-9q7G4NXmvDLjPxerDZ9hIRlPgh55aC5MyF6kPmd_x1PbF0ASKBXoVWMR2tXDHkmkIvH7HofO6sbzusth2jUb4jGXdpQWjhdISvaozruej1n--8x98LRCgwPLOU5TgAmpkWEJQ5dSrsxXepe_eUEeVSaZhgQUDHcD05ggqN5-m3LRQTic7_5ViM-KwdJ-xb2qMF7gim9kRQlCZZj8wpexZYHvURqe2Q]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.0.1]
+          websitemanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
       accept-language: [en-US]
-      x-ms-client-request-id: [14d51a54-7e9e-11e6-9f30-64510658e3b3]
+      x-ms-client-request-id: [2cce7c3a-869f-11e6-bf46-64510658e3b3]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/appsettings/list?api-version=2015-08-01
   response:
@@ -337,13 +336,13 @@ interactions:
         o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
         p/nndbVeNXezH6zrfFoW21f5JFuttqfV8ry4uLuqq8tiltfN3S+KaV011Xk7/m4+udsUbd7cDdpu
         0yftXfn9Ln3c5G1bLC+aj0YfLbNFTmiGH7bXK3wYgytAqE1ZTTOMidp9l6CnX72mD9uM3n+0XJfl
-        6CPCb5XXbZHTJ7/4o2aXGp5XFTVq9ujXSVbj13vy6x79/t3TJ6/P3pz+/i++fHr6+z89fXb81fM3
-        v/9Pnr56ffblC2q1P94fP/jol/yS/wcwPVXhWAEAAA==
+        6CPCb5XXbZHTJ7/4o2aXGp5XFTX67umT12dvTn//F18+Pf39n54+O/7q+Zvf/ydPX70++/IFNdof
+        748fULNmj/6YZDV+vSe/7n30S37J/wPhAmMKWAEAAA==
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Mon, 19 Sep 2016 19:20:09 GMT']
+      Date: ['Thu, 29 Sep 2016 23:48:09 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -351,21 +350,21 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11928']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc0MzEyNDQyLCJuYmYiOjE0NzQzMTI0NDIsImV4cCI6MTQ3NDMxNjM0MiwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoic2RrIiwiZ2l2ZW5fbmFtZSI6ImFkbWluMyIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4wLjEzMCIsIm5hbWUiOiJhZG1pbjMiLCJvaWQiOiJlN2UxNThkMy03Y2RjLTQ3Y2QtODgyNS01ODU5ZDdhYjJiNTUiLCJwdWlkIjoiMTAwMzNGRkY5NUQ0NEU4NCIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6ImhRenl3b3FTLUEtRzAySTl6ZE5TRmtGd3R2MGVwZ2lWY1Vsdm1PZEZHaFEiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluM0BBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4zQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAiLCJ3aWRzIjpbIjYyZTkwMzk0LTY5ZjUtNDIzNy05MTkwLTAxMjE3NzE0NWUxMCJdfQ.VhR3i26A_Ll2bGifjgEprzJ-C1gAUd9vqck9YmBO8QPIGvW5pNmIep5eYrFkgX5CjSn0QFxRVcF-V9biOH-4XbxuG3LqqWh0q1JvQH0b0fUaxPHQ4NZ-Cx497bPfhlpCa9DyYXsgiaJ4IQQ5nVN1imbX_Z3ybzLehV1rXeizWiJjwrD6zTvovhhqZ00WfbWm_Mj9aDliSNuIHH3KCBTKiotX4WAM4pqMBI8vhs5oE18bqHiuzEdebObzPyluxmQBDIleSr_fDqZhMSgP7xR7jpNrm-nTlVyeyonct_DyFFYNMVuzHaEXy7KoCvS6WfmohwJ2pie54BC09CBg18Gr2w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc1MTkyMTE3LCJuYmYiOjE0NzUxOTIxMTcsImV4cCI6MTQ3NTE5NjAxNywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA3OTksImZhbWlseV9uYW1lIjoic2RrIiwiZ2l2ZW5fbmFtZSI6ImFkbWluMyIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4wLjEzMCIsIm5hbWUiOiJhZG1pbjMiLCJvaWQiOiJlN2UxNThkMy03Y2RjLTQ3Y2QtODgyNS01ODU5ZDdhYjJiNTUiLCJwdWlkIjoiMTAwMzNGRkY5NUQ0NEU4NCIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6ImhRenl3b3FTLUEtRzAySTl6ZE5TRmtGd3R2MGVwZ2lWY1Vsdm1PZEZHaFEiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluM0BBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4zQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAiLCJ3aWRzIjpbIjYyZTkwMzk0LTY5ZjUtNDIzNy05MTkwLTAxMjE3NzE0NWUxMCJdfQ.g84028HOdopYMPs073rrNbx5z1ZAqarJ57bWWaLaoxNGDXZ6bLCGhGwSCBIbyu3x-H8dyhtzlfPe8kcMjbcrphuUwuTkwaWkTDw4fw2u23KvndH7EPI_9fK-9q7G4NXmvDLjPxerDZ9hIRlPgh55aC5MyF6kPmd_x1PbF0ASKBXoVWMR2tXDHkmkIvH7HofO6sbzusth2jUb4jGXdpQWjhdISvaozruej1n--8x98LRCgwPLOU5TgAmpkWEJQ5dSrsxXepe_eUEeVSaZhgQUDHcD05ggqN5-m3LRQTic7_5ViM-KwdJ-xb2qMF7gim9kRQlCZZj8wpexZYHvURqe2Q]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.0.1]
+          websitemanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
       accept-language: [en-US]
-      x-ms-client-request-id: [1dcfea80-7e9e-11e6-ba70-64510658e3b3]
+      x-ms-client-request-id: [2d91e6ca-869f-11e6-bf2d-64510658e3b3]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/appsettings/list?api-version=2015-08-01
   response:
@@ -376,13 +375,13 @@ interactions:
         o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
         p/nndbVeNXezH6zrfFoW21f5JFuttqfV8ry4uLuqq8tiltfN3S+KaV011Xk7/m4+udsUbd7cDdpu
         0yftXfn9Ln3c5G1bLC+aj0YfLbNFTmiGH7bXK3wYgytAqE1ZTTOMidp9l6CnX72mD9uM3n+0XJfl
-        6CPCb5XXbZHTJ7/4o2aXGp5XFTVq9ujXSVbj13vy6x79/t3TJ6/P3pz+/i++fHr6+z89fXb81fM3
-        v/9Pnr56ffblC2q1P94fP/jol/yS/wcwPVXhWAEAAA==
+        6CPCb5XXbZHTJ7/4o2aXGp5XFTX67umT12dvTn//F18+Pf39n54+O/7q+Zvf/ydPX70++/IFNdof
+        748fULNmj/6YZDV+vSe/7n30S37J/wPhAmMKWAEAAA==
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Mon, 19 Sep 2016 19:20:26 GMT']
+      Date: ['Thu, 29 Sep 2016 23:48:10 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -390,27 +389,27 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11946']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJsb2NhdGlvbiI6ICJXZXN0IFVTIiwgIm5hbWUiOiAiYXBwc2V0dGluZ3MiLCAicHJvcGVydGll
-      cyI6IHsiczMiOiAiYmFyMiIsICJXRUJTSVRFX05PREVfREVGQVVMVF9WRVJTSU9OIjogIjQuNC43
-      In0sICJ0eXBlIjogIk1pY3Jvc29mdC5XZWIvc2l0ZXMvY29uZmlnIiwgImlkIjogIi9zdWJzY3Jp
-      cHRpb25zLzBiMWY2NDcxLTFiZjAtNGRkYS1hZWMzLWNiOTI3MmYwOTU5MC9yZXNvdXJjZUdyb3Vw
-      cy9henVyZWNsaS13ZWJhcHAtY29uZmlnL3Byb3ZpZGVycy9NaWNyb3NvZnQuV2ViL3NpdGVzL3dl
-      YmFwcC1jb25maWctdGVzdC9jb25maWcvYXBwc2V0dGluZ3MifQ==
+      eyJwcm9wZXJ0aWVzIjogeyJXRUJTSVRFX05PREVfREVGQVVMVF9WRVJTSU9OIjogIjQuNC43Iiwg
+      InMzIjogImJhcjIifSwgIm5hbWUiOiAiYXBwc2V0dGluZ3MiLCAibG9jYXRpb24iOiAiV2VzdCBV
+      UyIsICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFmNjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJm
+      MDk1OTAvcmVzb3VyY2VHcm91cHMvYXp1cmVjbGktd2ViYXBwLWNvbmZpZy9wcm92aWRlcnMvTWlj
+      cm9zb2Z0LldlYi9zaXRlcy93ZWJhcHAtY29uZmlnLXRlc3QvY29uZmlnL2FwcHNldHRpbmdzIiwg
+      InR5cGUiOiAiTWljcm9zb2Z0LldlYi9zaXRlcy9jb25maWcifQ==
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc0MzEyNDQyLCJuYmYiOjE0NzQzMTI0NDIsImV4cCI6MTQ3NDMxNjM0MiwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoic2RrIiwiZ2l2ZW5fbmFtZSI6ImFkbWluMyIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4wLjEzMCIsIm5hbWUiOiJhZG1pbjMiLCJvaWQiOiJlN2UxNThkMy03Y2RjLTQ3Y2QtODgyNS01ODU5ZDdhYjJiNTUiLCJwdWlkIjoiMTAwMzNGRkY5NUQ0NEU4NCIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6ImhRenl3b3FTLUEtRzAySTl6ZE5TRmtGd3R2MGVwZ2lWY1Vsdm1PZEZHaFEiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluM0BBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4zQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAiLCJ3aWRzIjpbIjYyZTkwMzk0LTY5ZjUtNDIzNy05MTkwLTAxMjE3NzE0NWUxMCJdfQ.VhR3i26A_Ll2bGifjgEprzJ-C1gAUd9vqck9YmBO8QPIGvW5pNmIep5eYrFkgX5CjSn0QFxRVcF-V9biOH-4XbxuG3LqqWh0q1JvQH0b0fUaxPHQ4NZ-Cx497bPfhlpCa9DyYXsgiaJ4IQQ5nVN1imbX_Z3ybzLehV1rXeizWiJjwrD6zTvovhhqZ00WfbWm_Mj9aDliSNuIHH3KCBTKiotX4WAM4pqMBI8vhs5oE18bqHiuzEdebObzPyluxmQBDIleSr_fDqZhMSgP7xR7jpNrm-nTlVyeyonct_DyFFYNMVuzHaEXy7KoCvS6WfmohwJ2pie54BC09CBg18Gr2w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc1MTkyMTE3LCJuYmYiOjE0NzUxOTIxMTcsImV4cCI6MTQ3NTE5NjAxNywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA3OTksImZhbWlseV9uYW1lIjoic2RrIiwiZ2l2ZW5fbmFtZSI6ImFkbWluMyIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4wLjEzMCIsIm5hbWUiOiJhZG1pbjMiLCJvaWQiOiJlN2UxNThkMy03Y2RjLTQ3Y2QtODgyNS01ODU5ZDdhYjJiNTUiLCJwdWlkIjoiMTAwMzNGRkY5NUQ0NEU4NCIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6ImhRenl3b3FTLUEtRzAySTl6ZE5TRmtGd3R2MGVwZ2lWY1Vsdm1PZEZHaFEiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluM0BBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4zQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAiLCJ3aWRzIjpbIjYyZTkwMzk0LTY5ZjUtNDIzNy05MTkwLTAxMjE3NzE0NWUxMCJdfQ.g84028HOdopYMPs073rrNbx5z1ZAqarJ57bWWaLaoxNGDXZ6bLCGhGwSCBIbyu3x-H8dyhtzlfPe8kcMjbcrphuUwuTkwaWkTDw4fw2u23KvndH7EPI_9fK-9q7G4NXmvDLjPxerDZ9hIRlPgh55aC5MyF6kPmd_x1PbF0ASKBXoVWMR2tXDHkmkIvH7HofO6sbzusth2jUb4jGXdpQWjhdISvaozruej1n--8x98LRCgwPLOU5TgAmpkWEJQ5dSrsxXepe_eUEeVSaZhgQUDHcD05ggqN5-m3LRQTic7_5ViM-KwdJ-xb2qMF7gim9kRQlCZZj8wpexZYHvURqe2Q]
       Connection: [keep-alive]
       Content-Length: ['322']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.0.1]
+          websitemanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
       accept-language: [en-US]
-      x-ms-client-request-id: [28f383c6-7e9e-11e6-8671-64510658e3b3]
+      x-ms-client-request-id: [2e106566-869f-11e6-8b4c-64510658e3b3]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/appsettings?api-version=2015-08-01
   response:
@@ -421,13 +420,13 @@ interactions:
         o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
         p/nndbVeNXezH6zrfFoW21f5JFuttqfV8ry4uLuqq8tiltfN3S+KaV011Xk7/m4+udsUbd7cDdpu
         0yftXfn9Ln3c5G1bLC+aj0YfLbNFTmiGH7bXK3wYgytAqE1ZTTOMidp9l6CnX72mD9uM3n+0XJfl
-        6CPCb5XXbZHTJ7/4o+YeNZxk9R61+u7pk9dnb05//xdfPj39/Z+ePjv+6vmb3/8nT1+9PvvyBbXa
-        H++PH3z0S37J/wNOV4PAQgEAAA==
+        6CPCb5XXbZHTJ7/4o++ePnl99ub093/x5dPT3//p6bPjr56/+f1/8vTV67MvXxCI/fH++AEBaO7R
+        H5Os3vvol/yS/wfD4EiaQgEAAA==
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Mon, 19 Sep 2016 19:20:45 GMT']
+      Date: ['Thu, 29 Sep 2016 23:48:12 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -435,21 +434,21 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc0MzEyNDQyLCJuYmYiOjE0NzQzMTI0NDIsImV4cCI6MTQ3NDMxNjM0MiwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoic2RrIiwiZ2l2ZW5fbmFtZSI6ImFkbWluMyIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4wLjEzMCIsIm5hbWUiOiJhZG1pbjMiLCJvaWQiOiJlN2UxNThkMy03Y2RjLTQ3Y2QtODgyNS01ODU5ZDdhYjJiNTUiLCJwdWlkIjoiMTAwMzNGRkY5NUQ0NEU4NCIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6ImhRenl3b3FTLUEtRzAySTl6ZE5TRmtGd3R2MGVwZ2lWY1Vsdm1PZEZHaFEiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluM0BBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4zQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAiLCJ3aWRzIjpbIjYyZTkwMzk0LTY5ZjUtNDIzNy05MTkwLTAxMjE3NzE0NWUxMCJdfQ.VhR3i26A_Ll2bGifjgEprzJ-C1gAUd9vqck9YmBO8QPIGvW5pNmIep5eYrFkgX5CjSn0QFxRVcF-V9biOH-4XbxuG3LqqWh0q1JvQH0b0fUaxPHQ4NZ-Cx497bPfhlpCa9DyYXsgiaJ4IQQ5nVN1imbX_Z3ybzLehV1rXeizWiJjwrD6zTvovhhqZ00WfbWm_Mj9aDliSNuIHH3KCBTKiotX4WAM4pqMBI8vhs5oE18bqHiuzEdebObzPyluxmQBDIleSr_fDqZhMSgP7xR7jpNrm-nTlVyeyonct_DyFFYNMVuzHaEXy7KoCvS6WfmohwJ2pie54BC09CBg18Gr2w]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc1MTkyMTE3LCJuYmYiOjE0NzUxOTIxMTcsImV4cCI6MTQ3NTE5NjAxNywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA3OTksImZhbWlseV9uYW1lIjoic2RrIiwiZ2l2ZW5fbmFtZSI6ImFkbWluMyIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4wLjEzMCIsIm5hbWUiOiJhZG1pbjMiLCJvaWQiOiJlN2UxNThkMy03Y2RjLTQ3Y2QtODgyNS01ODU5ZDdhYjJiNTUiLCJwdWlkIjoiMTAwMzNGRkY5NUQ0NEU4NCIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6ImhRenl3b3FTLUEtRzAySTl6ZE5TRmtGd3R2MGVwZ2lWY1Vsdm1PZEZHaFEiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluM0BBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4zQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAiLCJ3aWRzIjpbIjYyZTkwMzk0LTY5ZjUtNDIzNy05MTkwLTAxMjE3NzE0NWUxMCJdfQ.g84028HOdopYMPs073rrNbx5z1ZAqarJ57bWWaLaoxNGDXZ6bLCGhGwSCBIbyu3x-H8dyhtzlfPe8kcMjbcrphuUwuTkwaWkTDw4fw2u23KvndH7EPI_9fK-9q7G4NXmvDLjPxerDZ9hIRlPgh55aC5MyF6kPmd_x1PbF0ASKBXoVWMR2tXDHkmkIvH7HofO6sbzusth2jUb4jGXdpQWjhdISvaozruej1n--8x98LRCgwPLOU5TgAmpkWEJQ5dSrsxXepe_eUEeVSaZhgQUDHcD05ggqN5-m3LRQTic7_5ViM-KwdJ-xb2qMF7gim9kRQlCZZj8wpexZYHvURqe2Q]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.0.1]
+          websitemanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
       accept-language: [en-US]
-      x-ms-client-request-id: [311dd730-7e9e-11e6-be5a-64510658e3b3]
+      x-ms-client-request-id: [2eea8026-869f-11e6-a1f7-64510658e3b3]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/config/appsettings/list?api-version=2015-08-01
   response:
@@ -460,13 +459,13 @@ interactions:
         o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
         p/nndbVeNXezH6zrfFoW21f5JFuttqfV8ry4uLuqq8tiltfN3S+KaV011Xk7/m4+udsUbd7cDdpu
         0yftXfn9Ln3c5G1bLC+aj0YfLbNFTmiGH7bXK3wYgytAqE1ZTTOMidp9l6CnX72mD9uM3n+0XJfl
-        6CPCb5XXbZHTJ7/4o+YeNZxk9R61+u7pk9dnb05//xdfPj39/Z+ePjv+6vmb3/8nT1+9PvvyBbXa
-        H++PH3z0S37J/wNOV4PAQgEAAA==
+        6CPCb5XXbZHTJ7/4o++ePnl99ub093/x5dPT3//p6bPjr56/+f1/8vTV67MvXxCI/fH++AEBaO7R
+        H5Os3vvol/yS/wfD4EiaQgEAAA==
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Mon, 19 Sep 2016 19:20:57 GMT']
+      Date: ['Thu, 29 Sep 2016 23:48:12 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -474,6 +473,43 @@ interactions:
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11949']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc1MTkyMTE3LCJuYmYiOjE0NzUxOTIxMTcsImV4cCI6MTQ3NTE5NjAxNywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA3OTksImZhbWlseV9uYW1lIjoic2RrIiwiZ2l2ZW5fbmFtZSI6ImFkbWluMyIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4wLjEzMCIsIm5hbWUiOiJhZG1pbjMiLCJvaWQiOiJlN2UxNThkMy03Y2RjLTQ3Y2QtODgyNS01ODU5ZDdhYjJiNTUiLCJwdWlkIjoiMTAwMzNGRkY5NUQ0NEU4NCIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6ImhRenl3b3FTLUEtRzAySTl6ZE5TRmtGd3R2MGVwZ2lWY1Vsdm1PZEZHaFEiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluM0BBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4zQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAiLCJ3aWRzIjpbIjYyZTkwMzk0LTY5ZjUtNDIzNy05MTkwLTAxMjE3NzE0NWUxMCJdfQ.g84028HOdopYMPs073rrNbx5z1ZAqarJ57bWWaLaoxNGDXZ6bLCGhGwSCBIbyu3x-H8dyhtzlfPe8kcMjbcrphuUwuTkwaWkTDw4fw2u23KvndH7EPI_9fK-9q7G4NXmvDLjPxerDZ9hIRlPgh55aC5MyF6kPmd_x1PbF0ASKBXoVWMR2tXDHkmkIvH7HofO6sbzusth2jUb4jGXdpQWjhdISvaozruej1n--8x98LRCgwPLOU5TgAmpkWEJQ5dSrsxXepe_eUEeVSaZhgQUDHcD05ggqN5-m3LRQTic7_5ViM-KwdJ-xb2qMF7gim9kRQlCZZj8wpexZYHvURqe2Q]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          websitemanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
+      accept-language: [en-US]
+      x-ms-client-request-id: [2f8f78a4-869f-11e6-a082-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-config/providers/Microsoft.Web/sites/webapp-config-test/hostNameBindings?api-version=2015-08-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
+        zsP7D3fu1nlTretp/nldrVfN3ewH6zqflsX2VT7JVqvtabU8Ly7ururqspjldXP3i2JaV0113o6/
+        m0/uNkWbN3eDttv0SXt3XjXti2yRPymWs2J5EWsz5r7ocwYyXubtR6OPlvQOjYQ+7bS+LYD2egUA
+        MTS7OFHrsppmIBa98V2CmH71mj5sM/ru0XJdlqOPaOCrvG6LnD75xR8BDiBQc+q2gw69OasWWbE8
+        o7mQt02PbwSpn8zr4rzIZx/9kl/yfRpq/q59XizfmsaYQvz2S/4fNRlO29gBAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Thu, 29 Sep 2016 23:48:13 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/tests/test_webapp_commands.py
+++ b/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/tests/test_webapp_commands.py
@@ -145,6 +145,11 @@ class WebappConfigureTest(ResourceGroupVCRTestBase):
         self.assertTrue('s2' not in result)
         self.assertTrue('s3' in result)
 
+        self.cmd('appservice web config hostname list -g {} -n {}'.format(self.resource_group, self.webapp_name), checks=[
+            JMESPathCheck('length(@)', 1),
+            JMESPathCheck('[0].name', '{}/{}.azurewebsites.net'.format(self.webapp_name, self.webapp_name))
+            ])
+
 
 class WebappScaleTest(ResourceGroupVCRTestBase):
 

--- a/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/tests/test_webapp_commands.py
+++ b/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/tests/test_webapp_commands.py
@@ -145,7 +145,7 @@ class WebappConfigureTest(ResourceGroupVCRTestBase):
         self.assertTrue('s2' not in result)
         self.assertTrue('s3' in result)
 
-        self.cmd('appservice web config hostname list -g {} -n {}'.format(self.resource_group, self.webapp_name), checks=[
+        self.cmd('appservice web config hostname list -g {} --webapp {}'.format(self.resource_group, self.webapp_name), checks=[
             JMESPathCheck('length(@)', 1),
             JMESPathCheck('[0].name', '{}/{}.azurewebsites.net'.format(self.webapp_name, self.webapp_name))
             ])

--- a/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/tests/test_webapp_commands.py
+++ b/src/command_modules/azure-cli-webapp/azure/cli/command_modules/webapp/tests/test_webapp_commands.py
@@ -147,7 +147,7 @@ class WebappConfigureTest(ResourceGroupVCRTestBase):
 
         self.cmd('appservice web config hostname list -g {} --webapp {}'.format(self.resource_group, self.webapp_name), checks=[
             JMESPathCheck('length(@)', 1),
-            JMESPathCheck('[0].name', '{}/{}.azurewebsites.net'.format(self.webapp_name, self.webapp_name))
+            JMESPathCheck('[0].name', '{0}/{0}.azurewebsites.net'.format(self.webapp_name))
             ])
 
 


### PR DESCRIPTION
Note: had to rename to "resource_group" to "resource_group_name", so tab completion would work
```bash 
Command
    az appservice web config hostname add: Bind a hostname(custom domain) to the app.

Arguments
    --slot             : The name of the slot. Default to the productions slot if not specified.

Resource Id Arguments
    --ids              : One or more resource IDs. If provided, no other 'Resource Id' arguments
                         should be specified.
    --name -n          : Hostname assigned to the site, such as custom domains.
    --resource-group -g: Name of resource group.
    --webapp           : Webapp name.

Command
    az appservice web config hostname list: List all hostname bindings.

Arguments
    --slot             : The name of the slot. Default to the productions slot if not specified.

Resource Id Arguments
    --ids              : One or more resource IDs. If provided, no other 'Resource Id' arguments
                         should be specified.
    --resource-group -g: Name of resource group.
    --webapp           : Webapp name.

Command
    az appservice web config hostname delete: Unbind a hostname(custom domain) from the app.

Arguments
    --slot             : The name of the slot. Default to the productions slot if not specified.

Resource Id Arguments
    --ids              : One or more resource IDs. If provided, no other 'Resource Id' arguments
                         should be specified.
    --name -n          : Hostname assigned to the site, such as custom domains.
    --resource-group -g: Name of resource group.
    --webapp           : Webapp name.
```