### PR TITLE
[IoT] add commands `iot hub show`, `iot device show` and `iot device delete`

### DIFF
--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_help.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_help.py
@@ -41,6 +41,11 @@ helps['iot device list'] = """
             short-summary: List devices in target Azure IoT Hub.
 """
 
+helps['iot device delete'] = """
+            type: command
+            short-summary: Delete a device from target Azure IoT Hub.
+"""
+
 helps['iot device show-connection-string'] = """
             type: command
             short-summary: Show connection string of device(s) in target Azure IoT Hub.

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_help.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_help.py
@@ -41,6 +41,11 @@ helps['iot device create'] = """
             short-summary: Register a device in your Azure IoT Hub.
 """
 
+helps['iot device show'] = """
+            type: command
+            short-summary: Show metadata of a device in an IoT Hub.
+"""
+
 helps['iot device list'] = """
             type: command
             short-summary: List devices in target Azure IoT Hub.

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_help.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_help.py
@@ -16,6 +16,11 @@ helps['iot hub create'] = """
             long-summary: See https://azure.microsoft.com/en-us/services/iot-hub/ for an intro to Azure IoT Hub.
 """
 
+helps['iot hub show'] = """
+            type: command
+            short-summary: Show non-security metadata of an IoT Hub.
+"""
+
 helps['iot hub list'] = """
             type: command
             short-summary: List IoT Hubs in your subscription or resource group.

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_params.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_params.py
@@ -43,6 +43,13 @@ register_cli_argument('iot device create', 'device_id', completer=None)
 # Arguments for 'iot device list'
 register_cli_argument('iot device list', 'top', help='Maximum number of device identities to return.', type=int)
 
+# Arguments for 'iot device delete'
+register_cli_argument('iot device delete', 'etag',
+                      help='ETag of the target device. It is used for the purpose of optimistic concurrency. '
+                           'Delete operation will be performed only if the specified ETag matches the value maintained by the server, '
+                           'indicating that the device identity has not been modified since it was retrieved. '
+                           'Default value is set to wildcard character (*) to force an unconditional delete.')
+
 # Arguments for 'iot device show-connection-string'
 register_cli_argument('iot device show-connection-string', 'top',
                       help='Maximum number of connection strings to return.', type=int)

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_params.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_params.py
@@ -20,7 +20,7 @@ hub_name_type = CliArgumentType(completer=get_resource_name_completion_list('Mic
                                 help='IoT Hub name.')
 
 register_cli_argument('iot hub', 'hub_name', hub_name_type, options_list=('--name', '-n'))
-register_cli_argument('iot device', 'hub_name', hub_name_type, options_list=('--hub-name', '--hub'))
+register_cli_argument('iot device', 'hub_name', hub_name_type)
 register_cli_argument('iot', 'device_id', options_list=('--device-id', '-d'), help='Device Id.',
                       completer=get_device_id_completion_list)
 

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_params.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_params.py
@@ -5,7 +5,7 @@
 #pylint: disable=line-too-long
 
 from azure.cli.core.commands.parameters import \
-    (location_type, enum_choice_list, get_resource_name_completion_list)
+    (CliArgumentType, location_type, enum_choice_list, get_resource_name_completion_list)
 from azure.cli.core.commands import register_cli_argument
 from azure.mgmt.iothub.models.iot_hub_client_enums import IotHubSku
 from ._factory import iot_hub_service_factory
@@ -16,12 +16,11 @@ def get_device_id_completion_list(prefix, action, parsed_args, **kwargs):#pylint
     client = iot_hub_service_factory(kwargs)
     return [d.device_id for d in iot_device_list(client, parsed_args.hub_name, top=100)] if parsed_args.hub_name else []
 
-register_cli_argument('iot hub', 'hub_name', options_list=('--name', '-n'),
-                      completer=get_resource_name_completion_list('Microsoft.Devices/IotHubs'),
-                      help='The IoT Hub name.')
-register_cli_argument('iot device', 'hub_name', options_list=('--hub-name', '--hub'),
-                      completer=get_resource_name_completion_list('Microsoft.Devices/IotHubs'),
-                      help='The IoT Hub name.')
+hub_name_type = CliArgumentType(completer=get_resource_name_completion_list('Microsoft.Devices/IotHubs'),
+                                help='IoT Hub name.')
+
+register_cli_argument('iot hub', 'hub_name', hub_name_type, options_list=('--name', '-n'))
+register_cli_argument('iot device', 'hub_name', hub_name_type, options_list=('--hub-name', '--hub'))
 register_cli_argument('iot', 'device_id', options_list=('--device-id', '-d'), help='Device Id.',
                       completer=get_device_id_completion_list)
 

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_params.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_params.py
@@ -16,7 +16,10 @@ def get_device_id_completion_list(prefix, action, parsed_args, **kwargs):#pylint
     client = iot_hub_service_factory(kwargs)
     return [d.device_id for d in iot_device_list(client, parsed_args.hub_name, top=100)] if parsed_args.hub_name else []
 
-register_cli_argument('iot', 'hub_name', options_list=('--hub-name', '--name', '--hub', '-n'),
+register_cli_argument('iot hub', 'hub_name', options_list=('--name', '-n'),
+                      completer=get_resource_name_completion_list('Microsoft.Devices/IotHubs'),
+                      help='The IoT Hub name.')
+register_cli_argument('iot device', 'hub_name', options_list=('--hub-name', '--hub'),
                       completer=get_resource_name_completion_list('Microsoft.Devices/IotHubs'),
                       help='The IoT Hub name.')
 register_cli_argument('iot', 'device_id', options_list=('--device-id', '-d'), help='Device Id.',

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/custom.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/custom.py
@@ -99,6 +99,13 @@ def iot_device_create(client, hub_name, device_id, resource_group_name=None):
     return result
 
 
+def iot_device_get(client, hub_name, device_id, resource_group_name=None):
+    if resource_group_name is None:
+        resource_group_name = _get_iot_hub_by_name(client, hub_name).resourcegroup
+    device_client = _get_iot_device_client(client, resource_group_name, hub_name, device_id)
+    return device_client.get(device_id)
+
+
 def iot_device_list(client, hub_name, resource_group_name=None, top=10):
     if resource_group_name is None:
         resource_group_name = _get_iot_hub_by_name(client, hub_name).resourcegroup

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/generated.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/generated.py
@@ -9,7 +9,7 @@ from __future__ import print_function
 from azure.cli.core.commands import cli_command, LongRunningOperation
 from ._factory import (iot_hub_service_factory,)
 from azure.cli.command_modules.iot.custom import \
-    (iot_hub_create, iot_device_create, iot_hub_list, iot_device_list,
+    (iot_hub_create, iot_device_create, iot_hub_list, iot_device_list, iot_device_delete,
      iot_hub_show_connection_string, iot_device_show_connection_string)
 
 # iot hub commands
@@ -25,5 +25,7 @@ cli_command('iot hub show-connection-string', iot_hub_show_connection_string, fa
 cli_command('iot device create', iot_device_create, factory)
 
 cli_command('iot device list', iot_device_list, factory)
+
+cli_command('iot device delete', iot_device_delete, factory)
 
 cli_command('iot device show-connection-string', iot_device_show_connection_string, factory)

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/generated.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/generated.py
@@ -9,14 +9,16 @@ from __future__ import print_function
 from azure.cli.core.commands import cli_command, LongRunningOperation
 from ._factory import (iot_hub_service_factory,)
 from azure.cli.command_modules.iot.custom import \
-    (iot_hub_create, iot_device_create, iot_hub_list, iot_device_list, iot_device_delete,
-     iot_hub_show_connection_string, iot_device_show_connection_string)
+    (iot_hub_create, iot_hub_get, iot_hub_list, iot_hub_show_connection_string,
+     iot_device_create, iot_device_list, iot_device_delete, iot_device_show_connection_string)
 
 # iot hub commands
 factory = iot_hub_service_factory
 
 cli_command('iot hub create', iot_hub_create, factory,
             transform=LongRunningOperation('creating IoT Hub...', '', 10000.0))
+
+cli_command('iot hub show', iot_hub_get, factory)
 
 cli_command('iot hub list', iot_hub_list, factory)
 

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/generated.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/generated.py
@@ -10,7 +10,7 @@ from azure.cli.core.commands import cli_command, LongRunningOperation
 from ._factory import (iot_hub_service_factory,)
 from azure.cli.command_modules.iot.custom import \
     (iot_hub_create, iot_hub_get, iot_hub_list, iot_hub_show_connection_string,
-     iot_device_create, iot_device_list, iot_device_delete, iot_device_show_connection_string)
+     iot_device_create, iot_device_get, iot_device_list, iot_device_delete, iot_device_show_connection_string)
 
 # iot hub commands
 factory = iot_hub_service_factory
@@ -25,6 +25,8 @@ cli_command('iot hub list', iot_hub_list, factory)
 cli_command('iot hub show-connection-string', iot_hub_show_connection_string, factory)
 
 cli_command('iot device create', iot_device_create, factory)
+
+cli_command('iot device show', iot_device_get, factory)
 
 cli_command('iot device list', iot_device_list, factory)
 

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/mgmt_iot_hub_device/lib/operations/iot_hub_devices_operations.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/mgmt_iot_hub_device/lib/operations/iot_hub_devices_operations.py
@@ -156,6 +156,58 @@ class IotHubDevicesOperations(object):
 
         return deserialized
 
+    def delete(
+            self, device_id, if_match, custom_headers=None, raw=False, **operation_config):
+        """Delete a device identity in the identity registry of an IoT Hub.
+
+        Delete a device identity in the identity registry of an IoT Hub.
+
+        :param device_id: The Id of the device.
+        :type device_id: str
+        :param if_match: Specify the ETag for the device identity.
+        :type if_match: str
+        :param dict custom_headers: headers that will be added to the request
+        :param bool raw: returns the direct response alongside the
+         deserialized response
+        :param operation_config: :ref:`Operation configuration
+         overrides<msrest:optionsforoperations>`.
+        :rtype: None
+        :rtype: :class:`ClientRawResponse<msrest.pipeline.ClientRawResponse>`
+         if raw=true
+        """
+        # Construct URL
+        url = '/devices/{deviceId}'
+        path_format_arguments = {
+            'deviceId': self._serialize.url("device_id", device_id, 'str', max_length=128, min_length=1)
+        }
+        url = self._client.format_url(url, **path_format_arguments)
+
+        # Construct parameters
+        query_parameters = {}
+        query_parameters['api-version'] = self._serialize.query("self.config.api_version", self.config.api_version, 'str')
+
+        # Construct headers
+        header_parameters = {}
+        header_parameters['Content-Type'] = 'application/json; charset=utf-8'
+        if self.config.generate_client_request_id:
+            header_parameters['x-ms-client-request-id'] = str(uuid.uuid1())
+        if custom_headers:
+            header_parameters.update(custom_headers)
+        header_parameters['If-Match'] = self._serialize.header("if_match", if_match, 'str')
+        if self.config.accept_language is not None:
+            header_parameters['accept-language'] = self._serialize.header("self.config.accept_language", self.config.accept_language, 'str')
+
+        # Construct and send request
+        request = self._client.delete(url, query_parameters)
+        response = self._client.send(request, header_parameters, **operation_config)
+
+        if response.status_code not in [204]:
+            raise models.ErrorDetailsException(self._deserialize, response)
+
+        if raw:
+            client_raw_response = ClientRawResponse(None, response)
+            return client_raw_response
+
     def list(
             self, top, custom_headers=None, raw=False, **operation_config):
         """List device identities from the identity registry of an IoT Hub.

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/mgmt_iot_hub_device/swagger_iot_hub_device_identity.json
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/mgmt_iot_hub_device/swagger_iot_hub_device_identity.json
@@ -113,6 +113,54 @@
             }
           }
         }
