### PR TITLE
[output] Convert the keys of dictionaries to camelCase also

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_util.py
+++ b/src/azure-cli-core/azure/cli/core/_util.py
@@ -91,7 +91,7 @@ def todict(obj): #pylint: disable=too-many-return-statements
         return re.sub(KEYS_CAMELCASE_PATTERN, lambda x: x.group(1).upper(), s)
 
     if isinstance(obj, dict):
-        return {k: todict(v) for (k, v) in obj.items()}
+        return {to_camelcase(k): todict(v) for (k, v) in obj.items()}
     elif isinstance(obj, list):
         return [todict(a) for a in obj]
     elif isinstance(obj, Enum):

--- a/src/azure-cli-core/azure/cli/core/tests/test_util.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_util.py
@@ -51,6 +51,18 @@ class TestUtils(unittest.TestCase):
         expected = {'a': {'a': 'x', 'b': 'y'}}
         self.assertEqual(actual, expected)
 
+    def test_application_todict__dict_is_camelcase(self):
+        the_input = {'contents': {'thisIsCamelCasedAlready': 'a_value'}}
+        actual = todict(the_input)
+        expected = {'contents': {'thisIsCamelCasedAlready': 'a_value'}}
+        self.assertEqual(actual, expected)
+
+    def test_application_todict__dict_is_not_camelcase(self):
+        the_input = {'contents': {'this_is_not_camel_cased_already': 'a_value'}}
+        actual = todict(the_input)
+        expected = {'contents': {'thisIsNotCamelCasedAlready': 'a_value'}}
+        self.assertEqual(actual, expected)
+
     def test_load_json_from_file(self):
         _, pathname = tempfile.mkstemp()
 


### PR DESCRIPTION
The dict that is passed in:
```
the_dict = {'params': {'test_key_here': 'value'}}
```

Output before:
```
  {
    "params": {
      "test_key_here": "value",
    }
  }
```

Output after:
```
  {
    "params": {
      "testKeyHere": "value",
    }
  }
```