### PR TITLE
commands: fix invalid helo texts in 'role' and 'resource' modules

### DIFF
--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
@@ -257,7 +257,7 @@ def _update_provider(namespace, registering):
 
     #timeout'd, normal for resources with many regions, but let users know.
     action = 'Registering' if registering else 'Unregistering'
-    msg_template = '%s is still on-going. You can monitor using \'az resource provider show -n %s\''
+    msg_template = '%s is still on-going. You can monitor using \'az provider show -n %s\''
     logger.warning(msg_template, action, namespace)
 
 def move_resource(ids, destination_group, destination_subscription_id=None):

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
@@ -17,6 +17,7 @@ register_cli_argument('ad app', 'reply_urls', nargs='+',
                       help='space separated URIs to which Azure AD will redirect in response to an OAuth 2.0 request. The value does not need to be a physical endpoint, but must be a valid URI.')
 register_cli_argument('ad app', 'start_date', help='the start date after which password or key would be valid. Default value is current time')
 register_cli_argument('ad app', 'end_date', help='the end date till which password or key is valid. Default value is one year after current time')
+register_cli_argument('ad app', 'available_to_other_tenants', action='store_true', help='the application can be used from any Azure AD tenants')
 register_cli_argument('ad app', 'key_value', help='the value for the key credentials associated with the application')
 # TODO: Update these with **enum_choice_list(...) when SDK supports proper enums
 register_cli_argument('ad app', 'key_type', default='AsymmetricX509Cert',


### PR DESCRIPTION
Fix #1069, fix #1163 