### PR TITLE
Move six dependency to the correct command module

### DIFF
--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -53,8 +53,7 @@ DEPENDENCIES = [
     'azure-cli-resource',
     'azure-cli-role',
     'azure-cli-storage',
-    'azure-cli-vm',
-    'six',
+    'azure-cli-vm'
 ]
 
 with open('README.rst', 'r', encoding='utf-8') as f:

--- a/src/command_modules/azure-cli-acs/setup.py
+++ b/src/command_modules/azure-cli-acs/setup.py
@@ -27,6 +27,7 @@ DEPENDENCIES = [
     'azure-mgmt-compute==0.30.0rc6',
     'paramiko',
     'pyyaml',
+    'six',
     'sshtunnel'
 ]
 


### PR DESCRIPTION
With a recent commit, the `six` dependency was added to the azure-cli module when it should have been added for azure-cli-acs.