### PR TITLE
ARM: provider command and resource show command improvements

### DIFF
--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
@@ -72,6 +72,17 @@ helps['resource'] = """
     type: group
     short-summary: Generic commands to manage Azure resources
 """
+helps['resource show'] = """
+    type: command
+    short-summary: display a resource detail
+    examples:
+        - name: show a virtual machine
+          text: >
+            az vm show -g mygroup -n mywebapp --resource-type "Microsoft.Compute/virtualMachines"
+        - name: show a webapp
+          text: >
+            az resource show -g mygroup -n mywebapp --resource-type "Microsoft.web/sites"
+"""
 helps['resource feature'] = """
     type: group
     short-summary: Commands to manage resource provider features, such as previews
@@ -88,11 +99,18 @@ helps['resource group deployment operation'] = """
     type: group
     short-summary: Commands to manage deployment operations
 """
-helps['resource provider'] = """
+helps['provider'] = """
     type: group
-    short-summary: Commands to manage resource providers
+    short-summary: Manage resource providers
 """
-
+helps['provider register'] = """
+    type: command
+    short-summary: Register a provider
+"""
+helps['provider unregister'] = """
+    type: command
+    short-summary: Unregister a provider
+"""
 helps['tag'] = """
     type: group
     short-summary: Manage resource tags

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
@@ -78,7 +78,7 @@ helps['resource show'] = """
     examples:
         - name: show a virtual machine
           text: >
-            az vm show -g mygroup -n mywebapp --resource-type "Microsoft.Compute/virtualMachines"
+            az vm show -g mygroup -n myvm --resource-type "Microsoft.Compute/virtualMachines"
         - name: show a webapp
           text: >
             az resource show -g mygroup -n mywebapp --resource-type "Microsoft.web/sites"

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
@@ -12,7 +12,7 @@ from azure.cli.core.commands.parameters import (ignore_type, resource_group_name
                                                 tags_type, get_resource_group_completion_list,
                                                 enum_choice_list)
 from .custom import (get_policy_completion_list, get_policy_assignment_completion_list,
-                     get_resource_types_completion_list)
+                     get_resource_types_completion_list, get_providers_completion_list)
 from ._validators import validate_resource_type, validate_parent, resolve_resource_parameters
 
 # BASIC PARAMETER CONFIGURATION