+      },
+      "delete" : {
+        "tags": [
+          "IoTDevices"
+        ],
+        "summary": "Delete a device identity in the identity registry of an IoT Hub.",
+        "description": "Delete a device identity in the identity registry of an IoT Hub.",
+        "operationId": "IotHubDevices_Delete",
+        "consumes": [
+          "application/json",
+          "text/json"
+        ],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "name": "deviceId",
+            "in": "path",
+            "description": "The Id of the device.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "Specify the ETag for the device identity.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successfully deleted"
+          },
+          "default": {
+            "description": "DefaultErrorResponse",
+            "schema": {
+              "$ref": "#/definitions/ErrorDetails"
+            }
+          }
+        }
       }
     },
     "/devices": {

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/tests/recordings/test_iot_hub.yaml
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/tests/recordings/test_iot_hub.yaml
@@ -5,14 +5,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc1MTYwNjc1LCJuYmYiOjE0NzUxNjA2NzUsImV4cCI6MTQ3NTE2NDU3NSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInJzYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaXBhZGRyIjoiMTM5LjIyNi44Ni44NyIsIm5hbWUiOiJLZXZpbiBaaGFvIiwib2lkIjoiODY3ZmI5ZDAtMTQzMS00MWM3LTk2ZTItODM1ZWE2M2Q2MmUyIiwib25wcmVtX3NpZCI6IlMtMS01LTIxLTIxNDY3NzMwODUtOTAzMzYzMjg1LTcxOTM0NDcwNy0xOTYzNTcyIiwicHVpZCI6IjEwMDMwMDAwOTBGRUNDQ0UiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJCTEc1SmxRcURabFdZNEM4QkpnNmZJcXRNelFxZ1ZVZllXemJPNjZvbFB3IiwidGlkIjoiNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3IiwidW5pcXVlX25hbWUiOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidXBuIjoia2V2aW56aGFAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCJ9.qTZd7EpdgfCb4y3-sibNUCjCKXOQMelsVWeGPrFgnIOCbrZzaaImGiJfUjej5DjGx_FreMJvdovrhF6LgS8SmjID3dlcU6lGpPn_99bt8OUSY93jN-6zp6S-MS7JjutyX6C7-vwscB0tK2jvMxSZBICdWNJMmWOF4xep6ava-OKtz7c25WKYiZFRd-lZptIf2DrqO1SIWEyw-CAdwKz6NoDGs-E3U4Id-QLcWlAQMB0AGke06RG3bywI7W40MkDSmWMs28C5iBcik_o3caq5drXu252LFBY_qxzFAq3YKzKydy6At3Bse5SfAUmv00WmmPQmcV4N5KDdfQCTcnMvQw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
       Connection: [keep-alive]
       Content-Length: ['31']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
+          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [fbfdd2a6-8656-11e6-a444-54ee7550b4da]
+      x-ms-client-request-id: [2c11f5d2-9f39-11e6-a24b-40a8f04ffd53]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/checkNameAvailability?api-version=2016-02-03
   response:
@@ -25,26 +25,26 @@ interactions:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 29 Sep 2016 15:11:25 GMT']
+      Date: ['Mon, 31 Oct 2016 07:10:59 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc1MTYwNjc1LCJuYmYiOjE0NzUxNjA2NzUsImV4cCI6MTQ3NTE2NDU3NSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInJzYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaXBhZGRyIjoiMTM5LjIyNi44Ni44NyIsIm5hbWUiOiJLZXZpbiBaaGFvIiwib2lkIjoiODY3ZmI5ZDAtMTQzMS00MWM3LTk2ZTItODM1ZWE2M2Q2MmUyIiwib25wcmVtX3NpZCI6IlMtMS01LTIxLTIxNDY3NzMwODUtOTAzMzYzMjg1LTcxOTM0NDcwNy0xOTYzNTcyIiwicHVpZCI6IjEwMDMwMDAwOTBGRUNDQ0UiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJCTEc1SmxRcURabFdZNEM4QkpnNmZJcXRNelFxZ1ZVZllXemJPNjZvbFB3IiwidGlkIjoiNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3IiwidW5pcXVlX25hbWUiOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidXBuIjoia2V2aW56aGFAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCJ9.qTZd7EpdgfCb4y3-sibNUCjCKXOQMelsVWeGPrFgnIOCbrZzaaImGiJfUjej5DjGx_FreMJvdovrhF6LgS8SmjID3dlcU6lGpPn_99bt8OUSY93jN-6zp6S-MS7JjutyX6C7-vwscB0tK2jvMxSZBICdWNJMmWOF4xep6ava-OKtz7c25WKYiZFRd-lZptIf2DrqO1SIWEyw-CAdwKz6NoDGs-E3U4Id-QLcWlAQMB0AGke06RG3bywI7W40MkDSmWMs28C5iBcik_o3caq5drXu252LFBY_qxzFAq3YKzKydy6At3Bse5SfAUmv00WmmPQmcV4N5KDdfQCTcnMvQw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          resourcemanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
+          resourcemanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [fce6fe12-8656-11e6-9b46-54ee7550b4da]
+      x-ms-client-request-id: [2d003576-9f39-11e6-89db-40a8f04ffd53]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/iot-hub-test-rg?api-version=2016-02-01
   response:
@@ -60,7 +60,7 @@ interactions:
       Content-Encoding: [gzip]
       Content-Length: ['262']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 29 Sep 2016 15:11:25 GMT']
+      Date: ['Mon, 31 Oct 2016 07:10:59 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -68,29 +68,29 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJza3UiOiB7Im5hbWUiOiAiUzEiLCAiY2FwYWNpdHkiOiAxfSwgImxvY2F0aW9uIjogIndlc3R1
-      cyJ9
+      eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAic2t1IjogeyJuYW1lIjogIlMxIiwgImNhcGFjaXR5Ijog
+      MX19
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc1MTYwNjc1LCJuYmYiOjE0NzUxNjA2NzUsImV4cCI6MTQ3NTE2NDU3NSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInJzYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaXBhZGRyIjoiMTM5LjIyNi44Ni44NyIsIm5hbWUiOiJLZXZpbiBaaGFvIiwib2lkIjoiODY3ZmI5ZDAtMTQzMS00MWM3LTk2ZTItODM1ZWE2M2Q2MmUyIiwib25wcmVtX3NpZCI6IlMtMS01LTIxLTIxNDY3NzMwODUtOTAzMzYzMjg1LTcxOTM0NDcwNy0xOTYzNTcyIiwicHVpZCI6IjEwMDMwMDAwOTBGRUNDQ0UiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJCTEc1SmxRcURabFdZNEM4QkpnNmZJcXRNelFxZ1ZVZllXemJPNjZvbFB3IiwidGlkIjoiNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3IiwidW5pcXVlX25hbWUiOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidXBuIjoia2V2aW56aGFAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCJ9.qTZd7EpdgfCb4y3-sibNUCjCKXOQMelsVWeGPrFgnIOCbrZzaaImGiJfUjej5DjGx_FreMJvdovrhF6LgS8SmjID3dlcU6lGpPn_99bt8OUSY93jN-6zp6S-MS7JjutyX6C7-vwscB0tK2jvMxSZBICdWNJMmWOF4xep6ava-OKtz7c25WKYiZFRd-lZptIf2DrqO1SIWEyw-CAdwKz6NoDGs-E3U4Id-QLcWlAQMB0AGke06RG3bywI7W40MkDSmWMs28C5iBcik_o3caq5drXu252LFBY_qxzFAq3YKzKydy6At3Bse5SfAUmv00WmmPQmcV4N5KDdfQCTcnMvQw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
       Connection: [keep-alive]
       Content-Length: ['60']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
+          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [fd2905a2-8656-11e6-8d19-54ee7550b4da]
+      x-ms-client-request-id: [2d66a400-9f39-11e6-8e3d-40a8f04ffd53]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing?api-version=2016-02-03
   response:
     body: {string: '{"id":"/subscriptions/faab228d-df7a-4086-991e-e81c4659d41a/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing","name":"iot-hub-for-testing","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"faab228d-df7a-4086-991e-e81c4659d41a","resourcegroup":"iot-hub-test-rg","properties":{"state":"Activating","provisioningState":"Accepted","enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}'}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/faab228d-df7a-4086-991e-e81c4659d41a/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing/operationResults/OTQ2ZWM5NWQtYjRhYS00ZWQ2LThhZmMtOTVjZWNmNDI4NjEz?api-version=2016-02-03&asyncinfo']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/faab228d-df7a-4086-991e-e81c4659d41a/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing/operationResults/ZDUyYzNkZjYtZTcwNS00YWY0LThiNDctOGM0ZjUyYmE5NTIz?api-version=2016-02-03&asyncinfo']
       Cache-Control: [no-cache]
       Content-Length: ['683']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 29 Sep 2016 15:11:30 GMT']
+      Date: ['Mon, 31 Oct 2016 07:11:05 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -102,15 +102,15 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc1MTYwNjc1LCJuYmYiOjE0NzUxNjA2NzUsImV4cCI6MTQ3NTE2NDU3NSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInJzYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaXBhZGRyIjoiMTM5LjIyNi44Ni44NyIsIm5hbWUiOiJLZXZpbiBaaGFvIiwib2lkIjoiODY3ZmI5ZDAtMTQzMS00MWM3LTk2ZTItODM1ZWE2M2Q2MmUyIiwib25wcmVtX3NpZCI6IlMtMS01LTIxLTIxNDY3NzMwODUtOTAzMzYzMjg1LTcxOTM0NDcwNy0xOTYzNTcyIiwicHVpZCI6IjEwMDMwMDAwOTBGRUNDQ0UiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJCTEc1SmxRcURabFdZNEM4QkpnNmZJcXRNelFxZ1ZVZllXemJPNjZvbFB3IiwidGlkIjoiNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3IiwidW5pcXVlX25hbWUiOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidXBuIjoia2V2aW56aGFAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCJ9.qTZd7EpdgfCb4y3-sibNUCjCKXOQMelsVWeGPrFgnIOCbrZzaaImGiJfUjej5DjGx_FreMJvdovrhF6LgS8SmjID3dlcU6lGpPn_99bt8OUSY93jN-6zp6S-MS7JjutyX6C7-vwscB0tK2jvMxSZBICdWNJMmWOF4xep6ava-OKtz7c25WKYiZFRd-lZptIf2DrqO1SIWEyw-CAdwKz6NoDGs-E3U4Id-QLcWlAQMB0AGke06RG3bywI7W40MkDSmWMs28C5iBcik_o3caq5drXu252LFBY_qxzFAq3YKzKydy6At3Bse5SfAUmv00WmmPQmcV4N5KDdfQCTcnMvQw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
+          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [fd2905a2-8656-11e6-8d19-54ee7550b4da]
+      x-ms-client-request-id: [2d66a400-9f39-11e6-8e3d-40a8f04ffd53]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing/operationResults/OTQ2ZWM5NWQtYjRhYS00ZWQ2LThhZmMtOTVjZWNmNDI4NjEz?api-version=2016-02-03&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing/operationResults/ZDUyYzNkZjYtZTcwNS00YWY0LThiNDctOGM0ZjUyYmE5NTIz?api-version=2016-02-03&asyncinfo
   response:
     body:
       string: !!binary |
@@ -121,7 +121,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 29 Sep 2016 15:12:01 GMT']
+      Date: ['Mon, 31 Oct 2016 07:11:36 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -133,15 +133,15 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc1MTYwNjc1LCJuYmYiOjE0NzUxNjA2NzUsImV4cCI6MTQ3NTE2NDU3NSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInJzYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaXBhZGRyIjoiMTM5LjIyNi44Ni44NyIsIm5hbWUiOiJLZXZpbiBaaGFvIiwib2lkIjoiODY3ZmI5ZDAtMTQzMS00MWM3LTk2ZTItODM1ZWE2M2Q2MmUyIiwib25wcmVtX3NpZCI6IlMtMS01LTIxLTIxNDY3NzMwODUtOTAzMzYzMjg1LTcxOTM0NDcwNy0xOTYzNTcyIiwicHVpZCI6IjEwMDMwMDAwOTBGRUNDQ0UiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJCTEc1SmxRcURabFdZNEM4QkpnNmZJcXRNelFxZ1ZVZllXemJPNjZvbFB3IiwidGlkIjoiNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3IiwidW5pcXVlX25hbWUiOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidXBuIjoia2V2aW56aGFAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCJ9.qTZd7EpdgfCb4y3-sibNUCjCKXOQMelsVWeGPrFgnIOCbrZzaaImGiJfUjej5DjGx_FreMJvdovrhF6LgS8SmjID3dlcU6lGpPn_99bt8OUSY93jN-6zp6S-MS7JjutyX6C7-vwscB0tK2jvMxSZBICdWNJMmWOF4xep6ava-OKtz7c25WKYiZFRd-lZptIf2DrqO1SIWEyw-CAdwKz6NoDGs-E3U4Id-QLcWlAQMB0AGke06RG3bywI7W40MkDSmWMs28C5iBcik_o3caq5drXu252LFBY_qxzFAq3YKzKydy6At3Bse5SfAUmv00WmmPQmcV4N5KDdfQCTcnMvQw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
+          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [fd2905a2-8656-11e6-8d19-54ee7550b4da]
+      x-ms-client-request-id: [2d66a400-9f39-11e6-8e3d-40a8f04ffd53]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing/operationResults/OTQ2ZWM5NWQtYjRhYS00ZWQ2LThhZmMtOTVjZWNmNDI4NjEz?api-version=2016-02-03&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing/operationResults/ZDUyYzNkZjYtZTcwNS00YWY0LThiNDctOGM0ZjUyYmE5NTIz?api-version=2016-02-03&asyncinfo
   response:
     body:
       string: !!binary |
@@ -152,7 +152,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 29 Sep 2016 15:12:33 GMT']
+      Date: ['Mon, 31 Oct 2016 07:12:08 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -164,15 +164,15 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc1MTYwNjc1LCJuYmYiOjE0NzUxNjA2NzUsImV4cCI6MTQ3NTE2NDU3NSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInJzYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaXBhZGRyIjoiMTM5LjIyNi44Ni44NyIsIm5hbWUiOiJLZXZpbiBaaGFvIiwib2lkIjoiODY3ZmI5ZDAtMTQzMS00MWM3LTk2ZTItODM1ZWE2M2Q2MmUyIiwib25wcmVtX3NpZCI6IlMtMS01LTIxLTIxNDY3NzMwODUtOTAzMzYzMjg1LTcxOTM0NDcwNy0xOTYzNTcyIiwicHVpZCI6IjEwMDMwMDAwOTBGRUNDQ0UiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJCTEc1SmxRcURabFdZNEM4QkpnNmZJcXRNelFxZ1ZVZllXemJPNjZvbFB3IiwidGlkIjoiNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3IiwidW5pcXVlX25hbWUiOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidXBuIjoia2V2aW56aGFAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCJ9.qTZd7EpdgfCb4y3-sibNUCjCKXOQMelsVWeGPrFgnIOCbrZzaaImGiJfUjej5DjGx_FreMJvdovrhF6LgS8SmjID3dlcU6lGpPn_99bt8OUSY93jN-6zp6S-MS7JjutyX6C7-vwscB0tK2jvMxSZBICdWNJMmWOF4xep6ava-OKtz7c25WKYiZFRd-lZptIf2DrqO1SIWEyw-CAdwKz6NoDGs-E3U4Id-QLcWlAQMB0AGke06RG3bywI7W40MkDSmWMs28C5iBcik_o3caq5drXu252LFBY_qxzFAq3YKzKydy6At3Bse5SfAUmv00WmmPQmcV4N5KDdfQCTcnMvQw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
+          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [fd2905a2-8656-11e6-8d19-54ee7550b4da]
+      x-ms-client-request-id: [2d66a400-9f39-11e6-8e3d-40a8f04ffd53]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing/operationResults/OTQ2ZWM5NWQtYjRhYS00ZWQ2LThhZmMtOTVjZWNmNDI4NjEz?api-version=2016-02-03&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing/operationResults/ZDUyYzNkZjYtZTcwNS00YWY0LThiNDctOGM0ZjUyYmE5NTIz?api-version=2016-02-03&asyncinfo
   response:
     body:
       string: !!binary |
@@ -183,7 +183,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 29 Sep 2016 15:13:05 GMT']
+      Date: ['Mon, 31 Oct 2016 07:12:40 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -195,15 +195,15 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc1MTYwNjc1LCJuYmYiOjE0NzUxNjA2NzUsImV4cCI6MTQ3NTE2NDU3NSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInJzYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaXBhZGRyIjoiMTM5LjIyNi44Ni44NyIsIm5hbWUiOiJLZXZpbiBaaGFvIiwib2lkIjoiODY3ZmI5ZDAtMTQzMS00MWM3LTk2ZTItODM1ZWE2M2Q2MmUyIiwib25wcmVtX3NpZCI6IlMtMS01LTIxLTIxNDY3NzMwODUtOTAzMzYzMjg1LTcxOTM0NDcwNy0xOTYzNTcyIiwicHVpZCI6IjEwMDMwMDAwOTBGRUNDQ0UiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJCTEc1SmxRcURabFdZNEM4QkpnNmZJcXRNelFxZ1ZVZllXemJPNjZvbFB3IiwidGlkIjoiNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3IiwidW5pcXVlX25hbWUiOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidXBuIjoia2V2aW56aGFAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCJ9.qTZd7EpdgfCb4y3-sibNUCjCKXOQMelsVWeGPrFgnIOCbrZzaaImGiJfUjej5DjGx_FreMJvdovrhF6LgS8SmjID3dlcU6lGpPn_99bt8OUSY93jN-6zp6S-MS7JjutyX6C7-vwscB0tK2jvMxSZBICdWNJMmWOF4xep6ava-OKtz7c25WKYiZFRd-lZptIf2DrqO1SIWEyw-CAdwKz6NoDGs-E3U4Id-QLcWlAQMB0AGke06RG3bywI7W40MkDSmWMs28C5iBcik_o3caq5drXu252LFBY_qxzFAq3YKzKydy6At3Bse5SfAUmv00WmmPQmcV4N5KDdfQCTcnMvQw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
+          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [fd2905a2-8656-11e6-8d19-54ee7550b4da]
+      x-ms-client-request-id: [2d66a400-9f39-11e6-8e3d-40a8f04ffd53]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing/operationResults/OTQ2ZWM5NWQtYjRhYS00ZWQ2LThhZmMtOTVjZWNmNDI4NjEz?api-version=2016-02-03&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing/operationResults/ZDUyYzNkZjYtZTcwNS00YWY0LThiNDctOGM0ZjUyYmE5NTIz?api-version=2016-02-03&asyncinfo
   response:
     body:
       string: !!binary |
@@ -214,7 +214,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 29 Sep 2016 15:13:36 GMT']
+      Date: ['Mon, 31 Oct 2016 07:13:11 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -226,15 +226,15 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc1MTYwNjc1LCJuYmYiOjE0NzUxNjA2NzUsImV4cCI6MTQ3NTE2NDU3NSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInJzYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaXBhZGRyIjoiMTM5LjIyNi44Ni44NyIsIm5hbWUiOiJLZXZpbiBaaGFvIiwib2lkIjoiODY3ZmI5ZDAtMTQzMS00MWM3LTk2ZTItODM1ZWE2M2Q2MmUyIiwib25wcmVtX3NpZCI6IlMtMS01LTIxLTIxNDY3NzMwODUtOTAzMzYzMjg1LTcxOTM0NDcwNy0xOTYzNTcyIiwicHVpZCI6IjEwMDMwMDAwOTBGRUNDQ0UiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJCTEc1SmxRcURabFdZNEM4QkpnNmZJcXRNelFxZ1ZVZllXemJPNjZvbFB3IiwidGlkIjoiNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3IiwidW5pcXVlX25hbWUiOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidXBuIjoia2V2aW56aGFAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCJ9.qTZd7EpdgfCb4y3-sibNUCjCKXOQMelsVWeGPrFgnIOCbrZzaaImGiJfUjej5DjGx_FreMJvdovrhF6LgS8SmjID3dlcU6lGpPn_99bt8OUSY93jN-6zp6S-MS7JjutyX6C7-vwscB0tK2jvMxSZBICdWNJMmWOF4xep6ava-OKtz7c25WKYiZFRd-lZptIf2DrqO1SIWEyw-CAdwKz6NoDGs-E3U4Id-QLcWlAQMB0AGke06RG3bywI7W40MkDSmWMs28C5iBcik_o3caq5drXu252LFBY_qxzFAq3YKzKydy6At3Bse5SfAUmv00WmmPQmcV4N5KDdfQCTcnMvQw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
+          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [fd2905a2-8656-11e6-8d19-54ee7550b4da]
+      x-ms-client-request-id: [2d66a400-9f39-11e6-8e3d-40a8f04ffd53]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing/operationResults/OTQ2ZWM5NWQtYjRhYS00ZWQ2LThhZmMtOTVjZWNmNDI4NjEz?api-version=2016-02-03&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing/operationResults/ZDUyYzNkZjYtZTcwNS00YWY0LThiNDctOGM0ZjUyYmE5NTIz?api-version=2016-02-03&asyncinfo
   response:
     body:
       string: !!binary |
@@ -245,7 +245,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 29 Sep 2016 15:14:07 GMT']
+      Date: ['Mon, 31 Oct 2016 07:13:43 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -257,15 +257,15 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc1MTYwNjc1LCJuYmYiOjE0NzUxNjA2NzUsImV4cCI6MTQ3NTE2NDU3NSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInJzYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaXBhZGRyIjoiMTM5LjIyNi44Ni44NyIsIm5hbWUiOiJLZXZpbiBaaGFvIiwib2lkIjoiODY3ZmI5ZDAtMTQzMS00MWM3LTk2ZTItODM1ZWE2M2Q2MmUyIiwib25wcmVtX3NpZCI6IlMtMS01LTIxLTIxNDY3NzMwODUtOTAzMzYzMjg1LTcxOTM0NDcwNy0xOTYzNTcyIiwicHVpZCI6IjEwMDMwMDAwOTBGRUNDQ0UiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJCTEc1SmxRcURabFdZNEM4QkpnNmZJcXRNelFxZ1ZVZllXemJPNjZvbFB3IiwidGlkIjoiNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3IiwidW5pcXVlX25hbWUiOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidXBuIjoia2V2aW56aGFAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCJ9.qTZd7EpdgfCb4y3-sibNUCjCKXOQMelsVWeGPrFgnIOCbrZzaaImGiJfUjej5DjGx_FreMJvdovrhF6LgS8SmjID3dlcU6lGpPn_99bt8OUSY93jN-6zp6S-MS7JjutyX6C7-vwscB0tK2jvMxSZBICdWNJMmWOF4xep6ava-OKtz7c25WKYiZFRd-lZptIf2DrqO1SIWEyw-CAdwKz6NoDGs-E3U4Id-QLcWlAQMB0AGke06RG3bywI7W40MkDSmWMs28C5iBcik_o3caq5drXu252LFBY_qxzFAq3YKzKydy6At3Bse5SfAUmv00WmmPQmcV4N5KDdfQCTcnMvQw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
+          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [fd2905a2-8656-11e6-8d19-54ee7550b4da]
+      x-ms-client-request-id: [2d66a400-9f39-11e6-8e3d-40a8f04ffd53]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing/operationResults/OTQ2ZWM5NWQtYjRhYS00ZWQ2LThhZmMtOTVjZWNmNDI4NjEz?api-version=2016-02-03&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing/operationResults/ZDUyYzNkZjYtZTcwNS00YWY0LThiNDctOGM0ZjUyYmE5NTIz?api-version=2016-02-03&asyncinfo
   response:
     body:
       string: !!binary |
@@ -276,7 +276,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 29 Sep 2016 15:14:38 GMT']
+      Date: ['Mon, 31 Oct 2016 07:14:13 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -288,15 +288,15 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc1MTYwNjc1LCJuYmYiOjE0NzUxNjA2NzUsImV4cCI6MTQ3NTE2NDU3NSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInJzYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaXBhZGRyIjoiMTM5LjIyNi44Ni44NyIsIm5hbWUiOiJLZXZpbiBaaGFvIiwib2lkIjoiODY3ZmI5ZDAtMTQzMS00MWM3LTk2ZTItODM1ZWE2M2Q2MmUyIiwib25wcmVtX3NpZCI6IlMtMS01LTIxLTIxNDY3NzMwODUtOTAzMzYzMjg1LTcxOTM0NDcwNy0xOTYzNTcyIiwicHVpZCI6IjEwMDMwMDAwOTBGRUNDQ0UiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJCTEc1SmxRcURabFdZNEM4QkpnNmZJcXRNelFxZ1ZVZllXemJPNjZvbFB3IiwidGlkIjoiNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3IiwidW5pcXVlX25hbWUiOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidXBuIjoia2V2aW56aGFAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCJ9.qTZd7EpdgfCb4y3-sibNUCjCKXOQMelsVWeGPrFgnIOCbrZzaaImGiJfUjej5DjGx_FreMJvdovrhF6LgS8SmjID3dlcU6lGpPn_99bt8OUSY93jN-6zp6S-MS7JjutyX6C7-vwscB0tK2jvMxSZBICdWNJMmWOF4xep6ava-OKtz7c25WKYiZFRd-lZptIf2DrqO1SIWEyw-CAdwKz6NoDGs-E3U4Id-QLcWlAQMB0AGke06RG3bywI7W40MkDSmWMs28C5iBcik_o3caq5drXu252LFBY_qxzFAq3YKzKydy6At3Bse5SfAUmv00WmmPQmcV4N5KDdfQCTcnMvQw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
+          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [fd2905a2-8656-11e6-8d19-54ee7550b4da]
+      x-ms-client-request-id: [2d66a400-9f39-11e6-8e3d-40a8f04ffd53]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing/operationResults/OTQ2ZWM5NWQtYjRhYS00ZWQ2LThhZmMtOTVjZWNmNDI4NjEz?api-version=2016-02-03&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing/operationResults/ZDUyYzNkZjYtZTcwNS00YWY0LThiNDctOGM0ZjUyYmE5NTIz?api-version=2016-02-03&asyncinfo
   response:
     body:
       string: !!binary |
@@ -307,7 +307,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 29 Sep 2016 15:15:10 GMT']
+      Date: ['Mon, 31 Oct 2016 07:14:45 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -319,15 +319,15 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc1MTYwNjc1LCJuYmYiOjE0NzUxNjA2NzUsImV4cCI6MTQ3NTE2NDU3NSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInJzYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaXBhZGRyIjoiMTM5LjIyNi44Ni44NyIsIm5hbWUiOiJLZXZpbiBaaGFvIiwib2lkIjoiODY3ZmI5ZDAtMTQzMS00MWM3LTk2ZTItODM1ZWE2M2Q2MmUyIiwib25wcmVtX3NpZCI6IlMtMS01LTIxLTIxNDY3NzMwODUtOTAzMzYzMjg1LTcxOTM0NDcwNy0xOTYzNTcyIiwicHVpZCI6IjEwMDMwMDAwOTBGRUNDQ0UiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJCTEc1SmxRcURabFdZNEM4QkpnNmZJcXRNelFxZ1ZVZllXemJPNjZvbFB3IiwidGlkIjoiNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3IiwidW5pcXVlX25hbWUiOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidXBuIjoia2V2aW56aGFAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCJ9.qTZd7EpdgfCb4y3-sibNUCjCKXOQMelsVWeGPrFgnIOCbrZzaaImGiJfUjej5DjGx_FreMJvdovrhF6LgS8SmjID3dlcU6lGpPn_99bt8OUSY93jN-6zp6S-MS7JjutyX6C7-vwscB0tK2jvMxSZBICdWNJMmWOF4xep6ava-OKtz7c25WKYiZFRd-lZptIf2DrqO1SIWEyw-CAdwKz6NoDGs-E3U4Id-QLcWlAQMB0AGke06RG3bywI7W40MkDSmWMs28C5iBcik_o3caq5drXu252LFBY_qxzFAq3YKzKydy6At3Bse5SfAUmv00WmmPQmcV4N5KDdfQCTcnMvQw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
+          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [fd2905a2-8656-11e6-8d19-54ee7550b4da]
+      x-ms-client-request-id: [2d66a400-9f39-11e6-8e3d-40a8f04ffd53]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing/operationResults/OTQ2ZWM5NWQtYjRhYS00ZWQ2LThhZmMtOTVjZWNmNDI4NjEz?api-version=2016-02-03&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing/operationResults/ZDUyYzNkZjYtZTcwNS00YWY0LThiNDctOGM0ZjUyYmE5NTIz?api-version=2016-02-03&asyncinfo
   response:
     body:
       string: !!binary |
@@ -338,7 +338,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 29 Sep 2016 15:15:40 GMT']
+      Date: ['Mon, 31 Oct 2016 07:15:16 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -350,15 +350,46 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc1MTYwNjc1LCJuYmYiOjE0NzUxNjA2NzUsImV4cCI6MTQ3NTE2NDU3NSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInJzYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaXBhZGRyIjoiMTM5LjIyNi44Ni44NyIsIm5hbWUiOiJLZXZpbiBaaGFvIiwib2lkIjoiODY3ZmI5ZDAtMTQzMS00MWM3LTk2ZTItODM1ZWE2M2Q2MmUyIiwib25wcmVtX3NpZCI6IlMtMS01LTIxLTIxNDY3NzMwODUtOTAzMzYzMjg1LTcxOTM0NDcwNy0xOTYzNTcyIiwicHVpZCI6IjEwMDMwMDAwOTBGRUNDQ0UiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJCTEc1SmxRcURabFdZNEM4QkpnNmZJcXRNelFxZ1ZVZllXemJPNjZvbFB3IiwidGlkIjoiNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3IiwidW5pcXVlX25hbWUiOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidXBuIjoia2V2aW56aGFAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCJ9.qTZd7EpdgfCb4y3-sibNUCjCKXOQMelsVWeGPrFgnIOCbrZzaaImGiJfUjej5DjGx_FreMJvdovrhF6LgS8SmjID3dlcU6lGpPn_99bt8OUSY93jN-6zp6S-MS7JjutyX6C7-vwscB0tK2jvMxSZBICdWNJMmWOF4xep6ava-OKtz7c25WKYiZFRd-lZptIf2DrqO1SIWEyw-CAdwKz6NoDGs-E3U4Id-QLcWlAQMB0AGke06RG3bywI7W40MkDSmWMs28C5iBcik_o3caq5drXu252LFBY_qxzFAq3YKzKydy6At3Bse5SfAUmv00WmmPQmcV4N5KDdfQCTcnMvQw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
+          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [fd2905a2-8656-11e6-8d19-54ee7550b4da]
+      x-ms-client-request-id: [2d66a400-9f39-11e6-8e3d-40a8f04ffd53]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing/operationResults/OTQ2ZWM5NWQtYjRhYS00ZWQ2LThhZmMtOTVjZWNmNDI4NjEz?api-version=2016-02-03&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing/operationResults/ZDUyYzNkZjYtZTcwNS00YWY0LThiNDctOGM0ZjUyYmE5NTIz?api-version=2016-02-03&asyncinfo
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
+        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 31 Oct 2016 07:15:48 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [2d66a400-9f39-11e6-8e3d-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing/operationResults/ZDUyYzNkZjYtZTcwNS00YWY0LThiNDctOGM0ZjUyYmE5NTIz?api-version=2016-02-03&asyncinfo
   response:
     body:
       string: !!binary |
@@ -369,7 +400,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 29 Sep 2016 15:16:12 GMT']
+      Date: ['Mon, 31 Oct 2016 07:16:20 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -381,13 +412,13 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc1MTYwNjc1LCJuYmYiOjE0NzUxNjA2NzUsImV4cCI6MTQ3NTE2NDU3NSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInJzYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaXBhZGRyIjoiMTM5LjIyNi44Ni44NyIsIm5hbWUiOiJLZXZpbiBaaGFvIiwib2lkIjoiODY3ZmI5ZDAtMTQzMS00MWM3LTk2ZTItODM1ZWE2M2Q2MmUyIiwib25wcmVtX3NpZCI6IlMtMS01LTIxLTIxNDY3NzMwODUtOTAzMzYzMjg1LTcxOTM0NDcwNy0xOTYzNTcyIiwicHVpZCI6IjEwMDMwMDAwOTBGRUNDQ0UiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJCTEc1SmxRcURabFdZNEM4QkpnNmZJcXRNelFxZ1ZVZllXemJPNjZvbFB3IiwidGlkIjoiNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3IiwidW5pcXVlX25hbWUiOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidXBuIjoia2V2aW56aGFAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCJ9.qTZd7EpdgfCb4y3-sibNUCjCKXOQMelsVWeGPrFgnIOCbrZzaaImGiJfUjej5DjGx_FreMJvdovrhF6LgS8SmjID3dlcU6lGpPn_99bt8OUSY93jN-6zp6S-MS7JjutyX6C7-vwscB0tK2jvMxSZBICdWNJMmWOF4xep6ava-OKtz7c25WKYiZFRd-lZptIf2DrqO1SIWEyw-CAdwKz6NoDGs-E3U4Id-QLcWlAQMB0AGke06RG3bywI7W40MkDSmWMs28C5iBcik_o3caq5drXu252LFBY_qxzFAq3YKzKydy6At3Bse5SfAUmv00WmmPQmcV4N5KDdfQCTcnMvQw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
+          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [aa2caeb8-8657-11e6-b18e-54ee7550b4da]
+      x-ms-client-request-id: [f2277742-9f39-11e6-8cfc-40a8f04ffd53]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
@@ -407,32 +438,30 @@ interactions:
         iAjxhyRPb5+uZeSdTr8g8G0UlUX27mleEo/X10r03R30my+zSZkTT+dfrcoqm3V6O8/KJieUy2o9
         e1OJbAOHGLjRR0qTODHOSYQm2fQtXv9Gh2DZwOPBl4GUOwl7US0Jf/kx+ujEzg99+dFpXVc1fSqj
         fJOX+SJv62vvm5O9pyfVYpEtwaP2U2l/NqM+ivb6S+pXsPGaOPpGvsYYzvOsJXWBDxW3i5w4hFu+
-        WC8mef3Rox1q17xdYxiqil9DQmiQ9OVHpKyWs6yGjppmq2xKqBCBCPY3Z0B+UCya7Ae3shzSlHBR
-        TO3fH2ovPqJ2r9dFm78RQK/yRdXmbuKhlPyR8thvM1jqwgzXGBSLdMeSzJ9UP+uWRPr+f4kREWTo
-        w2HdKk22P919uPvpdn6+c29vdp7fOx/Wq3G5/Vm1HYqj7dd1Sw2/waHR2H5kMn5emAz9UAbpWwz9
-        IjQY+qG0jtoLbeFo2/8W6H9NawF5oPHRlz8Ma1FU7XaTLVZlvv2DefHTP5hn1e1MhzbeJvEj9BT5
-        zqfvb0bW+Iz0OBHtmww6IqOkVj2DcfyzbzC0dxDo/y1mw0OJvtqgYW3D7U/v7e7skZZ9cO9g8mk2
-        nQ1r2bgU/+waEIsn4W17d51T8294kDTKH5mSH5kS+uL/XaYE0kHjoy9/GKbkJ1+fbJ9Vb7bfnL5+
-        s/3q81uZkctmWpBuhvC1eQMFqLj3v3h/YxLGJCAPNTNj5FHfZpgEwQzUmJPOSKlFaErmXy5/9k1J
-        h0L/L7EmHazo22Fd67X99MGD3Z3t/Yf3872dh9kkG9a1cVn+WTUoHp4Yk7MpC9s/vfENj5MG+iOb
-        8iObQl/8fLYpos5WRNlbmRPXnHBSjIPP/l9kRAK8QvtR7j37iZ91++H6/9k0HXveR4GaJWRUvUq/
-        QIS+GNairtn2g52D+/vbB3ufnh98Op3cPxjWonEpfX9r8V7DeG8D4b16+6HR2H5kIH5kIOiLn88G
-        giL1gnwrSe7cykboGyR6hJYiHXx2exthbMTPUtZKsZKx0fehkVi8Oj37WTcSigIR5mfTSLyHL+4Q
-        oi+GNaprtv1gd/fTh9v3H+a79x5O7p9vWBGIS+z7G4uvNZz3Nhreq7cfIo3xR0bjR0aDvvj5bDQK
-        khvRqttvacRLSvjeynTgPcibeYlQ1AFEvvl/jRkBbp3RUquuMVn+7K+WAxGfSP8vMSldtOjrYa1L
-        v2ljaN0Hn27Pdqf38v379yefDmvduFT/rBqWwuIpg3pv80K/KYD3GCiN9Efm5Ufmhb74+WxertfL
-        i/wH5kNWw7u3si/yYsEyCIFW9Lsf/7/GsghiwaegdMe0fHf/Z38xRDBREv2/xK4EONF3w7rWtSRd
-        u3dvdzs7P8gfzrKdTfmfuCz/rBoVhyeN6L0tinv7PUZJw/yRRfmRRaEvfj5blIKcMXXhfzAvfpr8
-        uWp7kU1vZVTsCxBDeonQ1EFEvnk/03JFq6E/S6ZlYMTUMrQuy+98cvCzbl0sBkqo/5cYmC5a9PWw
-        9nWNSfse7NzbvvfgPiWL9u8/mA5r37h0/6zaGIcn4U2Dem8z4wC8x0BppD8yMz8yM/TFz3czAylq
-        Sa9v17dbcjfvnFc1v0fTQhgq/vEv/19lZIAeUKPxUouOcfnJqvlZNy4GCY9G/y+xLxHMqMWw5qXf
-        tD1p3of7D7bPH04f7Nz7dPJgd1jzxiX7Z9XEFBZPO673tjL0m8J4j7HSYH9kZX5kZeiL/89Zme//
-        kv8HSvqIae0+AAA=
+        WC8mef3Rox1q17xdYxiqil9DQmiQ9OVHpKyWs6yGjppmq2xKqBCBCPY3Z0B+8vXJ9ln1ZvvN6es3
+        268+v5UJuWymRdVuQwLbvIEOVNz7X/y/yJR0RkotQmMy/3J5/LNuTDoU+n+JQelgRd8OK1yv7acP
+        HuzubO8/vJ/v7TzMJtmwwo0L9M+qUfHwxJicYVnY/umNb3icNNAfGZafF4ZFP5RB+nZFvwjNin4o
+        raNWRVs42va/Bfr/n7Apos5WRNlbmRPXnHBSjIPP/l9kRAK8QvtR7j37iZ91++H6/9k0HXveR4Ga
+        JWRUvUq/QIS+GNairtn2g52D+/vbB3ufnh98Op3cPxjWonEpfX9r8V7DeG8D4b16+6HR2H5kIH5k
+        IOiLn88GIqu2C/KtmmyxKvNb2Qh9g0SP0FKkg8/e30as8RlpcCLVN2khFCsZG30fGonFq9Ozn3Uj
+        oSgQYX42jcR7+OIOIfpiWKO6ZtsPdnc/fbh9/2G+e+/h5P75+bBGjUvs+xuLrzWc9zYa3qu3HyKN
+        8UdG40dGg774+Ww0CpIb0arbP5gXP/2DeVbdynRA1swLhJ4i3/n0/czHFSUUfpbMR2SU1Co0IvX9
+        L3d+1o2IT6CfTTNyCyedaAJscvyD/wta2w/29z7d2872d7J7efbwHrixp3jnzZrIMJtcE5139u7T
+        wDH/DXFoPqxv4/L8/iblQ4eGqTrYe3iwD0bZPLT9T283NBrbj0zJj0wJffH/KlPyDMJL46MvP3pW
+        53jtZ8uMXK+XF/kPzIesdndvZUfkxYIF9h4hqKh3Px62JAKHmhC/MD3o7Z/FQEQQCz4FlUNT0qy+
+        aH7WTYlgoiT62bQl7+HDBzjRdz31yt/AZXctSS1/ev/e9iTP72WfTs53Hwzr2bgcv78J+bojeu/A
+        xL39HqOkYf7ImvzImtAX/6+yJj9ngcmt7MgPikWzvcyv4O8RVopz59P3syI/lHiEvgxtx+UXez/7
+        uSyfLv8vMR0+SvTVsE51DbcffLp379Pt84Pd2e5DEvYNOjUusz+rlsPhSXjb3m9pONzL7zFIGuWP
+        DMePDAd98fPdcLyloS4px3Ir02Eamxwy4aaYR775f5UJMfjR16ER2f384md/1dz0bqjz/xJD0kWL
+        vh7Ws67x9sHO7sHu9nRvd/Zwuntwb4Oejcvxz6oxcXjKoN7boDgA7zFQGumPDMqPDAp98fPdoECK
+        WlLm2/XFrWyKeee8qvk9mhbCUPGPf/n/KssC9IAajZdadIzL/eUXP+vGxSDh0ej/JfYlghm1GNa8
+        9Ju2J8374NOD7emDnfv72eRe/nBY88Yl+2fVxBQWTzuu97Yy9JvCeI+x0mB/ZGV+ZGXoi//PWZnv
+        /5L/BwpMcMV/OAAA
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 29 Sep 2016 15:16:17 GMT']
+      Date: ['Mon, 31 Oct 2016 07:16:31 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -444,14 +473,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc1MTYwNjc1LCJuYmYiOjE0NzUxNjA2NzUsImV4cCI6MTQ3NTE2NDU3NSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInJzYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaXBhZGRyIjoiMTM5LjIyNi44Ni44NyIsIm5hbWUiOiJLZXZpbiBaaGFvIiwib2lkIjoiODY3ZmI5ZDAtMTQzMS00MWM3LTk2ZTItODM1ZWE2M2Q2MmUyIiwib25wcmVtX3NpZCI6IlMtMS01LTIxLTIxNDY3NzMwODUtOTAzMzYzMjg1LTcxOTM0NDcwNy0xOTYzNTcyIiwicHVpZCI6IjEwMDMwMDAwOTBGRUNDQ0UiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJCTEc1SmxRcURabFdZNEM4QkpnNmZJcXRNelFxZ1ZVZllXemJPNjZvbFB3IiwidGlkIjoiNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3IiwidW5pcXVlX25hbWUiOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidXBuIjoia2V2aW56aGFAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCJ9.qTZd7EpdgfCb4y3-sibNUCjCKXOQMelsVWeGPrFgnIOCbrZzaaImGiJfUjej5DjGx_FreMJvdovrhF6LgS8SmjID3dlcU6lGpPn_99bt8OUSY93jN-6zp6S-MS7JjutyX6C7-vwscB0tK2jvMxSZBICdWNJMmWOF4xep6ava-OKtz7c25WKYiZFRd-lZptIf2DrqO1SIWEyw-CAdwKz6NoDGs-E3U4Id-QLcWlAQMB0AGke06RG3bywI7W40MkDSmWMs28C5iBcik_o3caq5drXu252LFBY_qxzFAq3YKzKydy6At3Bse5SfAUmv00WmmPQmcV4N5KDdfQCTcnMvQw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
+          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [ab16f63a-8657-11e6-83ea-54ee7550b4da]
+      x-ms-client-request-id: [f350559e-9f39-11e6-8e36-40a8f04ffd53]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing/listkeys?api-version=2016-02-03
   response:
@@ -459,42 +488,42 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS9X/zR2/z6Rbag3z8qqna+nlRXy7z+aPTRqi4WWX39e+XX9NX5L3p98MlPPvn2onqe371/
-        96fXT5ft3vPF8smz/adfvX336dnBgy8e1Pe/89P3fp/P6N0mn1bLmX37cj69+4N3d49/6vXsq71f
-        9Hz9k5e7xU9c1l/99Ozqk4ft7O3b79w/vj754vPXn1/g7bq4mLcNvfcqvyiatr7+bl20+Sh9ndeX
-        xTQ/qZbLfNqO0qe59+dHv2Tkj6WRtgQtGMcXy5c7T+df/F6rnbsHl3d3n7bliy8vdmdPv/1g5wcH
-        7ybHD3/vX3Rxvnz28OX9Bph0xvETD3+q+qQ8XRdPlpcPf6/PF8t773Ze7/707k+v3/4+Z+vVd559
-        +vSL5cNFsfp2OI4Q8Q6mMx4FNQ8Q3X3xyennP/3w6S/6zsPPL5vy+Rf3fq+nX/3kF7OT6uTlk8n1
-        20/e7H3y/Nni3dWDHXTVQfTexao5Kd598bw42Lv+6YNfdPJyt3p4d2//J6rpT/6ip8c/8e73evPk
-        9zm4On3zU/y2RXQTRWudjFd5NqN3AmynX57PJqvTs8kXv9ebNaG283uvP23X6/Xi05PlwZu7+58+
-        /OTh6/zL8y+bK/TXxfYnDq5/8Iu+8/L4p5tJuZdNLr+73nv9nW+/3n19/9mbu7/3q8nx6v6DLz95
-        +nvJ2xZbwx6M0TCyzD30XoDx8qq+l03z7Ozhvae/z6f57u7+s0X7bv17/95PDy5WP/HJ8env8+L3
-        +kXP7/3Ud7/NfXYw/skX9eVVvl8urrOL6fwXZRcPz3+vX3T/bHVy0Ox++enDs+e/1/zt6ovzn/7q
-        3lu83cNYUPol3/8l/w8JNbR6iQMAAA==
+        uc4/evS9X/zR2/z6Rbag3z8qqna+nlRXy7z+aPTRqi4WWX39e+XX9NX07JPT3+d6f/9gsvjJbFKd
+        39//9oOr4vOdZfvtqy8eLn7Rq+f362dfVk8+/+mDz+jdJp9Wy5l9+6C9/PLld3/iTbv4yf37Pzmd
+        71YHL79a7u+V+f5PPG9/0U8+u/vt19W3r59fvGjwdl1czNuG3nuVXxRNW19/ty7afJS+zuvLYpqf
+        VMtlPm1H6dPc+/OjXzLyx9JIW4IWjONqffHFL3r+5vzJl5fnr7MnV7P9h/V368X66vd+vijO3719
+        frz8fb46rp/8XtPYOF7Mf+Lpd3+v3+vNT/6i3+vp/s5PVA/2furBd3/ybPeTH/zeP/hF3/3p4t5P
+        5bPf++Qie/6U37bjCBHvYDrjUVDzANEv85/4ibw8Xf5eV/Pf5xddXExPHj6YP5hMfq/rNz9RHl/9
+        5CfNk+LTd7/oq5PigrvqIDr7cvWLHv6i7P5+9eDbu1ev9r/9ez/7dtF89+7v9eq4+ck3zx68urx6
+        e/77TKtfdHGFty2imyha62S8yrMZvRNge7lTrL/97id2nv1gvXt/f7pX3//Ow5ezefNT8/Inf6/v
+        vvvJq5/euzxY/vQvevnyFP11sL38aufB5WXxe83eLfYvJ9/5ibc/qE9+8Hu1n/zE26c/8Xu/KJf3
+        fq/68++e/l7Xpwdv8bbF1rAHYzSMLHMPvRdgXP5eP3hwdW/5en7dXuVZ84ueVusy/+7O/Bc9/OrF
+        8SfF01/0Ovupe/lPFy9+8Pugzw7G73aeLmenry4P6tft3TffuS6v2ru71e/95HL1enqXhv7sJ8rF
+        zt7T36c5v8DbPYwFpV/y/V/y/wDMyV2RiQMAAA==
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 29 Sep 2016 15:16:18 GMT']
+      Date: ['Mon, 31 Oct 2016 07:16:32 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc1MTYwNjc1LCJuYmYiOjE0NzUxNjA2NzUsImV4cCI6MTQ3NTE2NDU3NSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInJzYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaXBhZGRyIjoiMTM5LjIyNi44Ni44NyIsIm5hbWUiOiJLZXZpbiBaaGFvIiwib2lkIjoiODY3ZmI5ZDAtMTQzMS00MWM3LTk2ZTItODM1ZWE2M2Q2MmUyIiwib25wcmVtX3NpZCI6IlMtMS01LTIxLTIxNDY3NzMwODUtOTAzMzYzMjg1LTcxOTM0NDcwNy0xOTYzNTcyIiwicHVpZCI6IjEwMDMwMDAwOTBGRUNDQ0UiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJCTEc1SmxRcURabFdZNEM4QkpnNmZJcXRNelFxZ1ZVZllXemJPNjZvbFB3IiwidGlkIjoiNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3IiwidW5pcXVlX25hbWUiOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidXBuIjoia2V2aW56aGFAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCJ9.qTZd7EpdgfCb4y3-sibNUCjCKXOQMelsVWeGPrFgnIOCbrZzaaImGiJfUjej5DjGx_FreMJvdovrhF6LgS8SmjID3dlcU6lGpPn_99bt8OUSY93jN-6zp6S-MS7JjutyX6C7-vwscB0tK2jvMxSZBICdWNJMmWOF4xep6ava-OKtz7c25WKYiZFRd-lZptIf2DrqO1SIWEyw-CAdwKz6NoDGs-E3U4Id-QLcWlAQMB0AGke06RG3bywI7W40MkDSmWMs28C5iBcik_o3caq5drXu252LFBY_qxzFAq3YKzKydy6At3Bse5SfAUmv00WmmPQmcV4N5KDdfQCTcnMvQw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
+          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [ac0bc63e-8657-11e6-87f2-54ee7550b4da]
+      x-ms-client-request-id: [f402bcac-9f39-11e6-bc38-40a8f04ffd53]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
@@ -505,21 +534,21 @@ interactions:
         uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXP3PMsme3sHs+3Z+YNse3/n4NPthw938+38YHe6/+n9
         h7P93exunTfVup7mn9fVetXcLap2e76ebLd5027XF3dXdXVZzPK6uftFMa2rpjpvx0/zy2KaN3fP
         qvbb1KF957yq+b1iefHR6KNltiDUPop/2V6v8OUgTGpSVtMM46BmV/TeGp+12UXz0aNf/EtGH/kj
-        5bHfZrAEwQz3AsOl1wx6QI3GSy1y6oS+OObnyfInq+Yz+pTosMrrtsjR/0dNm7XA/3jaFpe5fH1Z
-        NMBlefFav3y9nk7zfJbP6Pti9awo27x+tS4B4XvfH300r5r2xSCNxtkP1nW+PROyjJd5S1Dyy3wJ
-        8pwuZ6uqWLYE6RfLh/xbnbf0KyHxpljkZ8un2TV9vEvIZYQ4Pj+p1sv2o0f73kdnM2rzvY92CPou
-        /X+P/n/vI8JulbXzOGbUItf+qUEzeXQXDIBGy2abftP22w92H+4/2D5/OH2wc+/TyYPdcZPXGMxk
-        3YyviuWsuuJh3f2IZhO05cluviAStlVN/Zz+kMe1bZFYWBzorW94rDTYhmBnF3kwib/bLD/P1iX1
-        QsyVNW/a8rg5a6qDT3d2qeOXb3a/TahMq+UyJ46rlq9bxu7RR/JpmxXLvFZm4j4WedNkF9Qm6OW8
-        KPMXVVucFyJa/CHJ2dunaxl5p9MvCHwbRWWRvXual8T79bUSf3cH/ebLbFLmxOv5V6uyymad3s6z
-        sskJ5bJaz95UIvPAIQZu9JHSJE6McxKtSTZ9i9e/0SFYNvB48WUg/U7iXlRLwl9+jD46sfNDX5oP
-        ZZBv8jJf5G197b442Xt6Ui0W2RKcaj6U1mcz6qBor7+kTgUV18LRtv8t0D/Ps5Y0h/1s9NFFTszB
-        DV+sF5O8/ujRDrVr3q4xAtXSryEkND768iPSX8tZVkNtTbNVNiVEiDa/5Jd8/5f8P9T2yXtxBgAA
+        5bHfZrAEwQz3AsOl1wx6QI3GSy1y6oS+OObnye795Ref0adEh1Vet0WO/j9q2qwF/sfTtrjM5evL
+        ogEuy4vX+uXr9XSa57N8Rt8Xq2dF2eb1q3UJCN/7/uijedW0LwZpNM5+sK7z7ZmQZbzMW4KSX+ZL
+        kOd0OVtVxbIlSL9YPuTf6rylXwmJN8UiP1s+za7p411CLiPE8flJtV62Hz3a9z46m1Gb7320Q9B3
+        6f979P97HxF2q6ydxzGjFrn2Tw2ayaO7YAA0Wjbb9Ju23z7YefDpwfb0wc79/WxyL384bvIag5ms
+        m/FVsZxVVzysux/RbIK2PNnNF0TCtqqpn9Mf8ri2LRILiwO99Q2PlQbbEOzsIg8m8Xeb5efZuqRe
+        iLmy5k1bHjdnTXXw6c4udfzyze63CZVptVzmxHHV8nXL2D36SD5ts2KZ18pM3Mcib5rsgtoEvZwX
+        Zf6iaovzQkSLPyQ5e/t0LSPvdPoFgW+jqCyyd0/zkni/vlbi7+6g33yZTcqceD3/alVW2azT23lW
+        NjmhXFbr2ZtKZB44xMCNPlKaxIlxTqI1yaZv8fo3OgTLBh4vvgyk30nci2pJ+MuP0Ucndn7oS/Oh
+        DPJNXuaLvK2v3Rcne09PqsUiW4JTzYfS+mxGHRTt9ZfUqaDiWjja9r8F+ud51pLmsJ+NPrrIiTm4
+        4Yv1YpLXHz3aoXbN2zVGoFr6NYSExkdffkT6aznLaqitabbKpoQI0eaX/JLv/5L/B8obw3FxBgAA
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 29 Sep 2016 15:16:20 GMT']
+      Date: ['Mon, 31 Oct 2016 07:16:33 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -531,13 +560,143 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc1MTYwNjc1LCJuYmYiOjE0NzUxNjA2NzUsImV4cCI6MTQ3NTE2NDU3NSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInJzYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaXBhZGRyIjoiMTM5LjIyNi44Ni44NyIsIm5hbWUiOiJLZXZpbiBaaGFvIiwib2lkIjoiODY3ZmI5ZDAtMTQzMS00MWM3LTk2ZTItODM1ZWE2M2Q2MmUyIiwib25wcmVtX3NpZCI6IlMtMS01LTIxLTIxNDY3NzMwODUtOTAzMzYzMjg1LTcxOTM0NDcwNy0xOTYzNTcyIiwicHVpZCI6IjEwMDMwMDAwOTBGRUNDQ0UiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJCTEc1SmxRcURabFdZNEM4QkpnNmZJcXRNelFxZ1ZVZllXemJPNjZvbFB3IiwidGlkIjoiNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3IiwidW5pcXVlX25hbWUiOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidXBuIjoia2V2aW56aGFAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCJ9.qTZd7EpdgfCb4y3-sibNUCjCKXOQMelsVWeGPrFgnIOCbrZzaaImGiJfUjej5DjGx_FreMJvdovrhF6LgS8SmjID3dlcU6lGpPn_99bt8OUSY93jN-6zp6S-MS7JjutyX6C7-vwscB0tK2jvMxSZBICdWNJMmWOF4xep6ava-OKtz7c25WKYiZFRd-lZptIf2DrqO1SIWEyw-CAdwKz6NoDGs-E3U4Id-QLcWlAQMB0AGke06RG3bywI7W40MkDSmWMs28C5iBcik_o3caq5drXu252LFBY_qxzFAq3YKzKydy6At3Bse5SfAUmv00WmmPQmcV4N5KDdfQCTcnMvQw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [f4aaa2d8-9f39-11e6-83ab-40a8f04ffd53]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing/listkeys?api-version=2016-02-03
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/zR2/z6Rbag3z8qqna+nlRXy7z+aPTRqi4WWX39e+XX9NX07JPT3+d6f/9gsvjJbFKd
+        39//9oOr4vOdZfvtqy8eLn7Rq+f362dfVk8+/+mDz+jdJp9Wy5l9+6C9/PLld3/iTbv4yf37Pzmd
+        71YHL79a7u+V+f5PPG9/0U8+u/vt19W3r59fvGjwdl1czNuG3nuVXxRNW19/ty7afJS+zuvLYpqf
+        VMtlPm1H6dPc+/OjXzLyx9JIW4IWjONqffHFL3r+5vzJl5fnr7MnV7P9h/V368X66vd+vijO3719
+        frz8fb46rp/8XtPYOF7Mf+Lpd3+v3+vNT/6i3+vp/s5PVA/2furBd3/ybPeTH/zeP/hF3/3p4t5P
+        5bPf++Qie/6U37bjCBHvYDrjUVDzANEv85/4ibw8Xf5eV/Pf5xddXExPHj6YP5hMfq/rNz9RHl/9
+        5CfNk+LTd7/oq5PigrvqIDr7cvWLHv6i7P5+9eDbu1ev9r/9ez/7dtF89+7v9eq4+ck3zx68urx6
+        e/77TKtfdHGFty2imyha62S8yrMZvRNge7lTrL/97id2nv1gvXt/f7pX3//Ow5ezefNT8/Inf6/v
+        vvvJq5/euzxY/vQvevnyFP11sL38aufB5WXxe83eLfYvJ9/5ibc/qE9+8Hu1n/zE26c/8Xu/KJf3
+        fq/68++e/l7Xpwdv8bbF1rAHYzSMLHMPvRdgXP5eP3hwdW/5en7dXuVZ84ueVusy/+7O/Bc9/OrF
+        8SfF01/0Ovupe/lPFy9+8Pugzw7G73aeLmenry4P6tft3TffuS6v2ru71e/95HL1enqXhv7sJ8rF
+        zt7T36c5v8DbPYwFpV/y/V/y/wDMyV2RiQMAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 31 Oct 2016 07:16:36 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
+          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [acf3e9c2-8657-11e6-aa34-54ee7550b4da]
+      x-ms-client-request-id: [f5c17fda-9f39-11e6-acda-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing?api-version=2016-02-03
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3fMsm+ztHcy2Z+cPsu39nYNPtx8+3M2384Pd6f6n9x/O9nezu3XeVOt6
+        mn9eV+tVc7eo2u35erLd5k27XV/cXdXVZTHL6+buF8W0rprqvB0/zS+Lad7cPavab1OH9p3zqub3
+        iuXFR6OPltkiJ5ziX7bXK3w5CJOalNU0wzio2RW9t8ZnbXbRfPToF/+S0Uf+SHnstxksQTDDvcBw
+        6TWDHlCj8VKLnDqhL475ebJ7f/nFZ/Qp0WGV122Ro/+PmjZrgf/xtC0uc/n6smiAy/LitX75ej2d
+        5vksn9H3xepZUbZ5/WpdAsL3vj/6aF417YtBGo2zH6zrfHsmZBkv85ag5Jf5EuQ5Xc5WVbFsCdIv
+        lg/5tzpv6VdC4k2xyM+WT7Nr+niXkMsIcXx+Uq2X7UeP9r2PzmbU5nsf7RD0Xfr/Hv3/3keE3Spr
+        53HMqEWu/VODZvLoLhgAjZbNNv2m7bcPdh58erA9fbBzfz+b3Msfjpu8xmAm62Z8VSxn1RUP6+5H
+        NJugLU928wWRsK1q6uf0hzyubYvEwuJAb33DY6XBNgQ7u8iDSfzdZvl5ti6pF2KurHnTlsfNWVMd
+        fLqzSx2/fLP7bUJlWi2XOXFctXzdMnaPPpJP26xY5rUyE/exyJsmu6A2QS/nRZm/qNrivBDR4g9J
+        zt4+XcvIO51+QeDbKCqL7N3TvCTer6+V+Ls76DdfZpMyJ17Pv1qVVTbr9HaelU1OKJfVevamEpkH
+        DjFwo4+UJnFinJNoTbLpW7z+jQ7BsoHHiy8D6XcS96JaEv7yY/TRiZ0f+tJ8KIN8k5f5Im/ra/fF
+        yd7Tk2qxyJbgVPOhtD6bUQdFe/0ldSqouBaOtv1vgf55nrWkOexno48ucmIObvhivZjk9UePdqhd
+        83aNEaiWfg0hofHRlx+R/lrOshpqa5qtsikhQrT5Jb/k/wF1sxaPZQYAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 31 Oct 2016 07:16:37 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [f6cf8c98-9f39-11e6-80ed-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXP3PMsme3sHs+3Z+YNse3/n4NPthw938+38YHe6/+n9
+        h7P93exunTfVup7mn9fVetXcLap2e76ebLd5027XF3dXdXVZzPK6uftFMa2rpjpvx0/zy2KaN3fP
+        qvbb1KF957yq+b1iefHR6KNltiDUPop/2V6v8OUgTGpSVtMM46BmV/TeGp+12UXz0aNf/EtGH/kj
+        5bHfZrAEwQz3AsOl1wx6QI3GSy1y6oS+OObnye795Ref0adEh1Vet0WO/j9q2qwF/sfTtrjM5evL
+        ogEuy4vX+uXr9XSa57N8Rt8Xq2dF2eb1q3UJCN/7/uijedW0LwZpNM5+sK7z7ZmQZbzMW4KSX+ZL
+        kOd0OVtVxbIlSL9YPuTf6rylXwmJN8UiP1s+za7p411CLiPE8flJtV62Hz3a9z46m1Gb7320Q9B3
+        6f979P97HxF2q6ydxzGjFrn2Tw2ayaO7YAA0Wjbb9Ju23z7YefDpwfb0wc79/WxyL384bvIag5ms
+        m/FVsZxVVzysux/RbIK2PNnNF0TCtqqpn9Mf8ri2LRILiwO99Q2PlQbbEOzsIg8m8Xeb5efZuqRe
+        iLmy5k1bHjdnTXXw6c4udfzyze63CZVptVzmxHHV8nXL2D36SD5ts2KZ18pM3Mcib5rsgtoEvZwX
+        Zf6iaovzQkSLPyQ5e/t0LSPvdPoFgW+jqCyyd0/zkni/vlbi7+6g33yZTcqceD3/alVW2azT23lW
+        NjmhXFbr2ZtKZB44xMCNPlKaxIlxTqI1yaZv8fo3OgTLBh4vvgyk30nci2pJ+MuP0Ucndn7oS/Oh
+        DPJNXuaLvK2v3Rcne09PqsUiW4JTzYfS+mxGHRTt9ZfUqaDiWjja9r8F+ud51pLmsJ+NPrrIiTm4
+        4Yv1YpLXHz3aoXbN2zVGoFr6NYSExkdffkT6aznLaqitabbKpoQI0eaX/JLv/5L/B8obw3FxBgAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 31 Oct 2016 07:16:39 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [f7dbd678-9f39-11e6-87dd-40a8f04ffd53]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
@@ -557,32 +716,30 @@ interactions:
         iAjxhyRPb5+uZeSdTr8g8G0UlUX27mleEo/X10r03R30my+zSZkTT+dfrcoqm3V6O8/KJieUy2o9
         e1OJbAOHGLjRR0qTODHOSYQm2fQtXv9Gh2DZwOPBl4GUOwl7US0Jf/kx+ujEzg99+dFpXVc1fSqj
         fJOX+SJv62vvm5O9pyfVYpEtwaP2U2l/NqM+ivb6S+pXsPGaOPpGvsYYzvOsJXWBDxW3i5w4hFu+
-        WC8mef3Rox1q17xdYxiqil9DQmiQ9OVHpKyWs6yGjppmq2xKqBCBCPY3Z0B+UCya7Ae3shzSlHBR
-        TO3fH2ovPqJ2r9dFm78RQK/yRdXmbuKhlPyR8thvM1jqwgzXGBSLdMeSzJ9UP+uWRPr+f4kREWTo
-        w2HdKk22P919uPvpdn6+c29vdp7fOx/Wq3G5/Vm1HYqj7dd1Sw2/waHR2H5kMn5emAz9UAbpWwz9
-        IjQY+qG0jtoLbeFo2/8W6H9NawF5oPHRlz8Ma1FU7XaTLVZlvv2DefHTP5hn1e1MhzbeJvEj9BT5
-        zqfvb0bW+Iz0OBHtmww6IqOkVj2DcfyzbzC0dxDo/y1mw0OJvtqgYW3D7U/v7e7skZZ9cO9g8mk2
-        nQ1r2bgU/+waEIsn4W17d51T8294kDTKH5mSH5kS+uL/XaYE0kHjoy9/GKbkJ1+fbJ9Vb7bfnL5+
-        s/3q81uZkctmWpBuhvC1eQMFqLj3v3h/YxLGJCAPNTNj5FHfZpgEwQzUmJPOSKlFaErmXy5/9k1J
-        h0L/L7EmHazo22Fd67X99MGD3Z3t/Yf3872dh9kkG9a1cVn+WTUoHp4Yk7MpC9s/vfENj5MG+iOb
-        8iObQl/8fLYpos5WRNlbmRPXnHBSjIPP/l9kRAK8QvtR7j37iZ91++H6/9k0HXveR4GaJWRUvUq/
-        QIS+GNairtn2g52D+/vbB3ufnh98Op3cPxjWonEpfX9r8V7DeG8D4b16+6HR2H5kIH5kIOiLn88G
-        giL1gnwrSe7cykboGyR6hJYiHXx2exthbMTPUtZKsZKx0fehkVi8Oj37WTcSigIR5mfTSLyHL+4Q
-        oi+GNaprtv1gd/fTh9v3H+a79x5O7p9vWBGIS+z7G4uvNZz3Nhreq7cfIo3xR0bjR0aDvvj5bDQK
-        khvRqttvacRLSvjeynTgPcibeYlQ1AFEvvl/jRkBbp3RUquuMVn+7K+WAxGfSP8vMSldtOjrYa1L
-        v2ljaN0Hn27Pdqf38v379yefDmvduFT/rBqWwuIpg3pv80K/KYD3GCiN9Efm5Ufmhb74+WxertfL
-        i/wH5kNWw7u3si/yYsEyCIFW9Lsf/7/GsghiwaegdMe0fHf/Z38xRDBREv2/xK4EONF3w7rWtSRd
-        u3dvdzs7P8gfzrKdTfmfuCz/rBoVhyeN6L0tinv7PUZJw/yRRfmRRaEvfj5blIKcMXXhfzAvfpr8
-        uWp7kU1vZVTsCxBDeonQ1EFEvnk/03JFq6E/S6ZlYMTUMrQuy+98cvCzbl0sBkqo/5cYmC5a9PWw
-        9nWNSfse7NzbvvfgPiWL9u8/mA5r37h0/6zaGIcn4U2Dem8z4wC8x0BppD8yMz8yM/TFz3czAylq
-        Sa9v17dbcjfvnFc1v0fTQhgq/vEv/19lZIAeUKPxUouOcfnJqvlZNy4GCY9G/y+xLxHMqMWw5qXf
-        tD1p3of7D7bPH04f7Nz7dPJgd1jzxiX7Z9XEFBZPO673tjL0m8J4j7HSYH9kZX5kZeiL/89Zme//
-        kv8HSvqIae0+AAA=
+        WC8mef3Rox1q17xdYxiqil9DQmiQ9OVHpKyWs6yGjppmq2xKqBCBCPY3Z0B+8vXJ9ln1ZvvN6es3
+        268+v5UJuWymRdVuQwLbvIEOVNz7X/y/yJR0RkotQmMy/3J5/LNuTDoU+n+JQelgRd8OK1yv7acP
+        HuzubO8/vJ/v7TzMJtmwwo0L9M+qUfHwxJicYVnY/umNb3icNNAfGZafF4ZFP5RB+nZFvwjNin4o
+        raNWRVs42va/Bfr/n7Apos5WRNlbmRPXnHBSjIPP/l9kRAK8QvtR7j37iZ91++H6/9k0HXveR4Ga
+        JWRUvUq/QIS+GNairtn2g52D+/vbB3ufnh98Op3cPxjWonEpfX9r8V7DeG8D4b16+6HR2H5kIH5k
+        IOiLn88GIqu2C/KtmmyxKvNb2Qh9g0SP0FKkg8/e30as8RlpcCLVN2khFCsZG30fGonFq9Ozn3Uj
+        oSgQYX42jcR7+OIOIfpiWKO6ZtsPdnc/fbh9/2G+e+/h5P75+bBGjUvs+xuLrzWc9zYa3qu3HyKN
+        8UdG40dGg774+Ww0CpIb0arbP5gXP/2DeVbdynRA1swLhJ4i3/n0/czHFSUUfpbMR2SU1Co0IvX9
+        L3d+1o2IT6CfTTNyCyedaAJscvyD/wta2w/29z7d2872d7J7efbwHrixp3jnzZrIMJtcE5139u7T
+        wDH/DXFoPqxv4/L8/iblQ4eGqTrYe3iwD0bZPLT9T283NBrbj0zJj0wJffH/KlPyDMJL46MvP3pW
+        53jtZ8uMXK+XF/kPzIesdndvZUfkxYIF9h4hqKh3Px62JAKHmhC/MD3o7Z/FQEQQCz4FlUNT0qy+
+        aH7WTYlgoiT62bQl7+HDBzjRdz31yt/AZXctSS1/ev/e9iTP72WfTs53Hwzr2bgcv78J+bojeu/A
+        xL39HqOkYf7ImvzImtAX/6+yJj9ngcmt7MgPikWzvcyv4O8RVopz59P3syI/lHiEvgxtx+UXez/7
+        uSyfLv8vMR0+SvTVsE51DbcffLp379Pt84Pd2e5DEvYNOjUusz+rlsPhSXjb3m9pONzL7zFIGuWP
+        DMePDAd98fPdcLyloS4px3Ir02Eamxwy4aaYR775f5UJMfjR16ER2f384md/1dz0bqjz/xJD0kWL
+        vh7Ws67x9sHO7sHu9nRvd/Zwuntwb4Oejcvxz6oxcXjKoN7boDgA7zFQGumPDMqPDAp98fPdoECK
+        WlLm2/XFrWyKeee8qvk9mhbCUPGPf/n/KssC9IAajZdadIzL/eUXP+vGxSDh0ej/JfYlghm1GNa8
+        9Ju2J8374NOD7emDnfv72eRe/nBY88Yl+2fVxBQWTzuu97Yy9JvCeI+x0mB/ZGV+ZGXoi//PWZnv
+        /5L/BwpMcMV/OAAA
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 29 Sep 2016 15:16:25 GMT']
+      Date: ['Mon, 31 Oct 2016 07:16:41 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -594,14 +751,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc1MTYwNjc1LCJuYmYiOjE0NzUxNjA2NzUsImV4cCI6MTQ3NTE2NDU3NSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInJzYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaXBhZGRyIjoiMTM5LjIyNi44Ni44NyIsIm5hbWUiOiJLZXZpbiBaaGFvIiwib2lkIjoiODY3ZmI5ZDAtMTQzMS00MWM3LTk2ZTItODM1ZWE2M2Q2MmUyIiwib25wcmVtX3NpZCI6IlMtMS01LTIxLTIxNDY3NzMwODUtOTAzMzYzMjg1LTcxOTM0NDcwNy0xOTYzNTcyIiwicHVpZCI6IjEwMDMwMDAwOTBGRUNDQ0UiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJCTEc1SmxRcURabFdZNEM4QkpnNmZJcXRNelFxZ1ZVZllXemJPNjZvbFB3IiwidGlkIjoiNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3IiwidW5pcXVlX25hbWUiOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidXBuIjoia2V2aW56aGFAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCJ9.qTZd7EpdgfCb4y3-sibNUCjCKXOQMelsVWeGPrFgnIOCbrZzaaImGiJfUjej5DjGx_FreMJvdovrhF6LgS8SmjID3dlcU6lGpPn_99bt8OUSY93jN-6zp6S-MS7JjutyX6C7-vwscB0tK2jvMxSZBICdWNJMmWOF4xep6ava-OKtz7c25WKYiZFRd-lZptIf2DrqO1SIWEyw-CAdwKz6NoDGs-E3U4Id-QLcWlAQMB0AGke06RG3bywI7W40MkDSmWMs28C5iBcik_o3caq5drXu252LFBY_qxzFAq3YKzKydy6At3Bse5SfAUmv00WmmPQmcV4N5KDdfQCTcnMvQw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
+          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [afcb3a2e-8657-11e6-8086-54ee7550b4da]
+      x-ms-client-request-id: [f8d4ffa8-9f39-11e6-acb8-40a8f04ffd53]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing/listkeys?api-version=2016-02-03
   response:
@@ -609,23 +766,23 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS9X/zR2/z6Rbag3z8qqna+nlRXy7z+aPTRqi4WWX39e+XX9NX5L3p98MlPPvn2onqe371/
-        96fXT5ft3vPF8smz/adfvX336dnBgy8e1Pe/89P3fp/P6N0mn1bLmX37cj69+4N3d49/6vXsq71f
-        9Hz9k5e7xU9c1l/99Ozqk4ft7O3b79w/vj754vPXn1/g7bq4mLcNvfcqvyiatr7+bl20+Sh9ndeX
-        xTQ/qZbLfNqO0qe59+dHv2Tkj6WRtgQtGMcXy5c7T+df/F6rnbsHl3d3n7bliy8vdmdPv/1g5wcH
-        7ybHD3/vX3Rxvnz28OX9Bph0xvETD3+q+qQ8XRdPlpcPf6/PF8t773Ze7/707k+v3/4+Z+vVd559
-        +vSL5cNFsfp2OI4Q8Q6mMx4FNQ8Q3X3xyennP/3w6S/6zsPPL5vy+Rf3fq+nX/3kF7OT6uTlk8n1
-        20/e7H3y/Nni3dWDHXTVQfTexao5Kd598bw42Lv+6YNfdPJyt3p4d2//J6rpT/6ip8c/8e73evPk
-        9zm4On3zU/y2RXQTRWudjFd5NqN3AmynX57PJqvTs8kXv9ebNaG283uvP23X6/Xi05PlwZu7+58+
-        /OTh6/zL8y+bK/TXxfYnDq5/8Iu+8/L4p5tJuZdNLr+73nv9nW+/3n19/9mbu7/3q8nx6v6DLz95
-        +nvJ2xZbwx6M0TCyzD30XoDx8qq+l03z7Ozhvae/z6f57u7+s0X7bv17/95PDy5WP/HJ8env8+L3
-        +kXP7/3Ud7/NfXYw/skX9eVVvl8urrOL6fwXZRcPz3+vX3T/bHVy0Ox++enDs+e/1/zt6ovzn/7q
-        3lu83cNYUPol3/8l/w8JNbR6iQMAAA==
+        uc4/evS9X/zR2/z6Rbag3z8qqna+nlRXy7z+aPTRqi4WWX39e+XX9NX07JPT3+d6f/9gsvjJbFKd
+        39//9oOr4vOdZfvtqy8eLn7Rq+f362dfVk8+/+mDz+jdJp9Wy5l9+6C9/PLld3/iTbv4yf37Pzmd
+        71YHL79a7u+V+f5PPG9/0U8+u/vt19W3r59fvGjwdl1czNuG3nuVXxRNW19/ty7afJS+zuvLYpqf
+        VMtlPm1H6dPc+/OjXzLyx9JIW4IWjONqffHFL3r+5vzJl5fnr7MnV7P9h/V368X66vd+vijO3719
+        frz8fb46rp/8XtPYOF7Mf+Lpd3+v3+vNT/6i3+vp/s5PVA/2furBd3/ybPeTH/zeP/hF3/3p4t5P
+        5bPf++Qie/6U37bjCBHvYDrjUVDzANEv85/4ibw8Xf5eV/Pf5xddXExPHj6YP5hMfq/rNz9RHl/9
+        5CfNk+LTd7/oq5PigrvqIDr7cvWLHv6i7P5+9eDbu1ev9r/9ez/7dtF89+7v9eq4+ck3zx68urx6
+        e/77TKtfdHGFty2imyha62S8yrMZvRNge7lTrL/97id2nv1gvXt/f7pX3//Ow5ezefNT8/Inf6/v
+        vvvJq5/euzxY/vQvevnyFP11sL38aufB5WXxe83eLfYvJ9/5ibc/qE9+8Hu1n/zE26c/8Xu/KJf3
+        fq/68++e/l7Xpwdv8bbF1rAHYzSMLHMPvRdgXP5eP3hwdW/5en7dXuVZ84ueVusy/+7O/Bc9/OrF
+        8SfF01/0Ovupe/lPFy9+8Pugzw7G73aeLmenry4P6tft3TffuS6v2ru71e/95HL1enqXhv7sJ8rF
+        zt7T36c5v8DbPYwFpV/y/V/y/wDMyV2RiQMAAA==
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 29 Sep 2016 15:16:25 GMT']
+      Date: ['Mon, 31 Oct 2016 07:16:43 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -639,22 +796,22 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [SharedAccessSignature skn=iothubowner&se=1475165785&sr=iot-hub-for-testing.azure-devices.net%252fdevices%252fiot-device-for-testing&sig=zIU4%2FhLkL61TYRBnNv0zKdJbNMtjJXP9LKxT0gvBykE%3D]
+      Authorization: [SharedAccessSignature sig=HB%2FKu%2F6rkGRnaeLt4SSScwmYJPKMCmkXee3e56174xo%3D&sr=iot-hub-for-testing.azure-devices.net%252fdevices%252fiot-device-for-testing&se=1477901803&skn=iothubowner]
       Connection: [keep-alive]
       Content-Length: ['38']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
           iothubdeviceclient/2016-02-03 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [b038e4ec-8657-11e6-88d4-54ee7550b4da]
+      x-ms-client-request-id: [f9ede9e6-9f39-11e6-bc39-40a8f04ffd53]
     method: PUT
     uri: https://iot-hub-for-testing.azure-devices.net/devices/iot-device-for-testing?api-version=2016-02-03
   response:
-    body: {string: '{"deviceId":"iot-device-for-testing","generationId":"636107589882545869","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"qlhnBaWihYDHE/FlDZfngBTWfvwJ+BQbsmloLgl5+lU=","secondaryKey":"6hezQgeqN5e6bJ0bF0lBlONRYzY6q/UOUQrjjKULt8Q="},"x509Thumbprint":null},"isManaged":false,"deviceProperties":null,"configuration":null,"serviceProperties":null,"lastServicePropertiesUpdatedTime":"0001-01-01T00:00:00","lastDevicePropertiesUpdatedTime":"0001-01-01T00:00:00"}'}
+    body: {string: '{"deviceId":"iot-device-for-testing","generationId":"636134950041361377","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"dw93dOLBIxAcczUqoEDukwh1pVi7gzIQq65ahBS6qNw=","secondaryKey":"UtEyT1p11+SF1q2bsGPVGshmW3/dLeQhelLsdQnJG3c="},"x509Thumbprint":null}}'}
     headers:
-      Content-Length: ['704']
+      Content-Length: ['503']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 29 Sep 2016 15:16:28 GMT']
+      Date: ['Mon, 31 Oct 2016 07:16:44 GMT']
       ETag: ['"MA=="']
       Server: [Microsoft-HTTPAPI/2.0]
     status: {code: 200, message: OK}
@@ -663,13 +820,13 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc1MTYwNjc1LCJuYmYiOjE0NzUxNjA2NzUsImV4cCI6MTQ3NTE2NDU3NSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInJzYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaXBhZGRyIjoiMTM5LjIyNi44Ni44NyIsIm5hbWUiOiJLZXZpbiBaaGFvIiwib2lkIjoiODY3ZmI5ZDAtMTQzMS00MWM3LTk2ZTItODM1ZWE2M2Q2MmUyIiwib25wcmVtX3NpZCI6IlMtMS01LTIxLTIxNDY3NzMwODUtOTAzMzYzMjg1LTcxOTM0NDcwNy0xOTYzNTcyIiwicHVpZCI6IjEwMDMwMDAwOTBGRUNDQ0UiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJCTEc1SmxRcURabFdZNEM4QkpnNmZJcXRNelFxZ1ZVZllXemJPNjZvbFB3IiwidGlkIjoiNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3IiwidW5pcXVlX25hbWUiOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidXBuIjoia2V2aW56aGFAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCJ9.qTZd7EpdgfCb4y3-sibNUCjCKXOQMelsVWeGPrFgnIOCbrZzaaImGiJfUjej5DjGx_FreMJvdovrhF6LgS8SmjID3dlcU6lGpPn_99bt8OUSY93jN-6zp6S-MS7JjutyX6C7-vwscB0tK2jvMxSZBICdWNJMmWOF4xep6ava-OKtz7c25WKYiZFRd-lZptIf2DrqO1SIWEyw-CAdwKz6NoDGs-E3U4Id-QLcWlAQMB0AGke06RG3bywI7W40MkDSmWMs28C5iBcik_o3caq5drXu252LFBY_qxzFAq3YKzKydy6At3Bse5SfAUmv00WmmPQmcV4N5KDdfQCTcnMvQw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
+          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [b131593a-8657-11e6-9d1a-54ee7550b4da]
+      x-ms-client-request-id: [facd054c-9f39-11e6-81d5-40a8f04ffd53]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
@@ -689,32 +846,30 @@ interactions:
         iAjxhyRPb5+uZeSdTr8g8G0UlUX27mleEo/X10r03R30my+zSZkTT+dfrcoqm3V6O8/KJieUy2o9
         e1OJbAOHGLjRR0qTODHOSYQm2fQtXv9Gh2DZwOPBl4GUOwl7US0Jf/kx+ujEzg99+dFpXVc1fSqj
         fJOX+SJv62vvm5O9pyfVYpEtwaP2U2l/NqM+ivb6S+pXsPGaOPpGvsYYzvOsJXWBDxW3i5w4hFu+
-        WC8mef3Rox1q17xdYxiqil9DQmiQ9OVHpKyWs6yGjppmq2xKqBCBCPY3Z0B+UCya7Ae3shzSlHBR
-        TO3fH2ovPqJ2r9dFm78RQK/yRdXmbuKhlPyR8thvM1jqwgzXGBSLdMeSzJ9UP+uWRPr+f4kREWTo
-        w2HdKk22P919uPvpdn6+c29vdp7fOx/Wq3G5/Vm1HYqj7dd1Sw2/waHR2H5kMn5emAz9UAbpWwz9
-        IjQY+qG0jtoLbeFo2/8W6H9NawF5oPHRlz8Ma1FU7XaTLVZlvv2DefHTP5hn1e1MhzbeJvEj9BT5
-        zqfvb0bW+Iz0OBHtmww6IqOkVj2DcfyzbzC0dxDo/y1mw0OJvtqgYW3D7U/v7e7skZZ9cO9g8mk2
-        nQ1r2bgU/+waEIsn4W17d51T8294kDTKH5mSH5kS+uL/XaYE0kHjoy9/GKbkJ1+fbJ9Vb7bfnL5+
-        s/3q81uZkctmWpBuhvC1eQMFqLj3v3h/YxLGJCAPNTNj5FHfZpgEwQzUmJPOSKlFaErmXy5/9k1J
-        h0L/L7EmHazo22Fd67X99MGD3Z3t/Yf3872dh9kkG9a1cVn+WTUoHp4Yk7MpC9s/vfENj5MG+iOb
-        8iObQl/8fLYpos5WRNlbmRPXnHBSjIPP/l9kRAK8QvtR7j37iZ91++H6/9k0HXveR4GaJWRUvUq/
-        QIS+GNairtn2g52D+/vbB3ufnh98Op3cPxjWonEpfX9r8V7DeG8D4b16+6HR2H5kIH5kIOiLn88G
-        giL1gnwrSe7cykboGyR6hJYiHXx2exthbMTPUtZKsZKx0fehkVi8Oj37WTcSigIR5mfTSLyHL+4Q
-        oi+GNaprtv1gd/fTh9v3H+a79x5O7p9vWBGIS+z7G4uvNZz3Nhreq7cfIo3xR0bjR0aDvvj5bDQK
-        khvRqttvacRLSvjeynTgPcibeYlQ1AFEvvl/jRkBbp3RUquuMVn+7K+WAxGfSP8vMSldtOjrYa1L
-        v2ljaN0Hn27Pdqf38v379yefDmvduFT/rBqWwuIpg3pv80K/KYD3GCiN9Efm5Ufmhb74+WxertfL
-        i/wH5kNWw7u3si/yYsEyCIFW9Lsf/7/GsghiwaegdMe0fHf/Z38xRDBREv2/xK4EONF3w7rWtSRd
-        u3dvdzs7P8gfzrKdTfmfuCz/rBoVhyeN6L0tinv7PUZJw/yRRfmRRaEvfj5blIKcMXXhfzAvfpr8
-        uWp7kU1vZVTsCxBDeonQ1EFEvnk/03JFq6E/S6ZlYMTUMrQuy+98cvCzbl0sBkqo/5cYmC5a9PWw
-        9nWNSfse7NzbvvfgPiWL9u8/mA5r37h0/6zaGIcn4U2Dem8z4wC8x0BppD8yMz8yM/TFz3czAylq
-        Sa9v17dbcjfvnFc1v0fTQhgq/vEv/19lZIAeUKPxUouOcfnJqvlZNy4GCY9G/y+xLxHMqMWw5qXf
-        tD1p3of7D7bPH04f7Nz7dPJgd1jzxiX7Z9XEFBZPO673tjL0m8J4j7HSYH9kZX5kZeiL/89Zme//
-        kv8HSvqIae0+AAA=
+        WC8mef3Rox1q17xdYxiqil9DQmiQ9OVHpKyWs6yGjppmq2xKqBCBCPY3Z0B+8vXJ9ln1ZvvN6es3
+        268+v5UJuWymRdVuQwLbvIEOVNz7X/y/yJR0RkotQmMy/3J5/LNuTDoU+n+JQelgRd8OK1yv7acP
+        HuzubO8/vJ/v7TzMJtmwwo0L9M+qUfHwxJicYVnY/umNb3icNNAfGZafF4ZFP5RB+nZFvwjNin4o
+        raNWRVs42va/Bfr/n7Apos5WRNlbmRPXnHBSjIPP/l9kRAK8QvtR7j37iZ91++H6/9k0HXveR4Ga
+        JWRUvUq/QIS+GNairtn2g52D+/vbB3ufnh98Op3cPxjWonEpfX9r8V7DeG8D4b16+6HR2H5kIH5k
+        IOiLn88GIqu2C/KtmmyxKvNb2Qh9g0SP0FKkg8/e30as8RlpcCLVN2khFCsZG30fGonFq9Ozn3Uj
+        oSgQYX42jcR7+OIOIfpiWKO6ZtsPdnc/fbh9/2G+e+/h5P75+bBGjUvs+xuLrzWc9zYa3qu3HyKN
+        8UdG40dGg774+Ww0CpIb0arbP5gXP/2DeVbdynRA1swLhJ4i3/n0/czHFSUUfpbMR2SU1Co0IvX9
+        L3d+1o2IT6CfTTNyCyedaAJscvyD/wta2w/29z7d2872d7J7efbwHrixp3jnzZrIMJtcE5139u7T
+        wDH/DXFoPqxv4/L8/iblQ4eGqTrYe3iwD0bZPLT9T283NBrbj0zJj0wJffH/KlPyDMJL46MvP3pW
+        53jtZ8uMXK+XF/kPzIesdndvZUfkxYIF9h4hqKh3Px62JAKHmhC/MD3o7Z/FQEQQCz4FlUNT0qy+
+        aH7WTYlgoiT62bQl7+HDBzjRdz31yt/AZXctSS1/ev/e9iTP72WfTs53Hwzr2bgcv78J+bojeu/A
+        xL39HqOkYf7ImvzImtAX/6+yJj9ngcmt7MgPikWzvcyv4O8RVopz59P3syI/lHiEvgxtx+UXez/7
+        uSyfLv8vMR0+SvTVsE51DbcffLp379Pt84Pd2e5DEvYNOjUusz+rlsPhSXjb3m9pONzL7zFIGuWP
+        DMePDAd98fPdcLyloS4px3Ir02Eamxwy4aaYR775f5UJMfjR16ER2f384md/1dz0bqjz/xJD0kWL
+        vh7Ws67x9sHO7sHu9nRvd/Zwuntwb4Oejcvxz6oxcXjKoN7boDgA7zFQGumPDMqPDAp98fPdoECK
+        WlLm2/XFrWyKeee8qvk9mhbCUPGPf/n/KssC9IAajZdadIzL/eUXP+vGxSDh0ej/JfYlghm1GNa8
+        9Ju2J8374NOD7emDnfv72eRe/nBY88Yl+2fVxBQWTzuu97Yy9JvCeI+x0mB/ZGV+ZGXoi//PWZnv
+        /5L/BwpMcMV/OAAA
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 29 Sep 2016 15:16:28 GMT']
+      Date: ['Mon, 31 Oct 2016 07:16:46 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -726,14 +881,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc1MTYwNjc1LCJuYmYiOjE0NzUxNjA2NzUsImV4cCI6MTQ3NTE2NDU3NSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInJzYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaXBhZGRyIjoiMTM5LjIyNi44Ni44NyIsIm5hbWUiOiJLZXZpbiBaaGFvIiwib2lkIjoiODY3ZmI5ZDAtMTQzMS00MWM3LTk2ZTItODM1ZWE2M2Q2MmUyIiwib25wcmVtX3NpZCI6IlMtMS01LTIxLTIxNDY3NzMwODUtOTAzMzYzMjg1LTcxOTM0NDcwNy0xOTYzNTcyIiwicHVpZCI6IjEwMDMwMDAwOTBGRUNDQ0UiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJCTEc1SmxRcURabFdZNEM4QkpnNmZJcXRNelFxZ1ZVZllXemJPNjZvbFB3IiwidGlkIjoiNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3IiwidW5pcXVlX25hbWUiOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidXBuIjoia2V2aW56aGFAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCJ9.qTZd7EpdgfCb4y3-sibNUCjCKXOQMelsVWeGPrFgnIOCbrZzaaImGiJfUjej5DjGx_FreMJvdovrhF6LgS8SmjID3dlcU6lGpPn_99bt8OUSY93jN-6zp6S-MS7JjutyX6C7-vwscB0tK2jvMxSZBICdWNJMmWOF4xep6ava-OKtz7c25WKYiZFRd-lZptIf2DrqO1SIWEyw-CAdwKz6NoDGs-E3U4Id-QLcWlAQMB0AGke06RG3bywI7W40MkDSmWMs28C5iBcik_o3caq5drXu252LFBY_qxzFAq3YKzKydy6At3Bse5SfAUmv00WmmPQmcV4N5KDdfQCTcnMvQw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
+          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [b1b8b57e-8657-11e6-928f-54ee7550b4da]
+      x-ms-client-request-id: [fbf78580-9f39-11e6-a8c2-40a8f04ffd53]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing/listkeys?api-version=2016-02-03
   response:
@@ -741,50 +896,50 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS9X/zR2/z6Rbag3z8qqna+nlRXy7z+aPTRqi4WWX39e+XX9NX5L3p98MlPPvn2onqe371/
-        96fXT5ft3vPF8smz/adfvX336dnBgy8e1Pe/89P3fp/P6N0mn1bLmX37cj69+4N3d49/6vXsq71f
-        9Hz9k5e7xU9c1l/99Ozqk4ft7O3b79w/vj754vPXn1/g7bq4mLcNvfcqvyiatr7+bl20+Sh9ndeX
-        xTQ/qZbLfNqO0qe59+dHv2Tkj6WRtgQtGMcXy5c7T+df/F6rnbsHl3d3n7bliy8vdmdPv/1g5wcH
-        7ybHD3/vX3Rxvnz28OX9Bph0xvETD3+q+qQ8XRdPlpcPf6/PF8t773Ze7/707k+v3/4+Z+vVd559
-        +vSL5cNFsfp2OI4Q8Q6mMx4FNQ8Q3X3xyennP/3w6S/6zsPPL5vy+Rf3fq+nX/3kF7OT6uTlk8n1
-        20/e7H3y/Nni3dWDHXTVQfTexao5Kd598bw42Lv+6YNfdPJyt3p4d2//J6rpT/6ip8c/8e73evPk
-        9zm4On3zU/y2RXQTRWudjFd5NqN3AmynX57PJqvTs8kXv9ebNaG283uvP23X6/Xi05PlwZu7+58+
-        /OTh6/zL8y+bK/TXxfYnDq5/8Iu+8/L4p5tJuZdNLr+73nv9nW+/3n19/9mbu7/3q8nx6v6DLz95
-        +nvJ2xZbwx6M0TCyzD30XoDx8qq+l03z7Ozhvae/z6f57u7+s0X7bv17/95PDy5WP/HJ8env8+L3
-        +kXP7/3Ud7/NfXYw/skX9eVVvl8urrOL6fwXZRcPz3+vX3T/bHVy0Ox++enDs+e/1/zt6ovzn/7q
-        3lu83cNYUPol3/8l/w8JNbR6iQMAAA==
+        uc4/evS9X/zR2/z6Rbag3z8qqna+nlRXy7z+aPTRqi4WWX39e+XX9NX07JPT3+d6f/9gsvjJbFKd
+        39//9oOr4vOdZfvtqy8eLn7Rq+f362dfVk8+/+mDz+jdJp9Wy5l9+6C9/PLld3/iTbv4yf37Pzmd
+        71YHL79a7u+V+f5PPG9/0U8+u/vt19W3r59fvGjwdl1czNuG3nuVXxRNW19/ty7afJS+zuvLYpqf
+        VMtlPm1H6dPc+/OjXzLyx9JIW4IWjONqffHFL3r+5vzJl5fnr7MnV7P9h/V368X66vd+vijO3719
+        frz8fb46rp/8XtPYOF7Mf+Lpd3+v3+vNT/6i3+vp/s5PVA/2furBd3/ybPeTH/zeP/hF3/3p4t5P
+        5bPf++Qie/6U37bjCBHvYDrjUVDzANEv85/4ibw8Xf5eV/Pf5xddXExPHj6YP5hMfq/rNz9RHl/9
+        5CfNk+LTd7/oq5PigrvqIDr7cvWLHv6i7P5+9eDbu1ev9r/9ez/7dtF89+7v9eq4+ck3zx68urx6
+        e/77TKtfdHGFty2imyha62S8yrMZvRNge7lTrL/97id2nv1gvXt/f7pX3//Ow5ezefNT8/Inf6/v
+        vvvJq5/euzxY/vQvevnyFP11sL38aufB5WXxe83eLfYvJ9/5ibc/qE9+8Hu1n/zE26c/8Xu/KJf3
+        fq/68++e/l7Xpwdv8bbF1rAHYzSMLHMPvRdgXP5eP3hwdW/5en7dXuVZ84ueVusy/+7O/Bc9/OrF
+        8SfF01/0Ovupe/lPFy9+8Pugzw7G73aeLmenry4P6tft3TffuS6v2ru71e/95HL1enqXhv7sJ8rF
+        zt7T36c5v8DbPYwFpV/y/V/y/wDMyV2RiQMAAA==
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 29 Sep 2016 15:16:29 GMT']
+      Date: ['Mon, 31 Oct 2016 07:16:47 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1194']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [SharedAccessSignature skn=iothubowner&se=1475165789&sr=iot-hub-for-testing.azure-devices.net%252fdevices%252fiot-device-for-testing&sig=o6S58d30QjkAupNY5I1G7WPtvqKso2qYT5Po5fEYsyQ%3D]
+      Authorization: [SharedAccessSignature sig=Nf6Mu5DnDX4hevwsEhy%2BTCVTkDFVkUwRw7MlANOAXcc%3D&sr=iot-hub-for-testing.azure-devices.net%252fdevices%252fiot-device-for-testing&se=1477901808&skn=iothubowner]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
           iothubdeviceclient/2016-02-03 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [b29ad1c2-8657-11e6-b860-54ee7550b4da]
+      x-ms-client-request-id: [fcfb8364-9f39-11e6-9f76-40a8f04ffd53]
     method: GET
     uri: https://iot-hub-for-testing.azure-devices.net/devices/iot-device-for-testing?api-version=2016-02-03
   response:
-    body: {string: '{"deviceId":"iot-device-for-testing","generationId":"636107589882545869","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"qlhnBaWihYDHE/FlDZfngBTWfvwJ+BQbsmloLgl5+lU=","secondaryKey":"6hezQgeqN5e6bJ0bF0lBlONRYzY6q/UOUQrjjKULt8Q="},"x509Thumbprint":null},"isManaged":false,"deviceProperties":null,"configuration":null,"serviceProperties":null,"lastServicePropertiesUpdatedTime":"0001-01-01T00:00:00","lastDevicePropertiesUpdatedTime":"0001-01-01T00:00:00"}'}
+    body: {string: '{"deviceId":"iot-device-for-testing","generationId":"636134950041361377","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"dw93dOLBIxAcczUqoEDukwh1pVi7gzIQq65ahBS6qNw=","secondaryKey":"UtEyT1p11+SF1q2bsGPVGshmW3/dLeQhelLsdQnJG3c="},"x509Thumbprint":null}}'}
     headers:
-      Content-Length: ['704']
+      Content-Length: ['503']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 29 Sep 2016 15:16:31 GMT']
+      Date: ['Mon, 31 Oct 2016 07:16:49 GMT']
       ETag: ['"MA=="']
       Server: [Microsoft-HTTPAPI/2.0]
     status: {code: 200, message: OK}
@@ -793,13 +948,13 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc1MTYwNjc1LCJuYmYiOjE0NzUxNjA2NzUsImV4cCI6MTQ3NTE2NDU3NSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInJzYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaXBhZGRyIjoiMTM5LjIyNi44Ni44NyIsIm5hbWUiOiJLZXZpbiBaaGFvIiwib2lkIjoiODY3ZmI5ZDAtMTQzMS00MWM3LTk2ZTItODM1ZWE2M2Q2MmUyIiwib25wcmVtX3NpZCI6IlMtMS01LTIxLTIxNDY3NzMwODUtOTAzMzYzMjg1LTcxOTM0NDcwNy0xOTYzNTcyIiwicHVpZCI6IjEwMDMwMDAwOTBGRUNDQ0UiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJCTEc1SmxRcURabFdZNEM4QkpnNmZJcXRNelFxZ1ZVZllXemJPNjZvbFB3IiwidGlkIjoiNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3IiwidW5pcXVlX25hbWUiOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidXBuIjoia2V2aW56aGFAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCJ9.qTZd7EpdgfCb4y3-sibNUCjCKXOQMelsVWeGPrFgnIOCbrZzaaImGiJfUjej5DjGx_FreMJvdovrhF6LgS8SmjID3dlcU6lGpPn_99bt8OUSY93jN-6zp6S-MS7JjutyX6C7-vwscB0tK2jvMxSZBICdWNJMmWOF4xep6ava-OKtz7c25WKYiZFRd-lZptIf2DrqO1SIWEyw-CAdwKz6NoDGs-E3U4Id-QLcWlAQMB0AGke06RG3bywI7W40MkDSmWMs28C5iBcik_o3caq5drXu252LFBY_qxzFAq3YKzKydy6At3Bse5SfAUmv00WmmPQmcV4N5KDdfQCTcnMvQw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
+          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [b396e4ee-8657-11e6-bf9a-54ee7550b4da]
+      x-ms-client-request-id: [fdb9308c-9f39-11e6-ab5a-40a8f04ffd53]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
@@ -819,32 +974,30 @@ interactions:
         iAjxhyRPb5+uZeSdTr8g8G0UlUX27mleEo/X10r03R30my+zSZkTT+dfrcoqm3V6O8/KJieUy2o9
         e1OJbAOHGLjRR0qTODHOSYQm2fQtXv9Gh2DZwOPBl4GUOwl7US0Jf/kx+ujEzg99+dFpXVc1fSqj
         fJOX+SJv62vvm5O9pyfVYpEtwaP2U2l/NqM+ivb6S+pXsPGaOPpGvsYYzvOsJXWBDxW3i5w4hFu+
-        WC8mef3Rox1q17xdYxiqil9DQmiQ9OVHpKyWs6yGjppmq2xKqBCBCPY3Z0B+UCya7Ae3shzSlHBR
-        TO3fH2ovPqJ2r9dFm78RQK/yRdXmbuKhlPyR8thvM1jqwgzXGBSLdMeSzJ9UP+uWRPr+f4kREWTo
-        w2HdKk22P919uPvpdn6+c29vdp7fOx/Wq3G5/Vm1HYqj7dd1Sw2/waHR2H5kMn5emAz9UAbpWwz9
-        IjQY+qG0jtoLbeFo2/8W6H9NawF5oPHRlz8Ma1FU7XaTLVZlvv2DefHTP5hn1e1MhzbeJvEj9BT5
-        zqfvb0bW+Iz0OBHtmww6IqOkVj2DcfyzbzC0dxDo/y1mw0OJvtqgYW3D7U/v7e7skZZ9cO9g8mk2
-        nQ1r2bgU/+waEIsn4W17d51T8294kDTKH5mSH5kS+uL/XaYE0kHjoy9/GKbkJ1+fbJ9Vb7bfnL5+
-        s/3q81uZkctmWpBuhvC1eQMFqLj3v3h/YxLGJCAPNTNj5FHfZpgEwQzUmJPOSKlFaErmXy5/9k1J
-        h0L/L7EmHazo22Fd67X99MGD3Z3t/Yf3872dh9kkG9a1cVn+WTUoHp4Yk7MpC9s/vfENj5MG+iOb
-        8iObQl/8fLYpos5WRNlbmRPXnHBSjIPP/l9kRAK8QvtR7j37iZ91++H6/9k0HXveR4GaJWRUvUq/
-        QIS+GNairtn2g52D+/vbB3ufnh98Op3cPxjWonEpfX9r8V7DeG8D4b16+6HR2H5kIH5kIOiLn88G
-        giL1gnwrSe7cykboGyR6hJYiHXx2exthbMTPUtZKsZKx0fehkVi8Oj37WTcSigIR5mfTSLyHL+4Q
-        oi+GNaprtv1gd/fTh9v3H+a79x5O7p9vWBGIS+z7G4uvNZz3Nhreq7cfIo3xR0bjR0aDvvj5bDQK
-        khvRqttvacRLSvjeynTgPcibeYlQ1AFEvvl/jRkBbp3RUquuMVn+7K+WAxGfSP8vMSldtOjrYa1L
-        v2ljaN0Hn27Pdqf38v379yefDmvduFT/rBqWwuIpg3pv80K/KYD3GCiN9Efm5Ufmhb74+WxertfL
-        i/wH5kNWw7u3si/yYsEyCIFW9Lsf/7/GsghiwaegdMe0fHf/Z38xRDBREv2/xK4EONF3w7rWtSRd
-        u3dvdzs7P8gfzrKdTfmfuCz/rBoVhyeN6L0tinv7PUZJw/yRRfmRRaEvfj5blIKcMXXhfzAvfpr8
-        uWp7kU1vZVTsCxBDeonQ1EFEvnk/03JFq6E/S6ZlYMTUMrQuy+98cvCzbl0sBkqo/5cYmC5a9PWw
-        9nWNSfse7NzbvvfgPiWL9u8/mA5r37h0/6zaGIcn4U2Dem8z4wC8x0BppD8yMz8yM/TFz3czAylq
-        Sa9v17dbcjfvnFc1v0fTQhgq/vEv/19lZIAeUKPxUouOcfnJqvlZNy4GCY9G/y+xLxHMqMWw5qXf
-        tD1p3of7D7bPH04f7Nz7dPJgd1jzxiX7Z9XEFBZPO673tjL0m8J4j7HSYH9kZX5kZeiL/89Zme//
-        kv8HSvqIae0+AAA=
+        WC8mef3Rox1q17xdYxiqil9DQmiQ9OVHpKyWs6yGjppmq2xKqBCBCPY3Z0B+8vXJ9ln1ZvvN6es3
+        268+v5UJuWymRdVuQwLbvIEOVNz7X/y/yJR0RkotQmMy/3J5/LNuTDoU+n+JQelgRd8OK1yv7acP
+        HuzubO8/vJ/v7TzMJtmwwo0L9M+qUfHwxJicYVnY/umNb3icNNAfGZafF4ZFP5RB+nZFvwjNin4o
+        raNWRVs42va/Bfr/n7Apos5WRNlbmRPXnHBSjIPP/l9kRAK8QvtR7j37iZ91++H6/9k0HXveR4Ga
+        JWRUvUq/QIS+GNairtn2g52D+/vbB3ufnh98Op3cPxjWonEpfX9r8V7DeG8D4b16+6HR2H5kIH5k
+        IOiLn88GIqu2C/KtmmyxKvNb2Qh9g0SP0FKkg8/e30as8RlpcCLVN2khFCsZG30fGonFq9Ozn3Uj
+        oSgQYX42jcR7+OIOIfpiWKO6ZtsPdnc/fbh9/2G+e+/h5P75+bBGjUvs+xuLrzWc9zYa3qu3HyKN
+        8UdG40dGg774+Ww0CpIb0arbP5gXP/2DeVbdynRA1swLhJ4i3/n0/czHFSUUfpbMR2SU1Co0IvX9
+        L3d+1o2IT6CfTTNyCyedaAJscvyD/wta2w/29z7d2872d7J7efbwHrixp3jnzZrIMJtcE5139u7T
+        wDH/DXFoPqxv4/L8/iblQ4eGqTrYe3iwD0bZPLT9T283NBrbj0zJj0wJffH/KlPyDMJL46MvP3pW
+        53jtZ8uMXK+XF/kPzIesdndvZUfkxYIF9h4hqKh3Px62JAKHmhC/MD3o7Z/FQEQQCz4FlUNT0qy+
+        aH7WTYlgoiT62bQl7+HDBzjRdz31yt/AZXctSS1/ev/e9iTP72WfTs53Hwzr2bgcv78J+bojeu/A
+        xL39HqOkYf7ImvzImtAX/6+yJj9ngcmt7MgPikWzvcyv4O8RVopz59P3syI/lHiEvgxtx+UXez/7
+        uSyfLv8vMR0+SvTVsE51DbcffLp379Pt84Pd2e5DEvYNOjUusz+rlsPhSXjb3m9pONzL7zFIGuWP
+        DMePDAd98fPdcLyloS4px3Ir02Eamxwy4aaYR775f5UJMfjR16ER2f384md/1dz0bqjz/xJD0kWL
+        vh7Ws67x9sHO7sHu9nRvd/Zwuntwb4Oejcvxz6oxcXjKoN7boDgA7zFQGumPDMqPDAp98fPdoECK
+        WlLm2/XFrWyKeee8qvk9mhbCUPGPf/n/KssC9IAajZdadIzL/eUXP+vGxSDh0ej/JfYlghm1GNa8
+        9Ju2J8374NOD7emDnfv72eRe/nBY88Yl+2fVxBQWTzuu97Yy9JvCeI+x0mB/ZGV+ZGXoi//PWZnv
+        /5L/BwpMcMV/OAAA
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 29 Sep 2016 15:16:32 GMT']
+      Date: ['Mon, 31 Oct 2016 07:16:50 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -856,14 +1009,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc1MTYwNjc1LCJuYmYiOjE0NzUxNjA2NzUsImV4cCI6MTQ3NTE2NDU3NSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInJzYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaXBhZGRyIjoiMTM5LjIyNi44Ni44NyIsIm5hbWUiOiJLZXZpbiBaaGFvIiwib2lkIjoiODY3ZmI5ZDAtMTQzMS00MWM3LTk2ZTItODM1ZWE2M2Q2MmUyIiwib25wcmVtX3NpZCI6IlMtMS01LTIxLTIxNDY3NzMwODUtOTAzMzYzMjg1LTcxOTM0NDcwNy0xOTYzNTcyIiwicHVpZCI6IjEwMDMwMDAwOTBGRUNDQ0UiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJCTEc1SmxRcURabFdZNEM4QkpnNmZJcXRNelFxZ1ZVZllXemJPNjZvbFB3IiwidGlkIjoiNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3IiwidW5pcXVlX25hbWUiOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidXBuIjoia2V2aW56aGFAbWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCJ9.qTZd7EpdgfCb4y3-sibNUCjCKXOQMelsVWeGPrFgnIOCbrZzaaImGiJfUjej5DjGx_FreMJvdovrhF6LgS8SmjID3dlcU6lGpPn_99bt8OUSY93jN-6zp6S-MS7JjutyX6C7-vwscB0tK2jvMxSZBICdWNJMmWOF4xep6ava-OKtz7c25WKYiZFRd-lZptIf2DrqO1SIWEyw-CAdwKz6NoDGs-E3U4Id-QLcWlAQMB0AGke06RG3bywI7W40MkDSmWMs28C5iBcik_o3caq5drXu252LFBY_qxzFAq3YKzKydy6At3Bse5SfAUmv00WmmPQmcV4N5KDdfQCTcnMvQw]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
+          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [b49d4338-8657-11e6-a5ef-54ee7550b4da]
+      x-ms-client-request-id: [fe709e52-9f39-11e6-bf5c-40a8f04ffd53]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing/listkeys?api-version=2016-02-03
   response:
@@ -871,23 +1024,23 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS9X/zR2/z6Rbag3z8qqna+nlRXy7z+aPTRqi4WWX39e+XX9NX5L3p98MlPPvn2onqe371/
-        96fXT5ft3vPF8smz/adfvX336dnBgy8e1Pe/89P3fp/P6N0mn1bLmX37cj69+4N3d49/6vXsq71f
-        9Hz9k5e7xU9c1l/99Ozqk4ft7O3b79w/vj754vPXn1/g7bq4mLcNvfcqvyiatr7+bl20+Sh9ndeX
-        xTQ/qZbLfNqO0qe59+dHv2Tkj6WRtgQtGMcXy5c7T+df/F6rnbsHl3d3n7bliy8vdmdPv/1g5wcH
-        7ybHD3/vX3Rxvnz28OX9Bph0xvETD3+q+qQ8XRdPlpcPf6/PF8t773Ze7/707k+v3/4+Z+vVd559
-        +vSL5cNFsfp2OI4Q8Q6mMx4FNQ8Q3X3xyennP/3w6S/6zsPPL5vy+Rf3fq+nX/3kF7OT6uTlk8n1
-        20/e7H3y/Nni3dWDHXTVQfTexao5Kd598bw42Lv+6YNfdPJyt3p4d2//J6rpT/6ip8c/8e73evPk
-        9zm4On3zU/y2RXQTRWudjFd5NqN3AmynX57PJqvTs8kXv9ebNaG283uvP23X6/Xi05PlwZu7+58+
-        /OTh6/zL8y+bK/TXxfYnDq5/8Iu+8/L4p5tJuZdNLr+73nv9nW+/3n19/9mbu7/3q8nx6v6DLz95
-        +nvJ2xZbwx6M0TCyzD30XoDx8qq+l03z7Ozhvae/z6f57u7+s0X7bv17/95PDy5WP/HJ8env8+L3
-        +kXP7/3Ud7/NfXYw/skX9eVVvl8urrOL6fwXZRcPz3+vX3T/bHVy0Ox++enDs+e/1/zt6ovzn/7q
-        3lu83cNYUPol3/8l/w8JNbR6iQMAAA==
+        uc4/evS9X/zR2/z6Rbag3z8qqna+nlRXy7z+aPTRqi4WWX39e+XX9NX07JPT3+d6f/9gsvjJbFKd
+        39//9oOr4vOdZfvtqy8eLn7Rq+f362dfVk8+/+mDz+jdJp9Wy5l9+6C9/PLld3/iTbv4yf37Pzmd
+        71YHL79a7u+V+f5PPG9/0U8+u/vt19W3r59fvGjwdl1czNuG3nuVXxRNW19/ty7afJS+zuvLYpqf
+        VMtlPm1H6dPc+/OjXzLyx9JIW4IWjONqffHFL3r+5vzJl5fnr7MnV7P9h/V368X66vd+vijO3719
+        frz8fb46rp/8XtPYOF7Mf+Lpd3+v3+vNT/6i3+vp/s5PVA/2furBd3/ybPeTH/zeP/hF3/3p4t5P
+        5bPf++Qie/6U37bjCBHvYDrjUVDzANEv85/4ibw8Xf5eV/Pf5xddXExPHj6YP5hMfq/rNz9RHl/9
+        5CfNk+LTd7/oq5PigrvqIDr7cvWLHv6i7P5+9eDbu1ev9r/9ez/7dtF89+7v9eq4+ck3zx68urx6
+        e/77TKtfdHGFty2imyha62S8yrMZvRNge7lTrL/97id2nv1gvXt/f7pX3//Ow5ezefNT8/Inf6/v
+        vvvJq5/euzxY/vQvevnyFP11sL38aufB5WXxe83eLfYvJ9/5ibc/qE9+8Hu1n/zE26c/8Xu/KJf3
+        fq/68++e/l7Xpwdv8bbF1rAHYzSMLHMPvRdgXP5eP3hwdW/5en7dXuVZ84ueVusy/+7O/Bc9/OrF
+        8SfF01/0Ovupe/lPFy9+8Pugzw7G73aeLmenry4P6tft3TffuS6v2ru71e/95HL1enqXhv7sJ8rF
+        zt7T36c5v8DbPYwFpV/y/V/y/wDMyV2RiQMAAA==
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 29 Sep 2016 15:16:34 GMT']
+      Date: ['Mon, 31 Oct 2016 07:16:51 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -900,21 +1053,532 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [SharedAccessSignature skn=iothubowner&se=1475165794&sr=iot-hub-for-testing.azure-devices.net%252fdevices%252f&sig=uZsvDtL%2FYfU3%2FliCDG7RprUk%2BZubRSKTVwW41UZEiRA%3D]
+      Authorization: [SharedAccessSignature sig=ORWpJwhbz9QU68uJu6yR3ugLay5OQHJN2GJ5LeKYk0Y%3D&sr=iot-hub-for-testing.azure-devices.net%252fdevices%252f&se=1477901812&skn=iothubowner]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
           iothubdeviceclient/2016-02-03 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [b57cb054-8657-11e6-ad32-54ee7550b4da]
+      x-ms-client-request-id: [ff18429a-9f39-11e6-8584-40a8f04ffd53]
     method: GET
     uri: https://iot-hub-for-testing.azure-devices.net/devices?api-version=2016-02-03&top=10
   response:
-    body: {string: '[{"deviceId":"iot-device-for-testing","generationId":"636107589882545869","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"qlhnBaWihYDHE/FlDZfngBTWfvwJ+BQbsmloLgl5+lU=","secondaryKey":"6hezQgeqN5e6bJ0bF0lBlONRYzY6q/UOUQrjjKULt8Q="},"x509Thumbprint":null},"isManaged":false,"deviceProperties":null,"configuration":null,"serviceProperties":null,"lastServicePropertiesUpdatedTime":"0001-01-01T00:00:00","lastDevicePropertiesUpdatedTime":"0001-01-01T00:00:00"}]'}
+    body: {string: '[{"deviceId":"iot-device-for-testing","generationId":"636134950041361377","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"dw93dOLBIxAcczUqoEDukwh1pVi7gzIQq65ahBS6qNw=","secondaryKey":"UtEyT1p11+SF1q2bsGPVGshmW3/dLeQhelLsdQnJG3c="},"x509Thumbprint":null}}]'}
     headers:
-      Content-Length: ['706']
+      Content-Length: ['505']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 29 Sep 2016 15:16:36 GMT']
+      Date: ['Mon, 31 Oct 2016 07:16:53 GMT']
       Server: [Microsoft-HTTPAPI/2.0]
     status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [ffcbe374-9f39-11e6-9872-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXP3PMsme3sHs+3Z+YNse3/n4NPthw938+38YHe6/+n9
+        h7P93exunTfVup7mn9fVetXcvc6u8uKsavnPu6u6uixmed3c/aKY1lVTnbfjp/llMc2bu9To29Sd
+        fYP++Gj00TJbEEIfhR+21yt8OAiDmpTVNAPW1CzPmjZriow+bbOL5qNHv/iXjD7yR8Zjvc3gCIIZ
+        3gXGQ68ZxHh89H1OXdDHx/w8yS4++X0+o09p3Ku8boscvX9E6LTA/3jaFpe5fH1ZNMBkefFav3y9
+        nk7zfJbP6Pti9awo27x+tS4B4XvfH300r5r2RY824+wH6zrfngk5xsu8pbfzy3yJL0+Xs1VVLFuC
+        8IvlQ/6tzlv6lTp/Uyzys+XT7Jo+3iWkMkIYn59U62X70aN976OzGbX53kc7BH2X/r9H/7/3EWG1
+        ytp5iBF9k2u/9EUzeXT3blG18/Vke9lsczv+c/v+/YP9B9vn+fTT/P7+g7374yavMYjJuhlfFctZ
+        dcXDufsRzR1oyZPbfEEka6uayHb6QxrPtu3c9U2tv+Ex0iAbgp1d5MGk/W6z/Dxbl9QLMVHWvGnL
+        4+asqQ4+3dmljl++2f02oTKtlsucOKtavm4Zu0cfyadtVizzWpmG+1jkTZNdUJugl/OizF9UbXFe
+        iAjxhyRPb5+uZeSdTr8g8G0UlUX27mleEo/X10r03R30my+zSZkTT+dfrcoqm3V6O8/KJieUy2o9
+        e1OJbAOHGLjRR0qTODHOSYQm2fQtXv9Gh2DZwOPBl4GUOwl7US0Jf/kx+ujEzg99+dFpXVc1fSqj
+        fJOX+SJv62vvm5O9pyfVYpEtwaP2U2l/NqM+ivb6S+pXsPGaOPpGvsYYzvOsJXWBDxW3i5w4hFu+
+        WC8mef3Rox1q17xdYxiqil9DQmiQ9OVHpKyWs6yGjppmq2xKqBCBCPY3Z0B+8vXJ9ln1ZvvN6es3
+        268+v5UJuWymRdVuQwLbvIEOVNz7X/y/yJR0RkotQmMy/3J5/LNuTDoU+n+JQelgRd8OK1yv7acP
+        HuzubO8/vJ/v7TzMJtmwwo0L9M+qUfHwxJicYVnY/umNb3icNNAfGZafF4ZFP5RB+nZFvwjNin4o
+        raNWRVs42va/Bfr/n7Apos5WRNlbmRPXnHBSjIPP/l9kRAK8QvtR7j37iZ91++H6/9k0HXveR4Ga
+        JWRUvUq/QIS+GNairtn2g52D+/vbB3ufnh98Op3cPxjWonEpfX9r8V7DeG8D4b16+6HR2H5kIH5k
+        IOiLn88GIqu2C/KtmmyxKvNb2Qh9g0SP0FKkg8/e30as8RlpcCLVN2khFCsZG30fGonFq9Ozn3Uj
+        oSgQYX42jcR7+OIOIfpiWKO6ZtsPdnc/fbh9/2G+e+/h5P75+bBGjUvs+xuLrzWc9zYa3qu3HyKN
+        8UdG40dGg774+Ww0CpIb0arbP5gXP/2DeVbdynRA1swLhJ4i3/n0/czHFSUUfpbMR2SU1Co0IvX9
+        L3d+1o2IT6CfTTNyCyedaAJscvyD/wta2w/29z7d2872d7J7efbwHrixp3jnzZrIMJtcE5139u7T
+        wDH/DXFoPqxv4/L8/iblQ4eGqTrYe3iwD0bZPLT9T283NBrbj0zJj0wJffH/KlPyDMJL46MvP3pW
+        53jtZ8uMXK+XF/kPzIesdndvZUfkxYIF9h4hqKh3Px62JAKHmhC/MD3o7Z/FQEQQCz4FlUNT0qy+
+        aH7WTYlgoiT62bQl7+HDBzjRdz31yt/AZXctSS1/ev/e9iTP72WfTs53Hwzr2bgcv78J+bojeu/A
+        xL39HqOkYf7ImvzImtAX/6+yJj9ngcmt7MgPikWzvcyv4O8RVopz59P3syI/lHiEvgxtx+UXez/7
+        uSyfLv8vMR0+SvTVsE51DbcffLp379Pt84Pd2e5DEvYNOjUusz+rlsPhSXjb3m9pONzL7zFIGuWP
+        DMePDAd98fPdcLyloS4px3Ir02Eamxwy4aaYR775f5UJMfjR16ER2f384md/1dz0bqjz/xJD0kWL
+        vh7Ws67x9sHO7sHu9nRvd/Zwuntwb4Oejcvxz6oxcXjKoN7boDgA7zFQGumPDMqPDAp98fPdoECK
+        WlLm2/XFrWyKeee8qvk9mhbCUPGPf/n/KssC9IAajZdadIzL/eUXP+vGxSDh0ej/JfYlghm1GNa8
+        9Ju2J8374NOD7emDnfv72eRe/nBY88Yl+2fVxBQWTzuu97Yy9JvCeI+x0mB/ZGV+ZGXoi//PWZnv
+        /5L/BwpMcMV/OAAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 31 Oct 2016 07:16:54 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [0075ee76-9f3a-11e6-8b6a-40a8f04ffd53]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing/listkeys?api-version=2016-02-03
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/zR2/z6Rbag3z8qqna+nlRXy7z+aPTRqi4WWX39e+XX9NX07JPT3+d6f/9gsvjJbFKd
+        39//9oOr4vOdZfvtqy8eLn7Rq+f362dfVk8+/+mDz+jdJp9Wy5l9+6C9/PLld3/iTbv4yf37Pzmd
+        71YHL79a7u+V+f5PPG9/0U8+u/vt19W3r59fvGjwdl1czNuG3nuVXxRNW19/ty7afJS+zuvLYpqf
+        VMtlPm1H6dPc+/OjXzLyx9JIW4IWjONqffHFL3r+5vzJl5fnr7MnV7P9h/V368X66vd+vijO3719
+        frz8fb46rp/8XtPYOF7Mf+Lpd3+v3+vNT/6i3+vp/s5PVA/2furBd3/ybPeTH/zeP/hF3/3p4t5P
+        5bPf++Qie/6U37bjCBHvYDrjUVDzANEv85/4ibw8Xf5eV/Pf5xddXExPHj6YP5hMfq/rNz9RHl/9
+        5CfNk+LTd7/oq5PigrvqIDr7cvWLHv6i7P5+9eDbu1ev9r/9ez/7dtF89+7v9eq4+ck3zx68urx6
+        e/77TKtfdHGFty2imyha62S8yrMZvRNge7lTrL/97id2nv1gvXt/f7pX3//Ow5ezefNT8/Inf6/v
+        vvvJq5/euzxY/vQvevnyFP11sL38aufB5WXxe83eLfYvJ9/5ibc/qE9+8Hu1n/zE26c/8Xu/KJf3
+        fq/68++e/l7Xpwdv8bbF1rAHYzSMLHMPvRdgXP5eP3hwdW/5en7dXuVZ84ueVusy/+7O/Bc9/OrF
+        8SfF01/0Ovupe/lPFy9+8Pugzw7G73aeLmenry4P6tft3TffuS6v2ru71e/95HL1enqXhv7sJ8rF
+        zt7T36c5v8DbPYwFpV/y/V/y/wDMyV2RiQMAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 31 Oct 2016 07:16:55 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1194']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [SharedAccessSignature sig=8shi1sdfcwMkzQ6zi7T4KxmXw1Bf9vJ7x%2BTQG2Qc9mA%3D&sr=iot-hub-for-testing.azure-devices.net%252fdevices%252fiot-device-for-testing&se=1477901815&skn=iothubowner]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubdeviceclient/2016-02-03 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [010c694c-9f3a-11e6-8132-40a8f04ffd53]
+    method: GET
+    uri: https://iot-hub-for-testing.azure-devices.net/devices/iot-device-for-testing?api-version=2016-02-03
+  response:
+    body: {string: '{"deviceId":"iot-device-for-testing","generationId":"636134950041361377","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"dw93dOLBIxAcczUqoEDukwh1pVi7gzIQq65ahBS6qNw=","secondaryKey":"UtEyT1p11+SF1q2bsGPVGshmW3/dLeQhelLsdQnJG3c="},"x509Thumbprint":null}}'}
+    headers:
+      Content-Length: ['503']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 31 Oct 2016 07:16:56 GMT']
+      ETag: ['"MA=="']
+      Server: [Microsoft-HTTPAPI/2.0]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [01b73cd2-9f3a-11e6-acb2-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXP3PMsme3sHs+3Z+YNse3/n4NPthw938+38YHe6/+n9
+        h7P93exunTfVup7mn9fVetXcvc6u8uKsavnPu6u6uixmed3c/aKY1lVTnbfjp/llMc2bu9To29Sd
+        fYP++Gj00TJbEEIfhR+21yt8OAiDmpTVNAPW1CzPmjZriow+bbOL5qNHv/iXjD7yR8Zjvc3gCIIZ
+        3gXGQ68ZxHh89H1OXdDHx/w8yS4++X0+o09p3Ku8boscvX9E6LTA/3jaFpe5fH1ZNMBkefFav3y9
+        nk7zfJbP6Pti9awo27x+tS4B4XvfH300r5r2RY824+wH6zrfngk5xsu8pbfzy3yJL0+Xs1VVLFuC
+        8IvlQ/6tzlv6lTp/Uyzys+XT7Jo+3iWkMkIYn59U62X70aN976OzGbX53kc7BH2X/r9H/7/3EWG1
+        ytp5iBF9k2u/9EUzeXT3blG18/Vke9lsczv+c/v+/YP9B9vn+fTT/P7+g7374yavMYjJuhlfFctZ
+        dcXDufsRzR1oyZPbfEEka6uayHb6QxrPtu3c9U2tv+Ex0iAbgp1d5MGk/W6z/Dxbl9QLMVHWvGnL
+        4+asqQ4+3dmljl++2f02oTKtlsucOKtavm4Zu0cfyadtVizzWpmG+1jkTZNdUJugl/OizF9UbXFe
+        iAjxhyRPb5+uZeSdTr8g8G0UlUX27mleEo/X10r03R30my+zSZkTT+dfrcoqm3V6O8/KJieUy2o9
+        e1OJbAOHGLjRR0qTODHOSYQm2fQtXv9Gh2DZwOPBl4GUOwl7US0Jf/kx+ujEzg99+dFpXVc1fSqj
+        fJOX+SJv62vvm5O9pyfVYpEtwaP2U2l/NqM+ivb6S+pXsPGaOPpGvsYYzvOsJXWBDxW3i5w4hFu+
+        WC8mef3Rox1q17xdYxiqil9DQmiQ9OVHpKyWs6yGjppmq2xKqBCBCPY3Z0B+8vXJ9ln1ZvvN6es3
+        268+v5UJuWymRdVuQwLbvIEOVNz7X/y/yJR0RkotQmMy/3J5/LNuTDoU+n+JQelgRd8OK1yv7acP
+        HuzubO8/vJ/v7TzMJtmwwo0L9M+qUfHwxJicYVnY/umNb3icNNAfGZafF4ZFP5RB+nZFvwjNin4o
+        raNWRVs42va/Bfr/n7Apos5WRNlbmRPXnHBSjIPP/l9kRAK8QvtR7j37iZ91++H6/9k0HXveR4Ga
+        JWRUvUq/QIS+GNairtn2g52D+/vbB3ufnh98Op3cPxjWonEpfX9r8V7DeG8D4b16+6HR2H5kIH5k
+        IOiLn88GIqu2C/KtmmyxKvNb2Qh9g0SP0FKkg8/e30as8RlpcCLVN2khFCsZG30fGonFq9Ozn3Uj
+        oSgQYX42jcR7+OIOIfpiWKO6ZtsPdnc/fbh9/2G+e+/h5P75+bBGjUvs+xuLrzWc9zYa3qu3HyKN
+        8UdG40dGg774+Ww0CpIb0arbP5gXP/2DeVbdynRA1swLhJ4i3/n0/czHFSUUfpbMR2SU1Co0IvX9
+        L3d+1o2IT6CfTTNyCyedaAJscvyD/wta2w/29z7d2872d7J7efbwHrixp3jnzZrIMJtcE5139u7T
+        wDH/DXFoPqxv4/L8/iblQ4eGqTrYe3iwD0bZPLT9T283NBrbj0zJj0wJffH/KlPyDMJL46MvP3pW
+        53jtZ8uMXK+XF/kPzIesdndvZUfkxYIF9h4hqKh3Px62JAKHmhC/MD3o7Z/FQEQQCz4FlUNT0qy+
+        aH7WTYlgoiT62bQl7+HDBzjRdz31yt/AZXctSS1/ev/e9iTP72WfTs53Hwzr2bgcv78J+bojeu/A
+        xL39HqOkYf7ImvzImtAX/6+yJj9ngcmt7MgPikWzvcyv4O8RVopz59P3syI/lHiEvgxtx+UXez/7
+        uSyfLv8vMR0+SvTVsE51DbcffLp379Pt84Pd2e5DEvYNOjUusz+rlsPhSXjb3m9pONzL7zFIGuWP
+        DMePDAd98fPdcLyloS4px3Ir02Eamxwy4aaYR775f5UJMfjR16ER2f384md/1dz0bqjz/xJD0kWL
+        vh7Ws67x9sHO7sHu9nRvd/Zwuntwb4Oejcvxz6oxcXjKoN7boDgA7zFQGumPDMqPDAp98fPdoECK
+        WlLm2/XFrWyKeee8qvk9mhbCUPGPf/n/KssC9IAajZdadIzL/eUXP+vGxSDh0ej/JfYlghm1GNa8
+        9Ju2J8374NOD7emDnfv72eRe/nBY88Yl+2fVxBQWTzuu97Yy9JvCeI+x0mB/ZGV+ZGXoi//PWZnv
+        /5L/BwpMcMV/OAAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 31 Oct 2016 07:16:57 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [024d3882-9f3a-11e6-b6b3-40a8f04ffd53]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing/listkeys?api-version=2016-02-03
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/zR2/z6Rbag3z8qqna+nlRXy7z+aPTRqi4WWX39e+XX9NX07JPT3+d6f/9gsvjJbFKd
+        39//9oOr4vOdZfvtqy8eLn7Rq+f362dfVk8+/+mDz+jdJp9Wy5l9+6C9/PLld3/iTbv4yf37Pzmd
+        71YHL79a7u+V+f5PPG9/0U8+u/vt19W3r59fvGjwdl1czNuG3nuVXxRNW19/ty7afJS+zuvLYpqf
+        VMtlPm1H6dPc+/OjXzLyx9JIW4IWjONqffHFL3r+5vzJl5fnr7MnV7P9h/V368X66vd+vijO3719
+        frz8fb46rp/8XtPYOF7Mf+Lpd3+v3+vNT/6i3+vp/s5PVA/2furBd3/ybPeTH/zeP/hF3/3p4t5P
+        5bPf++Qie/6U37bjCBHvYDrjUVDzANEv85/4ibw8Xf5eV/Pf5xddXExPHj6YP5hMfq/rNz9RHl/9
+        5CfNk+LTd7/oq5PigrvqIDr7cvWLHv6i7P5+9eDbu1ev9r/9ez/7dtF89+7v9eq4+ck3zx68urx6
+        e/77TKtfdHGFty2imyha62S8yrMZvRNge7lTrL/97id2nv1gvXt/f7pX3//Ow5ezefNT8/Inf6/v
+        vvvJq5/euzxY/vQvevnyFP11sL38aufB5WXxe83eLfYvJ9/5ibc/qE9+8Hu1n/zE26c/8Xu/KJf3
+        fq/68++e/l7Xpwdv8bbF1rAHYzSMLHMPvRdgXP5eP3hwdW/5en7dXuVZ84ueVusy/+7O/Bc9/OrF
+        8SfF01/0Ovupe/lPFy9+8Pugzw7G73aeLmenry4P6tft3TffuS6v2ru71e/95HL1enqXhv7sJ8rF
+        zt7T36c5v8DbPYwFpV/y/V/y/wDMyV2RiQMAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 31 Oct 2016 07:16:58 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [SharedAccessSignature sig=D1OhM9T3n%2FQBmw%2BzGjZv3ngrw2bjQGynspq8e3EXYtE%3D&sr=iot-hub-for-testing.azure-devices.net%252fdevices%252fiot-device-for-testing&se=1477901819&skn=iothubowner]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubdeviceclient/2016-02-03 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [0339f7ee-9f3a-11e6-9b45-40a8f04ffd53]
+    method: GET
+    uri: https://iot-hub-for-testing.azure-devices.net/devices/iot-device-for-testing?api-version=2016-02-03
+  response:
+    body: {string: '{"deviceId":"iot-device-for-testing","generationId":"636134950041361377","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"dw93dOLBIxAcczUqoEDukwh1pVi7gzIQq65ahBS6qNw=","secondaryKey":"UtEyT1p11+SF1q2bsGPVGshmW3/dLeQhelLsdQnJG3c="},"x509Thumbprint":null}}'}
+    headers:
+      Content-Length: ['503']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 31 Oct 2016 07:17:01 GMT']
+      ETag: ['"MA=="']
+      Server: [Microsoft-HTTPAPI/2.0]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [03f528a8-9f3a-11e6-ab0a-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXP3PMsme3sHs+3Z+YNse3/n4NPthw938+38YHe6/+n9
+        h7P93exunTfVup7mn9fVetXcvc6u8uKsavnPu6u6uixmed3c/aKY1lVTnbfjp/llMc2bu9To29Sd
+        fYP++Gj00TJbEEIfhR+21yt8OAiDmpTVNAPW1CzPmjZriow+bbOL5qNHv/iXjD7yR8Zjvc3gCIIZ
+        3gXGQ68ZxHh89H1OXdDHx/w8yS4++X0+o09p3Ku8boscvX9E6LTA/3jaFpe5fH1ZNMBkefFav3y9
+        nk7zfJbP6Pti9awo27x+tS4B4XvfH300r5r2RY824+wH6zrfngk5xsu8pbfzy3yJL0+Xs1VVLFuC
+        8IvlQ/6tzlv6lTp/Uyzys+XT7Jo+3iWkMkIYn59U62X70aN976OzGbX53kc7BH2X/r9H/7/3EWG1
+        ytp5iBF9k2u/9EUzeXT3blG18/Vke9lsczv+c/v+/YP9B9vn+fTT/P7+g7374yavMYjJuhlfFctZ
+        dcXDufsRzR1oyZPbfEEka6uayHb6QxrPtu3c9U2tv+Ex0iAbgp1d5MGk/W6z/Dxbl9QLMVHWvGnL
+        4+asqQ4+3dmljl++2f02oTKtlsucOKtavm4Zu0cfyadtVizzWpmG+1jkTZNdUJugl/OizF9UbXFe
+        iAjxhyRPb5+uZeSdTr8g8G0UlUX27mleEo/X10r03R30my+zSZkTT+dfrcoqm3V6O8/KJieUy2o9
+        e1OJbAOHGLjRR0qTODHOSYQm2fQtXv9Gh2DZwOPBl4GUOwl7US0Jf/kx+ujEzg99+dFpXVc1fSqj
+        fJOX+SJv62vvm5O9pyfVYpEtwaP2U2l/NqM+ivb6S+pXsPGaOPpGvsYYzvOsJXWBDxW3i5w4hFu+
+        WC8mef3Rox1q17xdYxiqil9DQmiQ9OVHpKyWs6yGjppmq2xKqBCBCPY3Z0B+8vXJ9ln1ZvvN6es3
+        268+v5UJuWymRdVuQwLbvIEOVNz7X/y/yJR0RkotQmMy/3J5/LNuTDoU+n+JQelgRd8OK1yv7acP
+        HuzubO8/vJ/v7TzMJtmwwo0L9M+qUfHwxJicYVnY/umNb3icNNAfGZafF4ZFP5RB+nZFvwjNin4o
+        raNWRVs42va/Bfr/n7Apos5WRNlbmRPXnHBSjIPP/l9kRAK8QvtR7j37iZ91++H6/9k0HXveR4Ga
+        JWRUvUq/QIS+GNairtn2g52D+/vbB3ufnh98Op3cPxjWonEpfX9r8V7DeG8D4b16+6HR2H5kIH5k
+        IOiLn88GIqu2C/KtmmyxKvNb2Qh9g0SP0FKkg8/e30as8RlpcCLVN2khFCsZG30fGonFq9Ozn3Uj
+        oSgQYX42jcR7+OIOIfpiWKO6ZtsPdnc/fbh9/2G+e+/h5P75+bBGjUvs+xuLrzWc9zYa3qu3HyKN
+        8UdG40dGg774+Ww0CpIb0arbP5gXP/2DeVbdynRA1swLhJ4i3/n0/czHFSUUfpbMR2SU1Co0IvX9
+        L3d+1o2IT6CfTTNyCyedaAJscvyD/wta2w/29z7d2872d7J7efbwHrixp3jnzZrIMJtcE5139u7T
+        wDH/DXFoPqxv4/L8/iblQ4eGqTrYe3iwD0bZPLT9T283NBrbj0zJj0wJffH/KlPyDMJL46MvP3pW
+        53jtZ8uMXK+XF/kPzIesdndvZUfkxYIF9h4hqKh3Px62JAKHmhC/MD3o7Z/FQEQQCz4FlUNT0qy+
+        aH7WTYlgoiT62bQl7+HDBzjRdz31yt/AZXctSS1/ev/e9iTP72WfTs53Hwzr2bgcv78J+bojeu/A
+        xL39HqOkYf7ImvzImtAX/6+yJj9ngcmt7MgPikWzvcyv4O8RVopz59P3syI/lHiEvgxtx+UXez/7
+        uSyfLv8vMR0+SvTVsE51DbcffLp379Pt84Pd2e5DEvYNOjUusz+rlsPhSXjb3m9pONzL7zFIGuWP
+        DMePDAd98fPdcLyloS4px3Ir02Eamxwy4aaYR775f5UJMfjR16ER2f384md/1dz0bqjz/xJD0kWL
+        vh7Ws67x9sHO7sHu9nRvd/Zwuntwb4Oejcvxz6oxcXjKoN7boDgA7zFQGumPDMqPDAp98fPdoECK
+        WlLm2/XFrWyKeee8qvk9mhbCUPGPf/n/KssC9IAajZdadIzL/eUXP+vGxSDh0ej/JfYlghm1GNa8
+        9Ju2J8374NOD7emDnfv72eRe/nBY88Yl+2fVxBQWTzuu97Yy9JvCeI+x0mB/ZGV+ZGXoi//PWZnv
+        /5L/BwpMcMV/OAAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 31 Oct 2016 07:17:01 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [0499800a-9f3a-11e6-8b8c-40a8f04ffd53]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing/listkeys?api-version=2016-02-03
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/zR2/z6Rbag3z8qqna+nlRXy7z+aPTRqi4WWX39e+XX9NX07JPT3+d6f/9gsvjJbFKd
+        39//9oOr4vOdZfvtqy8eLn7Rq+f362dfVk8+/+mDz+jdJp9Wy5l9+6C9/PLld3/iTbv4yf37Pzmd
+        71YHL79a7u+V+f5PPG9/0U8+u/vt19W3r59fvGjwdl1czNuG3nuVXxRNW19/ty7afJS+zuvLYpqf
+        VMtlPm1H6dPc+/OjXzLyx9JIW4IWjONqffHFL3r+5vzJl5fnr7MnV7P9h/V368X66vd+vijO3719
+        frz8fb46rp/8XtPYOF7Mf+Lpd3+v3+vNT/6i3+vp/s5PVA/2furBd3/ybPeTH/zeP/hF3/3p4t5P
+        5bPf++Qie/6U37bjCBHvYDrjUVDzANEv85/4ibw8Xf5eV/Pf5xddXExPHj6YP5hMfq/rNz9RHl/9
+        5CfNk+LTd7/oq5PigrvqIDr7cvWLHv6i7P5+9eDbu1ev9r/9ez/7dtF89+7v9eq4+ck3zx68urx6
+        e/77TKtfdHGFty2imyha62S8yrMZvRNge7lTrL/97id2nv1gvXt/f7pX3//Ow5ezefNT8/Inf6/v
+        vvvJq5/euzxY/vQvevnyFP11sL38aufB5WXxe83eLfYvJ9/5ibc/qE9+8Hu1n/zE26c/8Xu/KJf3
+        fq/68++e/l7Xpwdv8bbF1rAHYzSMLHMPvRdgXP5eP3hwdW/5en7dXuVZ84ueVusy/+7O/Bc9/OrF
+        8SfF01/0Ovupe/lPFy9+8Pugzw7G73aeLmenry4P6tft3TffuS6v2ru71e/95HL1enqXhv7sJ8rF
+        zt7T36c5v8DbPYwFpV/y/V/y/wDMyV2RiQMAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 31 Oct 2016 07:17:02 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [SharedAccessSignature sig=vaz%2F7L2iza2VWTgPgqc8wjlgB98uwRqxF4KZW81LNiQ%3D&sr=iot-hub-for-testing.azure-devices.net%252fdevices%252f&se=1477901822&skn=iothubowner]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubdeviceclient/2016-02-03 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [0526e140-9f3a-11e6-8432-40a8f04ffd53]
+    method: GET
+    uri: https://iot-hub-for-testing.azure-devices.net/devices?api-version=2016-02-03&top=10
+  response:
+    body: {string: '[{"deviceId":"iot-device-for-testing","generationId":"636134950041361377","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"dw93dOLBIxAcczUqoEDukwh1pVi7gzIQq65ahBS6qNw=","secondaryKey":"UtEyT1p11+SF1q2bsGPVGshmW3/dLeQhelLsdQnJG3c="},"x509Thumbprint":null}}]'}
+    headers:
+      Content-Length: ['505']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 31 Oct 2016 07:17:02 GMT']
+      Server: [Microsoft-HTTPAPI/2.0]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [05e813ca-9f3a-11e6-be1d-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXP3PMsme3sHs+3Z+YNse3/n4NPthw938+38YHe6/+n9
+        h7P93exunTfVup7mn9fVetXcvc6u8uKsavnPu6u6uixmed3c/aKY1lVTnbfjp/llMc2bu9To29Sd
+        fYP++Gj00TJbEEIfhR+21yt8OAiDmpTVNAPW1CzPmjZriow+bbOL5qNHv/iXjD7yR8Zjvc3gCIIZ
+        3gXGQ68ZxHh89H1OXdDHx/w8yS4++X0+o09p3Ku8boscvX9E6LTA/3jaFpe5fH1ZNMBkefFav3y9
+        nk7zfJbP6Pti9awo27x+tS4B4XvfH300r5r2RY824+wH6zrfngk5xsu8pbfzy3yJL0+Xs1VVLFuC
+        8IvlQ/6tzlv6lTp/Uyzys+XT7Jo+3iWkMkIYn59U62X70aN976OzGbX53kc7BH2X/r9H/7/3EWG1
+        ytp5iBF9k2u/9EUzeXT3blG18/Vke9lsczv+c/v+/YP9B9vn+fTT/P7+g7374yavMYjJuhlfFctZ
+        dcXDufsRzR1oyZPbfEEka6uayHb6QxrPtu3c9U2tv+Ex0iAbgp1d5MGk/W6z/Dxbl9QLMVHWvGnL
+        4+asqQ4+3dmljl++2f02oTKtlsucOKtavm4Zu0cfyadtVizzWpmG+1jkTZNdUJugl/OizF9UbXFe
+        iAjxhyRPb5+uZeSdTr8g8G0UlUX27mleEo/X10r03R30my+zSZkTT+dfrcoqm3V6O8/KJieUy2o9
+        e1OJbAOHGLjRR0qTODHOSYQm2fQtXv9Gh2DZwOPBl4GUOwl7US0Jf/kx+ujEzg99+dFpXVc1fSqj
+        fJOX+SJv62vvm5O9pyfVYpEtwaP2U2l/NqM+ivb6S+pXsPGaOPpGvsYYzvOsJXWBDxW3i5w4hFu+
+        WC8mef3Rox1q17xdYxiqil9DQmiQ9OVHpKyWs6yGjppmq2xKqBCBCPY3Z0B+8vXJ9ln1ZvvN6es3
+        268+v5UJuWymRdVuQwLbvIEOVNz7X/y/yJR0RkotQmMy/3J5/LNuTDoU+n+JQelgRd8OK1yv7acP
+        HuzubO8/vJ/v7TzMJtmwwo0L9M+qUfHwxJicYVnY/umNb3icNNAfGZafF4ZFP5RB+nZFvwjNin4o
+        raNWRVs42va/Bfr/n7Apos5WRNlbmRPXnHBSjIPP/l9kRAK8QvtR7j37iZ91++H6/9k0HXveR4Ga
+        JWRUvUq/QIS+GNairtn2g52D+/vbB3ufnh98Op3cPxjWonEpfX9r8V7DeG8D4b16+6HR2H5kIH5k
+        IOiLn88GIqu2C/KtmmyxKvNb2Qh9g0SP0FKkg8/e30as8RlpcCLVN2khFCsZG30fGonFq9Ozn3Uj
+        oSgQYX42jcR7+OIOIfpiWKO6ZtsPdnc/fbh9/2G+e+/h5P75+bBGjUvs+xuLrzWc9zYa3qu3HyKN
+        8UdG40dGg774+Ww0CpIb0arbP5gXP/2DeVbdynRA1swLhJ4i3/n0/czHFSUUfpbMR2SU1Co0IvX9
+        L3d+1o2IT6CfTTNyCyedaAJscvyD/wta2w/29z7d2872d7J7efbwHrixp3jnzZrIMJtcE5139u7T
+        wDH/DXFoPqxv4/L8/iblQ4eGqTrYe3iwD0bZPLT9T283NBrbj0zJj0wJffH/KlPyDMJL46MvP3pW
+        53jtZ8uMXK+XF/kPzIesdndvZUfkxYIF9h4hqKh3Px62JAKHmhC/MD3o7Z/FQEQQCz4FlUNT0qy+
+        aH7WTYlgoiT62bQl7+HDBzjRdz31yt/AZXctSS1/ev/e9iTP72WfTs53Hwzr2bgcv78J+bojeu/A
+        xL39HqOkYf7ImvzImtAX/6+yJj9ngcmt7MgPikWzvcyv4O8RVopz59P3syI/lHiEvgxtx+UXez/7
+        uSyfLv8vMR0+SvTVsE51DbcffLp379Pt84Pd2e5DEvYNOjUusz+rlsPhSXjb3m9pONzL7zFIGuWP
+        DMePDAd98fPdcLyloS4px3Ir02Eamxwy4aaYR775f5UJMfjR16ER2f384md/1dz0bqjz/xJD0kWL
+        vh7Ws67x9sHO7sHu9nRvd/Zwuntwb4Oejcvxz6oxcXjKoN7boDgA7zFQGumPDMqPDAp98fPdoECK
+        WlLm2/XFrWyKeee8qvk9mhbCUPGPf/n/KssC9IAajZdadIzL/eUXP+vGxSDh0ej/JfYlghm1GNa8
+        9Ju2J8374NOD7emDnfv72eRe/nBY88Yl+2fVxBQWTzuu97Yy9JvCeI+x0mB/ZGV+ZGXoi//PWZnv
+        /5L/BwpMcMV/OAAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 31 Oct 2016 07:17:04 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNDc3ODk1MTI1LCJuYmYiOjE0Nzc4OTUxMjUsImV4cCI6MTQ3Nzg5OTAyNSwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzg2N2ZiOWQwLTE0MzEtNDFjNy05NmUyLTgzNWVhNjNkNjJlMi9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJaaGFvIiwiZ2l2ZW5fbmFtZSI6IktldmluIiwiaW5fY29ycCI6InRydWUiLCJpcGFkZHIiOiIxNjcuMjIwLjI1NS44IiwibmFtZSI6IktldmluIFpoYW8iLCJvaWQiOiI4NjdmYjlkMC0xNDMxLTQxYzctOTZlMi04MzVlYTYzZDYyZTIiLCJvbnByZW1fc2lkIjoiUy0xLTUtMjEtMjE0Njc3MzA4NS05MDMzNjMyODUtNzE5MzQ0NzA3LTE5NjM1NzIiLCJwdWlkIjoiMTAwMzAwMDA5MEZFQ0NDRSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6IkJMRzVKbFFxRFpsV1k0QzhCSmc2ZklxdE16UXFnVlVmWVd6Yk82Nm9sUHciLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1bmlxdWVfbmFtZSI6ImtldmluemhhQG1pY3Jvc29mdC5jb20iLCJ1cG4iOiJrZXZpbnpoYUBtaWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0.kv4-D6nXZfY0_I_wsbvyHHTidVx7t2VBQUbXRkeVdGsUNWKztyMlirTBtKeec9lbY5OJK4F5CkKpVPnOWlsdNtB_iD9lg1h8_MoXYwV0jusdyIJKB3mkHPuYQolfXfDNN8MA3ud4HOgDnjinG3GO_pNWgIXOGiTJY19SIH8lZ8IggZrpiaWOo6RxEilMJzZS8Ghe5mb4ZDJiYQpNucy0yQHcRE8s1fyBGoXofy45DCYGXdlP36qAUu16pyiyqSihSwsxp07-5OXD721Eadw-Car0KUpVSyN6MBg4vrBRxTb_i4t74hZ5pmtGmduIxeAgPfwwHVbk20X6J3o-2M1uIw]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [06eeb274-9f3a-11e6-b49d-40a8f04ffd53]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-testing/listkeys?api-version=2016-02-03
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/zR2/z6Rbag3z8qqna+nlRXy7z+aPTRqi4WWX39e+XX9NX07JPT3+d6f/9gsvjJbFKd
+        39//9oOr4vOdZfvtqy8eLn7Rq+f362dfVk8+/+mDz+jdJp9Wy5l9+6C9/PLld3/iTbv4yf37Pzmd
+        71YHL79a7u+V+f5PPG9/0U8+u/vt19W3r59fvGjwdl1czNuG3nuVXxRNW19/ty7afJS+zuvLYpqf
+        VMtlPm1H6dPc+/OjXzLyx9JIW4IWjONqffHFL3r+5vzJl5fnr7MnV7P9h/V368X66vd+vijO3719
+        frz8fb46rp/8XtPYOF7Mf+Lpd3+v3+vNT/6i3+vp/s5PVA/2furBd3/ybPeTH/zeP/hF3/3p4t5P
+        5bPf++Qie/6U37bjCBHvYDrjUVDzANEv85/4ibw8Xf5eV/Pf5xddXExPHj6YP5hMfq/rNz9RHl/9
+        5CfNk+LTd7/oq5PigrvqIDr7cvWLHv6i7P5+9eDbu1ev9r/9ez/7dtF89+7v9eq4+ck3zx68urx6
+        e/77TKtfdHGFty2imyha62S8yrMZvRNge7lTrL/97id2nv1gvXt/f7pX3//Ow5ezefNT8/Inf6/v
+        vvvJq5/euzxY/vQvevnyFP11sL38aufB5WXxe83eLfYvJ9/5ibc/qE9+8Hu1n/zE26c/8Xu/KJf3
+        fq/68++e/l7Xpwdv8bbF1rAHYzSMLHMPvRdgXP5eP3hwdW/5en7dXuVZ84ueVusy/+7O/Bc9/OrF
+        8SfF01/0Ovupe/lPFy9+8Pugzw7G73aeLmenry4P6tft3TffuS6v2ru71e/95HL1enqXhv7sJ8rF
+        zt7T36c5v8DbPYwFpV/y/V/y/wDMyV2RiQMAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 31 Oct 2016 07:17:06 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [SharedAccessSignature sig=1dFnq6EjhQTFZ0iA0y9yukLClUF9N19NR8sZ6%2BxlPsQ%3D&sr=iot-hub-for-testing.azure-devices.net%252fdevices%252fiot-device-for-testing&se=1477901827&skn=iothubowner]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      If-Match: ['*']
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubdeviceclient/2016-02-03 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [07e09dd2-9f3a-11e6-90f8-40a8f04ffd53]
+    method: DELETE
+    uri: https://iot-hub-for-testing.azure-devices.net/devices/iot-device-for-testing?api-version=2016-02-03
+  response:
+    body: {string: ''}
+    headers:
+      Content-Length: ['0']
+      Date: ['Mon, 31 Oct 2016 07:17:09 GMT']
+      Server: [Microsoft-HTTPAPI/2.0]
+    status: {code: 204, message: No Content}
 version: 1

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/tests/test_iot_commands.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/tests/test_iot_commands.py
@@ -65,7 +65,7 @@ class IoTHubTest(ResourceGroupVCRTestBase):
 
         # Test 'az iot device create'
         device_id = self.device_id
-        self.cmd('iot device create -n {0} -d {1}'.format(hub, device_id),
+        self.cmd('iot device create --hub-name {0} -d {1}'.format(hub, device_id),
                  checks=[
                      JMESPathCheck('deviceId', device_id),
                      JMESPathCheck('status', 'enabled'),
@@ -74,25 +74,25 @@ class IoTHubTest(ResourceGroupVCRTestBase):
 
         # Test 'az iot device show-connection-string'
         connection_string = 'HostName=iot-hub-for-testing.azure-devices.net;DeviceId=iot-device-for-testing;SharedAccessKey=dw93dOLBIxAcczUqoEDukwh1pVi7gzIQq65ahBS6qNw='
-        self.cmd('iot device show-connection-string -n {0} -d {1}'.format(hub, device_id), checks=[
+        self.cmd('iot device show-connection-string --hub-name {0} -d {1}'.format(hub, device_id), checks=[
             JMESPathCheck('connectionString', connection_string)
         ])
 
-        self.cmd('iot device show-connection-string -n {0}'.format(hub), checks=[
+        self.cmd('iot device show-connection-string --hub-name {0}'.format(hub), checks=[
             JMESPathCheck('length([*])', 1),
             JMESPathCheck('[0].deviceId', device_id),
             JMESPathCheck('[0].connectionString', connection_string)
         ])
 
         # Test 'az iot device show'
-        self.cmd('iot device show -n {0} -d {1}'.format(hub, device_id), checks=[
+        self.cmd('iot device show --hub-name {0} -d {1}'.format(hub, device_id), checks=[
             JMESPathCheck('deviceId', device_id),
             JMESPathCheck('status', 'enabled'),
             JMESPathCheck('connectionState', 'Disconnected')
         ])
 
         # Test 'az iot device list'
-        self.cmd('iot device list -n {0}'.format(hub), checks=[
+        self.cmd('iot device list --hub-name {0}'.format(hub), checks=[
             JMESPathCheck('length([*])', 1),
             JMESPathCheck('[0].deviceId', device_id),
             JMESPathCheck('[0].status', 'enabled'),
@@ -100,4 +100,4 @@ class IoTHubTest(ResourceGroupVCRTestBase):
         ])
 
         # Test 'az iot device delete'
-        self.cmd('iot device delete -n {0} -d {1}'.format(hub, device_id))
+        self.cmd('iot device delete --hub-name {0} -d {1}'.format(hub, device_id))

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/tests/test_iot_commands.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/tests/test_iot_commands.py
@@ -9,6 +9,7 @@ import azure.cli.core._logging as _logging
 
 logger = _logging.get_az_logger(__name__)
 
+
 class IoTHubTest(ResourceGroupVCRTestBase):
     def __init__(self, test_method):
         super(IoTHubTest, self).__init__(__file__, test_method)
@@ -34,9 +35,23 @@ class IoTHubTest(ResourceGroupVCRTestBase):
                  ])
 
         # Test 'az iot hub show-connection-string'
-        connection_string = 'HostName=iot-hub-for-testing.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=fqS8+VBHmoLe/5/juDnt2LmnBF4DUkx6I87M7r5Jj3Y='
+        connection_string = 'HostName=iot-hub-for-testing.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=cI+EYy448bmVabof54H7wiG0ntHwM9mqRL5rFOoBGj8='
         self.cmd('iot hub show-connection-string -n {0}'.format(hub), checks=[
-            JMESPathCheck('connectionString', connection_string),
+            JMESPathCheck('connectionString', connection_string)
+        ])
+
+        self.cmd('iot hub show-connection-string -g {0}'.format(rg), checks=[
+            JMESPathCheck('length([*])', 1),
+            JMESPathCheck('[0].name', hub),
+            JMESPathCheck('[0].connectionString', connection_string)
+        ])
+
+        # Test 'az iot hub show'
+        self.cmd('iot hub show -g {0} -n {1}'.format(rg, hub), checks=[
+            JMESPathCheck('resourceGroup', rg),
+            JMESPathCheck('location', location),
+            JMESPathCheck('name', hub),
+            JMESPathCheck('sku.name', 'S1')
         ])
 
         # Test 'az iot hub list'
@@ -58,9 +73,22 @@ class IoTHubTest(ResourceGroupVCRTestBase):
                  ])
 
         # Test 'az iot device show-connection-string'
-        connection_string = 'HostName=iot-hub-for-testing.azure-devices.net;DeviceId=iot-device-for-testing;SharedAccessKey=qlhnBaWihYDHE/FlDZfngBTWfvwJ+BQbsmloLgl5+lU='
+        connection_string = 'HostName=iot-hub-for-testing.azure-devices.net;DeviceId=iot-device-for-testing;SharedAccessKey=dw93dOLBIxAcczUqoEDukwh1pVi7gzIQq65ahBS6qNw='
         self.cmd('iot device show-connection-string -n {0} -d {1}'.format(hub, device_id), checks=[
-            JMESPathCheck('connectionString', connection_string),
+            JMESPathCheck('connectionString', connection_string)
+        ])
+
+        self.cmd('iot device show-connection-string -n {0}'.format(hub), checks=[
+            JMESPathCheck('length([*])', 1),
+            JMESPathCheck('[0].deviceId', device_id),
+            JMESPathCheck('[0].connectionString', connection_string)
+        ])
+
+        # Test 'az iot device show'
+        self.cmd('iot device show -n {0} -d {1}'.format(hub, device_id), checks=[
+            JMESPathCheck('deviceId', device_id),
+            JMESPathCheck('status', 'enabled'),
+            JMESPathCheck('connectionState', 'Disconnected')
         ])
 
         # Test 'az iot device list'
@@ -70,3 +98,6 @@ class IoTHubTest(ResourceGroupVCRTestBase):
             JMESPathCheck('[0].status', 'enabled'),
             JMESPathCheck('[0].connectionState', 'Disconnected')
         ])
+
+        # Test 'az iot device delete'
+        self.cmd('iot device delete -n {0} -d {1}'.format(hub, device_id))


### PR DESCRIPTION
Help messages for each command are listed as below. Global arguments are omitted.

```bash
>az iot hub show -h

Command
    az iot hub show: Show non-security metadata of an IoT Hub.

Arguments
    --name -n [Required]: The IoT Hub name.
    --resource-group -g : Name of resource group.
```

```
>az iot device show -h

Command
    az iot device show: Show metadata of a device in an IoT Hub.

Arguments
    --device-id -d [Required]: Device Id.
    --hub-name     [Required]: The IoT Hub name.
    --resource-group -g      : Name of resource group.
```

```
>az iot device delete -h

Command
    az iot device delete: Delete a device from target Azure IoT Hub.

Arguments
    --device-id -d [Required]: Device Id.
    --hub-name     [Required]: The IoT Hub name.
    --etag                   : ETag of the target device. It is used for the purpose of optimistic
                               concurrency. Delete operation will be performed only if the specified

                               ETag matches the value maintained by the server, indicating that the
                               device identity has not been modified since it was retrieved. Default

                               value is set to wildcard character (*) to force an unconditional
                               delete.  Default: *.
    --resource-group -g      : Name of resource group.
```