### PR TITLE
Ensure '--ids' validation failure prints usage string

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -144,7 +144,7 @@ def add_id_parameters(command_table):
 
             if errors:
                 missing_required = ' '.join((arg.options_list[0] for arg in errors))
-                raise CLIError('({} | {}) are required'.format(missing_required, '--ids'))
+                raise ValueError('({} | {}) are required'.format(missing_required, '--ids'))
 
         group_name = 'Resource Id'
         for key, arg in command.arguments.items():


### PR DESCRIPTION
Fixes #1254.

The validator for the `--ids` parameter raised a CLIError if it failed. After change #1037, CLIErrors thrown from a validator no longer cause the usage string to be printed. Thus, to ensure that a usage string is thrown when `--ids` usage is incorrect, this error was changed to a ValueError, which is the most common approach used by existing validators.