### PR TITLE
VM:  lro poller for vm create should use shorter timeout of 5 seconds

### DIFF
--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/generated.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/generated.py
@@ -47,8 +47,13 @@ from ._factory import _compute_client_factory
 # pylint: disable=line-too-long
 
 # VM
-factory = lambda _: get_mgmt_service_client(VMClient).vm
-cli_command('vm create', VmOperations.create_or_update, factory, transform=DeploymentOutputLongRunningOperation('Starting vm create'))
+def get_vm_client_with_shorter_polling_interval(_):
+    client = get_mgmt_service_client(VMClient)
+    #remove this hack once 'azure/autorest#1558' gets fixed. We should configure the timeout through constructor
+    client.config.long_running_operation_timeout = 5
+    return client.vm
+
+cli_command('vm create', VmOperations.create_or_update, get_vm_client_with_shorter_polling_interval, transform=DeploymentOutputLongRunningOperation('Starting vm create'))
 
 factory = lambda _: _compute_client_factory().virtual_machines
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/generated.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/generated.py
@@ -49,8 +49,7 @@ from ._factory import _compute_client_factory
 # VM
 def get_vm_client_with_shorter_polling_interval(_):
     client = get_mgmt_service_client(VMClient)
-    #remove this hack once 'azure/autorest#1558' gets fixed. We should configure the timeout through constructor
-    client.config.long_running_operation_timeout = 5
+    client.config.long_running_operation_timeout = 5 #seconds
     return client.vm
 
 cli_command('vm create', VmOperations.create_or_update, get_vm_client_with_shorter_polling_interval, transform=DeploymentOutputLongRunningOperation('Starting vm create'))


### PR DESCRIPTION
Address #1162
This contains a managable hack around azure/autorest#1558. We are working actively to fix that at autorest.