@@ -35,7 +35,8 @@ register_cli_argument('resource show', 'resource_type', completer=get_resource_t
 
 _PROVIDER_HELP_TEXT = 'the resource namespace, aka \'provider\''
 register_cli_argument('provider', 'top', ignore_type)
-register_cli_argument('provider', 'resource_provider_namespace', options_list=('--namespace', '-n'), help=_PROVIDER_HELP_TEXT)
+register_cli_argument('provider', 'resource_provider_namespace', options_list=('--namespace', '-n'), completer=get_providers_completion_list,
+                      help=_PROVIDER_HELP_TEXT)
 
 register_cli_argument('resource feature', 'resource_provider_namespace', options_list=('--namespace',), required=True, help=_PROVIDER_HELP_TEXT)
 register_cli_argument('resource feature list', 'resource_provider_namespace', options_list=('--namespace',), required=False, help=_PROVIDER_HELP_TEXT)

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
@@ -11,7 +11,8 @@ from azure.cli.core.commands import register_cli_argument, CliArgumentType
 from azure.cli.core.commands.parameters import (ignore_type, resource_group_name_type, tag_type,
                                                 tags_type, get_resource_group_completion_list,
                                                 enum_choice_list)
-from .custom import get_policy_completion_list, get_policy_assignment_completion_list
+from .custom import (get_policy_completion_list, get_policy_assignment_completion_list,
+                     get_resource_types_completion_list)
 from ._validators import validate_resource_type, validate_parent, resolve_resource_parameters
 
 # BASIC PARAMETER CONFIGURATION
@@ -30,10 +31,11 @@ register_cli_argument('resource', 'tag', tag_type)
 register_cli_argument('resource', 'tags', tags_type)
 register_cli_argument('resource list', 'name', resource_name_type)
 register_cli_argument('resource move', 'ids', nargs='+')
+register_cli_argument('resource show', 'resource_type', completer=get_resource_types_completion_list)
 
 _PROVIDER_HELP_TEXT = 'the resource namespace, aka \'provider\''
-register_cli_argument('resource provider', 'top', ignore_type)
-register_cli_argument('resource provider', 'resource_provider_namespace', options_list=('--namespace', '-n'), help=_PROVIDER_HELP_TEXT)
+register_cli_argument('provider', 'top', ignore_type)
+register_cli_argument('provider', 'resource_provider_namespace', options_list=('--namespace', '-n'), help=_PROVIDER_HELP_TEXT)
 
 register_cli_argument('resource feature', 'resource_provider_namespace', options_list=('--namespace',), required=True, help=_PROVIDER_HELP_TEXT)
 register_cli_argument('resource feature list', 'resource_provider_namespace', options_list=('--namespace',), required=False, help=_PROVIDER_HELP_TEXT)

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
@@ -234,6 +234,11 @@ def tag_resource(
         if '202' not in str(ex):
             raise ex
 
+def get_providers_completion_list(prefix, **kwargs): #pylint: disable=unused-argument
+    rcf = _resource_client_factory()
+    result = rcf.providers.list()
+    return [r.namespace for r in result]
+
 def get_resource_types_completion_list(prefix, **kwargs): #pylint: disable=unused-argument
     rcf = _resource_client_factory()
     result = rcf.providers.list()

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
@@ -234,6 +234,15 @@ def tag_resource(
         if '202' not in str(ex):
             raise ex
 
+def get_resource_types_completion_list(prefix, **kwargs): #pylint: disable=unused-argument
+    rcf = _resource_client_factory()
+    result = rcf.providers.list()
+    types = []
+    for p in list(result):
+        for r in p.resource_types:
+            types.append(p.namespace + '/' + r.resource_type)
+    return types
+
 def register_provider(resource_provider_namespace):
     _update_provider(resource_provider_namespace, registering=True)
 

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/generated.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/generated.py
@@ -34,14 +34,12 @@ from azure.cli.command_modules.resource.custom import (
 factory = lambda _: _resource_client_factory().resource_groups
 cli_command('resource group delete', ResourceGroupsOperations.delete, factory)
 cli_command('resource group show', ResourceGroupsOperations.get, factory)
-cli_command('resource group exists', ResourceGroupsOperations.check_existence, factory)
 cli_command('resource group list', list_resource_groups)
 cli_command('resource group create', create_resource_group)
 cli_command('resource group export', export_group_as_template)
 
 # Resource commands
 factory = lambda _: _resource_client_factory().resources
-cli_command('resource exists', ResourcesOperations.check_existence, factory)
 cli_command('resource delete', ResourcesOperations.delete, factory)
 cli_command('resource show', ResourcesOperations.get, factory)
 cli_command('resource list', list_resources)
@@ -50,10 +48,10 @@ cli_command('resource move', move_resource)
 
 # Resource provider commands
 factory = lambda _: _resource_client_factory().providers
-cli_command('resource provider list', ProvidersOperations.list, factory)
-cli_command('resource provider show', ProvidersOperations.get, factory)
-cli_command('resource provider register', register_provider)
-cli_command('resource provider unregister', unregister_provider)
+cli_command('provider list', ProvidersOperations.list, factory)
+cli_command('provider show', ProvidersOperations.get, factory)
+cli_command('provider register', register_provider)
+cli_command('provider unregister', unregister_provider)
 
 # Resource feature commands
 factory = lambda _: _resource_feature_client_factory().features
@@ -75,7 +73,6 @@ cli_command('resource group deployment create', deploy_arm_template)
 cli_command('resource group deployment list', DeploymentsOperations.list, factory)
 cli_command('resource group deployment show', DeploymentsOperations.get, factory)
 cli_command('resource group deployment validate', validate_arm_template)
-cli_command('resource group deployment exists', DeploymentsOperations.check_existence, factory)
 cli_command('resource group deployment export', export_deployment_as_template)
 
 # Resource group deployment operations commands

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/generated.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/generated.py
@@ -34,6 +34,7 @@ from azure.cli.command_modules.resource.custom import (
 factory = lambda _: _resource_client_factory().resource_groups
 cli_command('resource group delete', ResourceGroupsOperations.delete, factory)
 cli_command('resource group show', ResourceGroupsOperations.get, factory)
+cli_command('resource group exists', ResourceGroupsOperations.check_existence, factory)
 cli_command('resource group list', list_resource_groups)
 cli_command('resource group create', create_resource_group)
 cli_command('resource group export', export_group_as_template)
@@ -73,6 +74,7 @@ cli_command('resource group deployment create', deploy_arm_template)
 cli_command('resource group deployment list', DeploymentsOperations.list, factory)
 cli_command('resource group deployment show', DeploymentsOperations.get, factory)
 cli_command('resource group deployment validate', validate_arm_template)
+cli_command('resource group deployment exists', DeploymentsOperations.check_existence, factory)
 cli_command('resource group deployment export', export_deployment_as_template)
 
 # Resource group deployment operations commands

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/test_resource.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/test_resource.py
@@ -148,17 +148,17 @@ class ProviderRegistrationTest(VCRTestBase): # Not RG test base because it opera
 
     def body(self):
         provider = 'TrendMicro.DeepSecurity'
-        result = self.cmd('resource provider show -n {}'.format(provider), checks=None)
+        result = self.cmd('provider show -n {}'.format(provider), checks=None)
         if result['registrationState'] == 'Unregistered':
-            self.cmd('resource provider register -n {}'.format(provider), checks=None)
-            self.cmd('resource provider show -n {}'.format(provider), checks=[JMESPathCheck('registrationState', 'Registered')])
-            self.cmd('resource provider unregister -n {}'.format(provider), checks=None)
-            self.cmd('resource provider show -n {}'.format(provider), checks=[JMESPathCheck('registrationState', 'Unregistered')])
+            self.cmd('provider register -n {}'.format(provider), checks=None)
+            self.cmd('provider show -n {}'.format(provider), checks=[JMESPathCheck('registrationState', 'Registered')])
+            self.cmd('provider unregister -n {}'.format(provider), checks=None)
+            self.cmd('provider show -n {}'.format(provider), checks=[JMESPathCheck('registrationState', 'Unregistered')])
         else:
-            self.cmd('resource provider unregister -n {}'.format(provider), checks=None)
-            self.cmd('resource provider show -n {}'.format(provider), checks=[JMESPathCheck('registrationState', 'Unregistered')])
-            self.cmd('resource provider register -n {}'.format(provider), checks=None)
-            self.cmd('resource provider show -n {}'.format(provider), checks=[JMESPathCheck('registrationState', 'Registered')])
+            self.cmd('provider unregister -n {}'.format(provider), checks=None)
+            self.cmd('provider show -n {}'.format(provider), checks=[JMESPathCheck('registrationState', 'Unregistered')])
+            self.cmd('provider register -n {}'.format(provider), checks=None)
+            self.cmd('provider show -n {}'.format(provider), checks=[JMESPathCheck('registrationState', 'Registered')])
 
 class DeploymentTest(ResourceGroupVCRTestBase):
     def __init__(self, test_method):


### PR DESCRIPTION
1. Move `resource provider` to top:  `provider`
2. Enable tab completion on `provider` commands
3. Enable tab completion on `resource show --resource-type`
4. Remove `exists` command. ARM team has started the API will retire in near future.

Fix portion of #1033, portion of #1039 