### PR TITLE
Use objects for CloudEndpoints and CloudSuffixes instead of dicts

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -16,7 +16,7 @@ from azure.cli.core._session import ACCOUNT
 from azure.cli.core._util import CLIError, get_file_json
 from azure.cli.core.adal_authentication import AdalAuthentication
 
-from azure.cli.core.cloud import get_cloud, CloudEndpoint
+from azure.cli.core.cloud import get_cloud
 from azure.cli.core.context import get_active_context
 
 import azure.cli.core._logging as _logging
@@ -60,7 +60,7 @@ _AUTH_CTX_FACTORY = lambda authority, cache: adal.AuthenticationContext(authorit
 CLOUD = get_cloud(get_active_context()['cloud'])
 
 def get_authority_url(tenant=None):
-    return CLOUD.endpoints[CloudEndpoint.ACTIVE_DIRECTORY] + '/' + (tenant or _COMMON_TENANT)
+    return CLOUD.endpoints.active_directory + '/' + (tenant or _COMMON_TENANT)
 
 def _load_tokens_from_file(file_path):
     all_entries = []
@@ -76,8 +76,8 @@ def _delete_file(file_path):
             raise
 
 class CredentialType(Enum): # pylint: disable=too-few-public-methods
-    management = CLOUD.endpoints[CloudEndpoint.MANAGEMENT]
-    rbac = CLOUD.endpoints[CloudEndpoint.ACTIVE_DIRECTORY_GRAPH_RESOURCE_ID]
+    management = CLOUD.endpoints.management
+    rbac = CLOUD.endpoints.active_directory_graph_resource_id
 
 class Profile(object):
     def __init__(self, storage=None, auth_ctx_factory=None):
@@ -85,7 +85,7 @@ class Profile(object):
         factory = auth_ctx_factory or _AUTH_CTX_FACTORY
         self._creds_cache = CredsCache(factory)
         self._subscription_finder = SubscriptionFinder(factory, self._creds_cache.adal_token_cache)
-        self._management_resource_uri = CLOUD.endpoints[CloudEndpoint.MANAGEMENT]
+        self._management_resource_uri = CLOUD.endpoints.management
 
     def find_subscriptions_on_login(self, #pylint: disable=too-many-arguments
                                     interactive,
@@ -230,7 +230,7 @@ class Profile(object):
             raise CLIError("Please run 'az account set' to select active account.")
         return result[0]
 
-    def get_login_credentials(self, resource=CLOUD.endpoints[CloudEndpoint.MANAGEMENT],
+    def get_login_credentials(self, resource=CLOUD.endpoints.management,
                               subscription_id=None):
         account = self.get_subscription(subscription_id)
         user_type = account[_USER_ENTITY][_USER_TYPE]
@@ -265,7 +265,7 @@ class SubscriptionFinder(object):
         self._auth_context_factory = auth_context_factory
         self.user_id = None # will figure out after log user in
         self._arm_client_factory = arm_client_factory or \
-             (lambda config: SubscriptionClient(config, base_url=CLOUD.endpoints[CloudEndpoint.RESOURCE_MANAGER])) #pylint: disable=unnecessary-lambda, line-too-long
+             (lambda config: SubscriptionClient(config, base_url=CLOUD.endpoints.resource_manager)) #pylint: disable=unnecessary-lambda
 
     def find_from_user_account(self, username, password, resource):
         context = self._create_auth_context(_COMMON_TENANT)

--- a/src/azure-cli-core/azure/cli/core/_util.py
+++ b/src/azure-cli-core/azure/cli/core/_util.py
@@ -108,3 +108,7 @@ def todict(obj): #pylint: disable=too-many-return-statements
                      if not callable(v) and not k.startswith('_')])
     else:
         return obj
+
+def to_snake_case(s):
+    s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', s)
+    return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()

--- a/src/azure-cli-core/azure/cli/core/cloud.py
+++ b/src/azure-cli-core/azure/cli/core/cloud.py
@@ -27,6 +27,12 @@ class CloudAlreadyRegisteredException(Exception):
 class CannotUnregisterCloudException(Exception):
     pass
 
+class CloudEndpointNotSetException(Exception):
+    pass
+
+class CloudSuffixNotSetException(Exception):
+    pass
+
 class CloudEndpoints(object): #pylint: disable=too-few-public-methods
     def __init__(self, #pylint: disable=too-many-arguments
                  management=None,
@@ -45,6 +51,12 @@ class CloudEndpoints(object): #pylint: disable=too-few-public-methods
         self.active_directory_resource_id = active_directory_resource_id
         self.active_directory_graph_resource_id = active_directory_graph_resource_id
 
+    def __getattribute__(self, name):
+        val = object.__getattribute__(self, name)
+        if val is None:
+            raise CloudEndpointNotSetException("The endpoint '{}' for this cloud is not set but is used".format(name)) #pylint: disable=line-too-long
+        return val
+
 class CloudSuffixes(object): #pylint: disable=too-few-public-methods
     def __init__(self, #pylint: disable=too-many-arguments
                  storage_endpoint=None,
@@ -58,6 +70,12 @@ class CloudSuffixes(object): #pylint: disable=too-few-public-methods
         self.sql_server_hostname = sql_server_hostname
         self.azure_datalake_store_file_system_endpoint = azure_datalake_store_file_system_endpoint
         self.azure_datalake_analytics_catalog_and_job_endpoint = azure_datalake_analytics_catalog_and_job_endpoint #pylint: disable=line-too-long
+
+    def __getattribute__(self, name):
+        val = object.__getattribute__(self, name)
+        if val is None:
+            raise CloudSuffixNotSetException("The suffix '{}' for this cloud is not set but is used".format(name)) #pylint: disable=line-too-long
+        return val
 
 class Cloud(object): # pylint: disable=too-few-public-methods
     """ Represents an Azure Cloud instance """

--- a/src/azure-cli-core/azure/cli/core/cloud.py
+++ b/src/azure-cli-core/azure/cli/core/cloud.py
@@ -27,87 +27,107 @@ class CloudAlreadyRegisteredException(Exception):
 class CannotUnregisterCloudException(Exception):
     pass
 
-class CloudEndpoint(object): # pylint: disable=too-few-public-methods
-    MANAGEMENT = 'management'
-    RESOURCE_MANAGER = 'resource_manager'
-    SQL_MANAGEMENT = 'sql_management'
-    GALLERY = 'gallery'
-    ACTIVE_DIRECTORY = 'active_directory'
-    ACTIVE_DIRECTORY_RESOURCE_ID = 'active_directory_resource_id'
-    ACTIVE_DIRECTORY_GRAPH_RESOURCE_ID = 'active_directory_graph_resource_id'
+class CloudEndpoints(object):
+    def __init__(self,
+                 management=None,
+                 resource_manager=None,
+                 sql_management=None,
+                 gallery=None,
+                 active_directory=None,
+                 active_directory_resource_id=None,
+                 active_directory_graph_resource_id=None):
+        # Attribute names are significant. They are used when storing/retrieving clouds from config
+        self.management = management
+        self.resource_manager = resource_manager
+        self.sql_management = sql_management
+        self.gallery = gallery
+        self.active_directory = active_directory
+        self.active_directory_resource_id = active_directory_resource_id
+        self.active_directory_graph_resource_id = active_directory_graph_resource_id
 
-class CloudSuffix(object): # pylint: disable=too-few-public-methods
-    SQL_SERVER_HOSTNAME = 'sql_server_hostname'
-    STORAGE_ENDPOINT = 'storage_endpoint'
-    KEYVAULT_DNS = 'keyvault_dns'
-    AZURE_DATALAKE_STORE_FILE_SYSTEM_ENDPOINT = 'azure_datalake_store_file_system_endpoint' #pylint: disable=line-too-long
-    AZURE_DATALAKE_ANALYTICS_CATALOG_AND_JOB_ENDPOINT = 'azure_datalake_analytics_catalog_and_job_endpoint' #pylint: disable=line-too-long
+class CloudSuffixes(object):
+    def __init__(self,
+                 storage_endpoint=None,
+                 keyvault_dns=None,
+                 sql_server_hostname=None,
+                 azure_datalake_store_file_system_endpoint=None,
+                 azure_datalake_analytics_catalog_and_job_endpoint=None):
+        # Attribute names are significant. They are used when storing/retrieving clouds from config
+        self.storage_endpoint = storage_endpoint
+        self.keyvault_dns = keyvault_dns
+        self.sql_server_hostname = sql_server_hostname
+        self.azure_datalake_store_file_system_endpoint = azure_datalake_store_file_system_endpoint
+        self.azure_datalake_analytics_catalog_and_job_endpoint = azure_datalake_analytics_catalog_and_job_endpoint #pylint: disable=line-too-long
 
 class Cloud(object): # pylint: disable=too-few-public-methods
     """ Represents an Azure Cloud instance """
 
     def __init__(self, name, endpoints=None, suffixes=None):
         self.name = name
-        self.endpoints = endpoints
-        self.suffixes = suffixes
+        self.endpoints = endpoints or CloudEndpoints()
+        self.suffixes = suffixes or CloudSuffixes()
 
-AZURE_PUBLIC_CLOUD = Cloud('AzureCloud', endpoints={
-    CloudEndpoint.MANAGEMENT: 'https://management.core.windows.net/',
-    CloudEndpoint.RESOURCE_MANAGER: 'https://management.azure.com/',
-    CloudEndpoint.SQL_MANAGEMENT: 'https://management.core.windows.net:8443/',
-    CloudEndpoint.GALLERY: 'https://gallery.azure.com/',
-    CloudEndpoint.ACTIVE_DIRECTORY: 'https://login.microsoftonline.com',
-    CloudEndpoint.ACTIVE_DIRECTORY_RESOURCE_ID: 'https://management.core.windows.net/',
-    CloudEndpoint.ACTIVE_DIRECTORY_GRAPH_RESOURCE_ID: 'https://graph.windows.net/'
-    }, suffixes={
-        CloudSuffix.SQL_SERVER_HOSTNAME: '.database.windows.net',
-        CloudSuffix.STORAGE_ENDPOINT: 'core.windows.net',
-        CloudSuffix.KEYVAULT_DNS: '.vault.azure.net',
-        CloudSuffix.AZURE_DATALAKE_STORE_FILE_SYSTEM_ENDPOINT: 'azuredatalakestore.net',
-        CloudSuffix.AZURE_DATALAKE_ANALYTICS_CATALOG_AND_JOB_ENDPOINT: 'azuredatalakeanalytics.net' #pylint: disable=line-too-long
-    })
+AZURE_PUBLIC_CLOUD = Cloud('AzureCloud',
+                           endpoints=CloudEndpoints(
+                               management='https://management.core.windows.net/',
+                               resource_manager='https://management.azure.com/',
+                               sql_management='https://management.core.windows.net:8443/',
+                               gallery='https://gallery.azure.com/',
+                               active_directory='https://login.microsoftonline.com',
+                               active_directory_resource_id='https://management.core.windows.net/',
+                               active_directory_graph_resource_id='https://graph.windows.net/'),
+                           suffixes=CloudSuffixes(
+                               storage_endpoint='core.windows.net',
+                               keyvault_dns='.vault.azure.net',
+                               sql_server_hostname='.database.windows.net',
+                               azure_datalake_store_file_system_endpoint='azuredatalakestore.net',
+                               azure_datalake_analytics_catalog_and_job_endpoint='azuredatalakeanalytics.net') #pylint: disable=line-too-long
+                          )
 
-AZURE_CHINA_CLOUD = Cloud('AzureChinaCloud', endpoints={
-    CloudEndpoint.MANAGEMENT: 'https://management.core.chinacloudapi.cn/',
-    CloudEndpoint.RESOURCE_MANAGER: 'https://management.chinacloudapi.cn',
-    CloudEndpoint.SQL_MANAGEMENT: 'https://management.core.chinacloudapi.cn:8443/',
-    CloudEndpoint.GALLERY: 'https://gallery.chinacloudapi.cn/',
-    CloudEndpoint.ACTIVE_DIRECTORY: 'https://login.chinacloudapi.cn',
-    CloudEndpoint.ACTIVE_DIRECTORY_RESOURCE_ID: 'https://management.core.chinacloudapi.cn/',
-    CloudEndpoint.ACTIVE_DIRECTORY_GRAPH_RESOURCE_ID: 'https://graph.chinacloudapi.cn/'
-    }, suffixes={
-        CloudSuffix.SQL_SERVER_HOSTNAME: '.database.chinacloudapi.cn',
-        CloudSuffix.STORAGE_ENDPOINT: 'core.chinacloudapi.cn',
-        CloudSuffix.KEYVAULT_DNS: '.vault.azure.cn'
-    })
+AZURE_CHINA_CLOUD = Cloud('AzureChinaCloud',
+                          endpoints=CloudEndpoints(
+                              management='https://management.core.chinacloudapi.cn/',
+                              resource_manager='https://management.chinacloudapi.cn',
+                              sql_management='https://management.core.chinacloudapi.cn:8443/',
+                              gallery='https://gallery.chinacloudapi.cn/',
+                              active_directory='https://login.chinacloudapi.cn',
+                              active_directory_resource_id='https://management.core.chinacloudapi.cn/', #pylint: disable=line-too-long
+                              active_directory_graph_resource_id='https://graph.chinacloudapi.cn/'),
+                          suffixes=CloudSuffixes(
+                              storage_endpoint='core.chinacloudapi.cn',
+                              keyvault_dns='.vault.azure.cn',
+                              sql_server_hostname='.database.chinacloudapi.cn')
+                         )
 
-AZURE_US_GOV_CLOUD = Cloud('AzureUSGovernment', endpoints={
-    CloudEndpoint.MANAGEMENT: 'https://management.core.usgovcloudapi.net',
-    CloudEndpoint.RESOURCE_MANAGER: 'https://management.usgovcloudapi.net',
-    CloudEndpoint.SQL_MANAGEMENT: 'https://management.core.usgovcloudapi.net:8443/',
-    CloudEndpoint.GALLERY: 'https://gallery.usgovcloudapi.net/',
-    CloudEndpoint.ACTIVE_DIRECTORY: 'https://login.microsoftonline.com',
-    CloudEndpoint.ACTIVE_DIRECTORY_RESOURCE_ID: 'https://management.core.usgovcloudapi.net/',
-    CloudEndpoint.ACTIVE_DIRECTORY_GRAPH_RESOURCE_ID: 'https://graph.windows.net/'
-    }, suffixes={
-        CloudSuffix.SQL_SERVER_HOSTNAME: '.database.usgovcloudapi.net',
-        CloudSuffix.STORAGE_ENDPOINT: 'core.usgovcloudapi.net',
-        CloudSuffix.KEYVAULT_DNS: '.vault.usgovcloudapi.net'
-    })
+AZURE_US_GOV_CLOUD = Cloud('AzureUSGovernment',
+                           endpoints=CloudEndpoints(
+                               management='https://management.core.usgovcloudapi.net',
+                               resource_manager='https://management.usgovcloudapi.net',
+                               sql_management='https://management.core.usgovcloudapi.net:8443/',
+                               gallery='https://gallery.usgovcloudapi.net/',
+                               active_directory='https://login.microsoftonline.com',
+                               active_directory_resource_id='https://management.core.usgovcloudapi.net/', #pylint: disable=line-too-long
+                               active_directory_graph_resource_id='https://graph.windows.net/'),
+                           suffixes=CloudSuffixes(
+                               storage_endpoint='core.usgovcloudapi.net',
+                               keyvault_dns='.vault.usgovcloudapi.net',
+                               sql_server_hostname='.database.usgovcloudapi.net')
+                          )
 
-AZURE_GERMAN_CLOUD = Cloud('AzureGermanCloud', endpoints={
-    CloudEndpoint.MANAGEMENT: 'https://management.core.cloudapi.de/',
-    CloudEndpoint.RESOURCE_MANAGER: 'https://management.microsoftazure.de',
-    CloudEndpoint.SQL_MANAGEMENT: 'https://management.core.cloudapi.de:8443/',
-    CloudEndpoint.GALLERY: 'https://gallery.cloudapi.de/',
-    CloudEndpoint.ACTIVE_DIRECTORY: 'https://login.microsoftonline.de',
-    CloudEndpoint.ACTIVE_DIRECTORY_RESOURCE_ID: 'https://management.core.cloudapi.de/',
-    CloudEndpoint.ACTIVE_DIRECTORY_GRAPH_RESOURCE_ID: 'https://graph.cloudapi.de/'
-    }, suffixes={
-        CloudSuffix.SQL_SERVER_HOSTNAME: '.database.cloudapi.de',
-        CloudSuffix.STORAGE_ENDPOINT: 'core.cloudapi.de',
-        CloudSuffix.KEYVAULT_DNS: '.vault.microsoftazure.de'
-    })
+AZURE_GERMAN_CLOUD = Cloud('AzureGermanCloud',
+                           endpoints=CloudEndpoints(
+                               management='https://management.core.cloudapi.de/',
+                               resource_manager='https://management.microsoftazure.de',
+                               sql_management='https://management.core.cloudapi.de:8443/',
+                               gallery='https://gallery.cloudapi.de/',
+                               active_directory='https://login.microsoftonline.de',
+                               active_directory_resource_id='https://management.core.cloudapi.de/',
+                               active_directory_graph_resource_id='https://graph.cloudapi.de/'),
+                           suffixes=CloudSuffixes(
+                               storage_endpoint='core.cloudapi.de',
+                               keyvault_dns='.vault.microsoftazure.de',
+                               sql_server_hostname='.database.cloudapi.de')
+                          )
 
 KNOWN_CLOUDS = [AZURE_PUBLIC_CLOUD, AZURE_CHINA_CLOUD, AZURE_US_GOV_CLOUD, AZURE_GERMAN_CLOUD]
 
@@ -118,14 +138,13 @@ def get_custom_clouds():
     config = configparser.SafeConfigParser()
     config.read(CUSTOM_CLOUD_CONFIG_FILE)
     for section in config.sections():
-        cloud_to_add = Cloud(section, endpoints={}, suffixes={})
+        c = Cloud(section)
         for option in config.options(section):
             if option.startswith('endpoint_'):
-                cloud_to_add.endpoints[option.replace('endpoint_', '')] = config.get(section, option) # pylint: disable=line-too-long
+                setattr(c.endpoints, option.replace('endpoint_', ''), config.get(section, option))
             elif option.startswith('suffix_'):
-                cloud_to_add.suffixes[option.replace('suffix_', '')] = config.get(section, option)
-        clouds.append(cloud_to_add)
-    # print(clouds)
+                setattr(c.suffixes, option.replace('suffix_', ''), config.get(section, option))
+        clouds.append(c)
     return clouds
 
 def get_clouds():
@@ -148,12 +167,12 @@ def add_cloud(cloud):
         config.add_section(cloud.name)
     except configparser.DuplicateSectionError:
         raise CloudAlreadyRegisteredException(cloud.name)
-    for endpoint in cloud.endpoints:
-        if cloud.endpoints[endpoint]:
-            config.set(cloud.name, 'endpoint_{}'.format(endpoint), cloud.endpoints[endpoint])
-    for suffix in cloud.suffixes:
-        if cloud.suffixes[suffix]:
-            config.set(cloud.name, 'suffix_{}'.format(suffix), cloud.suffixes[suffix])
+    for k, v in cloud.endpoints.__dict__.items():
+        if v:
+            config.set(cloud.name, 'endpoint_{}'.format(k), v)
+    for k, v in cloud.suffixes.__dict__.items():
+        if v:
+            config.set(cloud.name, 'suffix_{}'.format(k), v)
     if not os.path.isdir(GLOBAL_CONFIG_DIR):
         os.makedirs(GLOBAL_CONFIG_DIR)
     with open(CUSTOM_CLOUD_CONFIG_FILE, 'w') as configfile:

--- a/src/azure-cli-core/azure/cli/core/cloud.py
+++ b/src/azure-cli-core/azure/cli/core/cloud.py
@@ -27,8 +27,8 @@ class CloudAlreadyRegisteredException(Exception):
 class CannotUnregisterCloudException(Exception):
     pass
 
-class CloudEndpoints(object):
-    def __init__(self,
+class CloudEndpoints(object): #pylint: disable=too-few-public-methods
+    def __init__(self, #pylint: disable=too-many-arguments
                  management=None,
                  resource_manager=None,
                  sql_management=None,
@@ -45,8 +45,8 @@ class CloudEndpoints(object):
         self.active_directory_resource_id = active_directory_resource_id
         self.active_directory_graph_resource_id = active_directory_graph_resource_id
 
-class CloudSuffixes(object):
-    def __init__(self,
+class CloudSuffixes(object): #pylint: disable=too-few-public-methods
+    def __init__(self, #pylint: disable=too-many-arguments
                  storage_endpoint=None,
                  keyvault_dns=None,
                  sql_server_hostname=None,

--- a/src/azure-cli-core/azure/cli/core/commands/client_factory.py
+++ b/src/azure-cli-core/azure/cli/core/commands/client_factory.py
@@ -10,8 +10,6 @@ import azure.cli.core._logging as _logging
 from azure.cli.core._util import CLIError
 from azure.cli.core.application import APPLICATION
 
-from azure.cli.core.cloud import CloudEndpoint
-
 logger = _logging.get_az_logger(__name__)
 
 UA_AGENT = "AZURECLI/{}".format(core_version)
@@ -46,7 +44,7 @@ def _get_mgmt_service_client(client_type, subscription_bound=True, subscription_
     logger.info('Getting management service client client_type=%s', client_type.__name__)
     profile = Profile()
     cred, subscription_id, _ = profile.get_login_credentials(subscription_id=subscription_id)
-    client_kwargs = {'base_url': CLOUD.endpoints[CloudEndpoint.RESOURCE_MANAGER]}
+    client_kwargs = {'base_url': CLOUD.endpoints.resource_manager}
     if api_version:
         client_kwargs['api_version'] = api_version
     if subscription_bound:

--- a/src/azure-cli-core/azure/cli/core/context.py
+++ b/src/azure-cli-core/azure/cli/core/context.py
@@ -31,7 +31,7 @@ class CannotDeleteDefaultContextException(Exception):
         return "You cannot delete the default context."
 
 ACTIVE_CONTEXT_FILE = os.path.join(GLOBAL_CONFIG_DIR, 'active_context')
-ACTIVE_CONTEXT_ENV_VAR = os.environ.get('AZURE_CONTEXT', None)
+ACTIVE_CONTEXT_ENV_VAR_NAME = 'AZURE_CONTEXT'
 DEFAULT_CONTEXT_NAME = 'default'
 
 get_active_context = lambda: get_context(get_active_context_name())
@@ -60,8 +60,9 @@ def _set_active_subscription(context):
         profile.set_active_subscription(subscription_to_use)
 
 def get_active_context_name():
-    if ACTIVE_CONTEXT_ENV_VAR:
-        return ACTIVE_CONTEXT_ENV_VAR
+    active_context_env_var = os.environ.get(ACTIVE_CONTEXT_ENV_VAR_NAME, None)
+    if active_context_env_var:
+        return active_context_env_var
     try:
         with open(ACTIVE_CONTEXT_FILE, "r") as active_context_file:
             return active_context_file.read()

--- a/src/azure-cli-core/azure/cli/core/tests/test_cloud.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_cloud.py
@@ -1,0 +1,51 @@
+#---------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+#---------------------------------------------------------------------------------------------
+
+import tempfile
+import unittest
+import mock
+
+#pylint: disable=line-too-long
+
+from azure.cli.core.cloud import (Cloud,
+                                  CloudEndpoints,
+                                  CloudSuffixes,
+                                  add_cloud,
+                                  get_custom_clouds,
+                                  remove_cloud,
+                                  CloudEndpointNotSetException)
+from azure.cli.core._profile import Profile
+
+class TestCloud(unittest.TestCase):
+
+    @mock.patch('azure.cli.core._profile.CLOUD', Cloud('AzureCloud'))
+    def test_endpoint_none(self):
+        with self.assertRaises(CloudEndpointNotSetException):
+            profile = Profile()
+            profile.get_login_credentials()
+
+    @mock.patch('azure.cli.core.cloud.get_custom_clouds', lambda: [])
+    def test_add_get_delete_custom_cloud(self):
+        endpoints = CloudEndpoints(management='http://management.contoso.com')
+        suffixes = CloudSuffixes(storage_endpoint='core.contoso.com')
+        c = Cloud('MyOwnCloud', endpoints=endpoints, suffixes=suffixes)
+        expected_config_file_result = "[MyOwnCloud]\nendpoint_management = http://management.contoso.com\nsuffix_storage_endpoint = core.contoso.com\n\n"
+        with mock.patch('azure.cli.core.cloud.CUSTOM_CLOUD_CONFIG_FILE', tempfile.mkstemp()[1]) as config_file:
+            with mock.patch('azure.cli.core.cloud.get_custom_clouds', lambda: []):
+                add_cloud(c)
+                with open(config_file, 'r') as cf:
+                    self.assertEqual(cf.read(), expected_config_file_result)
+            custom_clouds = get_custom_clouds()
+            self.assertEqual(len(custom_clouds), 1)
+            self.assertEqual(custom_clouds[0].name, c.name)
+            self.assertEqual(custom_clouds[0].endpoints.management, c.endpoints.management)
+            self.assertEqual(custom_clouds[0].suffixes.storage_endpoint, c.suffixes.storage_endpoint)
+            with mock.patch('azure.cli.core.cloud._get_cloud', lambda _: c):
+                remove_cloud(c.name)
+            custom_clouds = get_custom_clouds()
+            self.assertEqual(len(custom_clouds), 0)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/azure-cli-core/azure/cli/core/tests/test_context.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_context.py
@@ -1,0 +1,53 @@
+#---------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+#---------------------------------------------------------------------------------------------
+
+import os
+
+# Determine the correct patch target for open
+try:
+    # python 3
+    import builtins #pylint: disable=unused-import
+    OPEN_PATCH_TARGET = 'builtins.open'
+except ImportError:
+    OPEN_PATCH_TARGET = '__builtin__.open'
+
+import unittest
+import mock
+
+# Need to import config before we can import context
+import azure.cli.core._config #pylint: disable=unused-import
+
+from azure.cli.core.context import (get_active_context_name,
+                                    set_active_context,
+                                    ContextNotFoundException)
+
+class TestContext(unittest.TestCase):
+
+    def test_get_active_context_name_envvar(self):
+        expected = 'mycontextname'
+        with mock.patch.dict(os.environ, {'AZURE_CONTEXT': expected}):
+            actual = get_active_context_name()
+            self.assertEqual(expected, actual)
+
+    def test_get_active_context_name_default(self):
+        expected = 'default'
+        actual = get_active_context_name()
+        self.assertEqual(expected, actual)
+
+    def test_get_active_context_name_from_file(self):
+        expected = 'contextfromfile'
+        m = mock.mock_open(read_data=expected)
+        with mock.patch(OPEN_PATCH_TARGET, m, create=True):
+            actual = get_active_context_name()
+            self.assertEqual(expected, actual)
+
+    def test_set_active_context_not_exists(self):
+        context_name = 'mynewcontext'
+        # We haven't created the context yet so it doesn't exist
+        with self.assertRaises(ContextNotFoundException):
+            set_active_context(context_name, skip_set_active_subsciption=True)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -9,7 +9,6 @@ import unittest
 import mock
 from azure.mgmt.resource.subscriptions.models import (SubscriptionState, Subscription,
                                                       SubscriptionPolicies, spendingLimit)
-from azure.cli.core.cloud import CloudEndpoint
 from azure.cli.core._profile import Profile, CredsCache, SubscriptionFinder, CLOUD
 
 class Test_Profile(unittest.TestCase):
@@ -245,7 +244,7 @@ class Test_Profile(unittest.TestCase):
         profile._set_subscriptions(consolidated)
         #action
         cred, _, tenant_id = profile.get_login_credentials(
-            resource=CLOUD.endpoints[CloudEndpoint.ACTIVE_DIRECTORY_GRAPH_RESOURCE_ID])
+            resource=CLOUD.endpoints.active_directory_graph_resource_id)
         _, _ = cred._token_retriever()
         #verify
         mock_get_token.assert_called_once_with(mock.ANY, self.user1, self.tenant_id,

--- a/src/azure-cli-core/azure/cli/core/tests/test_util.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_util.py
@@ -8,7 +8,7 @@ from collections import namedtuple
 import unittest
 import tempfile
 
-from azure.cli.core._util import get_file_json, todict
+from azure.cli.core._util import get_file_json, todict, to_snake_case
 
 class TestUtils(unittest.TestCase):
 
@@ -69,6 +69,24 @@ class TestUtils(unittest.TestCase):
             except Exception as ex: #pylint: disable=broad-except
                 self.assertTrue(str(ex).find(
                     'contains error: Expecting value: line 1 column 1 (char 0)'))
+
+    def test_to_snake_case_from_camel(self):
+        the_input = 'thisIsCamelCase'
+        expected = 'this_is_camel_case'
+        actual = to_snake_case(the_input)
+        self.assertEqual(expected, actual)
+
+    def test_to_snake_case_empty(self):
+        the_input = ''
+        expected = ''
+        actual = to_snake_case(the_input)
+        self.assertEqual(expected, actual)
+
+    def test_to_snake_case_already_snake(self):
+        the_input = 'this_is_snake_cased'
+        expected = 'this_is_snake_cased'
+        actual = to_snake_case(the_input)
+        self.assertEqual(expected, actual)
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_validators.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_validators.py
@@ -117,6 +117,5 @@ def datetime_type(string):
 
 def vault_base_url_type(name):
     from azure.cli.core._profile import CLOUD
-    from azure.cli.core.cloud import CloudSuffix
-    suffix = CLOUD.suffixes[CloudSuffix.KEYVAULT_DNS]
+    suffix = CLOUD.suffixes.keyvault_dns
     return 'https://{}{}'.format(name, suffix)

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/custom.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/custom.py
@@ -88,13 +88,12 @@ def create_keyvault(client, resource_group_name, vault_name, location, #pylint:d
                     no_self_perms=False,
                     tags=None):
     from azure.cli.core._profile import Profile, CLOUD
-    from azure.cli.core.cloud import CloudEndpoint
     profile = Profile()
     cred, _, tenant_id = profile.get_login_credentials(
-        resource=CLOUD.endpoints[CloudEndpoint.ACTIVE_DIRECTORY_GRAPH_RESOURCE_ID])
+        resource=CLOUD.endpoints.active_directory_graph_resource_id)
     graph_client = GraphRbacManagementClient(cred,
                                              tenant_id,
-                                             base_url=CLOUD.endpoints[CloudEndpoint.ACTIVE_DIRECTORY_GRAPH_RESOURCE_ID]) # pylint: disable=line-too-long
+                                             base_url=CLOUD.endpoints.active_directory_graph_resource_id) # pylint: disable=line-too-long
     subscription = profile.get_subscription()
     if no_self_perms:
         access_policies = []
@@ -139,13 +138,12 @@ create_keyvault.__doc__ = VaultProperties.__doc__
 def _object_id_args_helper(object_id, spn, upn):
     if not object_id:
         from azure.cli.core._profile import Profile, CLOUD
-        from azure.cli.core.cloud import CloudEndpoint
         profile = Profile()
         cred, _, tenant_id = profile.get_login_credentials(
-            resource=CLOUD.endpoints[CloudEndpoint.ACTIVE_DIRECTORY_GRAPH_RESOURCE_ID])
+            resource=CLOUD.endpoints.active_directory_graph_resource_id)
         graph_client = GraphRbacManagementClient(cred,
                                                  tenant_id,
-                                                 base_url=CLOUD.endpoints[CloudEndpoint.ACTIVE_DIRECTORY_GRAPH_RESOURCE_ID]) # pylint: disable=line-too-long
+                                                 base_url=CLOUD.endpoints.active_directory_graph_resource_id) # pylint: disable=line-too-long
         object_id = _get_object_id(graph_client, spn=spn, upn=upn)
         if not object_id:
             raise CLIError('Unable to get object id from principal name.')

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
@@ -45,13 +45,12 @@ def _auth_client_factory(scope=None):
 
 def _graph_client_factory(**_):
     from azure.cli.core._profile import Profile, CLOUD
-    from azure.cli.core.cloud import CloudEndpoint
     profile = Profile()
     cred, _, tenant_id = profile.get_login_credentials(
-        resource=CLOUD.endpoints[CloudEndpoint.ACTIVE_DIRECTORY_GRAPH_RESOURCE_ID])
+        resource=CLOUD.endpoints.active_directory_graph_resource_id)
     client = GraphRbacManagementClient(cred,
                                        tenant_id,
-                                       base_url=CLOUD.endpoints[CloudEndpoint.ACTIVE_DIRECTORY_GRAPH_RESOURCE_ID]) # pylint: disable=line-too-long
+                                       base_url=CLOUD.endpoints.active_directory_graph_resource_id)
     configure_common_settings(client)
     return client
 

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_factory.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_factory.py
@@ -14,7 +14,6 @@ from azure.storage._error import _ERROR_STORAGE_MISSING_INFO
 
 from azure.cli.core.commands.client_factory import get_mgmt_service_client, get_data_service_client
 from azure.cli.core.commands import CLIError
-from azure.cli.core.cloud import CloudSuffix
 from azure.cli.core._profile import CLOUD
 
 NO_CREDENTIALS_ERROR_MESSAGE = """
@@ -34,7 +33,7 @@ def get_storage_data_service_client(service, name=None, key=None, connection_str
                                    key,
                                    connection_string,
                                    sas_token,
-                                   endpoint_suffix=CLOUD.suffixes[CloudSuffix.STORAGE_ENDPOINT])
+                                   endpoint_suffix=CLOUD.suffixes.storage_endpoint)
 
 def generic_data_service_factory(service, name=None, key=None, connection_string=None,
                                  sas_token=None):

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
@@ -13,7 +13,6 @@ from azure.cli.core._config import az_config
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.commands.validators import validate_key_value_pairs
 
-from azure.cli.core.cloud import CloudSuffix
 from azure.cli.core._profile import CLOUD
 
 from azure.mgmt.storage import StorageManagementClient
@@ -116,7 +115,7 @@ def validate_source_uri(namespace):
         blob if valid_blob_source else path,
         '?' if query_params else '',
         '&'.join(query_params),
-        CLOUD.suffixes[CloudSuffix.STORAGE_ENDPOINT])
+        CLOUD.suffixes.storage_endpoint)
 
     namespace.copy_source = uri
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -444,7 +444,6 @@ def enable_boot_diagnostics(resource_group_name, vm_name, storage):
 def get_boot_log(resource_group_name, vm_name):
     import sys
     import io
-    from azure.cli.core.cloud import CloudSuffix
     from azure.cli.core._profile import CLOUD
     from azure.storage.blob import BlockBlobService
 
@@ -486,7 +485,7 @@ def get_boot_log(resource_group_name, vm_name):
         BlockBlobService,
         storage_account.name,
         keys.key1,
-        endpoint_suffix=CLOUD.suffixes[CloudSuffix.STORAGE_ENDPOINT]) # pylint: disable=no-member
+        endpoint_suffix=CLOUD.suffixes.storage_endpoint) # pylint: disable=no-member
 
     class StreamWriter(object): # pylint: disable=too-few-public-methods
 


### PR DESCRIPTION
Making this change based off feedback from the previous PR https://github.com/Azure/azure-cli/pull/1098#discussion_r84160252

(this is an internal change and doesn't affect the 'az cloud' or 'az context' commands)