### PR TITLE
Logic to allow acs commands to be loaded from multiple modules

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -171,7 +171,8 @@ def get_command_table(module_name=None):
     If the module is not found, all commands are loaded.
     '''
     loaded = False
-    if module_name:
+    # TODO Remove check for acs module. Issue #1110
+    if module_name and module_name != 'acs':
         try:
             import_module('azure.cli.command_modules.' + module_name)
             logger.info("Successfully loaded command table from module '%s'.", module_name)


### PR DESCRIPTION
As discussed, this is a temporary work-around as https://github.com/Azure/azure-cli/issues/1110 has not been implemented yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/azure-cli/1111)
<!-- Reviewable:end -->
