### PR TITLE
Run module tests in parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ src/build
 /doc/sphinx/_build
 /.vs/config/applicationhost.config
 .vscode/settings.json
+.vscode/.ropeproject/
 
 # Azure deployment credentials
 *.pubxml

--- a/scripts/command_modules/_common.py
+++ b/scripts/command_modules/_common.py
@@ -42,16 +42,15 @@ def exec_command_output(command, env=None):
     """
     Execute a command and return its output as well as the status code.
     """
-    return_code = 0
     try:
         output = check_output(
             command if isinstance(command, list) else command.split(),
             env=os.environ.copy().update(env or {}),
             stderr=subprocess.STDOUT)
+        return (output.decode('utf-8'), 0)
     except CalledProcessError as err:
-        return_code = err.returncode
+        return (err.output, err.returncode)
 
-    return (output.decode('utf-8'), return_code)
 
 def print_summary(failed_modules):
     print()

--- a/scripts/command_modules/_common.py
+++ b/scripts/command_modules/_common.py
@@ -6,8 +6,9 @@
 from __future__ import print_function
 import os
 import sys
+import subprocess
 
-from subprocess import check_call, CalledProcessError
+from subprocess import check_call, check_output, CalledProcessError
 
 COMMAND_MODULE_PREFIX = 'azure-cli-'
 
@@ -36,6 +37,21 @@ def exec_command(command, cwd=None, stdout=None, env=None):
     except CalledProcessError as err:
         print(err, file=sys.stderr)
         return False
+
+def exec_command_output(command, env=None):
+    """
+    Execute a command and return its output as well as the status code.
+    """
+    return_code = 0
+    try:
+        output = check_output(
+            command if isinstance(command, list) else command.split(),
+            env=os.environ.copy().update(env or {}),
+            stderr=subprocess.STDOUT)
+    except CalledProcessError as err:
+        return_code = err.returncode
+
+    return (output.decode('utf-8'), return_code)
 
 def print_summary(failed_modules):
     print()

--- a/scripts/command_modules/test.py
+++ b/scripts/command_modules/test.py
@@ -60,11 +60,16 @@ class TestTask(Thread):
 
     def print_format(self, summary_format):
         status = 'skipped' if self.skipped else ('failed' if self.rtcode != 0 else 'passed')
-        print(summary_format.format(
-            self.name,
-            status,
-            self._started_on.strftime('%H:%M:%S') if self._started_on else '',
-            self._finished_on.strftime('%H:%M:%S') if self._finished_on else ''))
+
+        args = [self.name, status]
+        if self._started_on and self._finished_on: 
+            args.append(self._started_on.strftime('%H:%M:%S'))
+            args.append(str((self._finished_on - self._started_on).total_seconds()))
+        else:
+            args.append('')
+            args.append('')
+
+        print(summary_format.format(*args))
 
 
 def wait_all_tasks(tasks_list):
@@ -75,7 +80,7 @@ def get_print_template(tasks_list):
     max_module_name_len = max([len(t.name) for t in tasks_list])
 
     # the format: <module name>  <status> <start on> <finish on>
-    return '{0:' + str(max_module_name_len + 2) + '}{1:8}{2:10}{3:10}'
+    return '{0:' + str(max_module_name_len + 2) + '}{1:10}{2:12}{3:10}'
 
 def run_module_tests():
     print("Running tests on command modules.")

--- a/scripts/command_modules/test.py
+++ b/scripts/command_modules/test.py
@@ -6,37 +6,95 @@
 ## Run the tests for each command module ##
 
 from __future__ import print_function
+
 import os
 import sys
+from datetime import datetime
+from threading import Thread
+from _common import get_all_command_modules, exec_command_output, COMMAND_MODULE_PREFIX
 
-from _common import get_all_command_modules, exec_command, print_summary, COMMAND_MODULE_PREFIX
 
-LOG_DIR = os.path.expanduser(os.path.join('~', '.azure', 'logs'))
+class TestTask(Thread):
+    LOG_DIR = os.path.expanduser(os.path.join('~', '.azure', 'logs'))
 
-all_command_modules = get_all_command_modules()
-print("Running tests on command modules.")
+    """
+    Execute a test task in a separated task.
+    """
+    def __init__(self, module_name, module_path):
+        Thread.__init__(self)
+        module_name = module_name.replace(COMMAND_MODULE_PREFIX, '')
+        self._path_to_module = os.path.join(
+            module_path, 'azure', 'cli', 'command_modules', module_name, 'tests')
 
