### PR TITLE
Support packaging as .whl files

### DIFF
--- a/scripts/command_modules/package_verify.py
+++ b/scripts/command_modules/package_verify.py
@@ -32,7 +32,7 @@ def build_package(path_to_package, dist_dir):
     print_heading('Building {}'.format(path_to_package))
     path_to_setup = os.path.join(path_to_package, 'setup.py')
     set_version(path_to_setup)
-    cmd_success = exec_command('python setup.py sdist -d {}'.format(dist_dir), cwd=path_to_package)
+    cmd_success = exec_command('python setup.py sdist -d {0} bdist_wheel -d {0}'.format(dist_dir), cwd=path_to_package)
     if not cmd_success:
         print_heading('Error building {}!'.format(path_to_package), f=sys.stderr)
         sys.exit(1)

--- a/src/command_modules/azure-cli-acr/setup.cfg
+++ b/src/command_modules/azure-cli-acr/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/src/command_modules/azure-cli-acs/setup.cfg
+++ b/src/command_modules/azure-cli-acs/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/src/command_modules/azure-cli-cloud/setup.cfg
+++ b/src/command_modules/azure-cli-cloud/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/src/command_modules/azure-cli-component/setup.cfg
+++ b/src/command_modules/azure-cli-component/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/src/command_modules/azure-cli-configure/setup.cfg
+++ b/src/command_modules/azure-cli-configure/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/src/command_modules/azure-cli-context/setup.cfg
+++ b/src/command_modules/azure-cli-context/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/src/command_modules/azure-cli-feedback/setup.cfg
+++ b/src/command_modules/azure-cli-feedback/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/src/command_modules/azure-cli-iot/setup.cfg
+++ b/src/command_modules/azure-cli-iot/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/src/command_modules/azure-cli-keyvault/setup.cfg
+++ b/src/command_modules/azure-cli-keyvault/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/src/command_modules/azure-cli-network/setup.cfg
+++ b/src/command_modules/azure-cli-network/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/src/command_modules/azure-cli-profile/setup.cfg
+++ b/src/command_modules/azure-cli-profile/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/src/command_modules/azure-cli-redis/setup.cfg
+++ b/src/command_modules/azure-cli-redis/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/src/command_modules/azure-cli-resource/setup.cfg
+++ b/src/command_modules/azure-cli-resource/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/src/command_modules/azure-cli-role/setup.cfg
+++ b/src/command_modules/azure-cli-role/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/src/command_modules/azure-cli-storage/setup.cfg
+++ b/src/command_modules/azure-cli-storage/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/src/command_modules/azure-cli-taskhelp/setup.cfg
+++ b/src/command_modules/azure-cli-taskhelp/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/src/command_modules/azure-cli-vm/setup.cfg
+++ b/src/command_modules/azure-cli-vm/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/src/command_modules/azure-cli-vsts/setup.cfg
+++ b/src/command_modules/azure-cli-vsts/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/src/command_modules/azure-cli-webapp/setup.cfg
+++ b/src/command_modules/azure-cli-webapp/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1


### PR DESCRIPTION
When publishing on PyPI, we should publish both .tar.gz and .whl files.

Add setup.cfg files
- Update package-verify and nightly-build to use bdist_wheel also