### PR TITLE
Revert "Use setuptools entry_points for az executable"

### DIFF
--- a/src/azure-cli/az
+++ b/src/azure-cli/az
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+export PYTHONPATH="${DIR}/src:${PYTHONPATH}"
+
+python -m azure.cli "$@"
+

--- a/src/azure-cli/az.bat
+++ b/src/azure-cli/az.bat
@@ -1,0 +1,7 @@
+@echo off
+setlocal
+
+SET PYTHONPATH=%~dp0/src;%PYTHONPATH%
+python -m azure.cli %*
+
+endlocal

--- a/src/azure-cli/azure/cli/__main__.py
+++ b/src/azure-cli/azure/cli/__main__.py
@@ -11,33 +11,29 @@ import azure.cli.main
 from azure.cli.core.telemetry import (init_telemetry, user_agrees_to_telemetry,
                                       telemetry_flush, log_telemetry)
 
-def cli():
+try:
     try:
-        try:
-            if user_agrees_to_telemetry():
-                init_telemetry()
-        except Exception: #pylint: disable=broad-except
-            pass
+        if user_agrees_to_telemetry():
+            init_telemetry()
+    except Exception: #pylint: disable=broad-except
+        pass
 
-        args = sys.argv[1:]
+    args = sys.argv[1:]
 
-        # Check if we are in argcomplete mode - if so, we
-        # need to pick up our args from environment variables
-        if os.environ.get('_ARGCOMPLETE'):
-            comp_line = os.environ.get('COMP_LINE')
-            if comp_line:
-                args = comp_line.split()[1:]
+    # Check if we are in argcomplete mode - if so, we
+    # need to pick up our args from environment variables
+    if os.environ.get('_ARGCOMPLETE'):
+        comp_line = os.environ.get('COMP_LINE')
+        if comp_line:
+            args = comp_line.split()[1:]
 
-        sys.exit(azure.cli.main.main(args))
-    except KeyboardInterrupt:
-        log_telemetry('keyboard interrupt')
-        sys.exit(1)
-    finally:
-        try:
-            if user_agrees_to_telemetry():
-                telemetry_flush()
-        except Exception: #pylint: disable=broad-except
-            pass
-
-if __name__ == "__main__":
-    cli()
+    sys.exit(azure.cli.main.main(args))
+except KeyboardInterrupt:
+    log_telemetry('keyboard interrupt')
+    sys.exit(1)
+finally:
+    try:
+        if user_agrees_to_telemetry():
+            telemetry_flush()
+    except Exception: #pylint: disable=broad-except
+        pass

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -69,11 +69,10 @@ setup(
     zip_safe=False,
     classifiers=CLASSIFIERS,
     scripts=[
+        'az',
         'az.completion.sh',
+        'az.bat',
     ],
-    entry_points = {
-        'console_scripts': ['az=azure.cli.__main__:cli']
-    },
     namespace_packages = [
         'azure'
     ],


### PR DESCRIPTION
Reverts Azure/azure-cli#1014

Using the entry_points/console_scripts feature of setuptools has some drawbacks so reverting back to our own script files.
Drawbacks:
- It can be slow.
- In the script that setuptools creates, it imports `pkg_resource` which takes a significant time of the total 'az' load time (~50%).
- It does some version checking that can prevent 'az' from loading when 'az' can in-fact load fine.