### PR TITLE
Improvements to the 'az component' commands

### DIFF
--- a/src/command_modules/azure-cli-component/azure/cli/command_modules/component/custom.py
+++ b/src/command_modules/azure-cli-component/azure/cli/command_modules/component/custom.py
@@ -2,9 +2,14 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 #---------------------------------------------------------------------------------------------
+import logging
+from six import StringIO
 
 from azure.cli.core._util import CLIError
 from azure.cli.core._config import az_config
+import azure.cli.core._logging as _logging
+
+logger = _logging.get_az_logger(__name__)
 
 CLI_PACKAGE_NAME = 'azure-cli'
 COMPONENT_PREFIX = 'azure-cli-'
@@ -25,9 +30,26 @@ def remove(component_name, show_logs=False):
     if found:
         options = ['--isolated', '--yes']
         options += [] if show_logs else ['--quiet']
-        pip.main(['uninstall'] + options + ['--disable-pip-version-check', full_component_name])
+        pip_args = ['uninstall'] + options + ['--disable-pip-version-check', full_component_name]
+        _run_pip(pip, pip_args)
     else:
         raise CLIError("Component not installed.")
+
+def _run_pip(pip, pip_exec_args):
+    log_stream = StringIO()
+    log_handler = logging.StreamHandler(log_stream)
+    log_handler.setFormatter(logging.Formatter('%(name)s : %(message)s'))
+    pip.logger.addHandler(log_handler)
+    # Don't propagate to root logger as we catch the pip logs in our own log stream
+    pip.logger.propagate = False
+    status_code = pip.main(pip_exec_args)
+    log_output = log_stream.getvalue()
+    logger.debug(log_output)
+    log_stream.close()
+    if status_code > 0:
+        if '[Errno 13] Permission denied' in log_output:
+            raise CLIError('Permission denied. Run command with --debug for more information.')
+        raise CLIError('An error occurred. Run command with --debug for more information.')
 
 def _install_or_update(package_list, link, private, pre, show_logs=False):
     import pip
@@ -46,8 +68,8 @@ def _install_or_update(package_list, link, private, pre, show_logs=False):
             raise CLIError('AZURE_COMPONENT_PACKAGE_INDEX_URL environment variable not set and not specified in config. ' #pylint: disable=line-too-long
                            'AZURE_COMPONENT_PACKAGE_INDEX_TRUSTED_HOST may also need to be set.') #pylint: disable=line-too-long
         pkg_index_options += ['--trusted-host', package_index_trusted_host] if package_index_trusted_host else [] #pylint: disable=line-too-long
-    pip.main(['install'] + options + package_list
-             + pkg_index_options)
+    pip_args = ['install'] + options + package_list + pkg_index_options
+    _run_pip(pip, pip_args)
 
 def update(private=False, pre=False, link=None, additional_component=None, show_logs=False):
     """ Update the CLI and all installed components """


### PR DESCRIPTION
1. Fix should return error exit code if the command fails
2. Show 'Permission denied.' instead of full stacktrace if user attempts operation they don't have permissions for.
3. Send pip logs to CLI debug logs.

Fixes https://github.com/Azure/azure-cli/issues/1049, fixes https://github.com/Azure/azure-cli/issues/1050, fixes 