### PR TITLE
create-for-rbac: output sp information in json format to stdout for easy scripting

### DIFF
--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
@@ -16,7 +16,7 @@ helps['ad sp create-for-rbac'] = """
                 - name: Create role assignments at the same time
                   text: az ad sp create-for-rbac -n "http://my-app" --role contributor --scopes /subscriptions/11111111-2222-3333-4444-555555555555/resourceGroups/mygroup /subscriptions/11111111-2222-3333-4444-666666666666/resourceGroups/my-another-group
                 - name: Login with this service principal
-                  text: az login --service-principal -u <sp_name> -p <secret> --tenant <tenant>
+                  text: az login --service-principal -u <sp_name> -p <client_secret> --tenant <tenant>
                 - name: Reset credentials on expiration
                   text: az ad sp reset-credentials --name <sp_name>
                 - name: Create role assignments

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_help.py
@@ -15,6 +15,14 @@ helps['ad sp create-for-rbac'] = """
                   text: az ad sp create-for-rbac -n "http://my-app"
                 - name: Create role assignments at the same time
                   text: az ad sp create-for-rbac -n "http://my-app" --role contributor --scopes /subscriptions/11111111-2222-3333-4444-555555555555/resourceGroups/mygroup /subscriptions/11111111-2222-3333-4444-666666666666/resourceGroups/my-another-group
+                - name: Login with this service principal
+                  text: az login --service-principal -u <sp_name> -p <secret> --tenant <tenant>
+                - name: Reset credentials on expiration
+                  text: az ad sp reset-credentials --name <sp_name>
+                - name: Create role assignments
+                  text: az role assignment create --assignee <sp_name> --role Contributor
+                - name: Revoke the service principal when done with it
+                  text: az ad app delete --id <sp_name>
             """
 
 helps['role'] = """

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 #---------------------------------------------------------------------------------------------
-from __future__ import print_function
 import datetime
 import json
 import re

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
@@ -567,12 +567,20 @@ def _build_output_content(sp_name, app_id, secret, tenant):
     #this is a fairly special convinience command that the result is not associated
     #with one api response, so it controls its own output format for easy scripting
     #and also ensures warning (to stderr) goes after the stdout.
-    result = {
-        'app_id_uri': sp_name,
-        'client_id': app_id,
-        'client_secret': secret
-    }
-    print(json.dumps(result, indent=4))
+    from azure.cli.core.application import APPLICATION
+
+    if APPLICATION.configuration.output_format[:4] == 'json':
+        result = {
+            'client_id': app_id,
+            'client_secret': secret,
+            'sp_name': sp_name,
+        }
+        print(json.dumps(result, indent=2))
+    else:
+        logger.warning("Service principal has been configured.")
+        logger.warning("  client_id:     " + app_id)
+        logger.warning("  client_secret: " + secret)
+        logger.warning("  sp_name:       " + sp_name)
 
     logger.warning('Useful commands to manage azure:')
     logger.warning('Assign a role:')

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 #---------------------------------------------------------------------------------------------
+from __future__ import print_function
 import datetime
 import json
 import re
@@ -514,7 +515,8 @@ def create_service_principal_for_rbac(name=None, secret=None, years=1,
     #pylint: disable=no-member
     aad_sp = _create_service_principal(aad_application.app_id, bool(scopes))
     oid = aad_sp.output.object_id if scopes else aad_sp.object_id
-    _build_output_content(name, secret, client.config.tenant_id)
+
+    _build_output_content(name, aad_application.app_id, secret, client.config.tenant_id)
 
     if scopes:
         #It is possible the SP has not been propagated to all servers, so creating assignments
@@ -559,12 +561,18 @@ def reset_service_principal_credential(name, secret=None, years=1):
 
     client.applications.patch(app.object_id, app_create_param)
 
-    _build_output_content(name, secret, client.config.tenant_id)
+    _build_output_content(name, app.app_id, secret, client.config.tenant_id)
 
-def _build_output_content(sp_name, secret, tenant):
-    logger.warning("Service principal has been configured.")
-    logger.warning("  id(client_id):           " + sp_name)
-    logger.warning("  password(client_secret): " + secret)
+def _build_output_content(sp_name, app_id, secret, tenant):
+    #this is a fairly special convinience command that the result is not associated
+    #with one api response, so it controls its own output format for easy scripting
+    #and also ensures warning (to stderr) goes after the stdout.
+    result = {
+        'app_id_uri': sp_name,
+        'client_id': app_id,
+        'client_secret': secret
+    }
+    print(json.dumps(result, indent=4))
 
     logger.warning('Useful commands to manage azure:')
     logger.warning('Assign a role:')


### PR DESCRIPTION
//cc:@derekbekoe @ahmetalpbalkan 
This does what we want; however the shortcoming (minor, imo) is I hard code on json text to stdout. This ensures samples(logged by command to stderr) comes after the stdout. Normally dumping result to stdout is handled by core module after the custom handler exits, but this will cause sample commands get dumped before the SP info, which is odd.
It is very doable to share code at [core module](https://github.com/Azure/azure-cli/blob/master/src/azure-cli/azure/cli/main.py#L37-L39) to manipulate the format at command level, but not so sure whether it is worthwhile, considering the command has its own unique output format anyway.

```bash
{
    "client_secret": "c24fb79b-c0c7-48e3-a939-123456789012", 
    "client_id": "8c25c617-8ee3-45fa-836b-123456789012", 
    "app_id_uri": "http://yugangw112"
}
Useful commands to manage azure:
Assign a role:
    az role assignment create --assignee http://yugangw112 --role Contributor
Log in:
    az login --service-principal -u http://yugangw112 -p secret --tenant 54826b22-38d6-4fb2-bad9-123456789012
Reset credentials:
    az ad sp reset-credentials --name http://yugangw112
Revoke:
    az ad app delete --id http://yugangw112
```