### PR TITLE
acs: expose scale command

### DIFF
--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_help.py
@@ -179,9 +179,9 @@ helps['acs show'] = """
     type: command
     short-summary: show a container service
 """
-helps['acs update'] = """
+helps['acs scale'] = """
     type: command
-    short-summary: update a container service such as adding more private agents, etc.
+    short-summary: change private agent count of a container service.
 """
 helps['vm diagnostics'] = """
     type: group

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -76,7 +76,7 @@ register_cli_argument('acs', 'ssh_key_value', required=False, help='SSH key file
 register_extra_cli_argument('acs create', 'generate_ssh_keys', action='store_true', help='Generate SSH public and private key files if missing')
 register_cli_argument('acs', 'container_service_name', options_list=('--name', '-n'), help='The name of the container service', completer=get_resource_name_completion_list('Microsoft.ContainerService/ContainerServices'))
 register_cli_argument('acs create', 'agent_vm_size', completer=get_vm_size_completion_list)
-register_cli_argument('acs update', 'agent_count', type=int, help='The number of agents for the cluster')
+register_cli_argument('acs scale', 'new_agent_count', type=int, help='The number of agents for the cluster')
 
 register_cli_argument('vm capture', 'overwrite', action='store_true')
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -1018,5 +1018,6 @@ def update_acs(resource_group_name, container_service_name, new_agent_count):
     client = _compute_client_factory()
     instance = client.container_service.get(resource_group_name, container_service_name)
     instance.agent_pool_profiles[0].count = new_agent_count
-    return client.container_service.create_or_update(resource_group_name, container_service_name, instance)
+    return client.container_service.create_or_update(resource_group_name,
+                                                     container_service_name, instance)
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -1014,6 +1014,9 @@ def vmss_set(**kwargs):
 
 cli_generic_update_command('vmss update', vmss_get, vmss_set)
 
-def update_acs(instance, agent_count):
-    instance.agent_pool_profiles[0].count = agent_count
-    return instance
+def update_acs(resource_group_name, container_service_name, new_agent_count):
+    client = _compute_client_factory()
+    instance = client.container_service.get(resource_group_name, container_service_name)
+    instance.agent_pool_profiles[0].count = new_agent_count
+    return client.container_service.create_or_update(resource_group_name, container_service_name, instance)
+

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/generated.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/generated.py
@@ -116,9 +116,9 @@ ContainerService._attribute_map['tags']['type'] = '{str}'#pylint: disable=protec
 cli_command('acs show', ContainerServiceOperations.get, factory)
 cli_command('acs list', ContainerServiceOperations.list, factory)
 cli_command('acs delete', ContainerServiceOperations.delete, factory)
-cli_generic_update_command('acs update', ContainerServiceOperations.get,
-                           ContainerServiceOperations.create_or_update,
-                           custom_function=update_acs, factory=factory)
+cli_command('acs scale', update_acs)
+#Per conversation with ACS team, hide the update till we have something meaningful to tweak
+#cli_generic_update_command('acs update', ContainerServiceOperations.get, ContainerServiceOperations.create_or_update, factory)
 
 # VM Diagnostics
 cli_command('vm diagnostics set', set_diagnostics_extension)

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
@@ -1269,7 +1269,7 @@ class AzureContainerServiceScenarioTest(ResourceGroupVCRTestBase): #pylint: disa
             ])
 
         #scale-up
-        self.cmd('acs update -g {} -n {} --agent-count 5'.format(self.resource_group, acs_name), checks=[
+        self.cmd('acs scale -g {} -n {} --new-agent-count 5'.format(self.resource_group, acs_name), checks=[
             JMESPathCheck('agentPoolProfiles[0].count', 5),
             ])
         #show again


### PR DESCRIPTION
Notes:
1. Expose `scale` command which updates the private agent count, a common scenario.
2 Hide the `update`, as there are nothing else people can tweak. The `tagging` coming with the generic update can be accomplished by `az resource tag`.