-failed_module_names = []
-skipped_modules = []
-for name, fullpath in all_command_modules:
-    path_to_module = os.path.join(fullpath, 'azure', 'cli', 'command_modules', name.replace(COMMAND_MODULE_PREFIX, ''), 'tests')
-    if not os.path.isdir(path_to_module):
-        skipped_modules.append(name)
-        continue
-    command = "python -m unittest discover -s " + path_to_module
-    # append --buffer when running on CI to ensure any unrecorded tests fail instead of hang
-    if os.environ.get('CONTINUOUS_INTEGRATION') and os.environ.get('TRAVIS'):
-        command += " --buffer"
-    success = exec_command(command, env={'AZURE_CLI_ENABLE_LOG_FILE': '1', 'AZURE_CLI_LOG_DIR': LOG_DIR})
-    if not success:
-        failed_module_names.append(name)
+        self.name = module_name
+        self.skipped = not os.path.isdir(self._path_to_module)
+        self.rtcode = -1
+        self._started_on = None
+        self._finished_on = None
 
-print_summary(failed_module_names)
+        self.start()
 
-print("Full debug log available at '{}'.".format(LOG_DIR))
+    def run(self):
+        if self.skipped:
+            return
 
-if failed_module_names:
-    sys.exit(1)
+        command = 'python -m unittest discover -s {0}'.format(self._path_to_module)
 
-if skipped_modules:
-    print("Modules skipped as no test dir found:", ', '.join(skipped_modules), file=sys.stderr)
+        if os.environ.get('CONTINUOUS_INTEGRATION') and os.environ.get('TRAVIS'):
+            command += " --buffer"
+
+        env = os.environ.copy()
+        env.update({'AZURE_CLI_ENABLE_LOG_FILE': '1', 'AZURE_CLI_LOG_DIR': TestTask.LOG_DIR})
+
+        print('Executing tests for module {0}'.format(self.name))
+
+        self._started_on = datetime.now()
+        output, self.rtcode = exec_command_output(command, env)
+        self._finished_on = datetime.now()
+
+        print('[{1}] Finish testing module {0}.'.format(
+            self.name, 'Passed' if self.rtcode == 0 else 'Failed'))
+
+        if self.rtcode != 0:
+            print(output)
+
+    def print_format(self, summary_format):
+        status = 'skipped' if self.skipped else ('failed' if self.rtcode != 0 else 'passed')
+        print(summary_format.format(
+            self.name,
+            status,
+            self._started_on.strftime('%H:%M:%S') if self._started_on else '',
+            self._finished_on.strftime('%H:%M:%S') if self._finished_on else ''))
+
+
+def wait_all_tasks(tasks_list):
+    for each in tasks_list:
+        each.join()
+
+def get_print_template(tasks_list):
+    max_module_name_len = max([len(t.name) for t in tasks_list])
+
+    # the format: <module name>  <status> <start on> <finish on>
+    return '{0:' + str(max_module_name_len + 2) + '}{1:8}{2:10}{3:10}'
+
+def run_module_tests():
+    print("Running tests on command modules.")
+
+    tasks = [TestTask(name, path) for name, path in get_all_command_modules()]
+    wait_all_tasks(tasks)
+
+    print()
+    print("Summary")
+    print("========================")
+    summary_format = get_print_template(tasks)
+    for t in tasks:
+        t.print_format(summary_format)
+
+    print("========================")
+    print("* Full debug log available at '{}'.".format(TestTask.LOG_DIR))
+
+    if any([task.name for task in tasks if task.rtcode != 0 and not task.skipped]):
+        sys.exit(1)
+
+if __name__ == '__main__':
+    run_module_tests()


### PR DESCRIPTION
Running test modules in parallel. On my machine it reduces running time from 16 minutes to around 9 minutes.

The actual running time is shorter then that. I'm going to profile the test further to figure out where were the time spent on.
```
Summary
========================
acr        skipped                     
acs        passed  16:38:04  16:38:07  
cloud      skipped                     
component  skipped                     
configure  skipped                     
container  skipped                     
context    skipped                     
feedback   skipped                     
iot        passed  16:38:04  16:38:13  
keyvault   passed  16:38:04  16:38:31  
network    passed  16:38:04  16:42:15  
profile    skipped                     
redis      passed  16:38:04  16:38:07  
resource   passed  16:38:04  16:39:23  
role       passed  16:38:04  16:38:46  
storage    passed  16:38:04  16:39:43  
taskhelp   skipped                     
vm         passed  16:38:04  16:42:45  
webapp     passed  16:38:04  16:39:28  
========================
```

Running time on CI down to 29 minutes:
![screen shot 2016-11-08 at 9 49 20 am](https://cloud.githubusercontent.com/assets/1329240/20110287/b0e935e6-a598-11e6-8864-c3998c41d12c.png)

And the summary on the CI looks like:
![screen shot 2016-11-08 at 9 55 08 am](https://cloud.githubusercontent.com/assets/1329240/20110541/9f00deaa-a599-11e6-8f09-4117446a4788.png)

