### PR TITLE
[KeyVault] KeyVault Round 4 Commands

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/validators.py
+++ b/src/azure-cli-core/azure/cli/core/commands/validators.py
@@ -9,7 +9,7 @@ import random
 
 def validate_tags(ns):
     ''' Extracts multiple space-separated tags in key[=value] format '''
-    if ns.tags is not None:
+    if isinstance(ns.tags, list):
         tags_dict = {}
         for item in ns.tags:
             tags_dict.update(validate_tag(item))

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_command_type.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_command_type.py
@@ -89,7 +89,8 @@ def _create_key_vault_command(module_name, name, operation, transform_result, ta
         except ClientRequestError as ex:
             if 'Failed to establish a new connection' in str(ex.inner_exception):
                 raise CLIError('Max retries exceeded attempting to connect to vault. '
-                               'Try flushing your DNS cache or try again later.')
+                               'The vault may not exist or you may need to flush your DNS cache '
+                               'and try again later.')
             raise CLIError(ex)
 
     command_module_map[name] = module_name

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
@@ -7,13 +7,15 @@
 
 from azure.mgmt.keyvault.models.key_vault_management_client_enums import \
     (SkuName, KeyPermissions, SecretPermissions, CertificatePermissions)
-from azure.cli.core.commands.parameters import (
-    get_resource_name_completion_list, resource_group_name_type,
-    tags_type, ignore_type, enum_choice_list)
 from azure.cli.core.commands import \
     (register_cli_argument, register_extra_cli_argument, CliArgumentType)
 import azure.cli.core.commands.arm # pylint: disable=unused-import
+from azure.cli.core.commands.parameters import (
+    get_resource_name_completion_list, resource_group_name_type,
+    tags_type, ignore_type, enum_choice_list)
+from azure.cli.core._profile import Profile
 from azure.cli.core._util import get_json_object
+from azure.cli.command_modules.keyvault.keyvaultclient import KeyVaultClient, KeyVaultAuthentication
 
 from azure.cli.command_modules.keyvault.keyvaultclient.generated.models.key_vault_client_enums import \
     (JsonWebKeyOperation)
@@ -26,7 +28,40 @@ from azure.cli.command_modules.keyvault._validators import \
      validate_key_type, validate_key_ops, validate_policy_permissions,
      validate_principal, validate_resource_group_name,
      validate_x509_certificate_chain,
-     process_certificate_cancel_namespace)
+     process_certificate_cancel_namespace,
+     process_secret_set_namespace,
+     secret_text_encoding_values, secret_binary_encoding_values)
+
+# COMPLETERS
+
+def _get_token(server, resource, scope): # pylint: disable=unused-argument
+    return Profile().get_login_credentials(resource)[0]._token_retriever() # pylint: disable=protected-access
+
+def get_keyvault_name_completion_list(resource_name):
+    def completer(prefix, action, parsed_args, **kwargs): # pylint: disable=unused-argument
+        client = KeyVaultClient(KeyVaultAuthentication(_get_token)) # pylint: disable=redefined-variable-type
+        func_name = 'get_{}s'.format(resource_name)
+        vault = parsed_args.vault_base_url
+        items = []
+        for x in list(getattr(client, func_name)(vault)):
+            id_val = getattr(x, 'id', None) or getattr(x, 'kid', None)
+            items.append(id_val.rsplit('/', 1)[1])
+        return items
+    return completer
+
+def get_keyvault_version_completion_list(resource_name):
+    from argcomplete import warn
+    def completer(prefix, action, parsed_args, **kwargs): # pylint: disable=unused-argument
+        client = KeyVaultClient(KeyVaultAuthentication(_get_token)) # pylint: disable=redefined-variable-type
+        func_name = 'get_{}_versions'.format(resource_name)
+        vault = parsed_args.vault_base_url
+        name = getattr(parsed_args, '{}_name'.format(resource_name))
+        items = []
+        for x in list(getattr(client, func_name)(vault, name)):
+            id_val = getattr(x, 'id', None) or getattr(x, 'kid', None)
+            items.append(id_val.rsplit('/', 1)[1])
+        return items
+    return completer
 
 # CUSTOM CHOICE LISTS
 
@@ -34,9 +69,8 @@ key_permission_values = ', '.join([x.value for x in KeyPermissions])
 secret_permission_values = ', '.join([x.value for x in SecretPermissions])
 certificate_permission_values = ', '.join([x.value for x in CertificatePermissions])
 json_web_key_op_values = ', '.join([x.value for x in JsonWebKeyOperation])
-secret_file_encoding_values = ['utf8', 'utf16le', 'ucs2', 'ascii']
-secret_file_decoding_values = ['base64', 'hex']
-certificate_file_encoding_values = ['base64']
+secret_encoding_values = secret_text_encoding_values + secret_binary_encoding_values
+certificate_file_encoding_values = ['binary', 'string']
 
 # KEY ATTRIBUTE PARAMETER REGISTRATION
 
@@ -75,11 +109,13 @@ register_cli_argument('keyvault set-policy', 'secret_permissions', metavar='PERM
 register_cli_argument('keyvault set-policy', 'certificate_permissions', metavar='PERM', nargs='*', help='Space separated list. Possible values: {}'.format(certificate_permission_values), arg_group='Permission')
 
 for item in ['key', 'secret', 'certificate']:
-    register_cli_argument('keyvault {}'.format(item), '{}_name'.format(item), options_list=('--name', '-n'), help='Name of the {}.'.format(item), id_part='child_name')
+    register_cli_argument('keyvault {}'.format(item), '{}_name'.format(item), options_list=('--name', '-n'), help='Name of the {}.'.format(item), id_part='child_name', completer=get_keyvault_name_completion_list(item))
     register_cli_argument('keyvault {}'.format(item), 'vault_base_url', vault_name_type, type=vault_base_url_type, id_part=None)
+# TODO: Fix once service side issue is fixed that there is no way to list pending certificates
+register_cli_argument('keyvault certificate pending', 'certificate_name', options_list=('--name', '-n'), help='Name of the pending certificate.', id_part='child_name', completer=None)
 
 register_cli_argument('keyvault key', 'key_ops', options_list=('--ops',), nargs='*', help='Space separated list of permitted JSON web key operations. Possible values: {}'.format(json_web_key_op_values), validator=validate_key_ops, type=str.lower)
-register_cli_argument('keyvault key', 'key_version', options_list=('--version', '-v'), help='The key version. If omitted, uses the latest version.', default='', required=False)
+register_cli_argument('keyvault key', 'key_version', options_list=('--version', '-v'), help='The key version. If omitted, uses the latest version.', default='', required=False, completer=get_keyvault_version_completion_list('key'))
 
 for item in ['create', 'import']:
     register_cli_argument('keyvault key {}'.format(item), 'destination', options_list=('--protection', '-p'), choices=['software', 'hsm'], help='Specifies the type of key protection.', validator=validate_key_type, type=str.lower)
@@ -98,12 +134,20 @@ register_cli_argument('keyvault key restore', 'file_path', options_list=('--file
 
 register_attributes_argument('keyvault key set-attributes', 'key', KeyAttributes)
 
-register_cli_argument('keyvault secret', 'secret_version', options_list=('--version', '-v'), help='The secret version. If omitted, uses the latest version.', default='', required=False)
+register_cli_argument('keyvault secret', 'secret_version', options_list=('--version', '-v'), help='The secret version. If omitted, uses the latest version.', default='', required=False, completer=get_keyvault_version_completion_list('secret'))
 
+register_cli_argument('keyvault secret set', 'content_type', options_list=('--description',), help='Description of the secret contents (i.e. password, connection string, etc)')
 register_attributes_argument('keyvault secret set', 'secret', SecretAttributes, create=True)
+register_cli_argument('keyvault secret set', 'value', options_list=('--value',), help="Plain text secret value. Cannot be used with '--file' or '--encoding'", required=False, arg_group='Content Source')
+register_extra_cli_argument('keyvault secret set', 'file_path', options_list=('--file', '-f'), help="Source file for secret. Use in conjunction with '--encoding'", arg_group='Content Source')
+register_extra_cli_argument('keyvault secret set', 'encoding', options_list=('--encoding', '-e'), help='Source file encoding. The value is saved as a tag (file-encoding=<val>) and used during download to automtically encode the resulting file.', default='utf-8', validator=process_secret_set_namespace, arg_group='Content Source', **enum_choice_list(secret_encoding_values))
+
 register_attributes_argument('keyvault secret set-attributes', 'secret', SecretAttributes)
 
-register_cli_argument('keyvault certificate', 'certificate_version', options_list=('--version', '-v'), help='The certificate version. If omitted, uses the latest version.', default='', required=False)
+register_cli_argument('keyvault secret download', 'file_path', options_list=('--file', '-f'), help='File to receive the secret contents.')
+register_cli_argument('keyvault secret download', 'encoding', options_list=('--encoding', '-e'), help="Encoding of the destination file. By default, will look for the 'file-encoding' tag on the secret. Otherwise will assume 'utf-8'.", default=None, **enum_choice_list(secret_encoding_values))
+
+register_cli_argument('keyvault certificate', 'certificate_version', options_list=('--version', '-v'), help='The certificate version. If omitted, uses the latest version.', default='', required=False, completer=get_keyvault_version_completion_list('certificate'))
 register_attributes_argument('keyvault certificate create', 'certificate', CertificateAttributes, True)
 register_attributes_argument('keyvault certificate import', 'certificate', CertificateAttributes, True)
 register_attributes_argument('keyvault certificate set-attributes', 'certificate', CertificateAttributes)
@@ -111,6 +155,9 @@ for item in ['create', 'set-attributes', 'import']:
     register_cli_argument('keyvault certificate {}'.format(item), 'certificate_policy', options_list=('--policy', '-p'), help='JSON encoded policy defintion. Use @{file} to load from a file.', type=get_json_object)
 
 register_cli_argument('keyvault certificate import', 'base64_encoded_certificate', options_list=('--file', '-f'), help='PKCS12 file or PEM file containing the certificate and private key.', type=base64_encoded_certificate_type)
+
+register_cli_argument('keyvault certificate download', 'file_path', options_list=('--file', '-f'), help='File to receive the binary certificate contents.')
+register_cli_argument('keyvault certificate download', 'encoding', options_list=('--encoding', '-e'), help='How to store base64 certificate contents in file.', **enum_choice_list(certificate_file_encoding_values))
 
 register_cli_argument('keyvault certificate pending merge', 'x509_certificates', options_list=('--file', '-f'), help='File containing the certificate or certificate chain to merge.', validator=validate_x509_certificate_chain)
 register_attributes_argument('keyvault certificate pending merge', 'certificate', CertificateAttributes, True)

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
@@ -43,8 +43,8 @@ def get_keyvault_name_completion_list(resource_name):
         func_name = 'get_{}s'.format(resource_name)
         vault = parsed_args.vault_base_url
         items = []
-        for x in list(getattr(client, func_name)(vault)):
-            id_val = getattr(x, 'id', None) or getattr(x, 'kid', None)
+        for y in list(getattr(client, func_name)(vault)):
+            id_val = getattr(y, 'id', None) or getattr(y, 'kid', None)
             items.append(id_val.rsplit('/', 1)[1])
         return items
     return completer
@@ -57,8 +57,8 @@ def get_keyvault_version_completion_list(resource_name):
         vault = parsed_args.vault_base_url
         name = getattr(parsed_args, '{}_name'.format(resource_name))
         items = []
-        for x in list(getattr(client, func_name)(vault, name)):
-            id_val = getattr(x, 'id', None) or getattr(x, 'kid', None)
+        for y in list(getattr(client, func_name)(vault, name)):
+            id_val = getattr(y, 'id', None) or getattr(y, 'kid', None)
             items.append(id_val.rsplit('/', 1)[1])
         return items
     return completer

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
@@ -50,7 +50,7 @@ def get_keyvault_name_completion_list(resource_name):
     return completer
 
 def get_keyvault_version_completion_list(resource_name):
-    from argcomplete import warn
+
     def completer(prefix, action, parsed_args, **kwargs): # pylint: disable=unused-argument
         client = KeyVaultClient(KeyVaultAuthentication(_get_token)) # pylint: disable=redefined-variable-type
         func_name = 'get_{}_versions'.format(resource_name)
@@ -136,7 +136,7 @@ register_attributes_argument('keyvault key set-attributes', 'key', KeyAttributes
 
 register_cli_argument('keyvault secret', 'secret_version', options_list=('--version', '-v'), help='The secret version. If omitted, uses the latest version.', default='', required=False, completer=get_keyvault_version_completion_list('secret'))
 
-register_cli_argument('keyvault secret set', 'content_type', options_list=('--description',), help='Description of the secret contents (i.e. password, connection string, etc)')
+register_cli_argument('keyvault secret set', 'content_type', options_list=('--description',), help='Description of the secret contents (e.g. password, connection string, etc)')
 register_attributes_argument('keyvault secret set', 'secret', SecretAttributes, create=True)
 register_cli_argument('keyvault secret set', 'value', options_list=('--value',), help="Plain text secret value. Cannot be used with '--file' or '--encoding'", required=False, arg_group='Content Source')
 register_extra_cli_argument('keyvault secret set', 'file_path', options_list=('--file', '-f'), help="Source file for secret. Use in conjunction with '--encoding'", arg_group='Content Source')

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/commands.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/commands.py
@@ -54,6 +54,13 @@ cli_keyvault_data_plane_command('keyvault secret show', 'azure.cli.command_modul
 cli_keyvault_data_plane_command('keyvault secret delete', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.delete_secret')
 # Round 4
 # cli_keyvault_data_plane_command('keyvault secret download', download_secret)
+cli_keyvault_data_plane_command('keyvault secret list', KeyVaultClient.get_secrets)
+cli_keyvault_data_plane_command('keyvault secret list-versions', KeyVaultClient.get_secret_versions)
+cli_keyvault_data_plane_command('keyvault secret set', KeyVaultClient.set_secret)
+cli_keyvault_data_plane_command('keyvault secret set-attributes', BaseKeyVaultClient.update_secret)
+cli_keyvault_data_plane_command('keyvault secret show', BaseKeyVaultClient.get_secret)
+cli_keyvault_data_plane_command('keyvault secret delete', KeyVaultClient.delete_secret)
+cli_keyvault_data_plane_command('keyvault secret download', download_secret)
 
 cli_keyvault_data_plane_command('keyvault certificate create', 'azure.cli.command_modules.keyvault.custom#create_certificate')
 cli_keyvault_data_plane_command('keyvault certificate list', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.get_certificates')
@@ -64,6 +71,14 @@ cli_keyvault_data_plane_command('keyvault certificate set-attributes', 'azure.cl
 cli_keyvault_data_plane_command('keyvault certificate import', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.import_certificate')
 # Round 4
 # cli_keyvault_data_plane_command('keyvault certificate download', download_certificate)
+cli_keyvault_data_plane_command('keyvault certificate create', create_certificate)
+cli_keyvault_data_plane_command('keyvault certificate list', KeyVaultClient.get_certificates)
+cli_keyvault_data_plane_command('keyvault certificate list-versions', KeyVaultClient.get_certificate_versions)
+cli_keyvault_data_plane_command('keyvault certificate show', BaseKeyVaultClient.get_certificate)
+cli_keyvault_data_plane_command('keyvault certificate delete', KeyVaultClient.delete_certificate)
+cli_keyvault_data_plane_command('keyvault certificate set-attributes', BaseKeyVaultClient.update_certificate)
+cli_keyvault_data_plane_command('keyvault certificate import', KeyVaultClient.import_certificate)
+cli_keyvault_data_plane_command('keyvault certificate download', download_certificate)
 
 cli_keyvault_data_plane_command('keyvault key list', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.get_keys')
 cli_keyvault_data_plane_command('keyvault key list-versions', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.get_key_versions')

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/commands.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/commands.py
@@ -12,14 +12,19 @@ from azure.cli.core.commands.arm import cli_generic_update_command
 from ._client_factory import keyvault_client_factory
 from ._command_type import cli_keyvault_data_plane_command
 
-factory = lambda args: keyvault_client_factory(**args).vaults
-cli_command(__name__, 'keyvault create', 'azure.cli.command_modules.keyvault.custom#create_keyvault', factory)
-cli_command(__name__, 'keyvault list', 'azure.cli.command_modules.keyvault.custom#list_keyvault', factory)
-cli_command(__name__, 'keyvault show', 'azure.mgmt.keyvault.operations.vaults_operations#VaultsOperations.get', factory)
-cli_command(__name__, 'keyvault delete', 'azure.mgmt.keyvault.operations.vaults_operations#VaultsOperations.delete', factory)
+convenience_path = 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#{}'
+base_client_path = 'azure.cli.command_modules.keyvault.keyvaultclient.generated.key_vault_client#{}'
+custom_path = 'azure.cli.command_modules.keyvault.custom#{}'
+mgmt_path = 'azure.mgmt.keyvault.operations.vaults_operations#{}'
 
-cli_command(__name__, 'keyvault set-policy', 'azure.cli.command_modules.keyvault.custom#set_policy', factory)
-cli_command(__name__, 'keyvault delete-policy', 'azure.cli.command_modules.keyvault.custom#delete_policy', factory)
+factory = lambda args: keyvault_client_factory(**args).vaults
+cli_command(__name__, 'keyvault create', custom_path.format('create_keyvault'), factory)
+cli_command(__name__, 'keyvault list', custom_path.format('list_keyvault'), factory)
+cli_command(__name__, 'keyvault show', mgmt_path.format('VaultsOperations.get'), factory)
+cli_command(__name__, 'keyvault delete', mgmt_path.format('VaultsOperations.delete'), factory)
+
+cli_command(__name__, 'keyvault set-policy', custom_path.format('set_policy'), factory)
+cli_command(__name__, 'keyvault delete-policy', custom_path.format('delete_policy'), factory)
 
 def keyvault_update_setter(client, resource_group_name, vault_name, parameters):
     from azure.mgmt.keyvault.models import VaultCreateOrUpdateParameters
@@ -31,90 +36,74 @@ def keyvault_update_setter(client, resource_group_name, vault_name, parameters):
 
 cli_generic_update_command(__name__,
                            'keyvault update',
-                           'azure.mgmt.keyvault.operations.vaults_operations#VaultsOperations.get',
-                           'azure.cli.command_modules.keyvault.commands#keyvault_update_setter', lambda: keyvault_client_factory().vaults)
+                           mgmt_path.format('VaultsOperations.get'),
+                           'azure.cli.command_modules.keyvault.commands#keyvault_update_setter',
+                           lambda: keyvault_client_factory().vaults)
 
 # Data Plane Commands
 
-cli_keyvault_data_plane_command('keyvault key list', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.get_keys')
-cli_keyvault_data_plane_command('keyvault key list-versions', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.get_key_versions')
-cli_keyvault_data_plane_command('keyvault key create', 'azure.cli.command_modules.keyvault.custom#create_key')
-cli_keyvault_data_plane_command('keyvault key set-attributes', 'azure.cli.command_modules.keyvault.keyvaultclient.generated.key_vault_client#KeyVaultClient.update_key')
-cli_keyvault_data_plane_command('keyvault key show', 'azure.cli.command_modules.keyvault.keyvaultclient.generated.key_vault_client#KeyVaultClient.get_key')
-cli_keyvault_data_plane_command('keyvault key delete', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.delete_key')
-cli_keyvault_data_plane_command('keyvault key backup', 'azure.cli.command_modules.keyvault.custom#backup_key')
-cli_keyvault_data_plane_command('keyvault key restore', 'azure.cli.command_modules.keyvault.custom#restore_key')
-cli_keyvault_data_plane_command('keyvault key import', 'azure.cli.command_modules.keyvault.custom#import_key')
+cli_keyvault_data_plane_command('keyvault key list', convenience_path.format('KeyVaultClient.get_keys'))
+cli_keyvault_data_plane_command('keyvault key list-versions', convenience_path.format('KeyVaultClient.get_key_versions'))
+cli_keyvault_data_plane_command('keyvault key create', custom_path.format('create_key'))
+cli_keyvault_data_plane_command('keyvault key set-attributes', base_client_path.format('KeyVaultClient.update_key'))
+cli_keyvault_data_plane_command('keyvault key show', base_client_path.format('KeyVaultClient.get_key'))
+cli_keyvault_data_plane_command('keyvault key delete', convenience_path.format('KeyVaultClient.delete_key'))
+cli_keyvault_data_plane_command('keyvault key backup', custom_path.format('backup_key'))
+cli_keyvault_data_plane_command('keyvault key restore', custom_path.format('restore_key'))
+cli_keyvault_data_plane_command('keyvault key import', custom_path.format('import_key'))
 
-cli_keyvault_data_plane_command('keyvault secret list', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.get_secrets')
-cli_keyvault_data_plane_command('keyvault secret list-versions', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.get_secret_versions')
-cli_keyvault_data_plane_command('keyvault secret set', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.set_secret')
-cli_keyvault_data_plane_command('keyvault secret set-attributes', 'azure.cli.command_modules.keyvault.keyvaultclient.generated.key_vault_client#KeyVaultClient.update_secret')
-cli_keyvault_data_plane_command('keyvault secret show', 'azure.cli.command_modules.keyvault.keyvaultclient.generated.key_vault_client#KeyVaultClient.get_secret')
-cli_keyvault_data_plane_command('keyvault secret delete', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.delete_secret')
-# Round 4
-# cli_keyvault_data_plane_command('keyvault secret download', download_secret)
-cli_keyvault_data_plane_command('keyvault secret list', KeyVaultClient.get_secrets)
-cli_keyvault_data_plane_command('keyvault secret list-versions', KeyVaultClient.get_secret_versions)
-cli_keyvault_data_plane_command('keyvault secret set', KeyVaultClient.set_secret)
-cli_keyvault_data_plane_command('keyvault secret set-attributes', BaseKeyVaultClient.update_secret)
-cli_keyvault_data_plane_command('keyvault secret show', BaseKeyVaultClient.get_secret)
-cli_keyvault_data_plane_command('keyvault secret delete', KeyVaultClient.delete_secret)
-cli_keyvault_data_plane_command('keyvault secret download', download_secret)
+cli_keyvault_data_plane_command('keyvault secret list', convenience_path.format('KeyVaultClient.get_secrets'))
+cli_keyvault_data_plane_command('keyvault secret list-versions', convenience_path.format('KeyVaultClient.get_secret_versions'))
+cli_keyvault_data_plane_command('keyvault secret set', convenience_path.format('KeyVaultClient.set_secret'))
+cli_keyvault_data_plane_command('keyvault secret set-attributes', base_client_path.format('KeyVaultClient.update_secret'))
+cli_keyvault_data_plane_command('keyvault secret show', base_client_path.format('KeyVaultClient.get_secret'))
+cli_keyvault_data_plane_command('keyvault secret delete', convenience_path.format('KeyVaultClient.delete_secret'))
+cli_keyvault_data_plane_command('keyvault secret download', custom_path.format('download_secret'))
 
-cli_keyvault_data_plane_command('keyvault certificate create', 'azure.cli.command_modules.keyvault.custom#create_certificate')
-cli_keyvault_data_plane_command('keyvault certificate list', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.get_certificates')
-cli_keyvault_data_plane_command('keyvault certificate list-versions', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.get_certificate_versions')
-cli_keyvault_data_plane_command('keyvault certificate show', 'azure.cli.command_modules.keyvault.keyvaultclient.generated.key_vault_client#KeyVaultClient.get_certificate')
-cli_keyvault_data_plane_command('keyvault certificate delete', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.delete_certificate')
-cli_keyvault_data_plane_command('keyvault certificate set-attributes', 'azure.cli.command_modules.keyvault.keyvaultclient.generated.key_vault_client#KeyVaultClient.update_certificate')
-cli_keyvault_data_plane_command('keyvault certificate import', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.import_certificate')
-# Round 4
-# cli_keyvault_data_plane_command('keyvault certificate download', download_certificate)
-cli_keyvault_data_plane_command('keyvault certificate create', create_certificate)
-cli_keyvault_data_plane_command('keyvault certificate list', KeyVaultClient.get_certificates)
-cli_keyvault_data_plane_command('keyvault certificate list-versions', KeyVaultClient.get_certificate_versions)
-cli_keyvault_data_plane_command('keyvault certificate show', BaseKeyVaultClient.get_certificate)
-cli_keyvault_data_plane_command('keyvault certificate delete', KeyVaultClient.delete_certificate)
-cli_keyvault_data_plane_command('keyvault certificate set-attributes', BaseKeyVaultClient.update_certificate)
-cli_keyvault_data_plane_command('keyvault certificate import', KeyVaultClient.import_certificate)
-cli_keyvault_data_plane_command('keyvault certificate download', download_certificate)
+cli_keyvault_data_plane_command('keyvault certificate create', custom_path.format('create_certificate'))
+cli_keyvault_data_plane_command('keyvault certificate list', convenience_path.format('KeyVaultClient.get_certificates'))
+cli_keyvault_data_plane_command('keyvault certificate list-versions', convenience_path.format('KeyVaultClient.get_certificate_versions'))
+cli_keyvault_data_plane_command('keyvault certificate show', base_client_path.format('KeyVaultClient.get_certificate'))
+cli_keyvault_data_plane_command('keyvault certificate delete', convenience_path.format('KeyVaultClient.delete_certificate'))
+cli_keyvault_data_plane_command('keyvault certificate set-attributes', base_client_path.format('KeyVaultClient.update_certificate'))
+cli_keyvault_data_plane_command('keyvault certificate import', convenience_path.format('KeyVaultClient.import_certificate'))
+cli_keyvault_data_plane_command('keyvault certificate download', custom_path.format('download_certificate'))
 
-cli_keyvault_data_plane_command('keyvault key list', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.get_keys')
-cli_keyvault_data_plane_command('keyvault key list-versions', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.get_key_versions')
-cli_keyvault_data_plane_command('keyvault key create', 'azure.cli.command_modules.keyvault.custom#create_key')
-cli_keyvault_data_plane_command('keyvault key set-attributes', 'azure.cli.command_modules.keyvault.keyvaultclient.generated.key_vault_client#KeyVaultClient.update_key')
-cli_keyvault_data_plane_command('keyvault key show', 'azure.cli.command_modules.keyvault.keyvaultclient.generated.key_vault_client#KeyVaultClient.get_key')
-cli_keyvault_data_plane_command('keyvault key delete', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.delete_key')
+cli_keyvault_data_plane_command('keyvault key list', convenience_path.format('KeyVaultClient.get_keys'))
+cli_keyvault_data_plane_command('keyvault key list-versions', convenience_path.format('KeyVaultClient.get_key_versions'))
+cli_keyvault_data_plane_command('keyvault key create', custom_path.format('create_key'))
+cli_keyvault_data_plane_command('keyvault key set-attributes', base_client_path.format('KeyVaultClient.update_key'))
+cli_keyvault_data_plane_command('keyvault key show', base_client_path.format('KeyVaultClient.get_key'))
+cli_keyvault_data_plane_command('keyvault key delete', convenience_path.format('KeyVaultClient.delete_key'))
 
-cli_keyvault_data_plane_command('keyvault secret list', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.get_secrets')
-cli_keyvault_data_plane_command('keyvault secret list-versions', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.get_secret_versions')
-cli_keyvault_data_plane_command('keyvault secret set', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.set_secret')
-cli_keyvault_data_plane_command('keyvault secret set-attributes', 'azure.cli.command_modules.keyvault.keyvaultclient.generated.key_vault_client#KeyVaultClient.update_secret')
-cli_keyvault_data_plane_command('keyvault secret show', 'azure.cli.command_modules.keyvault.keyvaultclient.generated.key_vault_client#KeyVaultClient.get_secret')
-cli_keyvault_data_plane_command('keyvault secret delete', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.delete_secret')
+cli_keyvault_data_plane_command('keyvault secret list', convenience_path.format('KeyVaultClient.get_secrets'))
+cli_keyvault_data_plane_command('keyvault secret list-versions', convenience_path.format('KeyVaultClient.get_secret_versions'))
+cli_keyvault_data_plane_command('keyvault secret set', convenience_path.format('KeyVaultClient.set_secret'))
+cli_keyvault_data_plane_command('keyvault secret set-attributes', base_client_path.format('KeyVaultClient.update_secret'))
+cli_keyvault_data_plane_command('keyvault secret show', base_client_path.format('KeyVaultClient.get_secret'))
+cli_keyvault_data_plane_command('keyvault secret delete', convenience_path.format('KeyVaultClient.delete_secret'))
 
-cli_keyvault_data_plane_command('keyvault certificate create', 'azure.cli.command_modules.keyvault.custom#create_certificate')
-cli_keyvault_data_plane_command('keyvault certificate list', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.get_certificates')
-cli_keyvault_data_plane_command('keyvault certificate list-versions', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.get_certificate_versions')
-cli_keyvault_data_plane_command('keyvault certificate show', 'azure.cli.command_modules.keyvault.keyvaultclient.generated.key_vault_client#KeyVaultClient.get_certificate')
-cli_keyvault_data_plane_command('keyvault certificate delete', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.delete_certificate')
-cli_keyvault_data_plane_command('keyvault certificate set-attributes', 'azure.cli.command_modules.keyvault.keyvaultclient.generated.key_vault_client#KeyVaultClient.update_certificate')
+cli_keyvault_data_plane_command('keyvault certificate create', custom_path.format('create_certificate'))
+cli_keyvault_data_plane_command('keyvault certificate list', convenience_path.format('KeyVaultClient.get_certificates'))
+cli_keyvault_data_plane_command('keyvault certificate list-versions', convenience_path.format('KeyVaultClient.get_certificate_versions'))
+cli_keyvault_data_plane_command('keyvault certificate show', base_client_path.format('KeyVaultClient.get_certificate'))
+cli_keyvault_data_plane_command('keyvault certificate delete', convenience_path.format('KeyVaultClient.delete_certificate'))
+cli_keyvault_data_plane_command('keyvault certificate set-attributes', base_client_path.format('KeyVaultClient.update_certificate'))
 
-cli_keyvault_data_plane_command('keyvault certificate pending merge', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.merge_certificate')
-cli_keyvault_data_plane_command('keyvault certificate pending show', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.get_certificate_operation')
-cli_keyvault_data_plane_command('keyvault certificate pending delete', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.delete_certificate_operation')
+cli_keyvault_data_plane_command('keyvault certificate pending merge', convenience_path.format('KeyVaultClient.merge_certificate'))
+cli_keyvault_data_plane_command('keyvault certificate pending show', convenience_path.format('KeyVaultClient.get_certificate_operation'))
+cli_keyvault_data_plane_command('keyvault certificate pending delete', convenience_path.format('KeyVaultClient.delete_certificate_operation'))
 
-cli_keyvault_data_plane_command('keyvault certificate contact list', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.get_certificate_contacts')
-cli_keyvault_data_plane_command('keyvault certificate contact add', 'azure.cli.command_modules.keyvault.custom#add_certificate_contact')
-cli_keyvault_data_plane_command('keyvault certificate contact delete', 'azure.cli.command_modules.keyvault.custom#delete_certificate_contact')
+cli_keyvault_data_plane_command('keyvault certificate contact list', convenience_path.format('KeyVaultClient.get_certificate_contacts'))
+cli_keyvault_data_plane_command('keyvault certificate contact add', custom_path.format('add_certificate_contact'))
+cli_keyvault_data_plane_command('keyvault certificate contact delete', custom_path.format('delete_certificate_contact'))
 
-cli_keyvault_data_plane_command('keyvault certificate issuer update', 'azure.cli.command_modules.keyvault.custom#update_certificate_issuer')
-cli_keyvault_data_plane_command('keyvault certificate issuer list', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.get_certificate_issuers')
-cli_keyvault_data_plane_command('keyvault certificate issuer create', 'azure.cli.command_modules.keyvault.custom#create_certificate_issuer')
-cli_keyvault_data_plane_command('keyvault certificate issuer show', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.get_certificate_issuer')
-cli_keyvault_data_plane_command('keyvault certificate issuer delete', 'azure.cli.command_modules.keyvault.keyvaultclient.key_vault_client#KeyVaultClient.delete_certificate_issuer')
+cli_keyvault_data_plane_command('keyvault certificate issuer update', custom_path.format('update_certificate_issuer'))
+cli_keyvault_data_plane_command('keyvault certificate issuer list', convenience_path.format('KeyVaultClient.get_certificate_issuers'))
+cli_keyvault_data_plane_command('keyvault certificate issuer create', custom_path.format('create_certificate_issuer'))
+cli_keyvault_data_plane_command('keyvault certificate issuer show', convenience_path.format('KeyVaultClient.get_certificate_issuer'))
+cli_keyvault_data_plane_command('keyvault certificate issuer delete', convenience_path.format('KeyVaultClient.delete_certificate_issuer'))
 
-cli_keyvault_data_plane_command('keyvault certificate issuer admin list', 'azure.cli.command_modules.keyvault.custom#list_certificate_issuer_admins')
-cli_keyvault_data_plane_command('keyvault certificate issuer admin add', 'azure.cli.command_modules.keyvault.custom#add_certificate_issuer_admin')
-cli_keyvault_data_plane_command('keyvault certificate issuer admin delete', 'azure.cli.command_modules.keyvault.custom#delete_certificate_issuer_admin')
+cli_keyvault_data_plane_command('keyvault certificate issuer admin list', custom_path.format('list_certificate_issuer_admins'))
+cli_keyvault_data_plane_command('keyvault certificate issuer admin add', custom_path.format('add_certificate_issuer_admin'))
+cli_keyvault_data_plane_command('keyvault certificate issuer admin delete', custom_path.format('delete_certificate_issuer_admin'))

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/custom.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/custom.py
@@ -311,8 +311,8 @@ def import_key(client, vault_base_url, key_name, destination=None, key_ops=None,
 def download_secret(client, vault_base_url, secret_name, file_path, encoding=None,
                     secret_version=''):
     """ Download a secret from a KeyVault. """
-    if os.path.isfile(file_path):
-        raise CLIError("File '{}' already exists.".format(file_path))
+    if os.path.isfile(file_path) or os.path.isdir(file_path):
+        raise CLIError("File or directory named '{}' already exists.".format(file_path))
 
     secret = client.keyvault.get_secret(vault_base_url, secret_name, secret_version)
     encoding = encoding or secret.tags.get('file-encoding', 'utf-8')
@@ -332,9 +332,10 @@ def download_secret(client, vault_base_url, secret_name, file_path, encoding=Non
 
             with open(file_path, 'wb') as f:
                 f.write(decoded)
-    except Exception: # pylint: disable=broad-except
+    except Exception as ex: # pylint: disable=broad-except
         if os.path.isfile(file_path):
             os.remove(file_path)
+        raise ex
 
 def create_certificate(client, vault_base_url, certificate_name, certificate_policy,
                        disabled=False, expires=None, not_before=None, tags=None):
@@ -377,8 +378,8 @@ create_certificate.__doc__ = KeyVaultClient.create_certificate.__doc__
 def download_certificate(client, vault_base_url, certificate_name, file_path,
                          encoding='binary', certificate_version=''):
     """ Download a certificate from a KeyVault. """
-    if os.path.isfile(file_path):
-        raise CLIError("File '{}' already exists.".format(file_path))
+    if os.path.isfile(file_path) or os.path.isdir(file_path):
+        raise CLIError("File or directory named '{}' already exists.".format(file_path))
 
     cert = client.keyvault.get_certificate(
         vault_base_url, certificate_name, certificate_version).cer
@@ -396,6 +397,7 @@ def download_certificate(client, vault_base_url, certificate_name, file_path,
     except Exception as ex: # pylint: disable=broad-except
         if os.path.isfile(file_path):
             os.remove(file_path)
+        raise ex
 
 def add_certificate_contact(client, vault_base_url, contact_email, contact_name=None,
                             contact_phone=None):

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/custom.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/custom.py
@@ -4,6 +4,7 @@
 #---------------------------------------------------------------------------------------------
 
 import codecs
+import os
 import re
 import time
 
@@ -26,6 +27,7 @@ from azure.cli.core._util import CLIError
 import azure.cli.core._logging as _logging
 
 from azure.cli.command_modules.keyvault.keyvaultclient import KeyVaultClient
+from azure.cli.command_modules.keyvault._validators import secret_text_encoding_values
 
 logger = _logging.get_az_logger(__name__)
 
@@ -306,11 +308,33 @@ def import_key(client, vault_base_url, key_name, destination=None, key_ops=None,
     return client.import_key(
         vault_base_url, key_name, key_obj, destination == 'hsm', key_attrs, tags)
 
-# pylint: disable=unused-argument
-def download_secret(client, vault_base_url, secret_name, file_path, file_encoding='utf8',
-                    secret_version='', decode_binary=None):
+def download_secret(client, vault_base_url, secret_name, file_path, encoding=None,
+                    secret_version=''):
+    """ Download a secret from a KeyVault. """
+    if os.path.isfile(file_path):
+        raise CLIError("File '{}' already exists.".format(file_path))
+
     secret = client.keyvault.get_secret(vault_base_url, secret_name, secret_version)
-    raise CLIError('TODO: implement')
+    encoding = encoding or secret.tags.get('file-encoding', 'utf-8')
+    secret_value = secret.value
+
+    try:
+        if encoding in secret_text_encoding_values:
+            with open(file_path, 'w') as f:
+                f.write(secret_value)
+        else:
+            if encoding == 'base64':
+                import base64
+                decoded = base64.b64decode(secret_value)
+            elif encoding == 'hex':
+                import binascii
+                decoded = binascii.unhexlify(secret_value)
+
+            with open(file_path, 'wb') as f:
+                f.write(decoded)
+    except Exception: # pylint: disable=broad-except
+        if os.path.isfile(file_path):
+            os.remove(file_path)
 
 def create_certificate(client, vault_base_url, certificate_name, certificate_policy,
                        disabled=False, expires=None, not_before=None, tags=None):
@@ -350,12 +374,28 @@ def create_certificate(client, vault_base_url, certificate_name, certificate_pol
 
 create_certificate.__doc__ = KeyVaultClient.create_certificate.__doc__
 
-# pylint: disable=unused-argument
 def download_certificate(client, vault_base_url, certificate_name, file_path,
-                         file_encoding=None, certificate_version=''):
+                         encoding='binary', certificate_version=''):
+    """ Download a certificate from a KeyVault. """
+    if os.path.isfile(file_path):
+        raise CLIError("File '{}' already exists.".format(file_path))
+
     cert = client.keyvault.get_certificate(
-        vault_base_url, certificate_name, certificate_version)
-    raise CLIError('TODO: implement')
+        vault_base_url, certificate_name, certificate_version).cer
+
+    try:
+        with open(file_path, 'wb') as f:
+            if encoding == 'binary':
+                f.write(cert)
+            else:
+                import base64
+                try:
+                    f.write(base64.encodebytes(cert))
+                except AttributeError:
+                    f.write(base64.encodestring(cert)) # pylint: disable=deprecated-method
+    except Exception as ex: # pylint: disable=broad-except
+        if os.path.isfile(file_path):
+            os.remove(file_path)
 
 def add_certificate_contact(client, vault_base_url, contact_email, contact_name=None,
                             contact_phone=None):

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/recordings/test_keyvault_certificate.yaml
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/recordings/test_keyvault_certificate.yaml
@@ -1,41 +1,292 @@
 interactions:
 - request:
     body: !!binary |
-      eyJhdHRyaWJ1dGVzIjogeyJlbmFibGVkIjogdHJ1ZX0sICJwb2xpY3kiOiB7ImF0dHJpYnV0ZXMi
-      OiB7ImVuYWJsZWQiOiB0cnVlfSwgImlzc3VlciI6IHsibmFtZSI6ICJTZWxmIn0sICJrZXlfcHJv
-      cHMiOiB7ImV4cG9ydGFibGUiOiB0cnVlLCAia3R5IjogIlJTQSIsICJyZXVzZV9rZXkiOiBmYWxz
-      ZSwgImtleV9zaXplIjogMjA0OH0sICJzZWNyZXRfcHJvcHMiOiB7ImNvbnRlbnRUeXBlIjogImFw
-      cGxpY2F0aW9uL3gtcGtjczEyIn0sICJ4NTA5X3Byb3BzIjogeyJrZXlfdXNhZ2UiOiBbImRpZ2l0
-      YWxTaWduYXR1cmUiLCAibm9uUmVwdWRpYXRpb24iLCAia2V5RW5jaXBoZXJtZW50IiwgImtleUFn
-      cmVlbWVudCIsICJrZXlDZXJ0U2lnbiJdLCAic3ViamVjdCI6ICJDPVVTLCBTVD1XQSwgTD1SZWRt
-      b24sIE89VGVzdCBOb29kbGUsIE9VPVRlc3ROdWdnZXQsIENOPXd3dy5teXRlc3Rkb21haW4uY29t
-      IiwgInZhbGlkaXR5X21vbnRocyI6IDYwfSwgImxpZmV0aW1lX2FjdGlvbnMiOiBbeyJ0cmlnZ2Vy
-      IjogeyJsaWZldGltZV9wZXJjZW50YWdlIjogOTB9LCAiYWN0aW9uIjogeyJhY3Rpb25fdHlwZSI6
-      ICJBdXRvUmVuZXcifX1dfX0=
+      eyJ2YWx1ZSI6ICItLS0tLUJFR0lOIFBSSVZBVEUgS0VZLS0tLS1cbk1JSUV2Z0lCQURBTkJna3Fo
+      a2lHOXcwQkFRRUZBQVNDQktnd2dnU2tBZ0VBQW9JQkFRQ1JVUEZnT3Zvdk5KMGVcblhTSGxjbTJW
+      OXcvRUN3ek1jMzFCYU4yeEJtV2plZ21xaXh2OUdOM0dXTWdVUTl6QzlrOWJ4ZDQ5MUF3YTU1U3Fc
+      bmh0ODZUTDhRM0ZjbjhmWHVoV2JYL2dOQU84aDV0ZnVRVkExekI1YlZ4RVFzQ05tbUxycGdOaExZ
+      TytleGN5Q0pcbm9jcWlkUW9zdFNRZmNYVTdxSnRpZnBnbVJ0NW9XM1dobXBWc25BdWdTOHk4dmJD
+      R0pYZEtxTENaWGpML0gwYWFcbityL1ozQnpRK0JnbFVMS1lzaFNCaW54YlllKzFHSi8wMjgvNTB5
+      L01QZjlpRmlpUzl4dHNwT3RTemQxZStOQTVcbkcrcENNcHBKSGFyczlEL0ZhdlRld0kxekphOWpQ
+      eHRyd3I4TDNuRW15OWd2NnYxNDc0WE5ZYWFndFFOamRVMGJcbkFWM0VEZm45QWdNQkFBRUNnZ0VB
+      REp0R2pYQWdZemIveUhJUTdqeGFtRzk2RFNwZVBtQm9oZU9vaytKM3I5SjNcbkF6WVZSQVJEdlNE
+      WG5yWnljUEY0V2dCVTh1MHg3YVdZaHFDenZmV0pmOWQxc2kveUEzTE1STUd6RzMvME9PYmFcblA1
+      K2pHUThYL1V5TkUzcmpFdUVyNXd2WjM2dDJ3clMzcG1rRVVNcXhpc1plTDJJaTV2Mk9HV0hkSmpq
+      d3M0SFdcblA5cEJHamNneFVQN1VLUExRRXhIYjlvVXN3aDY2WitLOW8xMFp3QXJQWWhuaGM1NDZ2
+      UGxiSHFPNWJUUy9SemFcblBkK2MvaDdQcnJxd1NCYXZtNW1kamNId3FyNUpqaEU0T3piUzRIa2lZ
+      Vm5weDRPUFJjZ1IwdldFNmNHKzB6ZzVcbjRBUk9TTTlrdnJHZmxJcW4yRUFvalJBejVTNndITWs3
+      cEltazRrQWRTd0tCZ1FDL3dWc0VydXpVajNwN0R2WGNcblhSbzhqdVJyV3p0cm1PdnAwR3doc1ZJ
+      VmFGMEZyMmxxQ0VHZ09xcWo1SUVmdWUwVWFDTkNXM0k3M3JSU1lhTmVcbm5KN1BHWk1ZbUxrendj
+      dkdURWVWOUNScU9ndkt2YmYzUmlDcGtLZUx6M2RpbDhBR2R5Vmx3QUptcThGbitJTVRcbnJ3R2F3
+      My9VSFRSTW5zZTZKUG9RK2s0S013S0JnUURDQUk0TWxxNUs3V1NIMXpOS1NMZ0lJOUtuZkhIa3Vz
+      TlVcbjg4aHBhVlJlWG14VTd1UUlDMDJuYnRZbDJvTTNJL0x6OU90ay9uUEliaDRnOUxLbWp1NUdp
+      MVMyd2NoSW5EZlBcbkt3Z1BvQ2xNNi9WTTRlNkNTOXFxL0Z2SmRMdTIyMjhBeGNkU29Jd0dtcmti
+      aVR0R05lZE80Q2RCYTMvdmFjYWNcbnVEMGlEL2diRHdLQmdRQyttWHpWSE9KL0xkWjZ0eFllNGRR
+      UVdhQW1MZHJVU241RVBFMGUrRmcwdXpXclR2NGlcbnpPNGVTL0lOVWpZZXlQb2tqSlp2Z09IOUxK
+      SmtTSFRRdURFS2ZjcythWis5R0dacVJxdnBHM0dPdlArM2wvaGlcbkt5eVFIeDdLMDM5QldzRWVM
+      QlBhSFk3RmF2ZWxWdGxER1hNbzJDWVpPcVlmZXJ2Z0JKMGpmd2xQRFFLQmdDdUNcblNGbFdhZHh3
+      QlQzWjY2emJSanE5SGY5bUQzMEd6Y3Y5cUpMTGhwcHJmc3hGajJxbWJsSUFyNUpwd1VmYWppQmNc
+      bmEzYUpBcHFPNTc3b1lqQ3NtWS9FcThrWkNMd1FIUXdmVUgyQXBBS1dZTHRQYUZoY2Zyd2VRTSti
+      bUlYWURMc1Zcbm9EQk54Vm10MVpueFd4UFIvd0JYa1RaQXo3NTM4STB4WExTSTlGSE5Bb0dCQUov
+      MmNrNUcrcEtWSEpBOXNGb09cbndwQjFqaW1aTm1aancyRml1N3UzM0lRU3Exb01pakQvTThxTEZs
+      bnF1ZXRCcmpuaVc1NVZpUjg5SE1lKzVCd3Rcbm5aK1BxNnhES256eFJ5eUZXR004bHArSkRNTWox
+      eE9ISVlpbCthRmdaeVdtNi9Wek4yNHZkcDJlWVJZV0JkTVRcblA4bXVrcG5OaHl0bUkxLzRvemFV
+      K3dhaVxuLS0tLS1FTkQgUFJJVkFURSBLRVktLS0tLVxuLS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0t
+      LS0tXG5NSUlESkRDQ0FneWdBd0lCQWdJUWMvUnZjN1NOVC9pSnJlNklJNzh2cFRBTkJna3Foa2lH
+      OXcwQkFRc0ZBREFQXG5NUTB3Q3dZRFZRUURFd1JVWlhOME1CNFhEVEUyTVRBeU56RTRORE0xTmxv
+      WERURTNNVEF5TnpFNE5UTTFObG93XG5EekVOTUFzR0ExVUVBeE1FVkdWemREQ0NBU0l3RFFZSktv
+      WklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCXG5BSkZROFdBNitpODBuUjVkSWVWeWJaWDNE
+      OFFMRE14emZVRm8zYkVHWmFONkNhcUxHLzBZM2NaWXlCUkQzTUwyXG5UMXZGM2ozVURCcm5sS3FH
+      M3pwTXZ4RGNWeWZ4OWU2Rlp0ZitBMEE3eUhtMSs1QlVEWE1IbHRYRVJDd0kyYVl1XG51bUEyRXRn
+      NzU3RnpJSW1oeXFKMUNpeTFKQjl4ZFR1b20ySittQ1pHM21oYmRhR2FsV3ljQzZCTHpMeTlzSVls
+      XG5kMHFvc0psZU12OGZScHI2djluY0hORDRHQ1ZRc3BpeUZJR0tmRnRoNzdVWW4vVGJ6L25UTDh3
+      OS8ySVdLSkwzXG5HMnlrNjFMTjNWNzQwRGtiNmtJeW1ra2RxdXowUDhWcTlON0FqWE1scjJNL0cy
+      dkN2d3ZlY1NiTDJDL3EvWGp2XG5oYzFocHFDMUEyTjFUUnNCWGNRTitmMENBd0VBQWFOOE1Ib3dE
+      Z1lEVlIwUEFRSC9CQVFEQWdXZ01Ba0dBMVVkXG5Fd1FDTUFBd0hRWURWUjBsQkJZd0ZBWUlLd1lC
+      QlFVSEF3RUdDQ3NHQVFVRkJ3TUNNQjhHQTFVZEl3UVlNQmFBXG5GSmg5VG1OdWVzcWNjZ21kVnU3
+      V0Q2YllpdXJtTUIwR0ExVWREZ1FXQkJTWWZVNWpibnJLbkhJSm5WYnUxZyttXG4ySXJxNWpBTkJn
+      a3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWowdlR0U0NqU1FJWmFnek92alR0WnZuS0g2RTBxMHpYXG4r
+      TUF0Sm5TOENiL1hWUEVXMEZxTjVUTFh2dmFrdGpLQ0RIU1BtWXduZVRqVjNoak5lK2pCMDNSMVoy
+      YXV4bnNjXG5qU2ZMVDQrdHRockNpSFRMWCtXclIrRjNTd09YL2NWRkdpVTB6MUljSmU1bTQ5cWlV
+      SjZrZW1IYWE2dW1nZkdYXG5IYm5DcXpSNzZXa2hESldGejlNWEZGdkZUUkdFKzI2N3NsaVFmOFBy
+      S3I2NW9PRVZaVi9FK1NJblFkbStIMUxZXG5XQWJpZzRVeEhOOFVRNTRHOW1kVzFlL3VSdW1BVDcz
+      dXR5K0MwTzhWUXZOdnNjbzJIQWlQT3REY2U0Q0psZVp4XG5pQXY2ejBZNlBLUlliNHh3K3hubXFw
+      QzhrczFUOTNKRmFuaUhsNTNjcVJOYlh5NXQ5dDlDYWc9PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUt
+      LS0tLSIsICJhdHRyaWJ1dGVzIjogeyJlbmFibGVkIjogdHJ1ZX0sICJwb2xpY3kiOiB7ImtleV9w
+      cm9wcyI6IHsia3R5IjogIlJTQSIsICJleHBvcnRhYmxlIjogdHJ1ZSwgImtleV9zaXplIjogMjA0
+      OCwgInJldXNlX2tleSI6IGZhbHNlfSwgImlzc3VlciI6IHsibmFtZSI6ICJTZWxmIn0sICJzZWNy
+      ZXRfcHJvcHMiOiB7ImNvbnRlbnRUeXBlIjogImFwcGxpY2F0aW9uL3gtcGVtLWZpbGUifX19
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Connection: [keep-alive]
+      Content-Length: ['3132']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [32efaf00-a5fd-11e6-81cf-a0b3ccf7272a]
+    method: POST
+    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1/import?api-version=2015-06-01
+  response: null
+- request:
+    body: !!binary |
+      eyJ2YWx1ZSI6ICItLS0tLUJFR0lOIFBSSVZBVEUgS0VZLS0tLS1cbk1JSUV2Z0lCQURBTkJna3Fo
+      a2lHOXcwQkFRRUZBQVNDQktnd2dnU2tBZ0VBQW9JQkFRQ1JVUEZnT3Zvdk5KMGVcblhTSGxjbTJW
+      OXcvRUN3ek1jMzFCYU4yeEJtV2plZ21xaXh2OUdOM0dXTWdVUTl6QzlrOWJ4ZDQ5MUF3YTU1U3Fc
+      bmh0ODZUTDhRM0ZjbjhmWHVoV2JYL2dOQU84aDV0ZnVRVkExekI1YlZ4RVFzQ05tbUxycGdOaExZ
+      TytleGN5Q0pcbm9jcWlkUW9zdFNRZmNYVTdxSnRpZnBnbVJ0NW9XM1dobXBWc25BdWdTOHk4dmJD
+      R0pYZEtxTENaWGpML0gwYWFcbityL1ozQnpRK0JnbFVMS1lzaFNCaW54YlllKzFHSi8wMjgvNTB5
+      L01QZjlpRmlpUzl4dHNwT3RTemQxZStOQTVcbkcrcENNcHBKSGFyczlEL0ZhdlRld0kxekphOWpQ
+      eHRyd3I4TDNuRW15OWd2NnYxNDc0WE5ZYWFndFFOamRVMGJcbkFWM0VEZm45QWdNQkFBRUNnZ0VB
+      REp0R2pYQWdZemIveUhJUTdqeGFtRzk2RFNwZVBtQm9oZU9vaytKM3I5SjNcbkF6WVZSQVJEdlNE
+      WG5yWnljUEY0V2dCVTh1MHg3YVdZaHFDenZmV0pmOWQxc2kveUEzTE1STUd6RzMvME9PYmFcblA1
+      K2pHUThYL1V5TkUzcmpFdUVyNXd2WjM2dDJ3clMzcG1rRVVNcXhpc1plTDJJaTV2Mk9HV0hkSmpq
+      d3M0SFdcblA5cEJHamNneFVQN1VLUExRRXhIYjlvVXN3aDY2WitLOW8xMFp3QXJQWWhuaGM1NDZ2
+      UGxiSHFPNWJUUy9SemFcblBkK2MvaDdQcnJxd1NCYXZtNW1kamNId3FyNUpqaEU0T3piUzRIa2lZ
+      Vm5weDRPUFJjZ1IwdldFNmNHKzB6ZzVcbjRBUk9TTTlrdnJHZmxJcW4yRUFvalJBejVTNndITWs3
+      cEltazRrQWRTd0tCZ1FDL3dWc0VydXpVajNwN0R2WGNcblhSbzhqdVJyV3p0cm1PdnAwR3doc1ZJ
+      VmFGMEZyMmxxQ0VHZ09xcWo1SUVmdWUwVWFDTkNXM0k3M3JSU1lhTmVcbm5KN1BHWk1ZbUxrendj
+      dkdURWVWOUNScU9ndkt2YmYzUmlDcGtLZUx6M2RpbDhBR2R5Vmx3QUptcThGbitJTVRcbnJ3R2F3
+      My9VSFRSTW5zZTZKUG9RK2s0S013S0JnUURDQUk0TWxxNUs3V1NIMXpOS1NMZ0lJOUtuZkhIa3Vz
+      TlVcbjg4aHBhVlJlWG14VTd1UUlDMDJuYnRZbDJvTTNJL0x6OU90ay9uUEliaDRnOUxLbWp1NUdp
+      MVMyd2NoSW5EZlBcbkt3Z1BvQ2xNNi9WTTRlNkNTOXFxL0Z2SmRMdTIyMjhBeGNkU29Jd0dtcmti
+      aVR0R05lZE80Q2RCYTMvdmFjYWNcbnVEMGlEL2diRHdLQmdRQyttWHpWSE9KL0xkWjZ0eFllNGRR
+      UVdhQW1MZHJVU241RVBFMGUrRmcwdXpXclR2NGlcbnpPNGVTL0lOVWpZZXlQb2tqSlp2Z09IOUxK
+      SmtTSFRRdURFS2ZjcythWis5R0dacVJxdnBHM0dPdlArM2wvaGlcbkt5eVFIeDdLMDM5QldzRWVM
+      QlBhSFk3RmF2ZWxWdGxER1hNbzJDWVpPcVlmZXJ2Z0JKMGpmd2xQRFFLQmdDdUNcblNGbFdhZHh3
+      QlQzWjY2emJSanE5SGY5bUQzMEd6Y3Y5cUpMTGhwcHJmc3hGajJxbWJsSUFyNUpwd1VmYWppQmNc
+      bmEzYUpBcHFPNTc3b1lqQ3NtWS9FcThrWkNMd1FIUXdmVUgyQXBBS1dZTHRQYUZoY2Zyd2VRTSti
+      bUlYWURMc1Zcbm9EQk54Vm10MVpueFd4UFIvd0JYa1RaQXo3NTM4STB4WExTSTlGSE5Bb0dCQUov
+      MmNrNUcrcEtWSEpBOXNGb09cbndwQjFqaW1aTm1aancyRml1N3UzM0lRU3Exb01pakQvTThxTEZs
+      bnF1ZXRCcmpuaVc1NVZpUjg5SE1lKzVCd3Rcbm5aK1BxNnhES256eFJ5eUZXR004bHArSkRNTWox
+      eE9ISVlpbCthRmdaeVdtNi9Wek4yNHZkcDJlWVJZV0JkTVRcblA4bXVrcG5OaHl0bUkxLzRvemFV
+      K3dhaVxuLS0tLS1FTkQgUFJJVkFURSBLRVktLS0tLVxuLS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0t
+      LS0tXG5NSUlESkRDQ0FneWdBd0lCQWdJUWMvUnZjN1NOVC9pSnJlNklJNzh2cFRBTkJna3Foa2lH
+      OXcwQkFRc0ZBREFQXG5NUTB3Q3dZRFZRUURFd1JVWlhOME1CNFhEVEUyTVRBeU56RTRORE0xTmxv
+      WERURTNNVEF5TnpFNE5UTTFObG93XG5EekVOTUFzR0ExVUVBeE1FVkdWemREQ0NBU0l3RFFZSktv
+      WklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCXG5BSkZROFdBNitpODBuUjVkSWVWeWJaWDNE
+      OFFMRE14emZVRm8zYkVHWmFONkNhcUxHLzBZM2NaWXlCUkQzTUwyXG5UMXZGM2ozVURCcm5sS3FH
+      M3pwTXZ4RGNWeWZ4OWU2Rlp0ZitBMEE3eUhtMSs1QlVEWE1IbHRYRVJDd0kyYVl1XG51bUEyRXRn
+      NzU3RnpJSW1oeXFKMUNpeTFKQjl4ZFR1b20ySittQ1pHM21oYmRhR2FsV3ljQzZCTHpMeTlzSVls
+      XG5kMHFvc0psZU12OGZScHI2djluY0hORDRHQ1ZRc3BpeUZJR0tmRnRoNzdVWW4vVGJ6L25UTDh3
+      OS8ySVdLSkwzXG5HMnlrNjFMTjNWNzQwRGtiNmtJeW1ra2RxdXowUDhWcTlON0FqWE1scjJNL0cy
+      dkN2d3ZlY1NiTDJDL3EvWGp2XG5oYzFocHFDMUEyTjFUUnNCWGNRTitmMENBd0VBQWFOOE1Ib3dE
+      Z1lEVlIwUEFRSC9CQVFEQWdXZ01Ba0dBMVVkXG5Fd1FDTUFBd0hRWURWUjBsQkJZd0ZBWUlLd1lC
+      QlFVSEF3RUdDQ3NHQVFVRkJ3TUNNQjhHQTFVZEl3UVlNQmFBXG5GSmg5VG1OdWVzcWNjZ21kVnU3
+      V0Q2YllpdXJtTUIwR0ExVWREZ1FXQkJTWWZVNWpibnJLbkhJSm5WYnUxZyttXG4ySXJxNWpBTkJn
+      a3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWowdlR0U0NqU1FJWmFnek92alR0WnZuS0g2RTBxMHpYXG4r
+      TUF0Sm5TOENiL1hWUEVXMEZxTjVUTFh2dmFrdGpLQ0RIU1BtWXduZVRqVjNoak5lK2pCMDNSMVoy
+      YXV4bnNjXG5qU2ZMVDQrdHRockNpSFRMWCtXclIrRjNTd09YL2NWRkdpVTB6MUljSmU1bTQ5cWlV
+      SjZrZW1IYWE2dW1nZkdYXG5IYm5DcXpSNzZXa2hESldGejlNWEZGdkZUUkdFKzI2N3NsaVFmOFBy
+      S3I2NW9PRVZaVi9FK1NJblFkbStIMUxZXG5XQWJpZzRVeEhOOFVRNTRHOW1kVzFlL3VSdW1BVDcz
+      dXR5K0MwTzhWUXZOdnNjbzJIQWlQT3REY2U0Q0psZVp4XG5pQXY2ejBZNlBLUlliNHh3K3hubXFw
+      QzhrczFUOTNKRmFuaUhsNTNjcVJOYlh5NXQ5dDlDYWc9PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUt
+      LS0tLSIsICJhdHRyaWJ1dGVzIjogeyJlbmFibGVkIjogdHJ1ZX0sICJwb2xpY3kiOiB7ImtleV9w
+      cm9wcyI6IHsia3R5IjogIlJTQSIsICJleHBvcnRhYmxlIjogdHJ1ZSwgImtleV9zaXplIjogMjA0
+      OCwgInJldXNlX2tleSI6IGZhbHNlfSwgImlzc3VlciI6IHsibmFtZSI6ICJTZWxmIn0sICJzZWNy
+      ZXRfcHJvcHMiOiB7ImNvbnRlbnRUeXBlIjogImFwcGxpY2F0aW9uL3gtcGVtLWZpbGUifX19
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
+      Connection: [keep-alive]
+      Content-Length: ['3132']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [32efaf00-a5fd-11e6-81cf-a0b3ccf7272a]
+    method: POST
+    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1/import?api-version=2015-06-01
+  response:
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1/37deaf45e152451fb6948da886476832","kid":"https://cli-test-keyvault-cert.vault.azure.net/keys/pem-cert1/37deaf45e152451fb6948da886476832","sid":"https://cli-test-keyvault-cert.vault.azure.net/secrets/pem-cert1/37deaf45e152451fb6948da886476832","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1478641759,"updated":1478641759},"policy":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1478641759,"updated":1478641759}}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['2163']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 08 Nov 2016 21:49:20 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.783]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [3499ca24-a5fd-11e6-87bb-a0b3ccf7272a]
+    method: GET
+    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1/?api-version=2015-06-01
+  response:
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1/37deaf45e152451fb6948da886476832","kid":"https://cli-test-keyvault-cert.vault.azure.net/keys/pem-cert1/37deaf45e152451fb6948da886476832","sid":"https://cli-test-keyvault-cert.vault.azure.net/secrets/pem-cert1/37deaf45e152451fb6948da886476832","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1478641759,"updated":1478641759},"policy":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1478641759,"updated":1478641759}}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['2163']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 08 Nov 2016 21:49:20 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.783]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [34d1e21c-a5fd-11e6-a039-a0b3ccf7272a]
+    method: GET
+    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1/?api-version=2015-06-01
+  response:
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1/37deaf45e152451fb6948da886476832","kid":"https://cli-test-keyvault-cert.vault.azure.net/keys/pem-cert1/37deaf45e152451fb6948da886476832","sid":"https://cli-test-keyvault-cert.vault.azure.net/secrets/pem-cert1/37deaf45e152451fb6948da886476832","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1478641759,"updated":1478641759},"policy":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1478641759,"updated":1478641759}}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['2163']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 08 Nov 2016 21:49:20 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.783]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [3500881e-a5fd-11e6-8d64-a0b3ccf7272a]
+    method: DELETE
+    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1?api-version=2015-06-01
+  response:
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1/37deaf45e152451fb6948da886476832","kid":"https://cli-test-keyvault-cert.vault.azure.net/keys/pem-cert1/37deaf45e152451fb6948da886476832","sid":"https://cli-test-keyvault-cert.vault.azure.net/secrets/pem-cert1/37deaf45e152451fb6948da886476832","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1478641759,"updated":1478641759},"policy":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1478641759,"updated":1478641759}}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['2163']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 08 Nov 2016 21:49:21 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.783]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJhdHRyaWJ1dGVzIjogeyJlbmFibGVkIjogdHJ1ZX0sICJwb2xpY3kiOiB7ImtleV9wcm9wcyI6
+      IHsia3R5IjogIlJTQSIsICJleHBvcnRhYmxlIjogdHJ1ZSwgImtleV9zaXplIjogMjA0OCwgInJl
+      dXNlX2tleSI6IGZhbHNlfSwgImF0dHJpYnV0ZXMiOiB7ImVuYWJsZWQiOiB0cnVlfSwgInNlY3Jl
+      dF9wcm9wcyI6IHsiY29udGVudFR5cGUiOiAiYXBwbGljYXRpb24veC1wa2NzMTIifSwgImxpZmV0
+      aW1lX2FjdGlvbnMiOiBbeyJ0cmlnZ2VyIjogeyJsaWZldGltZV9wZXJjZW50YWdlIjogOTB9LCAi
+      YWN0aW9uIjogeyJhY3Rpb25fdHlwZSI6ICJBdXRvUmVuZXcifX1dLCAieDUwOV9wcm9wcyI6IHsi
+      a2V5X3VzYWdlIjogWyJkaWdpdGFsU2lnbmF0dXJlIiwgIm5vblJlcHVkaWF0aW9uIiwgImtleUVu
+      Y2lwaGVybWVudCIsICJrZXlBZ3JlZW1lbnQiLCAia2V5Q2VydFNpZ24iXSwgInZhbGlkaXR5X21v
+      bnRocyI6IDYwLCAic3ViamVjdCI6ICJDPVVTLCBTVD1XQSwgTD1SZWRtb24sIE89VGVzdCBOb29k
+      bGUsIE9VPVRlc3ROdWdnZXQsIENOPXd3dy5teXRlc3Rkb21haW4uY29tIn0sICJpc3N1ZXIiOiB7
+      Im5hbWUiOiAiU2VsZiJ9fX0=
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Length: ['587']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [5d5e306c-a14e-11e6-a825-a0b3ccf7272a]
+      x-ms-client-request-id: [355731ca-a5fd-11e6-b1f3-a0b3ccf7272a]
     method: POST
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/create?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMn1He0wxfnBqgfaxKtYSJ2/4A3HHz84LSxxA3PhJB6PjRNgZdHCGTa5REkll+3DEo3vq5cuIAHnFMvNwtzJWzMMKqKNvofOTCxKbD4ZCctbLShWRsAbtxQFhFZNyPcK+pUKDFnivSl1G92zZwOhN9zy5w31Dt19iyVobk7LCbCe+Vb/8eqVAb9gGrTpIwm/1zDR8s7wlwA+XXfrUjDYzagvuHDvbW0Expa57CTaiRBQ1zJ1bpQchImNgYUd8Ke+3guul/tYTFogvk3UQcw3C7nWLxggt8mxpvJcW3lgCoseTg30D1mfjgGE7dLuWR9lX5K4aLdFPw1yRwXJEhsrk9ECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCRPMr8inP7SlCaRpQtIbsQFyKXl8Kb3w49KHg3BDm5K1JOErywzyuNSFbPQUpDpu1ZKNAj+nCRu3L51qqGLVIytrJsit/0HKGelZoJvORwH53FnGE7GqUyTOwpTsZR4DE0rweVjJNcVrwEmoX5bpco5ne3Nbg3pMdWyFHIszEttRX3Zt8euTqqJugt0ummoVpbkXPcE5EnQHK3z4cSSQjp2i8UENUTNnOoXjGHrLCR5c8qbhFneYc3uBW5Zyykv69vJ8/l/EHQzUayuQY/WqkjuyY+c6ODMCKkpmlVNHMi4ZIpJgqq3w38uOaKqLhXLB7/77J0zBqGB/LHdb1n3+E/","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAIuIajEaFqbGZEfDlhXgVNvtECUw3QohaA1ykjNbkn1t5Uz73hyAlKJbWY0IzNMHI4gqt5QoZXBng1nxydDuTgQS1TPJdccUyQgpdMrtMQoaJKJxVnhf7ogww/o1JDZmtQdPhAba11GWWf+WGM6iTDbw0yu+Hk2msjwwvhT+84rtztMlJ0sLQhS53Zz9EQjXvVUR7ieX/IDTLmKEpQ2hbo+FuL5RBOVs1ILhOD0e/TRWOkFRQ5vVOBQxP0t21J2lQxrq0G9ouIBhkBoacVA77QUVyrJ2idOoNSj4on5K1yR+zu4fo0rPcEOCNsH4LExWoNRJGJMrxJEXOPMpv/B5PcECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBMcjmGAJkVS482d148ni1BiIbIUASig28mPuhj9EhmPVEOJIgaz1KEhh3DYx4lc9L1vyp56jbm8cGL5VXa9pks0o47LboVwEOktfzAPMJm9bRAf8P8HAXaQ/xCRbM91lshxJdsCOR6oIw3Wz3hCSXRdCDRLq5P6F9gGrYjxTm3VQMGsi9vghtgpxQ6Z/pa36dNqganmD0rLb1O77f8VARpFhy4eUbS2u3noiNICKphK+i2ajwCY8TgrTe7VIX5vwwXbu2HY33qpXg8jZ7/SwpJIghLfs9uWM2X+IZVC5DbRcZxG7AhKFUhElyxZMVnWgaL6pIqgHNJ75vUSaFHRmCp","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"a1c7557e3ef84fdab0433cbaac91786d"}'}
+        time based on the issuer provider. Please check again later.","request_id":"d1195e5afb0a42549799466b91340656"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['1417']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:47:43 GMT']
+      Date: ['Tue, 08 Nov 2016 21:49:22 GMT']
       Expires: ['-1']
-      Location: ['https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending?api-version=2015-06-01&request_id=a1c7557e3ef84fdab0433cbaac91786d']
+      Location: ['https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending?api-version=2015-06-01&request_id=d1195e5afb0a42549799466b91340656']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000;includeSubDomains]
@@ -43,31 +294,31 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 202, message: Accepted}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [5e823f3e-a14e-11e6-b330-a0b3ccf7272a]
+      x-ms-client-request-id: [364b8324-a5fd-11e6-8062-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMn1He0wxfnBqgfaxKtYSJ2/4A3HHz84LSxxA3PhJB6PjRNgZdHCGTa5REkll+3DEo3vq5cuIAHnFMvNwtzJWzMMKqKNvofOTCxKbD4ZCctbLShWRsAbtxQFhFZNyPcK+pUKDFnivSl1G92zZwOhN9zy5w31Dt19iyVobk7LCbCe+Vb/8eqVAb9gGrTpIwm/1zDR8s7wlwA+XXfrUjDYzagvuHDvbW0Expa57CTaiRBQ1zJ1bpQchImNgYUd8Ke+3guul/tYTFogvk3UQcw3C7nWLxggt8mxpvJcW3lgCoseTg30D1mfjgGE7dLuWR9lX5K4aLdFPw1yRwXJEhsrk9ECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCRPMr8inP7SlCaRpQtIbsQFyKXl8Kb3w49KHg3BDm5K1JOErywzyuNSFbPQUpDpu1ZKNAj+nCRu3L51qqGLVIytrJsit/0HKGelZoJvORwH53FnGE7GqUyTOwpTsZR4DE0rweVjJNcVrwEmoX5bpco5ne3Nbg3pMdWyFHIszEttRX3Zt8euTqqJugt0ummoVpbkXPcE5EnQHK3z4cSSQjp2i8UENUTNnOoXjGHrLCR5c8qbhFneYc3uBW5Zyykv69vJ8/l/EHQzUayuQY/WqkjuyY+c6ODMCKkpmlVNHMi4ZIpJgqq3w38uOaKqLhXLB7/77J0zBqGB/LHdb1n3+E/","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAIuIajEaFqbGZEfDlhXgVNvtECUw3QohaA1ykjNbkn1t5Uz73hyAlKJbWY0IzNMHI4gqt5QoZXBng1nxydDuTgQS1TPJdccUyQgpdMrtMQoaJKJxVnhf7ogww/o1JDZmtQdPhAba11GWWf+WGM6iTDbw0yu+Hk2msjwwvhT+84rtztMlJ0sLQhS53Zz9EQjXvVUR7ieX/IDTLmKEpQ2hbo+FuL5RBOVs1ILhOD0e/TRWOkFRQ5vVOBQxP0t21J2lQxrq0G9ouIBhkBoacVA77QUVyrJ2idOoNSj4on5K1yR+zu4fo0rPcEOCNsH4LExWoNRJGJMrxJEXOPMpv/B5PcECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBMcjmGAJkVS482d148ni1BiIbIUASig28mPuhj9EhmPVEOJIgaz1KEhh3DYx4lc9L1vyp56jbm8cGL5VXa9pks0o47LboVwEOktfzAPMJm9bRAf8P8HAXaQ/xCRbM91lshxJdsCOR6oIw3Wz3hCSXRdCDRLq5P6F9gGrYjxTm3VQMGsi9vghtgpxQ6Z/pa36dNqganmD0rLb1O77f8VARpFhy4eUbS2u3noiNICKphK+i2ajwCY8TgrTe7VIX5vwwXbu2HY33qpXg8jZ7/SwpJIghLfs9uWM2X+IZVC5DbRcZxG7AhKFUhElyxZMVnWgaL6pIqgHNJ75vUSaFHRmCp","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"a1c7557e3ef84fdab0433cbaac91786d"}'}
+        time based on the issuer provider. Please check again later.","request_id":"d1195e5afb0a42549799466b91340656"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['1417']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:47:43 GMT']
+      Date: ['Tue, 08 Nov 2016 21:49:23 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -76,29 +327,29 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [64e23992-a14e-11e6-a48e-a0b3ccf7272a]
+      x-ms-client-request-id: [3c7f83be-a5fd-11e6-b4c8-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMn1He0wxfnBqgfaxKtYSJ2/4A3HHz84LSxxA3PhJB6PjRNgZdHCGTa5REkll+3DEo3vq5cuIAHnFMvNwtzJWzMMKqKNvofOTCxKbD4ZCctbLShWRsAbtxQFhFZNyPcK+pUKDFnivSl1G92zZwOhN9zy5w31Dt19iyVobk7LCbCe+Vb/8eqVAb9gGrTpIwm/1zDR8s7wlwA+XXfrUjDYzagvuHDvbW0Expa57CTaiRBQ1zJ1bpQchImNgYUd8Ke+3guul/tYTFogvk3UQcw3C7nWLxggt8mxpvJcW3lgCoseTg30D1mfjgGE7dLuWR9lX5K4aLdFPw1yRwXJEhsrk9ECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCRPMr8inP7SlCaRpQtIbsQFyKXl8Kb3w49KHg3BDm5K1JOErywzyuNSFbPQUpDpu1ZKNAj+nCRu3L51qqGLVIytrJsit/0HKGelZoJvORwH53FnGE7GqUyTOwpTsZR4DE0rweVjJNcVrwEmoX5bpco5ne3Nbg3pMdWyFHIszEttRX3Zt8euTqqJugt0ummoVpbkXPcE5EnQHK3z4cSSQjp2i8UENUTNnOoXjGHrLCR5c8qbhFneYc3uBW5Zyykv69vJ8/l/EHQzUayuQY/WqkjuyY+c6ODMCKkpmlVNHMi4ZIpJgqq3w38uOaKqLhXLB7/77J0zBqGB/LHdb1n3+E/","cancellation_requested":false,"status":"completed","target":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1","request_id":"a1c7557e3ef84fdab0433cbaac91786d"}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIDBTCCAe0CAQAwdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAIuIajEaFqbGZEfDlhXgVNvtECUw3QohaA1ykjNbkn1t5Uz73hyAlKJbWY0IzNMHI4gqt5QoZXBng1nxydDuTgQS1TPJdccUyQgpdMrtMQoaJKJxVnhf7ogww/o1JDZmtQdPhAba11GWWf+WGM6iTDbw0yu+Hk2msjwwvhT+84rtztMlJ0sLQhS53Zz9EQjXvVUR7ieX/IDTLmKEpQ2hbo+FuL5RBOVs1ILhOD0e/TRWOkFRQ5vVOBQxP0t21J2lQxrq0G9ouIBhkBoacVA77QUVyrJ2idOoNSj4on5K1yR+zu4fo0rPcEOCNsH4LExWoNRJGJMrxJEXOPMpv/B5PcECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBMcjmGAJkVS482d148ni1BiIbIUASig28mPuhj9EhmPVEOJIgaz1KEhh3DYx4lc9L1vyp56jbm8cGL5VXa9pks0o47LboVwEOktfzAPMJm9bRAf8P8HAXaQ/xCRbM91lshxJdsCOR6oIw3Wz3hCSXRdCDRLq5P6F9gGrYjxTm3VQMGsi9vghtgpxQ6Z/pa36dNqganmD0rLb1O77f8VARpFhy4eUbS2u3noiNICKphK+i2ajwCY8TgrTe7VIX5vwwXbu2HY33qpXg8jZ7/SwpJIghLfs9uWM2X+IZVC5DbRcZxG7AhKFUhElyxZMVnWgaL6pIqgHNJ75vUSaFHRmCp","cancellation_requested":false,"status":"completed","target":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1","request_id":"d1195e5afb0a42549799466b91340656"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['1329']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:47:53 GMT']
+      Date: ['Tue, 08 Nov 2016 21:49:34 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -107,29 +358,29 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [650ef170-a14e-11e6-a117-a0b3ccf7272a]
+      x-ms-client-request-id: [3cdc6e98-a5fd-11e6-9432-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates?api-version=2015-06-01
   response:
-    body: {string: '{"value":[{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1","x5t":"mV2oNVytNpKK2fM31oGcpN_j6jE","attributes":{"enabled":true,"nbf":1478126272,"exp":1635893272,"created":1478126872,"updated":1478126872}}],"nextLink":null}'}
+    body: {string: '{"value":[{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1","x5t":"Q8W3tDCurhbS-lhEbo3-Hb60c8o","attributes":{"enabled":true,"nbf":1478641173,"exp":1636408173,"created":1478641773,"updated":1478641773}}],"nextLink":null}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['244']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:47:56 GMT']
+      Date: ['Tue, 08 Nov 2016 21:49:34 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -138,45 +389,45 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJhdHRyaWJ1dGVzIjogeyJlbmFibGVkIjogdHJ1ZX0sICJwb2xpY3kiOiB7ImF0dHJpYnV0ZXMi
-      OiB7ImVuYWJsZWQiOiB0cnVlfSwgImlzc3VlciI6IHsibmFtZSI6ICJTZWxmIn0sICJrZXlfcHJv
-      cHMiOiB7ImV4cG9ydGFibGUiOiB0cnVlLCAia3R5IjogIlJTQSIsICJyZXVzZV9rZXkiOiBmYWxz
-      ZSwgImtleV9zaXplIjogMjA0OH0sICJzZWNyZXRfcHJvcHMiOiB7ImNvbnRlbnRUeXBlIjogImFw
-      cGxpY2F0aW9uL3gtcGtjczEyIn0sICJ4NTA5X3Byb3BzIjogeyJrZXlfdXNhZ2UiOiBbImRpZ2l0
-      YWxTaWduYXR1cmUiLCAibm9uUmVwdWRpYXRpb24iLCAia2V5RW5jaXBoZXJtZW50IiwgImtleUFn
-      cmVlbWVudCIsICJrZXlDZXJ0U2lnbiJdLCAic3ViamVjdCI6ICJDPVVTLCBTVD1XQSwgTD1SZWRt
-      b25kLCBPPVRlc3RPLCBPVT1UZXN0T1UsIENOPXd3dy5teXRlc3Rkb21haW4uY29tIiwgInZhbGlk
-      aXR5X21vbnRocyI6IDUwfSwgImxpZmV0aW1lX2FjdGlvbnMiOiBbeyJ0cmlnZ2VyIjogeyJsaWZl
-      dGltZV9wZXJjZW50YWdlIjogOTB9LCAiYWN0aW9uIjogeyJhY3Rpb25fdHlwZSI6ICJBdXRvUmVu
-      ZXcifX1dfX0=
+      eyJhdHRyaWJ1dGVzIjogeyJlbmFibGVkIjogdHJ1ZX0sICJwb2xpY3kiOiB7ImtleV9wcm9wcyI6
+      IHsia3R5IjogIlJTQSIsICJleHBvcnRhYmxlIjogdHJ1ZSwgImtleV9zaXplIjogMjA0OCwgInJl
+      dXNlX2tleSI6IGZhbHNlfSwgImF0dHJpYnV0ZXMiOiB7ImVuYWJsZWQiOiB0cnVlfSwgInNlY3Jl
+      dF9wcm9wcyI6IHsiY29udGVudFR5cGUiOiAiYXBwbGljYXRpb24veC1wa2NzMTIifSwgImxpZmV0
+      aW1lX2FjdGlvbnMiOiBbeyJ0cmlnZ2VyIjogeyJsaWZldGltZV9wZXJjZW50YWdlIjogOTB9LCAi
+      YWN0aW9uIjogeyJhY3Rpb25fdHlwZSI6ICJBdXRvUmVuZXcifX1dLCAieDUwOV9wcm9wcyI6IHsi
+      a2V5X3VzYWdlIjogWyJkaWdpdGFsU2lnbmF0dXJlIiwgIm5vblJlcHVkaWF0aW9uIiwgImtleUVu
+      Y2lwaGVybWVudCIsICJrZXlBZ3JlZW1lbnQiLCAia2V5Q2VydFNpZ24iXSwgInZhbGlkaXR5X21v
+      bnRocyI6IDUwLCAic3ViamVjdCI6ICJDPVVTLCBTVD1XQSwgTD1SZWRtb25kLCBPPVRlc3RPLCBP
+      VT1UZXN0T1UsIENOPXd3dy5teXRlc3Rkb21haW4uY29tIn0sICJpc3N1ZXIiOiB7Im5hbWUiOiAi
+      U2VsZiJ9fX0=
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Length: ['578']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [6534e078-a14e-11e6-8533-a0b3ccf7272a]
+      x-ms-client-request-id: [3d04fc58-a5fd-11e6-b67b-a0b3ccf7272a]
     method: POST
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/create?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOJWappPwEMTtMpv3rdt4YQWTazWm0RHhO9dBaDVQ18ciTVeXtpDX5+xQ0fwD3YPobSko7rtnbz9LyLX60zY5bIAJv0ZjQ5Hjv293PV+c7fzM5U69m1nCrGMq6TFO1m/kWmrSh8Y/Pe3sm3rxHSs7LEP4DZ0PaNcEcB+rOgBYa04brO4inBf52QNAuxexG9/zspJ85nHpiGKKX9aL+NhJT+y9+sxD36sgqbeowRwakH+f+N5K0xYAqrhywxfYX4OtaAP4Wnhhfm58rEl1LC9pED/yb5sX6mSIRq0bay8hsAb5e1cJFkdC4e0ycI8QBCeIXc+hC9K2JqwOJIYshMR5h0CAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBp8FNV044SyMggZ4jCQLXvlOwqgLSbNKcrc42YF0I0nECElkhVQ2EJVEqj7JvuQn0Km0cHPQwHkTF4x9MVkJBQRTt6UodQpcBkK4HokUvYnxoNuv1orZqOh54YUuCMk4nh1EoW5K+jnFoLiiX0vqZna/llsHfyTtqbmPelfmiJGSKmwqAODktwyDTNrgH3wfi2i/fOllmG3h3zbLK/L/uR05dKKuHnYbqx51v+lX1B2sJygOTBc1DDcm6XlVGx77nGO78cKq2e8VFuMRI0qcWt8I1frndF049BgYzeJiSn5ly16kHGJMGHekXsjZVSPlALVz3kzsI46Qt/sJvfjYIS","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALsUb7nx5WLqwEj/UUe2kGKa2Y9gJVGwMj3+ezJpFlSjrKColnjxAwiKJaZ9X8B0VwB8jzartYQPwrEmnWxQLriOjdxIP++aYWGSuzARgc+7kIqF05n9UJ2F0IRmBq7t5e4e1EHs9g1pIfrHFDDcj3qarmny+cDbZA57d2C7TsHlEIo/W2L5tGzRyE6zzeclqErpf8NHI6mxWTL3BZ20nV9aHlRJH59ZabJBpgneUH5RUtYnVC7eJQ7dGjHWEb14BZaVe8cYGCZPM5V+r6E5foqyyYP11xY7LRGo+T+ABgLJRwOeT1lYiaErbA5zUzF/K6BHFpV1DbOM6uUL4px7HfcCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBd3Nanc1Cxd4vNNbCoBtrFoQD3I97DkbKgb2tX8WlQrY9pkqQouCENvkJyKG+qsBOzRSydBSgz038fW1gjnV4gmW4x8WN1es43nLuGRt3kcOb3M9msuXoSPiApwqWwtwy8zx1pANOlJx5Kz1B8zisxQfu2uaaJHP9iWklU+hN934F8MLGK6azvrtcz4cN6tRBHlsFwhJsEZ13iyqFMoEREgIQg/On2jZgI9qjNND0pOo8wY8dShuK4OuWMiUXS90ohmupqoVcyBPlXuNZIn6k6QK8lkcz4qq5mY+iySEavUCFYe4IdDnrm6L1vB+YEQSR+o0Rw8+xn5tZvkwIRUep4","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"b13c07a6f4a54be0a642c3b11bd17433"}'}
+        time based on the issuer provider. Please check again later.","request_id":"47fe7f1103d9402bb054f3f72a933d7f"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['1405']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:47:55 GMT']
+      Date: ['Tue, 08 Nov 2016 21:49:35 GMT']
       Expires: ['-1']
-      Location: ['https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending?api-version=2015-06-01&request_id=b13c07a6f4a54be0a642c3b11bd17433']
+      Location: ['https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending?api-version=2015-06-01&request_id=47fe7f1103d9402bb054f3f72a933d7f']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000;includeSubDomains]
@@ -184,31 +435,31 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 202, message: Accepted}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [66159bf8-a14e-11e6-a9ba-a0b3ccf7272a]
+      x-ms-client-request-id: [3dd64fde-a5fd-11e6-a3db-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOJWappPwEMTtMpv3rdt4YQWTazWm0RHhO9dBaDVQ18ciTVeXtpDX5+xQ0fwD3YPobSko7rtnbz9LyLX60zY5bIAJv0ZjQ5Hjv293PV+c7fzM5U69m1nCrGMq6TFO1m/kWmrSh8Y/Pe3sm3rxHSs7LEP4DZ0PaNcEcB+rOgBYa04brO4inBf52QNAuxexG9/zspJ85nHpiGKKX9aL+NhJT+y9+sxD36sgqbeowRwakH+f+N5K0xYAqrhywxfYX4OtaAP4Wnhhfm58rEl1LC9pED/yb5sX6mSIRq0bay8hsAb5e1cJFkdC4e0ycI8QBCeIXc+hC9K2JqwOJIYshMR5h0CAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBp8FNV044SyMggZ4jCQLXvlOwqgLSbNKcrc42YF0I0nECElkhVQ2EJVEqj7JvuQn0Km0cHPQwHkTF4x9MVkJBQRTt6UodQpcBkK4HokUvYnxoNuv1orZqOh54YUuCMk4nh1EoW5K+jnFoLiiX0vqZna/llsHfyTtqbmPelfmiJGSKmwqAODktwyDTNrgH3wfi2i/fOllmG3h3zbLK/L/uR05dKKuHnYbqx51v+lX1B2sJygOTBc1DDcm6XlVGx77nGO78cKq2e8VFuMRI0qcWt8I1frndF049BgYzeJiSn5ly16kHGJMGHekXsjZVSPlALVz3kzsI46Qt/sJvfjYIS","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALsUb7nx5WLqwEj/UUe2kGKa2Y9gJVGwMj3+ezJpFlSjrKColnjxAwiKJaZ9X8B0VwB8jzartYQPwrEmnWxQLriOjdxIP++aYWGSuzARgc+7kIqF05n9UJ2F0IRmBq7t5e4e1EHs9g1pIfrHFDDcj3qarmny+cDbZA57d2C7TsHlEIo/W2L5tGzRyE6zzeclqErpf8NHI6mxWTL3BZ20nV9aHlRJH59ZabJBpgneUH5RUtYnVC7eJQ7dGjHWEb14BZaVe8cYGCZPM5V+r6E5foqyyYP11xY7LRGo+T+ABgLJRwOeT1lYiaErbA5zUzF/K6BHFpV1DbOM6uUL4px7HfcCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBd3Nanc1Cxd4vNNbCoBtrFoQD3I97DkbKgb2tX8WlQrY9pkqQouCENvkJyKG+qsBOzRSydBSgz038fW1gjnV4gmW4x8WN1es43nLuGRt3kcOb3M9msuXoSPiApwqWwtwy8zx1pANOlJx5Kz1B8zisxQfu2uaaJHP9iWklU+hN934F8MLGK6azvrtcz4cN6tRBHlsFwhJsEZ13iyqFMoEREgIQg/On2jZgI9qjNND0pOo8wY8dShuK4OuWMiUXS90ohmupqoVcyBPlXuNZIn6k6QK8lkcz4qq5mY+iySEavUCFYe4IdDnrm6L1vB+YEQSR+o0Rw8+xn5tZvkwIRUep4","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"b13c07a6f4a54be0a642c3b11bd17433"}'}
+        time based on the issuer provider. Please check again later.","request_id":"47fe7f1103d9402bb054f3f72a933d7f"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['1405']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:47:56 GMT']
+      Date: ['Tue, 08 Nov 2016 21:49:35 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -217,31 +468,31 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [6c386812-a14e-11e6-8274-a0b3ccf7272a]
+      x-ms-client-request-id: [43ee668a-a5fd-11e6-9ef6-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOJWappPwEMTtMpv3rdt4YQWTazWm0RHhO9dBaDVQ18ciTVeXtpDX5+xQ0fwD3YPobSko7rtnbz9LyLX60zY5bIAJv0ZjQ5Hjv293PV+c7fzM5U69m1nCrGMq6TFO1m/kWmrSh8Y/Pe3sm3rxHSs7LEP4DZ0PaNcEcB+rOgBYa04brO4inBf52QNAuxexG9/zspJ85nHpiGKKX9aL+NhJT+y9+sxD36sgqbeowRwakH+f+N5K0xYAqrhywxfYX4OtaAP4Wnhhfm58rEl1LC9pED/yb5sX6mSIRq0bay8hsAb5e1cJFkdC4e0ycI8QBCeIXc+hC9K2JqwOJIYshMR5h0CAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBp8FNV044SyMggZ4jCQLXvlOwqgLSbNKcrc42YF0I0nECElkhVQ2EJVEqj7JvuQn0Km0cHPQwHkTF4x9MVkJBQRTt6UodQpcBkK4HokUvYnxoNuv1orZqOh54YUuCMk4nh1EoW5K+jnFoLiiX0vqZna/llsHfyTtqbmPelfmiJGSKmwqAODktwyDTNrgH3wfi2i/fOllmG3h3zbLK/L/uR05dKKuHnYbqx51v+lX1B2sJygOTBc1DDcm6XlVGx77nGO78cKq2e8VFuMRI0qcWt8I1frndF049BgYzeJiSn5ly16kHGJMGHekXsjZVSPlALVz3kzsI46Qt/sJvfjYIS","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALsUb7nx5WLqwEj/UUe2kGKa2Y9gJVGwMj3+ezJpFlSjrKColnjxAwiKJaZ9X8B0VwB8jzartYQPwrEmnWxQLriOjdxIP++aYWGSuzARgc+7kIqF05n9UJ2F0IRmBq7t5e4e1EHs9g1pIfrHFDDcj3qarmny+cDbZA57d2C7TsHlEIo/W2L5tGzRyE6zzeclqErpf8NHI6mxWTL3BZ20nV9aHlRJH59ZabJBpgneUH5RUtYnVC7eJQ7dGjHWEb14BZaVe8cYGCZPM5V+r6E5foqyyYP11xY7LRGo+T+ABgLJRwOeT1lYiaErbA5zUzF/K6BHFpV1DbOM6uUL4px7HfcCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBd3Nanc1Cxd4vNNbCoBtrFoQD3I97DkbKgb2tX8WlQrY9pkqQouCENvkJyKG+qsBOzRSydBSgz038fW1gjnV4gmW4x8WN1es43nLuGRt3kcOb3M9msuXoSPiApwqWwtwy8zx1pANOlJx5Kz1B8zisxQfu2uaaJHP9iWklU+hN934F8MLGK6azvrtcz4cN6tRBHlsFwhJsEZ13iyqFMoEREgIQg/On2jZgI9qjNND0pOo8wY8dShuK4OuWMiUXS90ohmupqoVcyBPlXuNZIn6k6QK8lkcz4qq5mY+iySEavUCFYe4IdDnrm6L1vB+YEQSR+o0Rw8+xn5tZvkwIRUep4","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"b13c07a6f4a54be0a642c3b11bd17433"}'}
+        time based on the issuer provider. Please check again later.","request_id":"47fe7f1103d9402bb054f3f72a933d7f"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['1405']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:07 GMT']
+      Date: ['Tue, 08 Nov 2016 21:49:46 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -250,29 +501,29 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [72535ab0-a14e-11e6-b1b4-a0b3ccf7272a]
+      x-ms-client-request-id: [4a086e1c-a5fd-11e6-9ff6-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOJWappPwEMTtMpv3rdt4YQWTazWm0RHhO9dBaDVQ18ciTVeXtpDX5+xQ0fwD3YPobSko7rtnbz9LyLX60zY5bIAJv0ZjQ5Hjv293PV+c7fzM5U69m1nCrGMq6TFO1m/kWmrSh8Y/Pe3sm3rxHSs7LEP4DZ0PaNcEcB+rOgBYa04brO4inBf52QNAuxexG9/zspJ85nHpiGKKX9aL+NhJT+y9+sxD36sgqbeowRwakH+f+N5K0xYAqrhywxfYX4OtaAP4Wnhhfm58rEl1LC9pED/yb5sX6mSIRq0bay8hsAb5e1cJFkdC4e0ycI8QBCeIXc+hC9K2JqwOJIYshMR5h0CAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBp8FNV044SyMggZ4jCQLXvlOwqgLSbNKcrc42YF0I0nECElkhVQ2EJVEqj7JvuQn0Km0cHPQwHkTF4x9MVkJBQRTt6UodQpcBkK4HokUvYnxoNuv1orZqOh54YUuCMk4nh1EoW5K+jnFoLiiX0vqZna/llsHfyTtqbmPelfmiJGSKmwqAODktwyDTNrgH3wfi2i/fOllmG3h3zbLK/L/uR05dKKuHnYbqx51v+lX1B2sJygOTBc1DDcm6XlVGx77nGO78cKq2e8VFuMRI0qcWt8I1frndF049BgYzeJiSn5ly16kHGJMGHekXsjZVSPlALVz3kzsI46Qt/sJvfjYIS","cancellation_requested":false,"status":"completed","target":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1","request_id":"b13c07a6f4a54be0a642c3b11bd17433"}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending","issuer":{"name":"Self"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALsUb7nx5WLqwEj/UUe2kGKa2Y9gJVGwMj3+ezJpFlSjrKColnjxAwiKJaZ9X8B0VwB8jzartYQPwrEmnWxQLriOjdxIP++aYWGSuzARgc+7kIqF05n9UJ2F0IRmBq7t5e4e1EHs9g1pIfrHFDDcj3qarmny+cDbZA57d2C7TsHlEIo/W2L5tGzRyE6zzeclqErpf8NHI6mxWTL3BZ20nV9aHlRJH59ZabJBpgneUH5RUtYnVC7eJQ7dGjHWEb14BZaVe8cYGCZPM5V+r6E5foqyyYP11xY7LRGo+T+ABgLJRwOeT1lYiaErbA5zUzF/K6BHFpV1DbOM6uUL4px7HfcCAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBd3Nanc1Cxd4vNNbCoBtrFoQD3I97DkbKgb2tX8WlQrY9pkqQouCENvkJyKG+qsBOzRSydBSgz038fW1gjnV4gmW4x8WN1es43nLuGRt3kcOb3M9msuXoSPiApwqWwtwy8zx1pANOlJx5Kz1B8zisxQfu2uaaJHP9iWklU+hN934F8MLGK6azvrtcz4cN6tRBHlsFwhJsEZ13iyqFMoEREgIQg/On2jZgI9qjNND0pOo8wY8dShuK4OuWMiUXS90ohmupqoVcyBPlXuNZIn6k6QK8lkcz4qq5mY+iySEavUCFYe4IdDnrm6L1vB+YEQSR+o0Rw8+xn5tZvkwIRUep4","cancellation_requested":false,"status":"completed","target":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1","request_id":"47fe7f1103d9402bb054f3f72a933d7f"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['1317']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:18 GMT']
+      Date: ['Tue, 08 Nov 2016 21:49:57 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -281,29 +532,29 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [731680a4-a14e-11e6-bf56-a0b3ccf7272a]
+      x-ms-client-request-id: [4a32d540-a5fd-11e6-856a-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/versions?api-version=2015-06-01
   response:
-    body: {string: '{"value":[{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/10f45a6a707e41f1b7ecfa7ee88030f8","x5t":"mj1fuTf9omfkTefinFUIxqD5vus","attributes":{"enabled":true,"nbf":1478126288,"exp":1609627688,"created":1478126888,"updated":1478126888}},{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/f97a4bf643da4bf3aa4c197219c88052","x5t":"mV2oNVytNpKK2fM31oGcpN_j6jE","attributes":{"enabled":true,"nbf":1478126272,"exp":1635893272,"created":1478126872,"updated":1478126872}}],"nextLink":null}'}
+    body: {string: '{"value":[{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/1da780c3692d4a87bb1e7830692ce9f5","x5t":"Q8W3tDCurhbS-lhEbo3-Hb60c8o","attributes":{"enabled":true,"nbf":1478641173,"exp":1636408173,"created":1478641773,"updated":1478641773}},{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/44dc3eba46d94d569f485465e0e51ce5","x5t":"muO0ox2wmAH7A5X6N-6WPZgS8_o","attributes":{"enabled":true,"nbf":1478641188,"exp":1610142588,"created":1478641788,"updated":1478641788}}],"nextLink":null}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['527']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:17 GMT']
+      Date: ['Tue, 08 Nov 2016 21:49:57 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -312,30 +563,30 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [734ffed2-a14e-11e6-984d-a0b3ccf7272a]
+      x-ms-client-request-id: [4a63d7c8-a5fd-11e6-9f62-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/10f45a6a707e41f1b7ecfa7ee88030f8","kid":"https://cli-test-keyvault-cert.vault.azure.net/keys/cert1/10f45a6a707e41f1b7ecfa7ee88030f8","sid":"https://cli-test-keyvault-cert.vault.azure.net/secrets/cert1/10f45a6a707e41f1b7ecfa7ee88030f8","x5t":"mj1fuTf9omfkTefinFUIxqD5vus","cer":"MIID3jCCAsagAwIBAgIQYVoYSlmBTbu2JbL++2zAwzANBgkqhkiG9w0BAQsFADBsMR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTEPMA0GA1UECxMGVGVzdE9VMQ4wDAYDVQQKEwVUZXN0TzEQMA4GA1UEBxMHUmVkbW9uZDELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE2MTEwMjIyMzgwOFoXDTIxMDEwMjIyNDgwOFowbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOJWappPwEMTtMpv3rdt4YQWTazWm0RHhO9dBaDVQ18ciTVeXtpDX5+xQ0fwD3YPobSko7rtnbz9LyLX60zY5bIAJv0ZjQ5Hjv293PV+c7fzM5U69m1nCrGMq6TFO1m/kWmrSh8Y/Pe3sm3rxHSs7LEP4DZ0PaNcEcB+rOgBYa04brO4inBf52QNAuxexG9/zspJ85nHpiGKKX9aL+NhJT+y9+sxD36sgqbeowRwakH+f+N5K0xYAqrhywxfYX4OtaAP4Wnhhfm58rEl1LC9pED/yb5sX6mSIRq0bay8hsAb5e1cJFkdC4e0ycI8QBCeIXc+hC9K2JqwOJIYshMR5h0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFH9vj6HbLIHF5jf7JzHtd7FiggrkMB0GA1UdDgQWBBR/b4+h2yyBxeY3+ycx7XexYoIK5DANBgkqhkiG9w0BAQsFAAOCAQEAb4Y8ITRskExg/4k/GXVPW+Z1MkNRVBwQc7/C0lHvuc7T6s4MwYZqmng14eWssHSKLnV1MsGxj6CewxLwtvrAprzkSu/dQyh1MhAC+nuikmWJTw5dNzFypW9CXw1/JxfxPy7IIDAvtBvazP4sF9Gp0MbUW2jRMFFfejl7+lGMHUSl8PNEQwiIXTey2w5LV5UXkh2hVyPzjOXu3XodtLoNeEggGawiWeNPu22CxiJSqv/e2zCa0x/+DkmoQmbqE4ZiFsOuK+Vr6FukdBHd02y9Q2QeOzfaJgAXplX7BZ7mFKi++10+340g2mtRFDoAWfRjj+OpCX1LAyGyXLLJLX2URg==","attributes":{"enabled":true,"nbf":1478126288,"exp":1609627688,"created":1478126888,"updated":1478126888},"policy":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"C=US,
-        ST=WA, L=Redmond, O=TestO, OU=TestOU, CN=www.mytestdomain.com","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyAgreement","keyCertSign","keyEncipherment","nonRepudiation"],"validity_months":50,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1478126863,"updated":1478126875}},"pending":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending"}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/44dc3eba46d94d569f485465e0e51ce5","kid":"https://cli-test-keyvault-cert.vault.azure.net/keys/cert1/44dc3eba46d94d569f485465e0e51ce5","sid":"https://cli-test-keyvault-cert.vault.azure.net/secrets/cert1/44dc3eba46d94d569f485465e0e51ce5","x5t":"muO0ox2wmAH7A5X6N-6WPZgS8_o","cer":"MIID3jCCAsagAwIBAgIQEHlxt9PCQqGZ36TRMETHvjANBgkqhkiG9w0BAQsFADBsMR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTEPMA0GA1UECxMGVGVzdE9VMQ4wDAYDVQQKEwVUZXN0TzEQMA4GA1UEBxMHUmVkbW9uZDELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE2MTEwODIxMzk0OFoXDTIxMDEwODIxNDk0OFowbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALsUb7nx5WLqwEj/UUe2kGKa2Y9gJVGwMj3+ezJpFlSjrKColnjxAwiKJaZ9X8B0VwB8jzartYQPwrEmnWxQLriOjdxIP++aYWGSuzARgc+7kIqF05n9UJ2F0IRmBq7t5e4e1EHs9g1pIfrHFDDcj3qarmny+cDbZA57d2C7TsHlEIo/W2L5tGzRyE6zzeclqErpf8NHI6mxWTL3BZ20nV9aHlRJH59ZabJBpgneUH5RUtYnVC7eJQ7dGjHWEb14BZaVe8cYGCZPM5V+r6E5foqyyYP11xY7LRGo+T+ABgLJRwOeT1lYiaErbA5zUzF/K6BHFpV1DbOM6uUL4px7HfcCAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFEDdGHa8w8PpASuPso+qXG6Huj3cMB0GA1UdDgQWBBRA3Rh2vMPD6QErj7KPqlxuh7o93DANBgkqhkiG9w0BAQsFAAOCAQEAquSzZhKeZ61jzg2nRkB0aLdfUfes1a7LJ8XhgMOJDUnDKizPRRUdjtf6GoIJ6Ub8To7f3QF0f3ideYohDRl1WzBL7X1K7vd4VNiqDlyfRgfLfU1mrEv4foYsWUgvjxTtZoSVWMDXOS1Lv8bVyEyWeW6raThZD9ylYKKtnC4rKP7Tx6A5wDWxkRHO6Nt8bwZB9z/a/CTfVY2jvRzzxZ46P4qR0Nbesmjua6FDyfjzNcLT4UOoTiViUQRth33p0gKOLv0dAfnR+eknScExN1YdMeGoN9M7OyeA9nCvM1i4nvyhonmzfpaWidvM0qbtP50MXi2oc5jVsmPAA7SSQ9qEbw==","attributes":{"enabled":true,"nbf":1478641188,"exp":1610142588,"created":1478641788,"updated":1478641788},"policy":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"C=US,
+        ST=WA, L=Redmond, O=TestO, OU=TestOU, CN=www.mytestdomain.com","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyAgreement","keyCertSign","keyEncipherment","nonRepudiation"],"validity_months":50,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1478641763,"updated":1478641775}},"pending":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['2592']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:18 GMT']
+      Date: ['Tue, 08 Nov 2016 21:49:56 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -344,29 +595,29 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [737d583e-a14e-11e6-9d78-a0b3ccf7272a]
+      x-ms-client-request-id: [4a902f02-a5fd-11e6-81b7-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/f97a4bf643da4bf3aa4c197219c88052?api-version=2015-06-01
+    uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/1da780c3692d4a87bb1e7830692ce9f5?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/f97a4bf643da4bf3aa4c197219c88052","kid":"https://cli-test-keyvault-cert.vault.azure.net/keys/cert1/f97a4bf643da4bf3aa4c197219c88052","sid":"https://cli-test-keyvault-cert.vault.azure.net/secrets/cert1/f97a4bf643da4bf3aa4c197219c88052","x5t":"mV2oNVytNpKK2fM31oGcpN_j6jE","cer":"MIID8DCCAtigAwIBAgIQZiFb1AM/Q9WjAViTZ9aJIDANBgkqhkiG9w0BAQsFADB1MR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTETMBEGA1UECxMKVGVzdE51Z2dldDEUMBIGA1UEChMLVGVzdCBOb29kbGUxDzANBgNVBAcTBlJlZG1vbjELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE2MTEwMjIyMzc1MloXDTIxMTEwMjIyNDc1MlowdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMn1He0wxfnBqgfaxKtYSJ2/4A3HHz84LSxxA3PhJB6PjRNgZdHCGTa5REkll+3DEo3vq5cuIAHnFMvNwtzJWzMMKqKNvofOTCxKbD4ZCctbLShWRsAbtxQFhFZNyPcK+pUKDFnivSl1G92zZwOhN9zy5w31Dt19iyVobk7LCbCe+Vb/8eqVAb9gGrTpIwm/1zDR8s7wlwA+XXfrUjDYzagvuHDvbW0Expa57CTaiRBQ1zJ1bpQchImNgYUd8Ke+3guul/tYTFogvk3UQcw3C7nWLxggt8mxpvJcW3lgCoseTg30D1mfjgGE7dLuWR9lX5K4aLdFPw1yRwXJEhsrk9ECAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFE3h9P2kz3JDxnLk4kefA7z1xelEMB0GA1UdDgQWBBRN4fT9pM9yQ8Zy5OJHnwO89cXpRDANBgkqhkiG9w0BAQsFAAOCAQEAM4P23cupKI5be9e7g6zd4KYQB6N0xT6GVFxYwOiAdYTQsp3BflGYiWxay90gCPcQx3EggzBmZh0/RyKQlGRRbcuZMStE48cuCFN1lTUdW5q8k884z5XgjDPxPJ5yo2YVoN5c8pwaEsQP37b5gR/3ke9mzwbulU/ZUw/VHpAoLWJRbK9kIXNBpQcydbN/KaPZMpHyHsVSluksi/zuA4SfBU91VldMHJqxfxMAMFRMbHxEsS2HBroe854Qj8b6gyQSsoAT9uzsiIAZ0soaMUlHcpsHxS8buO8HoyFW9scJqcDU5VLgwQ+I7BGTNSfEArHCYTlIfkWatY0x3NzbRJFwqw==","attributes":{"enabled":true,"nbf":1478126272,"exp":1635893272,"created":1478126872,"updated":1478126872}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/1da780c3692d4a87bb1e7830692ce9f5","kid":"https://cli-test-keyvault-cert.vault.azure.net/keys/cert1/1da780c3692d4a87bb1e7830692ce9f5","sid":"https://cli-test-keyvault-cert.vault.azure.net/secrets/cert1/1da780c3692d4a87bb1e7830692ce9f5","x5t":"Q8W3tDCurhbS-lhEbo3-Hb60c8o","cer":"MIID8DCCAtigAwIBAgIQaptdVSjdT/OKyU7BbA+iaTANBgkqhkiG9w0BAQsFADB1MR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTETMBEGA1UECxMKVGVzdE51Z2dldDEUMBIGA1UEChMLVGVzdCBOb29kbGUxDzANBgNVBAcTBlJlZG1vbjELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE2MTEwODIxMzkzM1oXDTIxMTEwODIxNDkzM1owdTEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xEzARBgNVBAsTClRlc3ROdWdnZXQxFDASBgNVBAoTC1Rlc3QgTm9vZGxlMQ8wDQYDVQQHEwZSZWRtb24xCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAIuIajEaFqbGZEfDlhXgVNvtECUw3QohaA1ykjNbkn1t5Uz73hyAlKJbWY0IzNMHI4gqt5QoZXBng1nxydDuTgQS1TPJdccUyQgpdMrtMQoaJKJxVnhf7ogww/o1JDZmtQdPhAba11GWWf+WGM6iTDbw0yu+Hk2msjwwvhT+84rtztMlJ0sLQhS53Zz9EQjXvVUR7ieX/IDTLmKEpQ2hbo+FuL5RBOVs1ILhOD0e/TRWOkFRQ5vVOBQxP0t21J2lQxrq0G9ouIBhkBoacVA77QUVyrJ2idOoNSj4on5K1yR+zu4fo0rPcEOCNsH4LExWoNRJGJMrxJEXOPMpv/B5PcECAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFA3hjjSJ18lxqQwHaj24WnnvY+n0MB0GA1UdDgQWBBQN4Y40idfJcakMB2o9uFp572Pp9DANBgkqhkiG9w0BAQsFAAOCAQEAKfqnkb6vF8u2SxpRZTUHuSoV93eSiGtMj/+CtUfbiYVjIe2qyuGSGLOO/4mBOPepF0+yaAMbSkun87VKbCTiEmA0U2ls2ccOiGFaX3pY2wiIySGn+7HpV4ey/rH28uBwZMyAwNDMLVBa1sl4qajJOoV7HK3+9UYyUeM6aBOquP1+rpn8qdRWh5MnCqZ5EomwLOXmLp/mKtw6pZzJ8M4I04N2V+20BGiPpQ6FZd6nL1mb2yeI2Lm3zeA+KEcLFltqW1VUx5wKiRtPfA+PsXBngWI6WECUzWTS7kFCS8FyktSY/s6drKuWknyvA6zxJ4tddMBOcgYWro5/n79h6J79Ug==","attributes":{"enabled":true,"nbf":1478641173,"exp":1636408173,"created":1478641773,"updated":1478641773}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['1811']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:21 GMT']
+      Date: ['Tue, 08 Nov 2016 21:49:57 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -375,42 +626,42 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJhdHRyaWJ1dGVzIjogeyJlbmFibGVkIjogZmFsc2V9LCAicG9saWN5IjogeyJhdHRyaWJ1dGVz
-      IjogeyJlbmFibGVkIjogdHJ1ZX0sICJpc3N1ZXIiOiB7Im5hbWUiOiAiU2VsZiJ9LCAia2V5X3By
-      b3BzIjogeyJleHBvcnRhYmxlIjogdHJ1ZSwgImt0eSI6ICJSU0EiLCAicmV1c2Vfa2V5IjogZmFs
-      c2UsICJrZXlfc2l6ZSI6IDIwNDh9LCAic2VjcmV0X3Byb3BzIjogeyJjb250ZW50VHlwZSI6ICJh
-      cHBsaWNhdGlvbi94LXBrY3MxMiJ9LCAieDUwOV9wcm9wcyI6IHsia2V5X3VzYWdlIjogWyJkaWdp
-      dGFsU2lnbmF0dXJlIiwgIm5vblJlcHVkaWF0aW9uIiwgImtleUVuY2lwaGVybWVudCIsICJrZXlB
-      Z3JlZW1lbnQiLCAia2V5Q2VydFNpZ24iXSwgInN1YmplY3QiOiAiQz1VUywgU1Q9V0EsIEw9UmVk
-      bW9uLCBPPVRlc3QgTm9vZGxlLCBPVT1UZXN0TnVnZ2V0LCBDTj13d3cubXl0ZXN0ZG9tYWluLmNv
-      bSIsICJ2YWxpZGl0eV9tb250aHMiOiA2MH0sICJsaWZldGltZV9hY3Rpb25zIjogW3sidHJpZ2dl
-      ciI6IHsibGlmZXRpbWVfcGVyY2VudGFnZSI6IDkwfSwgImFjdGlvbiI6IHsiYWN0aW9uX3R5cGUi
-      OiAiQXV0b1JlbmV3In19XX19
+      eyJhdHRyaWJ1dGVzIjogeyJlbmFibGVkIjogZmFsc2V9LCAicG9saWN5IjogeyJrZXlfcHJvcHMi
+      OiB7Imt0eSI6ICJSU0EiLCAiZXhwb3J0YWJsZSI6IHRydWUsICJrZXlfc2l6ZSI6IDIwNDgsICJy
+      ZXVzZV9rZXkiOiBmYWxzZX0sICJhdHRyaWJ1dGVzIjogeyJlbmFibGVkIjogdHJ1ZX0sICJzZWNy
+      ZXRfcHJvcHMiOiB7ImNvbnRlbnRUeXBlIjogImFwcGxpY2F0aW9uL3gtcGtjczEyIn0sICJsaWZl
+      dGltZV9hY3Rpb25zIjogW3sidHJpZ2dlciI6IHsibGlmZXRpbWVfcGVyY2VudGFnZSI6IDkwfSwg
+      ImFjdGlvbiI6IHsiYWN0aW9uX3R5cGUiOiAiQXV0b1JlbmV3In19XSwgIng1MDlfcHJvcHMiOiB7
+      ImtleV91c2FnZSI6IFsiZGlnaXRhbFNpZ25hdHVyZSIsICJub25SZXB1ZGlhdGlvbiIsICJrZXlF
+      bmNpcGhlcm1lbnQiLCAia2V5QWdyZWVtZW50IiwgImtleUNlcnRTaWduIl0sICJ2YWxpZGl0eV9t
+      b250aHMiOiA2MCwgInN1YmplY3QiOiAiQz1VUywgU1Q9V0EsIEw9UmVkbW9uLCBPPVRlc3QgTm9v
+      ZGxlLCBPVT1UZXN0TnVnZ2V0LCBDTj13d3cubXl0ZXN0ZG9tYWluLmNvbSJ9LCAiaXNzdWVyIjog
+      eyJuYW1lIjogIlNlbGYifX19
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Length: ['588']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [73e9f30a-a14e-11e6-9742-a0b3ccf7272a]
+      x-ms-client-request-id: [4ab205d4-a5fd-11e6-94ff-a0b3ccf7272a]
     method: PATCH
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/10f45a6a707e41f1b7ecfa7ee88030f8","kid":"https://cli-test-keyvault-cert.vault.azure.net/keys/cert1/10f45a6a707e41f1b7ecfa7ee88030f8","sid":"https://cli-test-keyvault-cert.vault.azure.net/secrets/cert1/10f45a6a707e41f1b7ecfa7ee88030f8","x5t":"mj1fuTf9omfkTefinFUIxqD5vus","cer":"MIID3jCCAsagAwIBAgIQYVoYSlmBTbu2JbL++2zAwzANBgkqhkiG9w0BAQsFADBsMR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTEPMA0GA1UECxMGVGVzdE9VMQ4wDAYDVQQKEwVUZXN0TzEQMA4GA1UEBxMHUmVkbW9uZDELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE2MTEwMjIyMzgwOFoXDTIxMDEwMjIyNDgwOFowbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOJWappPwEMTtMpv3rdt4YQWTazWm0RHhO9dBaDVQ18ciTVeXtpDX5+xQ0fwD3YPobSko7rtnbz9LyLX60zY5bIAJv0ZjQ5Hjv293PV+c7fzM5U69m1nCrGMq6TFO1m/kWmrSh8Y/Pe3sm3rxHSs7LEP4DZ0PaNcEcB+rOgBYa04brO4inBf52QNAuxexG9/zspJ85nHpiGKKX9aL+NhJT+y9+sxD36sgqbeowRwakH+f+N5K0xYAqrhywxfYX4OtaAP4Wnhhfm58rEl1LC9pED/yb5sX6mSIRq0bay8hsAb5e1cJFkdC4e0ycI8QBCeIXc+hC9K2JqwOJIYshMR5h0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFH9vj6HbLIHF5jf7JzHtd7FiggrkMB0GA1UdDgQWBBR/b4+h2yyBxeY3+ycx7XexYoIK5DANBgkqhkiG9w0BAQsFAAOCAQEAb4Y8ITRskExg/4k/GXVPW+Z1MkNRVBwQc7/C0lHvuc7T6s4MwYZqmng14eWssHSKLnV1MsGxj6CewxLwtvrAprzkSu/dQyh1MhAC+nuikmWJTw5dNzFypW9CXw1/JxfxPy7IIDAvtBvazP4sF9Gp0MbUW2jRMFFfejl7+lGMHUSl8PNEQwiIXTey2w5LV5UXkh2hVyPzjOXu3XodtLoNeEggGawiWeNPu22CxiJSqv/e2zCa0x/+DkmoQmbqE4ZiFsOuK+Vr6FukdBHd02y9Q2QeOzfaJgAXplX7BZ7mFKi++10+340g2mtRFDoAWfRjj+OpCX1LAyGyXLLJLX2URg==","attributes":{"enabled":false,"nbf":1478126288,"exp":1609627688,"created":1478126888,"updated":1478126900},"policy":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"C=US,
-        ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyAgreement","keyCertSign","keyEncipherment","nonRepudiation"],"validity_months":60,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1478126863,"updated":1478126900}},"pending":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending"}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/44dc3eba46d94d569f485465e0e51ce5","kid":"https://cli-test-keyvault-cert.vault.azure.net/keys/cert1/44dc3eba46d94d569f485465e0e51ce5","sid":"https://cli-test-keyvault-cert.vault.azure.net/secrets/cert1/44dc3eba46d94d569f485465e0e51ce5","x5t":"muO0ox2wmAH7A5X6N-6WPZgS8_o","cer":"MIID3jCCAsagAwIBAgIQEHlxt9PCQqGZ36TRMETHvjANBgkqhkiG9w0BAQsFADBsMR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTEPMA0GA1UECxMGVGVzdE9VMQ4wDAYDVQQKEwVUZXN0TzEQMA4GA1UEBxMHUmVkbW9uZDELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE2MTEwODIxMzk0OFoXDTIxMDEwODIxNDk0OFowbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALsUb7nx5WLqwEj/UUe2kGKa2Y9gJVGwMj3+ezJpFlSjrKColnjxAwiKJaZ9X8B0VwB8jzartYQPwrEmnWxQLriOjdxIP++aYWGSuzARgc+7kIqF05n9UJ2F0IRmBq7t5e4e1EHs9g1pIfrHFDDcj3qarmny+cDbZA57d2C7TsHlEIo/W2L5tGzRyE6zzeclqErpf8NHI6mxWTL3BZ20nV9aHlRJH59ZabJBpgneUH5RUtYnVC7eJQ7dGjHWEb14BZaVe8cYGCZPM5V+r6E5foqyyYP11xY7LRGo+T+ABgLJRwOeT1lYiaErbA5zUzF/K6BHFpV1DbOM6uUL4px7HfcCAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFEDdGHa8w8PpASuPso+qXG6Huj3cMB0GA1UdDgQWBBRA3Rh2vMPD6QErj7KPqlxuh7o93DANBgkqhkiG9w0BAQsFAAOCAQEAquSzZhKeZ61jzg2nRkB0aLdfUfes1a7LJ8XhgMOJDUnDKizPRRUdjtf6GoIJ6Ub8To7f3QF0f3ideYohDRl1WzBL7X1K7vd4VNiqDlyfRgfLfU1mrEv4foYsWUgvjxTtZoSVWMDXOS1Lv8bVyEyWeW6raThZD9ylYKKtnC4rKP7Tx6A5wDWxkRHO6Nt8bwZB9z/a/CTfVY2jvRzzxZ46P4qR0Nbesmjua6FDyfjzNcLT4UOoTiViUQRth33p0gKOLv0dAfnR+eknScExN1YdMeGoN9M7OyeA9nCvM1i4nvyhonmzfpaWidvM0qbtP50MXi2oc5jVsmPAA7SSQ9qEbw==","attributes":{"enabled":false,"nbf":1478641188,"exp":1610142588,"created":1478641788,"updated":1478641798},"policy":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"C=US,
+        ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyAgreement","keyCertSign","keyEncipherment","nonRepudiation"],"validity_months":60,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1478641763,"updated":1478641798}},"pending":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['2602']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:20 GMT']
+      Date: ['Tue, 08 Nov 2016 21:49:58 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -419,20 +670,20 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [74f0beca-a14e-11e6-b93a-a0b3ccf7272a]
+      x-ms-client-request-id: [4b38507a-a5fd-11e6-aa73-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/contacts?api-version=2015-06-01
   response:
@@ -441,7 +692,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['68']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:21 GMT']
+      Date: ['Tue, 08 Nov 2016 21:49:58 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -450,23 +701,23 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 404, message: Not Found}
 - request:
     body: !!binary |
-      eyJjb250YWN0cyI6IFt7Im5hbWUiOiAiSm9obiBEb2UiLCAicGhvbmUiOiAiMTIzLTQ1Ni03ODkw
-      IiwgImVtYWlsIjogImFkbWluQGNvbnRvc28uY29tIn1dfQ==
+      eyJjb250YWN0cyI6IFt7Im5hbWUiOiAiSm9obiBEb2UiLCAiZW1haWwiOiAiYWRtaW5AY29udG9z
+      by5jb20iLCAicGhvbmUiOiAiMTIzLTQ1Ni03ODkwIn1dfQ==
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Length: ['91']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7517fcae-a14e-11e6-bfa4-a0b3ccf7272a]
+      x-ms-client-request-id: [4b507a54-a5fd-11e6-9cd7-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/contacts?api-version=2015-06-01
   response:
@@ -476,7 +727,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['161']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:21 GMT']
+      Date: ['Tue, 08 Nov 2016 21:49:59 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -485,20 +736,20 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [754fa4a6-a14e-11e6-be7d-a0b3ccf7272a]
+      x-ms-client-request-id: [4b7ab5d8-a5fd-11e6-9eec-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/contacts?api-version=2015-06-01
   response:
@@ -508,7 +759,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['161']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:22 GMT']
+      Date: ['Tue, 08 Nov 2016 21:49:59 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -517,24 +768,24 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJjb250YWN0cyI6IFt7Im5hbWUiOiAiSm9obiBEb2UiLCAicGhvbmUiOiAiMTIzLTQ1Ni03ODkw
-      IiwgImVtYWlsIjogImFkbWluQGNvbnRvc28uY29tIn0sIHsiZW1haWwiOiAib3RoZXJAY29udG9z
+      eyJjb250YWN0cyI6IFt7Im5hbWUiOiAiSm9obiBEb2UiLCAiZW1haWwiOiAiYWRtaW5AY29udG9z
+      by5jb20iLCAicGhvbmUiOiAiMTIzLTQ1Ni03ODkwIn0sIHsiZW1haWwiOiAib3RoZXJAY29udG9z
       by5jb20ifV19
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Length: ['123']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [756e6918-a14e-11e6-870e-a0b3ccf7272a]
+      x-ms-client-request-id: [4b92be34-a5fd-11e6-ba64-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/contacts?api-version=2015-06-01
   response:
@@ -544,7 +795,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['191']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:21 GMT']
+      Date: ['Tue, 08 Nov 2016 21:49:58 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -553,20 +804,20 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [75a15550-a14e-11e6-b7d3-a0b3ccf7272a]
+      x-ms-client-request-id: [4bbb2028-a5fd-11e6-8909-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/contacts?api-version=2015-06-01
   response:
@@ -576,7 +827,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['191']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:21 GMT']
+      Date: ['Tue, 08 Nov 2016 21:49:59 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -585,20 +836,20 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [75c9b9f6-a14e-11e6-93d5-a0b3ccf7272a]
+      x-ms-client-request-id: [4be14c5e-a5fd-11e6-91ee-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/contacts?api-version=2015-06-01
   response:
@@ -608,7 +859,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['191']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:21 GMT']
+      Date: ['Tue, 08 Nov 2016 21:49:59 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -617,7 +868,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
@@ -625,14 +876,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Length: ['46']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [75ea6706-a14e-11e6-80a2-a0b3ccf7272a]
+      x-ms-client-request-id: [4c08bd22-a5fd-11e6-8ba7-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/contacts?api-version=2015-06-01
   response:
@@ -641,7 +892,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['120']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:23 GMT']
+      Date: ['Tue, 08 Nov 2016 21:49:59 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -650,20 +901,20 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [76208810-a14e-11e6-b0e8-a0b3ccf7272a]
+      x-ms-client-request-id: [4c46e562-a5fd-11e6-88a1-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/contacts?api-version=2015-06-01
   response:
@@ -672,7 +923,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['120']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:22 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:00 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -681,20 +932,20 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7649e934-a14e-11e6-9ad8-a0b3ccf7272a]
+      x-ms-client-request-id: [4c6e476c-a5fd-11e6-aa2a-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2015-06-01
   response:
@@ -704,7 +955,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['75']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:23 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:01 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -713,32 +964,32 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 404, message: Not Found}
 - request:
     body: !!binary |
-      eyJhdHRyaWJ1dGVzIjogeyJlbmFibGVkIjogdHJ1ZX0sICJjcmVkZW50aWFscyI6IHt9LCAib3Jn
-      X2RldGFpbHMiOiB7ImFkbWluX2RldGFpbHMiOiBbXX0sICJwcm92aWRlciI6ICJUZXN0In0=
+      eyJwcm92aWRlciI6ICJUZXN0IiwgImNyZWRlbnRpYWxzIjoge30sICJhdHRyaWJ1dGVzIjogeyJl
+      bmFibGVkIjogdHJ1ZX0sICJvcmdfZGV0YWlscyI6IHsiYWRtaW5fZGV0YWlscyI6IFtdfX0=
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Length: ['110']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [766b9458-a14e-11e6-8bc1-a0b3ccf7272a]
+      x-ms-client-request-id: [4c99b64a-a5fd-11e6-b517-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1478126903,"updated":1478126903}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1478641801,"updated":1478641801}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['234']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:23 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:01 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -747,29 +998,29 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7698da42-a14e-11e6-b7ce-a0b3ccf7272a]
+      x-ms-client-request-id: [4cc57d2c-a5fd-11e6-a943-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1478126903,"updated":1478126903}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1478641801,"updated":1478641801}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['234']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:25 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:00 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -778,29 +1029,29 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [76c49db4-a14e-11e6-8812-a0b3ccf7272a]
+      x-ms-client-request-id: [4cf27d5e-a5fd-11e6-8f9d-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1478126903,"updated":1478126903}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1478641801,"updated":1478641801}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['234']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:24 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:01 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -809,29 +1060,29 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [76edb11e-a14e-11e6-8da4-a0b3ccf7272a]
+      x-ms-client-request-id: [4d25abb6-a5fd-11e6-ad32-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1478126903,"updated":1478126903}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1478641801,"updated":1478641801}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['234']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:23 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:01 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -840,33 +1091,33 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJhdHRyaWJ1dGVzIjogeyJlbmFibGVkIjogdHJ1ZX0sICJjcmVkZW50aWFscyI6IHsiYWNjb3Vu
-      dF9pZCI6ICJ0ZXN0X2FjY291bnQifSwgIm9yZ19kZXRhaWxzIjogeyJpZCI6ICJUZXN0T3JnIiwg
-      ImFkbWluX2RldGFpbHMiOiBbXX0sICJwcm92aWRlciI6ICJUZXN0In0=
+      eyJwcm92aWRlciI6ICJUZXN0IiwgImNyZWRlbnRpYWxzIjogeyJhY2NvdW50X2lkIjogInRlc3Rf
+      YWNjb3VudCJ9LCAiYXR0cmlidXRlcyI6IHsiZW5hYmxlZCI6IHRydWV9LCAib3JnX2RldGFpbHMi
+      OiB7ImlkIjogIlRlc3RPcmciLCAiYWRtaW5fZGV0YWlscyI6IFtdfX0=
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Length: ['155']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [770fd182-a14e-11e6-ad74-a0b3ccf7272a]
+      x-ms-client-request-id: [4d4d92f6-a5fd-11e6-8553-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{"account_id":"test_account"},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1478126903,"updated":1478126905}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{"account_id":"test_account"},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1478641801,"updated":1478641802}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['276']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:24 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:01 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -875,20 +1126,20 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7743c4ec-a14e-11e6-872d-a0b3ccf7272a]
+      x-ms-client-request-id: [4d8c4502-a5fd-11e6-82eb-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/notexist?api-version=2015-06-01
   response:
@@ -898,7 +1149,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['75']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:24 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:02 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -907,29 +1158,29 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 404, message: Not Found}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [77682fa8-a14e-11e6-aa48-a0b3ccf7272a]
+      x-ms-client-request-id: [4db100fe-a5fd-11e6-90a6-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{"account_id":"test_account"},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1478126903,"updated":1478126905}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{"account_id":"test_account"},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1478641801,"updated":1478641802}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['276']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:24 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:02 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -938,33 +1189,33 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJhdHRyaWJ1dGVzIjogeyJlbmFibGVkIjogdHJ1ZX0sICJjcmVkZW50aWFscyI6IHt9LCAib3Jn
-      X2RldGFpbHMiOiB7ImlkIjogIlRlc3RPcmciLCAiYWRtaW5fZGV0YWlscyI6IFtdfSwgInByb3Zp
-      ZGVyIjogIlRlc3QifQ==
+      eyJwcm92aWRlciI6ICJUZXN0IiwgImNyZWRlbnRpYWxzIjoge30sICJhdHRyaWJ1dGVzIjogeyJl
+      bmFibGVkIjogdHJ1ZX0sICJvcmdfZGV0YWlscyI6IHsiaWQiOiAiVGVzdE9yZyIsICJhZG1pbl9k
+      ZXRhaWxzIjogW119fQ==
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Length: ['127']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [77881948-a14e-11e6-894d-a0b3ccf7272a]
+      x-ms-client-request-id: [4dd3e9f8-a5fd-11e6-92a1-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1478126903,"updated":1478126907}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1478641801,"updated":1478641804}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['249']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:26 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:03 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -973,20 +1224,20 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [77c10d76-a14e-11e6-9bf2-a0b3ccf7272a]
+      x-ms-client-request-id: [4e455306-a5fd-11e6-bed5-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers?api-version=2015-06-01
   response:
@@ -995,7 +1246,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['130']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:27 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:03 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1004,29 +1255,29 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [79233ac0-a14e-11e6-801d-a0b3ccf7272a]
+      x-ms-client-request-id: [4e80aedc-a5fd-11e6-b0ba-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1478126903,"updated":1478126907}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[]},"attributes":{"enabled":true,"created":1478641801,"updated":1478641804}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['249']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:28 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:04 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1035,34 +1286,34 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJhdHRyaWJ1dGVzIjogeyJlbmFibGVkIjogdHJ1ZX0sICJjcmVkZW50aWFscyI6IHt9LCAib3Jn
-      X2RldGFpbHMiOiB7ImlkIjogIlRlc3RPcmciLCAiYWRtaW5fZGV0YWlscyI6IFt7InBob25lIjog
-      IjEyMy00NTYtNzg5MCIsICJsYXN0X25hbWUiOiAiQWRtaW4iLCAiZmlyc3RfbmFtZSI6ICJUZXN0
-      IiwgImVtYWlsIjogInRlc3RAdGVzdC5jb20ifV19LCAicHJvdmlkZXIiOiAiVGVzdCJ9
+      eyJwcm92aWRlciI6ICJUZXN0IiwgImNyZWRlbnRpYWxzIjoge30sICJhdHRyaWJ1dGVzIjogeyJl
+      bmFibGVkIjogdHJ1ZX0sICJvcmdfZGV0YWlscyI6IHsiaWQiOiAiVGVzdE9yZyIsICJhZG1pbl9k
+      ZXRhaWxzIjogW3siZmlyc3RfbmFtZSI6ICJUZXN0IiwgImVtYWlsIjogInRlc3RAdGVzdC5jb20i
+      LCAicGhvbmUiOiAiMTIzLTQ1Ni03ODkwIiwgImxhc3RfbmFtZSI6ICJBZG1pbiJ9XX19
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Length: ['222']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7948cab0-a14e-11e6-8c02-a0b3ccf7272a]
+      x-ms-client-request-id: [4e9ceefe-a5fd-11e6-905b-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"}]},"attributes":{"enabled":true,"created":1478126903,"updated":1478126908}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"}]},"attributes":{"enabled":true,"created":1478641801,"updated":1478641804}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['337']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:28 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:04 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1071,29 +1322,29 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [797bcaf8-a14e-11e6-8669-a0b3ccf7272a]
+      x-ms-client-request-id: [4ecee89a-a5fd-11e6-8ec7-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"}]},"attributes":{"enabled":true,"created":1478126903,"updated":1478126908}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"}]},"attributes":{"enabled":true,"created":1478641801,"updated":1478641804}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['337']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:28 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:04 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1102,29 +1353,29 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [79a63e88-a14e-11e6-8740-a0b3ccf7272a]
+      x-ms-client-request-id: [4ef2649e-a5fd-11e6-af95-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"}]},"attributes":{"enabled":true,"created":1478126903,"updated":1478126908}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"}]},"attributes":{"enabled":true,"created":1478641801,"updated":1478641804}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['337']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:29 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:04 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1133,35 +1384,35 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJhdHRyaWJ1dGVzIjogeyJlbmFibGVkIjogdHJ1ZX0sICJjcmVkZW50aWFscyI6IHt9LCAib3Jn
-      X2RldGFpbHMiOiB7ImlkIjogIlRlc3RPcmciLCAiYWRtaW5fZGV0YWlscyI6IFt7InBob25lIjog
-      IjEyMy00NTYtNzg5MCIsICJsYXN0X25hbWUiOiAiQWRtaW4iLCAiZmlyc3RfbmFtZSI6ICJUZXN0
-      IiwgImVtYWlsIjogInRlc3RAdGVzdC5jb20ifSwgeyJlbWFpbCI6ICJ0ZXN0MkB0ZXN0LmNvbSJ9
-      XX0sICJwcm92aWRlciI6ICJUZXN0In0=
+      eyJwcm92aWRlciI6ICJUZXN0IiwgImNyZWRlbnRpYWxzIjoge30sICJhdHRyaWJ1dGVzIjogeyJl
+      bmFibGVkIjogdHJ1ZX0sICJvcmdfZGV0YWlscyI6IHsiaWQiOiAiVGVzdE9yZyIsICJhZG1pbl9k
+      ZXRhaWxzIjogW3siZmlyc3RfbmFtZSI6ICJUZXN0IiwgImVtYWlsIjogInRlc3RAdGVzdC5jb20i
+      LCAicGhvbmUiOiAiMTIzLTQ1Ni03ODkwIiwgImxhc3RfbmFtZSI6ICJBZG1pbiJ9LCB7ImVtYWls
+      IjogInRlc3QyQHRlc3QuY29tIn1dfX0=
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Length: ['251']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [79d40d9c-a14e-11e6-96c4-a0b3ccf7272a]
+      x-ms-client-request-id: [4f11371c-a5fd-11e6-b9ef-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"},{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1478126903,"updated":1478126911}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"},{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1478641801,"updated":1478641805}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['364']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:31 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:05 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1170,29 +1421,29 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7a02eed2-a14e-11e6-a375-a0b3ccf7272a]
+      x-ms-client-request-id: [4f3be93e-a5fd-11e6-92a3-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"},{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1478126903,"updated":1478126911}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"},{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1478641801,"updated":1478641805}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['364']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:30 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:06 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1201,29 +1452,29 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7a32bcb4-a14e-11e6-a084-a0b3ccf7272a]
+      x-ms-client-request-id: [4f83915c-a5fd-11e6-a327-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"},{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1478126903,"updated":1478126911}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"first_name":"Test","last_name":"Admin","email":"test@test.com","phone":"123-456-7890"},{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1478641801,"updated":1478641805}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['364']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:31 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:06 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1232,33 +1483,33 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJhdHRyaWJ1dGVzIjogeyJlbmFibGVkIjogdHJ1ZX0sICJjcmVkZW50aWFscyI6IHt9LCAib3Jn
-      X2RldGFpbHMiOiB7ImlkIjogIlRlc3RPcmciLCAiYWRtaW5fZGV0YWlscyI6IFt7ImVtYWlsIjog
-      InRlc3QyQHRlc3QuY29tIn1dfSwgInByb3ZpZGVyIjogIlRlc3QifQ==
+      eyJwcm92aWRlciI6ICJUZXN0IiwgImNyZWRlbnRpYWxzIjoge30sICJhdHRyaWJ1dGVzIjogeyJl
+      bmFibGVkIjogdHJ1ZX0sICJvcmdfZGV0YWlscyI6IHsiaWQiOiAiVGVzdE9yZyIsICJhZG1pbl9k
+      ZXRhaWxzIjogW3siZW1haWwiOiAidGVzdDJAdGVzdC5jb20ifV19fQ==
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Length: ['154']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7a5b0d98-a14e-11e6-bdb0-a0b3ccf7272a]
+      x-ms-client-request-id: [4f9ee5ee-a5fd-11e6-9bc6-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1478126903,"updated":1478126910}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1478641801,"updated":1478641806}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['275']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:30 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:05 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1267,29 +1518,29 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7a8fcede-a14e-11e6-99cf-a0b3ccf7272a]
+      x-ms-client-request-id: [4fca99de-a5fd-11e6-a587-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1478126903,"updated":1478126910}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1478641801,"updated":1478641806}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['275']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:31 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:05 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1298,30 +1549,30 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7ad2727e-a14e-11e6-ac2c-a0b3ccf7272a]
+      x-ms-client-request-id: [4fe94450-a5fd-11e6-890a-a0b3ccf7272a]
     method: DELETE
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1478126903,"updated":1478126910}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers/issuer1","provider":"Test","credentials":{},"org_details":{"id":"TestOrg","zip":0,"admin_details":[{"email":"test2@test.com"}]},"attributes":{"enabled":true,"created":1478641801,"updated":1478641806}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['275']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:33 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:06 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1330,20 +1581,20 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7b4421e8-a14e-11e6-826d-a0b3ccf7272a]
+      x-ms-client-request-id: [501d11ca-a5fd-11e6-bd88-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/issuers?api-version=2015-06-01
   response:
@@ -1352,7 +1603,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['28']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:32 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:06 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1361,42 +1612,42 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJhdHRyaWJ1dGVzIjogeyJlbmFibGVkIjogdHJ1ZX0sICJwb2xpY3kiOiB7ImF0dHJpYnV0ZXMi
-      OiB7ImVuYWJsZWQiOiB0cnVlfSwgImlzc3VlciI6IHsibmFtZSI6ICJVbmtub3duIn0sICJrZXlf
-      cHJvcHMiOiB7ImV4cG9ydGFibGUiOiB0cnVlLCAia3R5IjogIlJTQSIsICJyZXVzZV9rZXkiOiBm
-      YWxzZSwgImtleV9zaXplIjogMjA0OH0sICJ4NTA5X3Byb3BzIjogeyJrZXlfdXNhZ2UiOiBbImRp
-      Z2l0YWxTaWduYXR1cmUiLCAibm9uUmVwdWRpYXRpb24iLCAia2V5RW5jaXBoZXJtZW50IiwgImtl
-      eUFncmVlbWVudCIsICJrZXlDZXJ0U2lnbiJdLCAic3ViamVjdCI6ICJDPVVTLCBTVD1XQSwgTD1S
-      ZWRtb25kLCBPPVRlc3RPLCBPVT1UZXN0T1UsIENOPXd3dy5teXRlc3Rkb21haW4uY29tIiwgInZh
-      bGlkaXR5X21vbnRocyI6IDUwfSwgInNlY3JldF9wcm9wcyI6IHsiY29udGVudFR5cGUiOiAiYXBw
+      eyJhdHRyaWJ1dGVzIjogeyJlbmFibGVkIjogdHJ1ZX0sICJwb2xpY3kiOiB7ImtleV9wcm9wcyI6
+      IHsia3R5IjogIlJTQSIsICJleHBvcnRhYmxlIjogdHJ1ZSwgImtleV9zaXplIjogMjA0OCwgInJl
+      dXNlX2tleSI6IGZhbHNlfSwgIng1MDlfcHJvcHMiOiB7ImtleV91c2FnZSI6IFsiZGlnaXRhbFNp
+      Z25hdHVyZSIsICJub25SZXB1ZGlhdGlvbiIsICJrZXlFbmNpcGhlcm1lbnQiLCAia2V5QWdyZWVt
+      ZW50IiwgImtleUNlcnRTaWduIl0sICJ2YWxpZGl0eV9tb250aHMiOiA1MCwgInN1YmplY3QiOiAi
+      Qz1VUywgU1Q9V0EsIEw9UmVkbW9uZCwgTz1UZXN0TywgT1U9VGVzdE9VLCBDTj13d3cubXl0ZXN0
+      ZG9tYWluLmNvbSJ9LCAiaXNzdWVyIjogeyJuYW1lIjogIlVua25vd24ifSwgImF0dHJpYnV0ZXMi
+      OiB7ImVuYWJsZWQiOiB0cnVlfSwgInNlY3JldF9wcm9wcyI6IHsiY29udGVudFR5cGUiOiAiYXBw
       bGljYXRpb24veC1wa2NzMTIifX19
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Length: ['477']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7bba06c0-a14e-11e6-b3be-a0b3ccf7272a]
+      x-ms-client-request-id: [50562cda-a5fd-11e6-9a64-a0b3ccf7272a]
     method: POST
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/pending-cert/create?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKGgd+4clmFYfhUCmpWvXwXjME3w98lNEhU2MWuLy87khKkNkBcIb1kJLw5GlYjMAADBIlej928YPsOswGruWrmd+DLptNxDGNhI0NBIevTV1HOb/pWQtYyLrr6xrnSBFCDs3+A52vdhQGWZWX+C+fFqpSxtgUQLTzput67mc7f8t4TXWLfxqUmjePYAnQncQZdMgGeRxbwPkmzlf0Wv3HuKJlI60exWWrQxhsHM93Levb6kbKkHrdC42j16Su7Sjkk+PRVRljNG0/JR3kmdtUSLfhCwCYcZO8nadaHk1TLlY4dFUd5nTZfwJS7ihlE8hcRpe2FQ21H5kpz6K6VK020CAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAtchGEKTbo09dAfmIWwdBuSpyJreWN00/TiTzCkv79m0UxVxsu0xDqeEwFZCmVYR15MIK/GHYwcEVdu7yLaC+ulKeIt8jb5wcf+gX8ayu2Frh8edPefbfDwUVFAOCLx2TFJKb/k5EnBis+QRoZG9leXhnJXEM91DWSAM59QH/dIcb2NJPxR8MiLJ5/LSaKYa5jOA89Rv2EGgAH6VpKoMFvBAbub1SY3zcHoc6/fJIXYpx7EV1XYH6ZEJ6yrg4XWyGb0hlC/0XvUkmjnHMvC2wx/AM2kxgzA6e+yR1lbdBAJIYeSzjfQ5e5/a88Wkg4Aovfx0jWoWMHEFqQpsd3pLdw","cancellation_requested":false,"status":"inProgress","status_details":"Pending
-        certificate created. Please Perform Merge to complete the request.","request_id":"d1c6607668a74b9cb14203bd7a528985"}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANq0Hwj088dk2AwcUsdYnGUBx74JoyAXlU7k0UmVWZueqBlDC3regi2/jUyr3LDm/Le7iILk4UiT0asQ3g8PVBNdBURV5wcV6NGl17aQuxxcmbuLcmMlqmtE6pw71ccsajKWWqrbh9tfSusJOcsScIc0Hh8/IBTEMMVvUBKDrdKEEH41XJFYtizfTft7PG1zoLM6/ayjMaYP4tnOMhK/zSd9Mg4IioFuBt+DoZq77XW9BJjFOCanp6LfVWWoEe5gQm/b9T/GHV7LbHrG6qVBM3YrFXNjtubFq+4VVkoBMKVQxp2wuOL+M3Wa9tXyXi+hkHvwo4l02GYN0zwhU8oUdzECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBitR3HRTwAAYT9vUv0XVsVVPXpp74PYYvr4ufbZU4RpELm8Wk9Bms/hIY++/Zpf4K1FbIkU+omYH8nSp4a9s1H9f9oJjUPqLWqgcxReLjLxdnxl2x7ZTtewKWlb2PezXJWG/9upLc7+rC7B/o+hHW83tyuoKjoD2iTnYZ2dCX+0sLmSwvp22D4v5KnXt4CdK8Ce0t9534AwLnuW7FCrvUC+hsEsm5WHLu8FYMkx5TxiWpwDiUuwKAyD2aOdLf6WLQ9sS/IHysMbno/T7V3Y0tHpJxfHqMut9wbb9ldPNQqTsxKVS4pPl2tZ7l1x2wTwX504yVNpfDVjglQUnOsJLF6","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Please Perform Merge to complete the request.","request_id":"47a24fb56a8947dd91a6c2796ce341da"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['1345']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:35 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:08 GMT']
       Expires: ['-1']
-      Location: ['https://cli-test-keyvault-cert.vault.azure.net/certificates/pending-cert/pending?api-version=2015-06-01&request_id=d1c6607668a74b9cb14203bd7a528985']
+      Location: ['https://cli-test-keyvault-cert.vault.azure.net/certificates/pending-cert/pending?api-version=2015-06-01&request_id=47a24fb56a8947dd91a6c2796ce341da']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000;includeSubDomains]
@@ -1404,30 +1655,30 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 202, message: Accepted}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7d2d99ac-a14e-11e6-bd5b-a0b3ccf7272a]
+      x-ms-client-request-id: [515d5f0a-a5fd-11e6-90a4-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/pending-cert/pending?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKGgd+4clmFYfhUCmpWvXwXjME3w98lNEhU2MWuLy87khKkNkBcIb1kJLw5GlYjMAADBIlej928YPsOswGruWrmd+DLptNxDGNhI0NBIevTV1HOb/pWQtYyLrr6xrnSBFCDs3+A52vdhQGWZWX+C+fFqpSxtgUQLTzput67mc7f8t4TXWLfxqUmjePYAnQncQZdMgGeRxbwPkmzlf0Wv3HuKJlI60exWWrQxhsHM93Levb6kbKkHrdC42j16Su7Sjkk+PRVRljNG0/JR3kmdtUSLfhCwCYcZO8nadaHk1TLlY4dFUd5nTZfwJS7ihlE8hcRpe2FQ21H5kpz6K6VK020CAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAtchGEKTbo09dAfmIWwdBuSpyJreWN00/TiTzCkv79m0UxVxsu0xDqeEwFZCmVYR15MIK/GHYwcEVdu7yLaC+ulKeIt8jb5wcf+gX8ayu2Frh8edPefbfDwUVFAOCLx2TFJKb/k5EnBis+QRoZG9leXhnJXEM91DWSAM59QH/dIcb2NJPxR8MiLJ5/LSaKYa5jOA89Rv2EGgAH6VpKoMFvBAbub1SY3zcHoc6/fJIXYpx7EV1XYH6ZEJ6yrg4XWyGb0hlC/0XvUkmjnHMvC2wx/AM2kxgzA6e+yR1lbdBAJIYeSzjfQ5e5/a88Wkg4Aovfx0jWoWMHEFqQpsd3pLdw","cancellation_requested":false,"status":"inProgress","status_details":"Pending
-        certificate created. Please Perform Merge to complete the request.","request_id":"d1c6607668a74b9cb14203bd7a528985"}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANq0Hwj088dk2AwcUsdYnGUBx74JoyAXlU7k0UmVWZueqBlDC3regi2/jUyr3LDm/Le7iILk4UiT0asQ3g8PVBNdBURV5wcV6NGl17aQuxxcmbuLcmMlqmtE6pw71ccsajKWWqrbh9tfSusJOcsScIc0Hh8/IBTEMMVvUBKDrdKEEH41XJFYtizfTft7PG1zoLM6/ayjMaYP4tnOMhK/zSd9Mg4IioFuBt+DoZq77XW9BJjFOCanp6LfVWWoEe5gQm/b9T/GHV7LbHrG6qVBM3YrFXNjtubFq+4VVkoBMKVQxp2wuOL+M3Wa9tXyXi+hkHvwo4l02GYN0zwhU8oUdzECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBitR3HRTwAAYT9vUv0XVsVVPXpp74PYYvr4ufbZU4RpELm8Wk9Bms/hIY++/Zpf4K1FbIkU+omYH8nSp4a9s1H9f9oJjUPqLWqgcxReLjLxdnxl2x7ZTtewKWlb2PezXJWG/9upLc7+rC7B/o+hHW83tyuoKjoD2iTnYZ2dCX+0sLmSwvp22D4v5KnXt4CdK8Ce0t9534AwLnuW7FCrvUC+hsEsm5WHLu8FYMkx5TxiWpwDiUuwKAyD2aOdLf6WLQ9sS/IHysMbno/T7V3Y0tHpJxfHqMut9wbb9ldPNQqTsxKVS4pPl2tZ7l1x2wTwX504yVNpfDVjglQUnOsJLF6","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Please Perform Merge to complete the request.","request_id":"47a24fb56a8947dd91a6c2796ce341da"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['1345']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:34 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:08 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1436,30 +1687,30 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7d54c400-a14e-11e6-88c3-a0b3ccf7272a]
+      x-ms-client-request-id: [518160cc-a5fd-11e6-bd88-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/pending-cert/pending?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKGgd+4clmFYfhUCmpWvXwXjME3w98lNEhU2MWuLy87khKkNkBcIb1kJLw5GlYjMAADBIlej928YPsOswGruWrmd+DLptNxDGNhI0NBIevTV1HOb/pWQtYyLrr6xrnSBFCDs3+A52vdhQGWZWX+C+fFqpSxtgUQLTzput67mc7f8t4TXWLfxqUmjePYAnQncQZdMgGeRxbwPkmzlf0Wv3HuKJlI60exWWrQxhsHM93Levb6kbKkHrdC42j16Su7Sjkk+PRVRljNG0/JR3kmdtUSLfhCwCYcZO8nadaHk1TLlY4dFUd5nTZfwJS7ihlE8hcRpe2FQ21H5kpz6K6VK020CAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAtchGEKTbo09dAfmIWwdBuSpyJreWN00/TiTzCkv79m0UxVxsu0xDqeEwFZCmVYR15MIK/GHYwcEVdu7yLaC+ulKeIt8jb5wcf+gX8ayu2Frh8edPefbfDwUVFAOCLx2TFJKb/k5EnBis+QRoZG9leXhnJXEM91DWSAM59QH/dIcb2NJPxR8MiLJ5/LSaKYa5jOA89Rv2EGgAH6VpKoMFvBAbub1SY3zcHoc6/fJIXYpx7EV1XYH6ZEJ6yrg4XWyGb0hlC/0XvUkmjnHMvC2wx/AM2kxgzA6e+yR1lbdBAJIYeSzjfQ5e5/a88Wkg4Aovfx0jWoWMHEFqQpsd3pLdw","cancellation_requested":false,"status":"inProgress","status_details":"Pending
-        certificate created. Please Perform Merge to complete the request.","request_id":"d1c6607668a74b9cb14203bd7a528985"}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANq0Hwj088dk2AwcUsdYnGUBx74JoyAXlU7k0UmVWZueqBlDC3regi2/jUyr3LDm/Le7iILk4UiT0asQ3g8PVBNdBURV5wcV6NGl17aQuxxcmbuLcmMlqmtE6pw71ccsajKWWqrbh9tfSusJOcsScIc0Hh8/IBTEMMVvUBKDrdKEEH41XJFYtizfTft7PG1zoLM6/ayjMaYP4tnOMhK/zSd9Mg4IioFuBt+DoZq77XW9BJjFOCanp6LfVWWoEe5gQm/b9T/GHV7LbHrG6qVBM3YrFXNjtubFq+4VVkoBMKVQxp2wuOL+M3Wa9tXyXi+hkHvwo4l02GYN0zwhU8oUdzECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBitR3HRTwAAYT9vUv0XVsVVPXpp74PYYvr4ufbZU4RpELm8Wk9Bms/hIY++/Zpf4K1FbIkU+omYH8nSp4a9s1H9f9oJjUPqLWqgcxReLjLxdnxl2x7ZTtewKWlb2PezXJWG/9upLc7+rC7B/o+hHW83tyuoKjoD2iTnYZ2dCX+0sLmSwvp22D4v5KnXt4CdK8Ce0t9534AwLnuW7FCrvUC+hsEsm5WHLu8FYMkx5TxiWpwDiUuwKAyD2aOdLf6WLQ9sS/IHysMbno/T7V3Y0tHpJxfHqMut9wbb9ldPNQqTsxKVS4pPl2tZ7l1x2wTwX504yVNpfDVjglQUnOsJLF6","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Please Perform Merge to complete the request.","request_id":"47a24fb56a8947dd91a6c2796ce341da"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['1345']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:35 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:09 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1468,7 +1719,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
@@ -1495,14 +1746,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Length: ['1126']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7d85dc8c-a14e-11e6-a988-a0b3ccf7272a]
+      x-ms-client-request-id: [51a21678-a5fd-11e6-988b-a0b3ccf7272a]
     method: POST
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/pending-cert/pending/merge?api-version=2015-06-01
   response:
@@ -1512,7 +1763,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['117']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:35 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:09 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1521,31 +1772,31 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 400, message: Bad Request}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7db1eef6-a14e-11e6-a1dd-a0b3ccf7272a]
+      x-ms-client-request-id: [51c30d4a-a5fd-11e6-835a-a0b3ccf7272a]
     method: DELETE
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/pending-cert/pending?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKGgd+4clmFYfhUCmpWvXwXjME3w98lNEhU2MWuLy87khKkNkBcIb1kJLw5GlYjMAADBIlej928YPsOswGruWrmd+DLptNxDGNhI0NBIevTV1HOb/pWQtYyLrr6xrnSBFCDs3+A52vdhQGWZWX+C+fFqpSxtgUQLTzput67mc7f8t4TXWLfxqUmjePYAnQncQZdMgGeRxbwPkmzlf0Wv3HuKJlI60exWWrQxhsHM93Levb6kbKkHrdC42j16Su7Sjkk+PRVRljNG0/JR3kmdtUSLfhCwCYcZO8nadaHk1TLlY4dFUd5nTZfwJS7ihlE8hcRpe2FQ21H5kpz6K6VK020CAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAtchGEKTbo09dAfmIWwdBuSpyJreWN00/TiTzCkv79m0UxVxsu0xDqeEwFZCmVYR15MIK/GHYwcEVdu7yLaC+ulKeIt8jb5wcf+gX8ayu2Frh8edPefbfDwUVFAOCLx2TFJKb/k5EnBis+QRoZG9leXhnJXEM91DWSAM59QH/dIcb2NJPxR8MiLJ5/LSaKYa5jOA89Rv2EGgAH6VpKoMFvBAbub1SY3zcHoc6/fJIXYpx7EV1XYH6ZEJ6yrg4XWyGb0hlC/0XvUkmjnHMvC2wx/AM2kxgzA6e+yR1lbdBAJIYeSzjfQ5e5/a88Wkg4Aovfx0jWoWMHEFqQpsd3pLdw","cancellation_requested":false,"status":"inProgress","status_details":"Pending
-        certificate created. Please Perform Merge to complete the request.","request_id":"d1c6607668a74b9cb14203bd7a528985"}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pending-cert/pending","issuer":{"name":"Unknown"},"csr":"MIIC/DCCAeQCAQAwbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANq0Hwj088dk2AwcUsdYnGUBx74JoyAXlU7k0UmVWZueqBlDC3regi2/jUyr3LDm/Le7iILk4UiT0asQ3g8PVBNdBURV5wcV6NGl17aQuxxcmbuLcmMlqmtE6pw71ccsajKWWqrbh9tfSusJOcsScIc0Hh8/IBTEMMVvUBKDrdKEEH41XJFYtizfTft7PG1zoLM6/ayjMaYP4tnOMhK/zSd9Mg4IioFuBt+DoZq77XW9BJjFOCanp6LfVWWoEe5gQm/b9T/GHV7LbHrG6qVBM3YrFXNjtubFq+4VVkoBMKVQxp2wuOL+M3Wa9tXyXi+hkHvwo4l02GYN0zwhU8oUdzECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgLsMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBitR3HRTwAAYT9vUv0XVsVVPXpp74PYYvr4ufbZU4RpELm8Wk9Bms/hIY++/Zpf4K1FbIkU+omYH8nSp4a9s1H9f9oJjUPqLWqgcxReLjLxdnxl2x7ZTtewKWlb2PezXJWG/9upLc7+rC7B/o+hHW83tyuoKjoD2iTnYZ2dCX+0sLmSwvp22D4v5KnXt4CdK8Ce0t9534AwLnuW7FCrvUC+hsEsm5WHLu8FYMkx5TxiWpwDiUuwKAyD2aOdLf6WLQ9sS/IHysMbno/T7V3Y0tHpJxfHqMut9wbb9ldPNQqTsxKVS4pPl2tZ7l1x2wTwX504yVNpfDVjglQUnOsJLF6","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Please Perform Merge to complete the request.","request_id":"47a24fb56a8947dd91a6c2796ce341da"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['1345']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:36 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:09 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1554,20 +1805,20 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7e054fbe-a14e-11e6-97e8-a0b3ccf7272a]
+      x-ms-client-request-id: [52095028-a5fd-11e6-b4d5-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/pending-cert/pending?api-version=2015-06-01
   response:
@@ -1577,7 +1828,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['103']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:35 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:10 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1586,31 +1837,31 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 404, message: Not Found}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7e2c52f4-a14e-11e6-8600-a0b3ccf7272a]
+      x-ms-client-request-id: [523bccfa-a5fd-11e6-9106-a0b3ccf7272a]
     method: DELETE
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/10f45a6a707e41f1b7ecfa7ee88030f8","kid":"https://cli-test-keyvault-cert.vault.azure.net/keys/cert1/10f45a6a707e41f1b7ecfa7ee88030f8","sid":"https://cli-test-keyvault-cert.vault.azure.net/secrets/cert1/10f45a6a707e41f1b7ecfa7ee88030f8","x5t":"mj1fuTf9omfkTefinFUIxqD5vus","cer":"MIID3jCCAsagAwIBAgIQYVoYSlmBTbu2JbL++2zAwzANBgkqhkiG9w0BAQsFADBsMR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTEPMA0GA1UECxMGVGVzdE9VMQ4wDAYDVQQKEwVUZXN0TzEQMA4GA1UEBxMHUmVkbW9uZDELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE2MTEwMjIyMzgwOFoXDTIxMDEwMjIyNDgwOFowbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOJWappPwEMTtMpv3rdt4YQWTazWm0RHhO9dBaDVQ18ciTVeXtpDX5+xQ0fwD3YPobSko7rtnbz9LyLX60zY5bIAJv0ZjQ5Hjv293PV+c7fzM5U69m1nCrGMq6TFO1m/kWmrSh8Y/Pe3sm3rxHSs7LEP4DZ0PaNcEcB+rOgBYa04brO4inBf52QNAuxexG9/zspJ85nHpiGKKX9aL+NhJT+y9+sxD36sgqbeowRwakH+f+N5K0xYAqrhywxfYX4OtaAP4Wnhhfm58rEl1LC9pED/yb5sX6mSIRq0bay8hsAb5e1cJFkdC4e0ycI8QBCeIXc+hC9K2JqwOJIYshMR5h0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFH9vj6HbLIHF5jf7JzHtd7FiggrkMB0GA1UdDgQWBBR/b4+h2yyBxeY3+ycx7XexYoIK5DANBgkqhkiG9w0BAQsFAAOCAQEAb4Y8ITRskExg/4k/GXVPW+Z1MkNRVBwQc7/C0lHvuc7T6s4MwYZqmng14eWssHSKLnV1MsGxj6CewxLwtvrAprzkSu/dQyh1MhAC+nuikmWJTw5dNzFypW9CXw1/JxfxPy7IIDAvtBvazP4sF9Gp0MbUW2jRMFFfejl7+lGMHUSl8PNEQwiIXTey2w5LV5UXkh2hVyPzjOXu3XodtLoNeEggGawiWeNPu22CxiJSqv/e2zCa0x/+DkmoQmbqE4ZiFsOuK+Vr6FukdBHd02y9Q2QeOzfaJgAXplX7BZ7mFKi++10+340g2mtRFDoAWfRjj+OpCX1LAyGyXLLJLX2URg==","attributes":{"enabled":false,"nbf":1478126288,"exp":1609627688,"created":1478126888,"updated":1478126900},"policy":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"C=US,
-        ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyAgreement","keyCertSign","keyEncipherment","nonRepudiation"],"validity_months":60,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1478126863,"updated":1478126900}},"pending":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending"}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/44dc3eba46d94d569f485465e0e51ce5","kid":"https://cli-test-keyvault-cert.vault.azure.net/keys/cert1/44dc3eba46d94d569f485465e0e51ce5","sid":"https://cli-test-keyvault-cert.vault.azure.net/secrets/cert1/44dc3eba46d94d569f485465e0e51ce5","x5t":"muO0ox2wmAH7A5X6N-6WPZgS8_o","cer":"MIID3jCCAsagAwIBAgIQEHlxt9PCQqGZ36TRMETHvjANBgkqhkiG9w0BAQsFADBsMR0wGwYDVQQDExR3d3cubXl0ZXN0ZG9tYWluLmNvbTEPMA0GA1UECxMGVGVzdE9VMQ4wDAYDVQQKEwVUZXN0TzEQMA4GA1UEBxMHUmVkbW9uZDELMAkGA1UECBMCV0ExCzAJBgNVBAYTAlVTMB4XDTE2MTEwODIxMzk0OFoXDTIxMDEwODIxNDk0OFowbDEdMBsGA1UEAxMUd3d3Lm15dGVzdGRvbWFpbi5jb20xDzANBgNVBAsTBlRlc3RPVTEOMAwGA1UEChMFVGVzdE8xEDAOBgNVBAcTB1JlZG1vbmQxCzAJBgNVBAgTAldBMQswCQYDVQQGEwJVUzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALsUb7nx5WLqwEj/UUe2kGKa2Y9gJVGwMj3+ezJpFlSjrKColnjxAwiKJaZ9X8B0VwB8jzartYQPwrEmnWxQLriOjdxIP++aYWGSuzARgc+7kIqF05n9UJ2F0IRmBq7t5e4e1EHs9g1pIfrHFDDcj3qarmny+cDbZA57d2C7TsHlEIo/W2L5tGzRyE6zzeclqErpf8NHI6mxWTL3BZ20nV9aHlRJH59ZabJBpgneUH5RUtYnVC7eJQ7dGjHWEb14BZaVe8cYGCZPM5V+r6E5foqyyYP11xY7LRGo+T+ABgLJRwOeT1lYiaErbA5zUzF/K6BHFpV1DbOM6uUL4px7HfcCAwEAAaN8MHowDgYDVR0PAQH/BAQDAgLsMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFEDdGHa8w8PpASuPso+qXG6Huj3cMB0GA1UdDgQWBBRA3Rh2vMPD6QErj7KPqlxuh7o93DANBgkqhkiG9w0BAQsFAAOCAQEAquSzZhKeZ61jzg2nRkB0aLdfUfes1a7LJ8XhgMOJDUnDKizPRRUdjtf6GoIJ6Ub8To7f3QF0f3ideYohDRl1WzBL7X1K7vd4VNiqDlyfRgfLfU1mrEv4foYsWUgvjxTtZoSVWMDXOS1Lv8bVyEyWeW6raThZD9ylYKKtnC4rKP7Tx6A5wDWxkRHO6Nt8bwZB9z/a/CTfVY2jvRzzxZ46P4qR0Nbesmjua6FDyfjzNcLT4UOoTiViUQRth33p0gKOLv0dAfnR+eknScExN1YdMeGoN9M7OyeA9nCvM1i4nvyhonmzfpaWidvM0qbtP50MXi2oc5jVsmPAA7SSQ9qEbw==","attributes":{"enabled":false,"nbf":1478641188,"exp":1610142588,"created":1478641788,"updated":1478641798},"policy":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"C=US,
+        ST=WA, L=Redmon, O=Test Noodle, OU=TestNugget, CN=www.mytestdomain.com","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyAgreement","keyCertSign","keyEncipherment","nonRepudiation"],"validity_months":60,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1478641763,"updated":1478641798}},"pending":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/cert1/pending"}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['2602']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:36 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:09 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1619,20 +1870,20 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7e7d2df8-a14e-11e6-8e00-a0b3ccf7272a]
+      x-ms-client-request-id: [529f0a86-a5fd-11e6-84fd-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates?api-version=2015-06-01
   response:
@@ -1641,7 +1892,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['28']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:37 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:11 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1650,85 +1901,85 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJhdHRyaWJ1dGVzIjogeyJlbmFibGVkIjogdHJ1ZX0sICJwb2xpY3kiOiB7InNlY3JldF9wcm9w
-      cyI6IHsiY29udGVudFR5cGUiOiAiYXBwbGljYXRpb24veC1wZW0tZmlsZSJ9LCAiaXNzdWVyIjog
-      eyJuYW1lIjogIlNlbGYifSwgImtleV9wcm9wcyI6IHsiZXhwb3J0YWJsZSI6IHRydWUsICJrdHki
-      OiAiUlNBIiwgInJldXNlX2tleSI6IGZhbHNlLCAia2V5X3NpemUiOiAyMDQ4fX0sICJ2YWx1ZSI6
-      ICItLS0tLUJFR0lOIFBSSVZBVEUgS0VZLS0tLS1cbk1JSUV2Z0lCQURBTkJna3Foa2lHOXcwQkFR
-      RUZBQVNDQktnd2dnU2tBZ0VBQW9JQkFRQ1JVUEZnT3Zvdk5KMGVcblhTSGxjbTJWOXcvRUN3ek1j
-      MzFCYU4yeEJtV2plZ21xaXh2OUdOM0dXTWdVUTl6QzlrOWJ4ZDQ5MUF3YTU1U3Fcbmh0ODZUTDhR
-      M0ZjbjhmWHVoV2JYL2dOQU84aDV0ZnVRVkExekI1YlZ4RVFzQ05tbUxycGdOaExZTytleGN5Q0pc
-      bm9jcWlkUW9zdFNRZmNYVTdxSnRpZnBnbVJ0NW9XM1dobXBWc25BdWdTOHk4dmJDR0pYZEtxTENa
-      WGpML0gwYWFcbityL1ozQnpRK0JnbFVMS1lzaFNCaW54YlllKzFHSi8wMjgvNTB5L01QZjlpRmlp
-      Uzl4dHNwT3RTemQxZStOQTVcbkcrcENNcHBKSGFyczlEL0ZhdlRld0kxekphOWpQeHRyd3I4TDNu
-      RW15OWd2NnYxNDc0WE5ZYWFndFFOamRVMGJcbkFWM0VEZm45QWdNQkFBRUNnZ0VBREp0R2pYQWdZ
-      emIveUhJUTdqeGFtRzk2RFNwZVBtQm9oZU9vaytKM3I5SjNcbkF6WVZSQVJEdlNEWG5yWnljUEY0
-      V2dCVTh1MHg3YVdZaHFDenZmV0pmOWQxc2kveUEzTE1STUd6RzMvME9PYmFcblA1K2pHUThYL1V5
-      TkUzcmpFdUVyNXd2WjM2dDJ3clMzcG1rRVVNcXhpc1plTDJJaTV2Mk9HV0hkSmpqd3M0SFdcblA5
-      cEJHamNneFVQN1VLUExRRXhIYjlvVXN3aDY2WitLOW8xMFp3QXJQWWhuaGM1NDZ2UGxiSHFPNWJU
-      Uy9SemFcblBkK2MvaDdQcnJxd1NCYXZtNW1kamNId3FyNUpqaEU0T3piUzRIa2lZVm5weDRPUFJj
-      Z1IwdldFNmNHKzB6ZzVcbjRBUk9TTTlrdnJHZmxJcW4yRUFvalJBejVTNndITWs3cEltazRrQWRT
-      d0tCZ1FDL3dWc0VydXpVajNwN0R2WGNcblhSbzhqdVJyV3p0cm1PdnAwR3doc1ZJVmFGMEZyMmxx
-      Q0VHZ09xcWo1SUVmdWUwVWFDTkNXM0k3M3JSU1lhTmVcbm5KN1BHWk1ZbUxrendjdkdURWVWOUNS
-      cU9ndkt2YmYzUmlDcGtLZUx6M2RpbDhBR2R5Vmx3QUptcThGbitJTVRcbnJ3R2F3My9VSFRSTW5z
-      ZTZKUG9RK2s0S013S0JnUURDQUk0TWxxNUs3V1NIMXpOS1NMZ0lJOUtuZkhIa3VzTlVcbjg4aHBh
-      VlJlWG14VTd1UUlDMDJuYnRZbDJvTTNJL0x6OU90ay9uUEliaDRnOUxLbWp1NUdpMVMyd2NoSW5E
-      ZlBcbkt3Z1BvQ2xNNi9WTTRlNkNTOXFxL0Z2SmRMdTIyMjhBeGNkU29Jd0dtcmtiaVR0R05lZE80
-      Q2RCYTMvdmFjYWNcbnVEMGlEL2diRHdLQmdRQyttWHpWSE9KL0xkWjZ0eFllNGRRUVdhQW1MZHJV
-      U241RVBFMGUrRmcwdXpXclR2NGlcbnpPNGVTL0lOVWpZZXlQb2tqSlp2Z09IOUxKSmtTSFRRdURF
-      S2ZjcythWis5R0dacVJxdnBHM0dPdlArM2wvaGlcbkt5eVFIeDdLMDM5QldzRWVMQlBhSFk3RmF2
-      ZWxWdGxER1hNbzJDWVpPcVlmZXJ2Z0JKMGpmd2xQRFFLQmdDdUNcblNGbFdhZHh3QlQzWjY2emJS
-      anE5SGY5bUQzMEd6Y3Y5cUpMTGhwcHJmc3hGajJxbWJsSUFyNUpwd1VmYWppQmNcbmEzYUpBcHFP
-      NTc3b1lqQ3NtWS9FcThrWkNMd1FIUXdmVUgyQXBBS1dZTHRQYUZoY2Zyd2VRTStibUlYWURMc1Zc
-      bm9EQk54Vm10MVpueFd4UFIvd0JYa1RaQXo3NTM4STB4WExTSTlGSE5Bb0dCQUovMmNrNUcrcEtW
-      SEpBOXNGb09cbndwQjFqaW1aTm1aancyRml1N3UzM0lRU3Exb01pakQvTThxTEZsbnF1ZXRCcmpu
-      aVc1NVZpUjg5SE1lKzVCd3Rcbm5aK1BxNnhES256eFJ5eUZXR004bHArSkRNTWoxeE9ISVlpbCth
-      RmdaeVdtNi9Wek4yNHZkcDJlWVJZV0JkTVRcblA4bXVrcG5OaHl0bUkxLzRvemFVK3dhaVxuLS0t
-      LS1FTkQgUFJJVkFURSBLRVktLS0tLVxuLS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tXG5NSUlE
-      SkRDQ0FneWdBd0lCQWdJUWMvUnZjN1NOVC9pSnJlNklJNzh2cFRBTkJna3Foa2lHOXcwQkFRc0ZB
-      REFQXG5NUTB3Q3dZRFZRUURFd1JVWlhOME1CNFhEVEUyTVRBeU56RTRORE0xTmxvWERURTNNVEF5
-      TnpFNE5UTTFObG93XG5EekVOTUFzR0ExVUVBeE1FVkdWemREQ0NBU0l3RFFZSktvWklodmNOQVFF
-      QkJRQURnZ0VQQURDQ0FRb0NnZ0VCXG5BSkZROFdBNitpODBuUjVkSWVWeWJaWDNEOFFMRE14emZV
-      Rm8zYkVHWmFONkNhcUxHLzBZM2NaWXlCUkQzTUwyXG5UMXZGM2ozVURCcm5sS3FHM3pwTXZ4RGNW
-      eWZ4OWU2Rlp0ZitBMEE3eUhtMSs1QlVEWE1IbHRYRVJDd0kyYVl1XG51bUEyRXRnNzU3RnpJSW1o
-      eXFKMUNpeTFKQjl4ZFR1b20ySittQ1pHM21oYmRhR2FsV3ljQzZCTHpMeTlzSVlsXG5kMHFvc0ps
-      ZU12OGZScHI2djluY0hORDRHQ1ZRc3BpeUZJR0tmRnRoNzdVWW4vVGJ6L25UTDh3OS8ySVdLSkwz
-      XG5HMnlrNjFMTjNWNzQwRGtiNmtJeW1ra2RxdXowUDhWcTlON0FqWE1scjJNL0cydkN2d3ZlY1Ni
-      TDJDL3EvWGp2XG5oYzFocHFDMUEyTjFUUnNCWGNRTitmMENBd0VBQWFOOE1Ib3dEZ1lEVlIwUEFR
-      SC9CQVFEQWdXZ01Ba0dBMVVkXG5Fd1FDTUFBd0hRWURWUjBsQkJZd0ZBWUlLd1lCQlFVSEF3RUdD
-      Q3NHQVFVRkJ3TUNNQjhHQTFVZEl3UVlNQmFBXG5GSmg5VG1OdWVzcWNjZ21kVnU3V0Q2YllpdXJt
-      TUIwR0ExVWREZ1FXQkJTWWZVNWpibnJLbkhJSm5WYnUxZyttXG4ySXJxNWpBTkJna3Foa2lHOXcw
-      QkFRc0ZBQU9DQVFFQWowdlR0U0NqU1FJWmFnek92alR0WnZuS0g2RTBxMHpYXG4rTUF0Sm5TOENi
-      L1hWUEVXMEZxTjVUTFh2dmFrdGpLQ0RIU1BtWXduZVRqVjNoak5lK2pCMDNSMVoyYXV4bnNjXG5q
-      U2ZMVDQrdHRockNpSFRMWCtXclIrRjNTd09YL2NWRkdpVTB6MUljSmU1bTQ5cWlVSjZrZW1IYWE2
-      dW1nZkdYXG5IYm5DcXpSNzZXa2hESldGejlNWEZGdkZUUkdFKzI2N3NsaVFmOFByS3I2NW9PRVZa
-      Vi9FK1NJblFkbStIMUxZXG5XQWJpZzRVeEhOOFVRNTRHOW1kVzFlL3VSdW1BVDczdXR5K0MwTzhW
-      UXZOdnNjbzJIQWlQT3REY2U0Q0psZVp4XG5pQXY2ejBZNlBLUlliNHh3K3hubXFwQzhrczFUOTNK
-      RmFuaUhsNTNjcVJOYlh5NXQ5dDlDYWc9PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJ9
+      eyJ2YWx1ZSI6ICItLS0tLUJFR0lOIFBSSVZBVEUgS0VZLS0tLS1cbk1JSUV2Z0lCQURBTkJna3Fo
+      a2lHOXcwQkFRRUZBQVNDQktnd2dnU2tBZ0VBQW9JQkFRQ1JVUEZnT3Zvdk5KMGVcblhTSGxjbTJW
+      OXcvRUN3ek1jMzFCYU4yeEJtV2plZ21xaXh2OUdOM0dXTWdVUTl6QzlrOWJ4ZDQ5MUF3YTU1U3Fc
+      bmh0ODZUTDhRM0ZjbjhmWHVoV2JYL2dOQU84aDV0ZnVRVkExekI1YlZ4RVFzQ05tbUxycGdOaExZ
+      TytleGN5Q0pcbm9jcWlkUW9zdFNRZmNYVTdxSnRpZnBnbVJ0NW9XM1dobXBWc25BdWdTOHk4dmJD
+      R0pYZEtxTENaWGpML0gwYWFcbityL1ozQnpRK0JnbFVMS1lzaFNCaW54YlllKzFHSi8wMjgvNTB5
+      L01QZjlpRmlpUzl4dHNwT3RTemQxZStOQTVcbkcrcENNcHBKSGFyczlEL0ZhdlRld0kxekphOWpQ
+      eHRyd3I4TDNuRW15OWd2NnYxNDc0WE5ZYWFndFFOamRVMGJcbkFWM0VEZm45QWdNQkFBRUNnZ0VB
+      REp0R2pYQWdZemIveUhJUTdqeGFtRzk2RFNwZVBtQm9oZU9vaytKM3I5SjNcbkF6WVZSQVJEdlNE
+      WG5yWnljUEY0V2dCVTh1MHg3YVdZaHFDenZmV0pmOWQxc2kveUEzTE1STUd6RzMvME9PYmFcblA1
+      K2pHUThYL1V5TkUzcmpFdUVyNXd2WjM2dDJ3clMzcG1rRVVNcXhpc1plTDJJaTV2Mk9HV0hkSmpq
+      d3M0SFdcblA5cEJHamNneFVQN1VLUExRRXhIYjlvVXN3aDY2WitLOW8xMFp3QXJQWWhuaGM1NDZ2
+      UGxiSHFPNWJUUy9SemFcblBkK2MvaDdQcnJxd1NCYXZtNW1kamNId3FyNUpqaEU0T3piUzRIa2lZ
+      Vm5weDRPUFJjZ1IwdldFNmNHKzB6ZzVcbjRBUk9TTTlrdnJHZmxJcW4yRUFvalJBejVTNndITWs3
+      cEltazRrQWRTd0tCZ1FDL3dWc0VydXpVajNwN0R2WGNcblhSbzhqdVJyV3p0cm1PdnAwR3doc1ZJ
+      VmFGMEZyMmxxQ0VHZ09xcWo1SUVmdWUwVWFDTkNXM0k3M3JSU1lhTmVcbm5KN1BHWk1ZbUxrendj
+      dkdURWVWOUNScU9ndkt2YmYzUmlDcGtLZUx6M2RpbDhBR2R5Vmx3QUptcThGbitJTVRcbnJ3R2F3
+      My9VSFRSTW5zZTZKUG9RK2s0S013S0JnUURDQUk0TWxxNUs3V1NIMXpOS1NMZ0lJOUtuZkhIa3Vz
+      TlVcbjg4aHBhVlJlWG14VTd1UUlDMDJuYnRZbDJvTTNJL0x6OU90ay9uUEliaDRnOUxLbWp1NUdp
+      MVMyd2NoSW5EZlBcbkt3Z1BvQ2xNNi9WTTRlNkNTOXFxL0Z2SmRMdTIyMjhBeGNkU29Jd0dtcmti
+      aVR0R05lZE80Q2RCYTMvdmFjYWNcbnVEMGlEL2diRHdLQmdRQyttWHpWSE9KL0xkWjZ0eFllNGRR
+      UVdhQW1MZHJVU241RVBFMGUrRmcwdXpXclR2NGlcbnpPNGVTL0lOVWpZZXlQb2tqSlp2Z09IOUxK
+      SmtTSFRRdURFS2ZjcythWis5R0dacVJxdnBHM0dPdlArM2wvaGlcbkt5eVFIeDdLMDM5QldzRWVM
+      QlBhSFk3RmF2ZWxWdGxER1hNbzJDWVpPcVlmZXJ2Z0JKMGpmd2xQRFFLQmdDdUNcblNGbFdhZHh3
+      QlQzWjY2emJSanE5SGY5bUQzMEd6Y3Y5cUpMTGhwcHJmc3hGajJxbWJsSUFyNUpwd1VmYWppQmNc
+      bmEzYUpBcHFPNTc3b1lqQ3NtWS9FcThrWkNMd1FIUXdmVUgyQXBBS1dZTHRQYUZoY2Zyd2VRTSti
+      bUlYWURMc1Zcbm9EQk54Vm10MVpueFd4UFIvd0JYa1RaQXo3NTM4STB4WExTSTlGSE5Bb0dCQUov
+      MmNrNUcrcEtWSEpBOXNGb09cbndwQjFqaW1aTm1aancyRml1N3UzM0lRU3Exb01pakQvTThxTEZs
+      bnF1ZXRCcmpuaVc1NVZpUjg5SE1lKzVCd3Rcbm5aK1BxNnhES256eFJ5eUZXR004bHArSkRNTWox
+      eE9ISVlpbCthRmdaeVdtNi9Wek4yNHZkcDJlWVJZV0JkTVRcblA4bXVrcG5OaHl0bUkxLzRvemFV
+      K3dhaVxuLS0tLS1FTkQgUFJJVkFURSBLRVktLS0tLVxuLS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0t
+      LS0tXG5NSUlESkRDQ0FneWdBd0lCQWdJUWMvUnZjN1NOVC9pSnJlNklJNzh2cFRBTkJna3Foa2lH
+      OXcwQkFRc0ZBREFQXG5NUTB3Q3dZRFZRUURFd1JVWlhOME1CNFhEVEUyTVRBeU56RTRORE0xTmxv
+      WERURTNNVEF5TnpFNE5UTTFObG93XG5EekVOTUFzR0ExVUVBeE1FVkdWemREQ0NBU0l3RFFZSktv
+      WklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCXG5BSkZROFdBNitpODBuUjVkSWVWeWJaWDNE
+      OFFMRE14emZVRm8zYkVHWmFONkNhcUxHLzBZM2NaWXlCUkQzTUwyXG5UMXZGM2ozVURCcm5sS3FH
+      M3pwTXZ4RGNWeWZ4OWU2Rlp0ZitBMEE3eUhtMSs1QlVEWE1IbHRYRVJDd0kyYVl1XG51bUEyRXRn
+      NzU3RnpJSW1oeXFKMUNpeTFKQjl4ZFR1b20ySittQ1pHM21oYmRhR2FsV3ljQzZCTHpMeTlzSVls
+      XG5kMHFvc0psZU12OGZScHI2djluY0hORDRHQ1ZRc3BpeUZJR0tmRnRoNzdVWW4vVGJ6L25UTDh3
+      OS8ySVdLSkwzXG5HMnlrNjFMTjNWNzQwRGtiNmtJeW1ra2RxdXowUDhWcTlON0FqWE1scjJNL0cy
+      dkN2d3ZlY1NiTDJDL3EvWGp2XG5oYzFocHFDMUEyTjFUUnNCWGNRTitmMENBd0VBQWFOOE1Ib3dE
+      Z1lEVlIwUEFRSC9CQVFEQWdXZ01Ba0dBMVVkXG5Fd1FDTUFBd0hRWURWUjBsQkJZd0ZBWUlLd1lC
+      QlFVSEF3RUdDQ3NHQVFVRkJ3TUNNQjhHQTFVZEl3UVlNQmFBXG5GSmg5VG1OdWVzcWNjZ21kVnU3
+      V0Q2YllpdXJtTUIwR0ExVWREZ1FXQkJTWWZVNWpibnJLbkhJSm5WYnUxZyttXG4ySXJxNWpBTkJn
+      a3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWowdlR0U0NqU1FJWmFnek92alR0WnZuS0g2RTBxMHpYXG4r
+      TUF0Sm5TOENiL1hWUEVXMEZxTjVUTFh2dmFrdGpLQ0RIU1BtWXduZVRqVjNoak5lK2pCMDNSMVoy
+      YXV4bnNjXG5qU2ZMVDQrdHRockNpSFRMWCtXclIrRjNTd09YL2NWRkdpVTB6MUljSmU1bTQ5cWlV
+      SjZrZW1IYWE2dW1nZkdYXG5IYm5DcXpSNzZXa2hESldGejlNWEZGdkZUUkdFKzI2N3NsaVFmOFBy
+      S3I2NW9PRVZaVi9FK1NJblFkbStIMUxZXG5XQWJpZzRVeEhOOFVRNTRHOW1kVzFlL3VSdW1BVDcz
+      dXR5K0MwTzhWUXZOdnNjbzJIQWlQT3REY2U0Q0psZVp4XG5pQXY2ejBZNlBLUlliNHh3K3hubXFw
+      QzhrczFUOTNKRmFuaUhsNTNjcVJOYlh5NXQ5dDlDYWc9PVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUt
+      LS0tLSIsICJhdHRyaWJ1dGVzIjogeyJlbmFibGVkIjogdHJ1ZX0sICJwb2xpY3kiOiB7ImtleV9w
+      cm9wcyI6IHsia3R5IjogIlJTQSIsICJleHBvcnRhYmxlIjogdHJ1ZSwgImtleV9zaXplIjogMjA0
+      OCwgInJldXNlX2tleSI6IGZhbHNlfSwgImlzc3VlciI6IHsibmFtZSI6ICJTZWxmIn0sICJzZWNy
+      ZXRfcHJvcHMiOiB7ImNvbnRlbnRUeXBlIjogImFwcGxpY2F0aW9uL3gtcGVtLWZpbGUifX19
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Length: ['3132']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7ea36fda-a14e-11e6-873e-a0b3ccf7272a]
+      x-ms-client-request-id: [52c48a00-a5fd-11e6-aa6c-a0b3ccf7272a]
     method: POST
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1/import?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1/ec5055e577354f86b66010175eceb5a9","kid":"https://cli-test-keyvault-cert.vault.azure.net/keys/pem-cert1/ec5055e577354f86b66010175eceb5a9","sid":"https://cli-test-keyvault-cert.vault.azure.net/secrets/pem-cert1/ec5055e577354f86b66010175eceb5a9","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1478126917,"updated":1478126917},"policy":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1478126917,"updated":1478126917}}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1/c0c9a7e9699a408492a25ecb921c7b54","kid":"https://cli-test-keyvault-cert.vault.azure.net/keys/pem-cert1/c0c9a7e9699a408492a25ecb921c7b54","sid":"https://cli-test-keyvault-cert.vault.azure.net/secrets/pem-cert1/c0c9a7e9699a408492a25ecb921c7b54","x5t":"lDc9zly8mcTcjym-jyov2aJhNDA","cer":"MIIDJDCCAgygAwIBAgIQc/Rvc7SNT/iJre6II78vpTANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDEwRUZXN0MB4XDTE2MTAyNzE4NDM1NloXDTE3MTAyNzE4NTM1NlowDzENMAsGA1UEAxMEVGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJFQ8WA6+i80nR5dIeVybZX3D8QLDMxzfUFo3bEGZaN6CaqLG/0Y3cZYyBRD3ML2T1vF3j3UDBrnlKqG3zpMvxDcVyfx9e6FZtf+A0A7yHm1+5BUDXMHltXERCwI2aYuumA2Etg757FzIImhyqJ1Ciy1JB9xdTuom2J+mCZG3mhbdaGalWycC6BLzLy9sIYld0qosJleMv8fRpr6v9ncHND4GCVQspiyFIGKfFth77UYn/Tbz/nTL8w9/2IWKJL3G2yk61LN3V740Dkb6kIymkkdquz0P8Vq9N7AjXMlr2M/G2vCvwvecSbL2C/q/Xjvhc1hpqC1A2N1TRsBXcQN+f0CAwEAAaN8MHowDgYDVR0PAQH/BAQDAgWgMAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFJh9TmNuesqccgmdVu7WD6bYiurmMB0GA1UdDgQWBBSYfU5jbnrKnHIJnVbu1g+m2Irq5jANBgkqhkiG9w0BAQsFAAOCAQEAj0vTtSCjSQIZagzOvjTtZvnKH6E0q0zX+MAtJnS8Cb/XVPEW0FqN5TLXvvaktjKCDHSPmYwneTjV3hjNe+jB03R1Z2auxnscjSfLT4+tthrCiHTLX+WrR+F3SwOX/cVFGiU0z1IcJe5m49qiUJ6kemHaa6umgfGXHbnCqzR76WkhDJWFz9MXFFvFTRGE+267sliQf8PrKr65oOEVZV/E+SInQdm+H1LYWAbig4UxHN8UQ54G9mdW1e/uRumAT73uty+C0O8VQvNvsco2HAiPOtDce4CJleZxiAv6z0Y6PKRYb4xw+xnmqpC8ks1T93JFaniHl53cqRNbXy5t9t9Cag==","attributes":{"enabled":true,"nbf":1477593836,"exp":1509130436,"created":1478641811,"updated":1478641811},"policy":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert1/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"CN=Test","ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":13,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1478641811,"updated":1478641811}}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['2163']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:37 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:12 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1737,90 +1988,90 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJwd2QiOiAiMTIzNCIsICJhdHRyaWJ1dGVzIjogeyJlbmFibGVkIjogdHJ1ZX0sICJwb2xpY3ki
-      OiB7InNlY3JldF9wcm9wcyI6IHsiY29udGVudFR5cGUiOiAiYXBwbGljYXRpb24veC1wZW0tZmls
-      ZSJ9LCAiaXNzdWVyIjogeyJuYW1lIjogIlNlbGYifSwgImtleV9wcm9wcyI6IHsiZXhwb3J0YWJs
-      ZSI6IHRydWUsICJrdHkiOiAiUlNBIiwgInJldXNlX2tleSI6IGZhbHNlLCAia2V5X3NpemUiOiAy
-      MDQ4fX0sICJ2YWx1ZSI6ICItLS0tLUJFR0lOIENFUlRJRklDQVRFLS0tLS1cbk1JSURnekNDQW11
-      Z0F3SUJBZ0lKQUkwbFB4UGI5Z24rTUEwR0NTcUdTSWIzRFFFQkN3VUFNRmd4Q3pBSkJnTlZcbkJB
-      WVRBa0ZWTVJNd0VRWURWUVFJREFwVGIyMWxMVk4wWVhSbE1TRXdId1lEVlFRS0RCaEpiblJsY201
-      bGRDQlhcbmFXUm5hWFJ6SUZCMGVTQk1kR1F4RVRBUEJnTlZCQXNNQ0V0bGVWWmhkV3gwTUI0WERU
-      RTJNRGN5TnpBM01UVXdcbk0xb1hEVEU1TURReU16QTNNVFV3TTFvd1dERUxNQWtHQTFVRUJoTUNR
-      VlV4RXpBUkJnTlZCQWdNQ2xOdmJXVXRcblUzUmhkR1V4SVRBZkJnTlZCQW9NR0VsdWRHVnlibVYw
-      SUZkcFpHZHBkSE1nVUhSNUlFeDBaREVSTUE4R0ExVUVcbkN3d0lTMlY1Vm1GMWJIUXdnZ0VpTUEw
-      R0NTcUdTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFDOEVmTm5cbkI3emh1WktHN3BmVDRN
-      SzVpUC94UVNJdlZNeWJNdTlydllOeUZJbE1BbXM2eTlDQjRRUWZObVJ6Sm1OQXBQWnFcbmxTVStn
-      bk9yU0hRK1dzYU1KTk1GamIzditXRmJnY3VleXdGVCs3NmI0SnRTcEJINzgwbjJ5SnJQZHNoV2Vz
-      Tytcbmx6MDhDbWJZWFJac2pMRisvLzBBOWJvWmFlc3RNbGtNZUJxaHdwNEpUQzR3RUpHNUVIT3hE
-      TXkrdTVjbkd3R0dcbnBnWTRDZjZqU3pXK2hPWlo0Y3ByeXNOODV3Y2pNTmNiR2RLek9WaHJzYW00
-      c3pKRitJeFhpVTJKdVU4MjdnVzhcbk5LVzBWTVRZaW9vcnFXTTRRNmw2QTBOVnlGc3NZNS9WM0la
-      L1IyMzdDUUpKUHdzS2lTbTRjYUljZlk0U0RweFRcblFIRmovbzdyUkVkNTAveERBZ01CQUFHalVE
-      Qk9NQjBHQTFVZERnUVdCQlFmTTllUWJGNUR0UlowQ1VjWDBFcm5cbjBhR0FpekFmQmdOVkhTTUVH
-      REFXZ0JRZk05ZVFiRjVEdFJaMENVY1gwRXJuMGFHQWl6QU1CZ05WSFJNRUJUQURcbkFRSC9NQTBH
-      Q1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUJzbHhHUU13NzJBS2h2bDRraG0yTStnTG5XdW9hVnp6WVFc
-      bktxNFlNeUk1Qlc1bmw1UU8vODQ5cTVLMGFMTXpQbGxxY2p0MzFlbmoycTgydXdWVTlDdk80QTQ2
-      eGRaK1BKRDFcbk5mN0pJcXhSUU41bTlFek9SQmVsMGFGUjZ6ZFVxV0szMnRBcmpMejBrOVcyeEk3
-      YVFUZlNXa1dFM3E2MStpL3JcbjhYWUl3a3k5clAvaGUxTmN2U0tXc3VTZHJMRXRka0xHcXRtU291
-      RVF4YStRKzdLZXRmZy90ald1dEVhV25PSzFcbnJxS0hmZ1pUMlJOb2VSbk14NEhTZWpRSkxyWkh1
-      dnBDRC8vZllySzJVUTlqVWFEejg4NjNHUG0vYm4vODA3alBcbndORXRyTmRZYTI2bE0wWXRoSUhJ
-      RVBFZG42cmd4SVhPWU1VQm5JUXZhZnBJcTg4RE5LZVRcbi0tLS0tRU5EIENFUlRJRklDQVRFLS0t
-      LS1cbi0tLS0tQkVHSU4gRU5DUllQVEVEIFBSSVZBVEUgS0VZLS0tLS1cbk1JSUU2akFjQmdvcWhr
-      aUc5dzBCREFFRE1BNEVDSmlMQ2xQTTZ0NUpBZ0lJQUFTQ0JNaWdMK0tsRUE5ZmFnWDBcblBGaFFC
-      ZUZqRGllYkpiTXVUZmE5SGNPVlpFRHlycW1HbmcyTGZ6K1RVYTN5cy9WODZva2JVcDJOOU1vR0s3
-      Z3hcbmNQcWRxN3JudTU2M0xUOXdHaHRuOG1VbjhXdWwwRmZWMks1NndzQkdlaEorTVBtbEVqczZP
-      WlIwblZkWGt3QWhcbmRWSXpIOWVGZHo4bWhKWk9aSTYxVFFOS0NLYkNxc1I3bHNsa0wyVldyU0Zn
-      bkhDVWo1YlIvQkxJQTJvUnBRWnZcbm53MFNlWUZRV01SeVhnS0g0VldNcU9sT2JYbS9FTG5WT3I5
-      ZEpWenZURzQyRFJhSzVOOEJBOU5UTXNLMSs4bStcbmVuQ2c0aU5JL3M4MU1EOGlJeS9kN01tc0pG
-      aDhXUW9xelVabU9WeGZxTkh3MFRQZ0RwYkNwQ1dSTmlna1JvR1NcblJvc2M3TUlsQ1BQYW5nalBN
-      RlpnNVFlTXVVQnJFMDFmU3ZKdFo1MmpTTWt5bG9TZlF6UUpKYjlBYW02cTZEem9cbnVQQ0gzMnp6
-      MUdWLzU2eUpvTzhJZWZPTUl1anZYRlprdS9RTnpLV2lYbnVTQSt4akZaaEdFR1FUb1U1d0x0SFhc
-      bmVFaHoxY0Y1MTljOENrTTRMbC9VVUhQV3RiOTB2cU8yK08yREx1ZzlxVVVub1FsN1AwTzNXMk5w
-      QW9CQ0x4VU9cbnFyZlN5TFVvc21zN0VnMURJVm81cHd4YXdQSzhxazdnd0xudEFUWmMrYVRTVVI5
-      WTFkbjR2SjlqOUdaV0l1OUpcblZLTzYxNmdETzdxOFIxQzNtVDcyazJvVXVVRzI1VHRaT3hzbCtZ
-      M2lKZ0V5cDlON2pvL1JkeDVLa2N2dkI4enRcbmdQQ2g1ZGlLRGpibzNMeG1ZUnQ2MmhlT0xFUHMy
-      WURqS0J5bjBOaWtjbzNMcVRuZWRKZVhFSDJtQmM3eDFWV0VcbjBxVFY0eHFPWEw5RjcwMDBNdjFj
-      SmNFMkU4OGZONnREZ2UxSXB1SmJzMDNJajBPZ3BhRlJmUzU3TmNpQnRoZ21cbkJwM2xSRUhZTlZh
-      NHNxV0hsVXFha29OdGMySDYydDlubXB6RlY3elhKa3FLUFBwYW5LVjVROXpPRDBWS2djb0ZcbnlB
-      dU1raHVQVjRJZk9FYkc4aWlab3pheWsybmZScm00K256N2IzMS81SGltMk1FY2Uzd2JVdG1XUjZP
-      UGRzd3JcbkI2SzU4ajhUR0d6T0FFRFRkV2M5eU9mL2F1U0lCVkR3KzIzL1RiclZEM3hSV2Rlc0th
-      NHNqN3JNVyszVloxbWhcbjMvZ2h5aFZQdHZGY1VLckFqakJqa2RlTWw4NG0rUCtLY1Y5T3Y1N2Jv
-      aktWUWRLYzdrSHJrcGk0RjY2czRaL0pcblp2V0h3NEx5SzRQUmxSRnptOGVLdFhrWUxGc3N4dFRS
-      WVJ5ZFQ0d2g2VkphT1FEMld3MWNQT2MvRDc0UXIvYXBcbndRdS9meDFHdXFrMWFydGJFK0JhbEph
-      a01OS2Q1Q3UyL01mV3Q4a0VqTmN0R3JBSGVEbXpuay9UYnZYMnJFcHZcbi9QMTZXRmNqQjRiYjFO
-      ZWU5NnhmdUdQVWNIdWwzZkc1VFJtS0puYXhXZWc1Rk00SDRjUDVqbWVYeUdOcWRiRFNcbnJncXBY
-      Q2hlblRCd1M1SnZBVmd2OFp2eEp4cDRoOGZMRmxVT0t1S1VSOTVnQjA5bkJHbndBdEVNNHpnaktr
-      Y0NcblBjdkRaN1lwelU0MGd4NlFpQ1ZiMlVQdGdnaUVwMld5SXJwZThWZnpLNEM3cFFHSW5MbjNS
-      bTRHN21FRmFjdjVcbkhsYkdKTysyWElrM2liRkpZVFF2TUZZYy9FU2VSU093NlREb3kxc2czK1ls
-      NUJYWUMrOTBsQ0dSOUpLL3NCWXNcbjEyZVZFcXhpOGttb05YSjRvbjBzbmZEdVJEdi82YklJRHBm
-      UEFLcVp6YlRxN2g2d3pJcmVvejN3eDRPYThBOVZcbnJ0RzhUT2tDWWFvSlJZRDV1VjFsYzZPazND
-      cFpySTdrVEdBZnZRTmkrSDBPYnorc1NYR2tzTnRmZHdOVXpVZDZcbnA0Q1hyWm1jL3I2bzNqNGJp
-      dGVXVFVSblJRcWtoNjdRTTVxSEpobVh1V0Q4MnNqU0tVMTZNTTBLcVB6ZS9UbCtcbitGaWd4OHBn
-      azI5SDZMTStOOVk9XG4tLS0tLUVORCBFTkNSWVBURUQgUFJJVkFURSBLRVktLS0tLSJ9
+      eyJ2YWx1ZSI6ICItLS0tLUJFR0lOIENFUlRJRklDQVRFLS0tLS1cbk1JSURnekNDQW11Z0F3SUJB
+      Z0lKQUkwbFB4UGI5Z24rTUEwR0NTcUdTSWIzRFFFQkN3VUFNRmd4Q3pBSkJnTlZcbkJBWVRBa0ZW
+      TVJNd0VRWURWUVFJREFwVGIyMWxMVk4wWVhSbE1TRXdId1lEVlFRS0RCaEpiblJsY201bGRDQlhc
+      bmFXUm5hWFJ6SUZCMGVTQk1kR1F4RVRBUEJnTlZCQXNNQ0V0bGVWWmhkV3gwTUI0WERURTJNRGN5
+      TnpBM01UVXdcbk0xb1hEVEU1TURReU16QTNNVFV3TTFvd1dERUxNQWtHQTFVRUJoTUNRVlV4RXpB
+      UkJnTlZCQWdNQ2xOdmJXVXRcblUzUmhkR1V4SVRBZkJnTlZCQW9NR0VsdWRHVnlibVYwSUZkcFpH
+      ZHBkSE1nVUhSNUlFeDBaREVSTUE4R0ExVUVcbkN3d0lTMlY1Vm1GMWJIUXdnZ0VpTUEwR0NTcUdT
+      SWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFDOEVmTm5cbkI3emh1WktHN3BmVDRNSzVpUC94
+      UVNJdlZNeWJNdTlydllOeUZJbE1BbXM2eTlDQjRRUWZObVJ6Sm1OQXBQWnFcbmxTVStnbk9yU0hR
+      K1dzYU1KTk1GamIzditXRmJnY3VleXdGVCs3NmI0SnRTcEJINzgwbjJ5SnJQZHNoV2VzTytcbmx6
+      MDhDbWJZWFJac2pMRisvLzBBOWJvWmFlc3RNbGtNZUJxaHdwNEpUQzR3RUpHNUVIT3hETXkrdTVj
+      bkd3R0dcbnBnWTRDZjZqU3pXK2hPWlo0Y3ByeXNOODV3Y2pNTmNiR2RLek9WaHJzYW00c3pKRitJ
+      eFhpVTJKdVU4MjdnVzhcbk5LVzBWTVRZaW9vcnFXTTRRNmw2QTBOVnlGc3NZNS9WM0laL1IyMzdD
+      UUpKUHdzS2lTbTRjYUljZlk0U0RweFRcblFIRmovbzdyUkVkNTAveERBZ01CQUFHalVEQk9NQjBH
+      QTFVZERnUVdCQlFmTTllUWJGNUR0UlowQ1VjWDBFcm5cbjBhR0FpekFmQmdOVkhTTUVHREFXZ0JR
+      Zk05ZVFiRjVEdFJaMENVY1gwRXJuMGFHQWl6QU1CZ05WSFJNRUJUQURcbkFRSC9NQTBHQ1NxR1NJ
+      YjNEUUVCQ3dVQUE0SUJBUUJzbHhHUU13NzJBS2h2bDRraG0yTStnTG5XdW9hVnp6WVFcbktxNFlN
+      eUk1Qlc1bmw1UU8vODQ5cTVLMGFMTXpQbGxxY2p0MzFlbmoycTgydXdWVTlDdk80QTQ2eGRaK1BK
+      RDFcbk5mN0pJcXhSUU41bTlFek9SQmVsMGFGUjZ6ZFVxV0szMnRBcmpMejBrOVcyeEk3YVFUZlNX
+      a1dFM3E2MStpL3JcbjhYWUl3a3k5clAvaGUxTmN2U0tXc3VTZHJMRXRka0xHcXRtU291RVF4YStR
+      KzdLZXRmZy90ald1dEVhV25PSzFcbnJxS0hmZ1pUMlJOb2VSbk14NEhTZWpRSkxyWkh1dnBDRC8v
+      ZllySzJVUTlqVWFEejg4NjNHUG0vYm4vODA3alBcbndORXRyTmRZYTI2bE0wWXRoSUhJRVBFZG42
+      cmd4SVhPWU1VQm5JUXZhZnBJcTg4RE5LZVRcbi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS1cbi0t
+      LS0tQkVHSU4gRU5DUllQVEVEIFBSSVZBVEUgS0VZLS0tLS1cbk1JSUU2akFjQmdvcWhraUc5dzBC
+      REFFRE1BNEVDSmlMQ2xQTTZ0NUpBZ0lJQUFTQ0JNaWdMK0tsRUE5ZmFnWDBcblBGaFFCZUZqRGll
+      YkpiTXVUZmE5SGNPVlpFRHlycW1HbmcyTGZ6K1RVYTN5cy9WODZva2JVcDJOOU1vR0s3Z3hcbmNQ
+      cWRxN3JudTU2M0xUOXdHaHRuOG1VbjhXdWwwRmZWMks1NndzQkdlaEorTVBtbEVqczZPWlIwblZk
+      WGt3QWhcbmRWSXpIOWVGZHo4bWhKWk9aSTYxVFFOS0NLYkNxc1I3bHNsa0wyVldyU0ZnbkhDVWo1
+      YlIvQkxJQTJvUnBRWnZcbm53MFNlWUZRV01SeVhnS0g0VldNcU9sT2JYbS9FTG5WT3I5ZEpWenZU
+      RzQyRFJhSzVOOEJBOU5UTXNLMSs4bStcbmVuQ2c0aU5JL3M4MU1EOGlJeS9kN01tc0pGaDhXUW9x
+      elVabU9WeGZxTkh3MFRQZ0RwYkNwQ1dSTmlna1JvR1NcblJvc2M3TUlsQ1BQYW5nalBNRlpnNVFl
+      TXVVQnJFMDFmU3ZKdFo1MmpTTWt5bG9TZlF6UUpKYjlBYW02cTZEem9cbnVQQ0gzMnp6MUdWLzU2
+      eUpvTzhJZWZPTUl1anZYRlprdS9RTnpLV2lYbnVTQSt4akZaaEdFR1FUb1U1d0x0SFhcbmVFaHox
+      Y0Y1MTljOENrTTRMbC9VVUhQV3RiOTB2cU8yK08yREx1ZzlxVVVub1FsN1AwTzNXMk5wQW9CQ0x4
+      VU9cbnFyZlN5TFVvc21zN0VnMURJVm81cHd4YXdQSzhxazdnd0xudEFUWmMrYVRTVVI5WTFkbjR2
+      SjlqOUdaV0l1OUpcblZLTzYxNmdETzdxOFIxQzNtVDcyazJvVXVVRzI1VHRaT3hzbCtZM2lKZ0V5
+      cDlON2pvL1JkeDVLa2N2dkI4enRcbmdQQ2g1ZGlLRGpibzNMeG1ZUnQ2MmhlT0xFUHMyWURqS0J5
+      bjBOaWtjbzNMcVRuZWRKZVhFSDJtQmM3eDFWV0VcbjBxVFY0eHFPWEw5RjcwMDBNdjFjSmNFMkU4
+      OGZONnREZ2UxSXB1SmJzMDNJajBPZ3BhRlJmUzU3TmNpQnRoZ21cbkJwM2xSRUhZTlZhNHNxV0hs
+      VXFha29OdGMySDYydDlubXB6RlY3elhKa3FLUFBwYW5LVjVROXpPRDBWS2djb0ZcbnlBdU1raHVQ
+      VjRJZk9FYkc4aWlab3pheWsybmZScm00K256N2IzMS81SGltMk1FY2Uzd2JVdG1XUjZPUGRzd3Jc
+      bkI2SzU4ajhUR0d6T0FFRFRkV2M5eU9mL2F1U0lCVkR3KzIzL1RiclZEM3hSV2Rlc0thNHNqN3JN
+      VyszVloxbWhcbjMvZ2h5aFZQdHZGY1VLckFqakJqa2RlTWw4NG0rUCtLY1Y5T3Y1N2JvaktWUWRL
+      YzdrSHJrcGk0RjY2czRaL0pcblp2V0h3NEx5SzRQUmxSRnptOGVLdFhrWUxGc3N4dFRSWVJ5ZFQ0
+      d2g2VkphT1FEMld3MWNQT2MvRDc0UXIvYXBcbndRdS9meDFHdXFrMWFydGJFK0JhbEpha01OS2Q1
+      Q3UyL01mV3Q4a0VqTmN0R3JBSGVEbXpuay9UYnZYMnJFcHZcbi9QMTZXRmNqQjRiYjFOZWU5Nnhm
+      dUdQVWNIdWwzZkc1VFJtS0puYXhXZWc1Rk00SDRjUDVqbWVYeUdOcWRiRFNcbnJncXBYQ2hlblRC
+      d1M1SnZBVmd2OFp2eEp4cDRoOGZMRmxVT0t1S1VSOTVnQjA5bkJHbndBdEVNNHpnaktrY0NcblBj
+      dkRaN1lwelU0MGd4NlFpQ1ZiMlVQdGdnaUVwMld5SXJwZThWZnpLNEM3cFFHSW5MbjNSbTRHN21F
+      RmFjdjVcbkhsYkdKTysyWElrM2liRkpZVFF2TUZZYy9FU2VSU093NlREb3kxc2czK1lsNUJYWUMr
+      OTBsQ0dSOUpLL3NCWXNcbjEyZVZFcXhpOGttb05YSjRvbjBzbmZEdVJEdi82YklJRHBmUEFLcVp6
+      YlRxN2g2d3pJcmVvejN3eDRPYThBOVZcbnJ0RzhUT2tDWWFvSlJZRDV1VjFsYzZPazNDcFpySTdr
+      VEdBZnZRTmkrSDBPYnorc1NYR2tzTnRmZHdOVXpVZDZcbnA0Q1hyWm1jL3I2bzNqNGJpdGVXVFVS
+      blJRcWtoNjdRTTVxSEpobVh1V0Q4MnNqU0tVMTZNTTBLcVB6ZS9UbCtcbitGaWd4OHBnazI5SDZM
+      TStOOVk9XG4tLS0tLUVORCBFTkNSWVBURUQgUFJJVkFURSBLRVktLS0tLSIsICJhdHRyaWJ1dGVz
+      IjogeyJlbmFibGVkIjogdHJ1ZX0sICJwb2xpY3kiOiB7ImtleV9wcm9wcyI6IHsia3R5IjogIlJT
+      QSIsICJleHBvcnRhYmxlIjogdHJ1ZSwgImtleV9zaXplIjogMjA0OCwgInJldXNlX2tleSI6IGZh
+      bHNlfSwgImlzc3VlciI6IHsibmFtZSI6ICJTZWxmIn0sICJzZWNyZXRfcHJvcHMiOiB7ImNvbnRl
+      bnRUeXBlIjogImFwcGxpY2F0aW9uL3gtcGVtLWZpbGUifX0sICJwd2QiOiAiMTIzNCJ9
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Length: ['3357']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7f050322-a14e-11e6-8b8c-a0b3ccf7272a]
+      x-ms-client-request-id: [5343c44c-a5fd-11e6-9bf6-a0b3ccf7272a]
     method: POST
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert2/import?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert2/111a6caf42f7451b97d2cd8cbad59d55","kid":"https://cli-test-keyvault-cert.vault.azure.net/keys/pem-cert2/111a6caf42f7451b97d2cd8cbad59d55","sid":"https://cli-test-keyvault-cert.vault.azure.net/secrets/pem-cert2/111a6caf42f7451b97d2cd8cbad59d55","x5t":"clJKMjpxEajEvB7NiPaP-Sk0UGM","cer":"MIIDgzCCAmugAwIBAgIJAI0lPxPb9gn+MA0GCSqGSIb3DQEBCwUAMFgxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQxETAPBgNVBAsMCEtleVZhdWx0MB4XDTE2MDcyNzA3MTUwM1oXDTE5MDQyMzA3MTUwM1owWDELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDERMA8GA1UECwwIS2V5VmF1bHQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8EfNnB7zhuZKG7pfT4MK5iP/xQSIvVMybMu9rvYNyFIlMAms6y9CB4QQfNmRzJmNApPZqlSU+gnOrSHQ+WsaMJNMFjb3v+WFbgcueywFT+76b4JtSpBH780n2yJrPdshWesO+lz08CmbYXRZsjLF+//0A9boZaestMlkMeBqhwp4JTC4wEJG5EHOxDMy+u5cnGwGGpgY4Cf6jSzW+hOZZ4cprysN85wcjMNcbGdKzOVhrsam4szJF+IxXiU2JuU827gW8NKW0VMTYioorqWM4Q6l6A0NVyFssY5/V3IZ/R237CQJJPwsKiSm4caIcfY4SDpxTQHFj/o7rREd50/xDAgMBAAGjUDBOMB0GA1UdDgQWBBQfM9eQbF5DtRZ0CUcX0Ern0aGAizAfBgNVHSMEGDAWgBQfM9eQbF5DtRZ0CUcX0Ern0aGAizAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBslxGQMw72AKhvl4khm2M+gLnWuoaVzzYQKq4YMyI5BW5nl5QO/849q5K0aLMzPllqcjt31enj2q82uwVU9CvO4A46xdZ+PJD1Nf7JIqxRQN5m9EzORBel0aFR6zdUqWK32tArjLz0k9W2xI7aQTfSWkWE3q61+i/r8XYIwky9rP/he1NcvSKWsuSdrLEtdkLGqtmSouEQxa+Q+7Ketfg/tjWutEaWnOK1rqKHfgZT2RNoeRnMx4HSejQJLrZHuvpCD//fYrK2UQ9jUaDz8863GPm/bn/807jPwNEtrNdYa26lM0YthIHIEPEdn6rgxIXOYMUBnIQvafpIq88DNKeT","attributes":{"enabled":true,"nbf":1469603703,"exp":1556003703,"created":1478126918,"updated":1478126918},"policy":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert2/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"OU=KeyVault,
-        O=Internet Widgits Pty Ltd, S=Some-State, C=AU","ekus":[],"key_usage":[],"validity_months":33,"basic_constraints":{"ca":true}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1478126918,"updated":1478126918}}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert2/1d92c5ba5b3041b2be6dedb44f60f2ff","kid":"https://cli-test-keyvault-cert.vault.azure.net/keys/pem-cert2/1d92c5ba5b3041b2be6dedb44f60f2ff","sid":"https://cli-test-keyvault-cert.vault.azure.net/secrets/pem-cert2/1d92c5ba5b3041b2be6dedb44f60f2ff","x5t":"clJKMjpxEajEvB7NiPaP-Sk0UGM","cer":"MIIDgzCCAmugAwIBAgIJAI0lPxPb9gn+MA0GCSqGSIb3DQEBCwUAMFgxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQxETAPBgNVBAsMCEtleVZhdWx0MB4XDTE2MDcyNzA3MTUwM1oXDTE5MDQyMzA3MTUwM1owWDELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDERMA8GA1UECwwIS2V5VmF1bHQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8EfNnB7zhuZKG7pfT4MK5iP/xQSIvVMybMu9rvYNyFIlMAms6y9CB4QQfNmRzJmNApPZqlSU+gnOrSHQ+WsaMJNMFjb3v+WFbgcueywFT+76b4JtSpBH780n2yJrPdshWesO+lz08CmbYXRZsjLF+//0A9boZaestMlkMeBqhwp4JTC4wEJG5EHOxDMy+u5cnGwGGpgY4Cf6jSzW+hOZZ4cprysN85wcjMNcbGdKzOVhrsam4szJF+IxXiU2JuU827gW8NKW0VMTYioorqWM4Q6l6A0NVyFssY5/V3IZ/R237CQJJPwsKiSm4caIcfY4SDpxTQHFj/o7rREd50/xDAgMBAAGjUDBOMB0GA1UdDgQWBBQfM9eQbF5DtRZ0CUcX0Ern0aGAizAfBgNVHSMEGDAWgBQfM9eQbF5DtRZ0CUcX0Ern0aGAizAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBslxGQMw72AKhvl4khm2M+gLnWuoaVzzYQKq4YMyI5BW5nl5QO/849q5K0aLMzPllqcjt31enj2q82uwVU9CvO4A46xdZ+PJD1Nf7JIqxRQN5m9EzORBel0aFR6zdUqWK32tArjLz0k9W2xI7aQTfSWkWE3q61+i/r8XYIwky9rP/he1NcvSKWsuSdrLEtdkLGqtmSouEQxa+Q+7Ketfg/tjWutEaWnOK1rqKHfgZT2RNoeRnMx4HSejQJLrZHuvpCD//fYrK2UQ9jUaDz8863GPm/bn/807jPwNEtrNdYa26lM0YthIHIEPEdn6rgxIXOYMUBnIQvafpIq88DNKeT","attributes":{"enabled":true,"nbf":1469603703,"exp":1556003703,"created":1478641812,"updated":1478641812},"policy":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pem-cert2/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pem-file"},"x509_props":{"subject":"OU=KeyVault,
+        O=Internet Widgits Pty Ltd, S=Some-State, C=AU","ekus":[],"key_usage":[],"validity_months":33,"basic_constraints":{"ca":true}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1478641812,"updated":1478641812}}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['2263']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:37 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:12 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1829,99 +2080,99 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJhdHRyaWJ1dGVzIjogeyJlbmFibGVkIjogdHJ1ZX0sICJwb2xpY3kiOiB7InNlY3JldF9wcm9w
-      cyI6IHsiY29udGVudFR5cGUiOiAiYXBwbGljYXRpb24veC1wa2NzMTIifSwgImlzc3VlciI6IHsi
-      bmFtZSI6ICJTZWxmIn0sICJrZXlfcHJvcHMiOiB7ImV4cG9ydGFibGUiOiB0cnVlLCAia3R5Ijog
-      IlJTQSIsICJyZXVzZV9rZXkiOiBmYWxzZSwgImtleV9zaXplIjogMjA0OH19LCAidmFsdWUiOiAi
-      TUlJS2lRSUJBekNDQ2s4R0NTcUdTSWIzRFFFSEFhQ0NDa0FFZ2dvOE1JSUtPRENDQk84R0NTcUdT
-      SWIzRFFFSEJxQ0NCT0F3Z2dUY0FnRUFNSUlFMVFZSktvWklodmNOQVFjQk1Cd0dDaXFHU0liM0RR
-      RU1BUVl3RGdRSWJ3T0J4NC9OcmhZQ0FnZ0FnSUlFcUZ0MmpSb1JlT2lzUFJoaytQSGV2Rk9JSEll
-      VDc1aGlqQzY4VEtBSG1FSzdiQ1o2UkZ6eUNEK2dNYXJGNlh5YUhpTlc2R0RkWFc0eHk4ZXlmODlE
-      ZXlpSG1iY2tjUUtZWlcwMWNxTE53bVd5MzZoYVhJK1JXK1lCRUdPbmRCaXllUUVpWGdGQVN5RFRx
-      ZlA3ZG15RWU5SjFqOEpva2JtanU3dEJGTVJSeEFkR1FEeVBzY2F6QTJxMEJGOXVYM2pEWnZRcmE3
-      dXB4bjljaEhKcU9kTzIxZ1ErRG9ndjBiYjZmT0V2aW85QXFVV2Ztc3RIWWlYVElrd2FxOG94Tnk1
-      MDlPa0hTaU5GZUV2SktVSzRFVjdIeWUxbXFRdzQxVUp1NCtSOG5JOUhuY0U1MDRwandEYzBmM3Z3
-      aFFUK2orZUgxSEd1Z2F5VXpFQmlobDlZbHAvVmZ4ZVNJSUV0TGVnRUxDSGFzOUU3eWdXU0Zvblhk
-      Q1BNQUtFM296V29YTTQzZXcyQ1FaZStqMnYxZVg1dDlLU215ZGN3RzB3L0RkYklQUVFlaVIvQTd4
-      WThESDR6MlY0OXYxMG1td0gwdUcvLzFKTldjaUtidDQ3QzJzQmN4UHZMRGtHWHE3eFgwZjl6WmNX
-      TzVpcE51YVBxN1JocjdKSEZuZnZsVmFnM0NnOWo3MEdRNmMxeGhnc3VOelYwTDZOcmFqc3U1V1Mr
-      R0UwNWhGb3MxRWFsSHo1OEtPQUYwUTRzbjdjZzlubXdHZnZYRFBSREE4b2wyeVNYV0QvVERqMEdO
-      TWFMVEVvWFVRdHh3ZWJWaDJ3dWlwb0VCMTNLanpXL202QWVLRW1YTG1rU3dRZVpxMklCVFp4eHpy
-      eFhVYklUMnFUVWJqSTk2ZnhlWG0rVkhtOUpaU2E3M3I2dmtPTkExWGN4OVE4dHZWMlpDZlRWejlk
-      bkVjRDRDRTMzZlgwWFM1clpFaVVHcW1OZG52UUkzQjdnc29QdDhlaDE3dlNwSE5lSlRoRDI0a0JF
-      WGY0YzNEYUdaQXZLT3V0NnBpMjhxU05lMU9jUXd6Wm5wTnJvOEFLbUhWc3JNSUNHN1p1Y21Lb1lO
-      bmRSbFBySHJma0ZpMWFvTnVnSk92UGNjNHgwdTVPWWU3WFc2L01CVS9iblVib3cydlJ0a2xJNjhU
-      Q0VwQ2o5WVMvZGJBQjV1eFR4eG5samF0cWg3T3lxY2Q2VDhMYTdXdWd6MFVmdTZkZGp1b2hmdTlJ
-      SFNBQUswcXZyTytBQU9JbDE5cCt3T3gwUlZidFpjcHBJSVF1dGZmMGRUb3A1K2F1TkRpblk2UTRM
-      NEVvVWIyenFaL1pBOGZ5ZWNNenVPTjNoaktJM2NCMFdteDdkWlVnYzR3MW1ORCtBeFFwOGlySVlU
-      OFJmaDE2YVlnL2dQOS9xOGtkNUZEQXBQa09kQjV3a0lhdWRBcnRkdEFvOGptSnpQeUJWcXRaWWRL
-      QTg4V0lOcWFCdDljMVJNWWdUbFU2dExsbHNlSk5SQnRHSGFXMGtkVzhxQnhJYlc4TTQ0M25qaXF0
-      ck55NVFSZFlYb0sxMnc1VFFFUzlydEcwblJMTm1hQjBXajBzZFRNeWY1dnBXbmFBd3FZU0VCNHVS
-      RmRGTVRiYUZOT05DeW4xY1lTUG5lZ2pPZnZ2blMyL0tXWEsyT3luQWFKbjc3Znk4ZUdzc011dlZo
-      NzV2YjVXOTV6R2hWdEhwRzROK25oSm96VlRvdWZZUEQzVjlFY1RuT1VhblRJNXVpZW4rRDVEb3k4
-      TCtLeFU2SWtpMm05ZGJMT1M1NVRQYlRoNUxMN1VDOEFXWmNkM29sNWtnczVYeFVPVk1jOFJHdXRt
-      ZWI0QWpHTTJiRzZBYzJCeStMSFpBaXJUZG9WOVRQOENVaEZaOWlvd2lwWmhLQUNWVHRoaktRYS80
-      UFZGQUxjbjlQMy91ZjBnMEJnaGsyTGdYbi9TWkZBVFpwMFdxeU5IUjZNR3V0aGpZZWJWYm16YjNX
-      V0VsZGxMWFhuaHF4QU5pQUlEelNXcHBsSC9DNXdQQkNTN204OWxrNEh1cGkzNFNlRnlHQnA4M0sx
-      b1Y5cGRnVjJrMGJiM2VoS3pFYzRyRld6VXdnZ1ZCQmdrcWhraUc5dzBCQndHZ2dnVXlCSUlGTGpD
-      Q0JTb3dnZ1VtQmdzcWhraUc5dzBCREFvQkFxQ0NCTzR3Z2dUcU1Cd0dDaXFHU0liM0RRRU1BUU13
-      RGdRSS9JQXNuR2J3bGxzQ0FnZ0FCSUlFeU1rRC9yYU8yNmJuWC8rVGtXNzJEdWVSSksxVXJVekpm
-      dHJtZ2ltRXVWNXhQN05xS2FPRGl1YzYzNkxwMFZKdktlZVMzeEZrLzNRVGVOV0ZSNlRNMHZoYUo1
-      ZTJXa0ZTY1krY1JXd1lCRzFFOTErRlNzclpXTGkxeUFzcmZ5ZGR5OG9jQ2NhOVBQOE1nTUZLRC96
-      Qmh4dHc2Nko5a1BUWkM4MGY1M3NJdW1Yd3Z6elEwRkE1SkI3a2ZkZFBnMmZab2tnN0RGM1pvQlMv
-      UDNhbGFRK2pweDBrNXMxOWwwall6dkkrMkZ6SWFzb1hzL014OE9KYm5QK1FUa21VdjdBT3d0WmZQ
-      UmcxVlZvTHRCMWVEeUV3REdqUjluZURnbXhJSExGYTFJOTExRDZmeVIxTEwvanFqejJIUk1JWkJ4
-      MXg1Ykk1aXBwUU1uZXVhZVpxOVpwVTllbDNKajhVenhrcG1QMWd6VG5mbGQzQlNpbDBMTGpnalRP
-      VjBIWXRiOGlmYi9MbGk4ckpvVXB5Y01kWkYxOURQbmowQ1pLYVRoVjlmR2xNbTlNYmZFSytFTklL
-      WFhMbUM5a1Y1cGl5ekY0cS9PUkd5c2JlbW9XMUc4VXZQc3h5S09XVmVBTEtFZHdNWEp5WjRHK0tm
-      Z2Q1ek1NcklHZzhDOHhvWDV3UTNrS0lWWnFodUttUVZNMXQ3cExPdUpOeE5GbXZ6Uy8wOHRydWx6
-      UEJOSytVREdnaHJpMlZCclJyRThORWxOYnNERFduTU50RjN1dm15UU1hMU1oeVQvN1A0dmlUZGNV
-      MUM2V0Y0eTVJNksyeVNYL3g1VW91a2gwemZOenNNdDNoemVZeVFEQXNjSTZnS1VxcUFpbkVVUVdZ
-      ajFFclVzZ3o3dThxRkFlN1pKRUt0Vk9QV09yR0VPbk1kSjdZZVI1ZG54OVdYK3M4VXkyK2dGSlZP
-      R3JXbjZVUXp6LysrRE9NMkFINm9GNlFEd3BUNTFmbFN6Qk41VWhMbDg4dXVidGdvN0pCNjdSSnBC
-      QzRlWjZNam5oODhndEVuOUx2YVVVcDhxVnNZRUNySzRQRjNrZkdia251MnkySy9yUE1lbEt2U0dp
-      a1MyS0hNRFBwZjRIS3NodUlsQjJobjhmSW1jckx5bURDemtxaVNWN1dkY0s2RC8vd25RRUxSayt4
-      bjdTWEpVK1N0UEdmY09uQzFIY25zdG5oMTd3OUc0WEo5R3NiNmtiWlA3R3B5M0wwdndCUjNQVTRT
-      OGtrT0VwQkVMaVRZaHJtV0hCV3k1elM5aDJVTUU2L0VhZWJ5b2tQcnpyRHJGMnRna0tIVjRtODRw
-      S1BmZUN4QUVHc1VtOEhnVFVCYU1TL1oweVI1K0I3b2FjN3ladWhSQnRlY0RGc2cvQVZ6c2p5V0Iv
-      MFBid01FNmJSUWJhdTh2SlJWQ1M4TmNwYkpZY3d6T25PRW9PMEdqSWVzMXRZZGRtWlh4OEpsL1Zl
-      dnFlTXcydTMvZkl0TEN5eER3ODk0ZmxGMnRieFdDL2xEN1lHZVU3Y25BZnNjcktYQk5VdUhaVER2
-      MmwxazFSNEdudm5GZXA0YmN2T1dJOU1kcFYwT21vdjZkRUM4eDE4Um1meFdvZmhBRlRIdnoxZmlJ
-      N215UFlSZEF4d2h4cWtzbEt1UkljWDh6bHVPZjFMN1AzbzZnb0pmR2VUbGorNmlCMU44MnUrekVD
-      Qy8zN2M2dmF6NDBISS9rK2srS3l5S2U3RlF5cmJoZXB5LzhkczFOTXBzR1BtcXNKeHJ2eXI0dndE
-      ZmtCekJlU1BsTzhjMHI0TkJTUkYzak9qQU8ySDJteG5CU0d2KzR1THR5UENUd1ZnM0hPSWU2WFRJ
-      dFdDaVQwbGZmdUpyNVViUzBaM1hxZmtvNzBaVk16bkxvb1NsZXZiakhLSTdaWDVISWpXVDlocktZ
-      UlcyeHJkZmhIRTh1T3NPSmdWRFBrcGFCUEJUdTdsMnZjK0NRbFcvczBIaHVJY25WVW9MOGYyRFBW
-      VUhXUk01STlZS3JscG1ERXlPYyswRUhyRW1lVkQ5SG01NzBIZzRqQzFNdFF2RmpCeHVhMnRtaUY3
-      dktoME9MTjk3WS90bE1lWWdXREh1U0tDUnpTMTFMdU9VWUFRUEd2NHJYV283U0E0ZFNNMzlQQndz
-      UTlCVURFbE1DTUdDU3FHU0liM0RRRUpGVEVXQkJTVTJIaE8wVlZqVzNkNkwvZ0wvNkd3aHZrOGhq
-      QXhNQ0V3Q1FZRkt3NERBaG9GQUFRVW0vN3hWUUdHcXB4Q0NwMVRjKzQ4anY2R3hia0VDRjhZa0Mw
-      bnpxd3JBZ0lJQUE9PVxuIn0=
+      eyJ2YWx1ZSI6ICJNSUlLaVFJQkF6Q0NDazhHQ1NxR1NJYjNEUUVIQWFDQ0NrQUVnZ284TUlJS09E
+      Q0NCTzhHQ1NxR1NJYjNEUUVIQnFDQ0JPQXdnZ1RjQWdFQU1JSUUxUVlKS29aSWh2Y05BUWNCTUJ3
+      R0NpcUdTSWIzRFFFTUFRWXdEZ1FJYndPQng0L05yaFlDQWdnQWdJSUVxRnQyalJvUmVPaXNQUmhr
+      K1BIZXZGT0lISWVUNzVoaWpDNjhUS0FIbUVLN2JDWjZSRnp5Q0QrZ01hckY2WHlhSGlOVzZHRGRY
+      VzR4eThleWY4OURleWlIbWJja2NRS1laVzAxY3FMTndtV3kzNmhhWEkrUlcrWUJFR09uZEJpeWVR
+      RWlYZ0ZBU3lEVHFmUDdkbXlFZTlKMWo4Sm9rYm1qdTd0QkZNUlJ4QWRHUUR5UHNjYXpBMnEwQkY5
+      dVgzakRadlFyYTd1cHhuOWNoSEpxT2RPMjFnUStEb2d2MGJiNmZPRXZpbzlBcVVXZm1zdEhZaVhU
+      SWt3YXE4b3hOeTUwOU9rSFNpTkZlRXZKS1VLNEVWN0h5ZTFtcVF3NDFVSnU0K1I4bkk5SG5jRTUw
+      NHBqd0RjMGYzdndoUVQraitlSDFIR3VnYXlVekVCaWhsOVlscC9WZnhlU0lJRXRMZWdFTENIYXM5
+      RTd5Z1dTRm9uWGRDUE1BS0Uzb3pXb1hNNDNldzJDUVplK2oydjFlWDV0OUtTbXlkY3dHMHcvRGRi
+      SVBRUWVpUi9BN3hZOERINHoyVjQ5djEwbW13SDB1Ry8vMUpOV2NpS2J0NDdDMnNCY3hQdkxEa0dY
+      cTd4WDBmOXpaY1dPNWlwTnVhUHE3UmhyN0pIRm5mdmxWYWczQ2c5ajcwR1E2YzF4aGdzdU56VjBM
+      Nk5yYWpzdTVXUytHRTA1aEZvczFFYWxIejU4S09BRjBRNHNuN2NnOW5td0dmdlhEUFJEQThvbDJ5
+      U1hXRC9URGowR05NYUxURW9YVVF0eHdlYlZoMnd1aXBvRUIxM0tqelcvbTZBZUtFbVhMbWtTd1Fl
+      WnEySUJUWnh4enJ4WFViSVQycVRVYmpJOTZmeGVYbStWSG05SlpTYTczcjZ2a09OQTFYY3g5UTh0
+      dlYyWkNmVFZ6OWRuRWNENENFMzNmWDBYUzVyWkVpVUdxbU5kbnZRSTNCN2dzb1B0OGVoMTd2U3BI
+      TmVKVGhEMjRrQkVYZjRjM0RhR1pBdktPdXQ2cGkyOHFTTmUxT2NRd3pabnBOcm84QUttSFZzck1J
+      Q0c3WnVjbUtvWU5uZFJsUHJIcmZrRmkxYW9OdWdKT3ZQY2M0eDB1NU9ZZTdYVzYvTUJVL2JuVWJv
+      dzJ2UnRrbEk2OFRDRXBDajlZUy9kYkFCNXV4VHh4bmxqYXRxaDdPeXFjZDZUOExhN1d1Z3owVWZ1
+      NmRkanVvaGZ1OUlIU0FBSzBxdnJPK0FBT0lsMTlwK3dPeDBSVmJ0WmNwcElJUXV0ZmYwZFRvcDUr
+      YXVORGluWTZRNEw0RW9VYjJ6cVovWkE4ZnllY016dU9OM2hqS0kzY0IwV214N2RaVWdjNHcxbU5E
+      K0F4UXA4aXJJWVQ4UmZoMTZhWWcvZ1A5L3E4a2Q1RkRBcFBrT2RCNXdrSWF1ZEFydGR0QW84am1K
+      elB5QlZxdFpZZEtBODhXSU5xYUJ0OWMxUk1ZZ1RsVTZ0TGxsc2VKTlJCdEdIYVcwa2RXOHFCeEli
+      VzhNNDQzbmppcXRyTnk1UVJkWVhvSzEydzVUUUVTOXJ0RzBuUkxObWFCMFdqMHNkVE15ZjV2cFdu
+      YUF3cVlTRUI0dVJGZEZNVGJhRk5PTkN5bjFjWVNQbmVnak9mdnZuUzIvS1dYSzJPeW5BYUpuNzdm
+      eThlR3NzTXV2Vmg3NXZiNVc5NXpHaFZ0SHBHNE4rbmhKb3pWVG91ZllQRDNWOUVjVG5PVWFuVEk1
+      dWllbitENURveThMK0t4VTZJa2kybTlkYkxPUzU1VFBiVGg1TEw3VUM4QVdaY2Qzb2w1a2dzNVh4
+      VU9WTWM4Ukd1dG1lYjRBakdNMmJHNkFjMkJ5K0xIWkFpclRkb1Y5VFA4Q1VoRlo5aW93aXBaaEtB
+      Q1ZUdGhqS1FhLzRQVkZBTGNuOVAzL3VmMGcwQmdoazJMZ1huL1NaRkFUWnAwV3F5TkhSNk1HdXRo
+      alllYlZibXpiM1dXRWxkbExYWG5ocXhBTmlBSUR6U1dwcGxIL0M1d1BCQ1M3bTg5bGs0SHVwaTM0
+      U2VGeUdCcDgzSzFvVjlwZGdWMmswYmIzZWhLekVjNHJGV3pVd2dnVkJCZ2txaGtpRzl3MEJCd0dn
+      Z2dVeUJJSUZMakNDQlNvd2dnVW1CZ3NxaGtpRzl3MEJEQW9CQXFDQ0JPNHdnZ1RxTUJ3R0NpcUdT
+      SWIzRFFFTUFRTXdEZ1FJL0lBc25HYndsbHNDQWdnQUJJSUV5TWtEL3JhTzI2Ym5YLytUa1c3MkR1
+      ZVJKSzFVclV6SmZ0cm1naW1FdVY1eFA3TnFLYU9EaXVjNjM2THAwVkp2S2VlUzN4RmsvM1FUZU5X
+      RlI2VE0wdmhhSjVlMldrRlNjWStjUld3WUJHMUU5MStGU3NyWldMaTF5QXNyZnlkZHk4b2NDY2E5
+      UFA4TWdNRktEL3pCaHh0dzY2SjlrUFRaQzgwZjUzc0l1bVh3dnp6UTBGQTVKQjdrZmRkUGcyZlpv
+      a2c3REYzWm9CUy9QM2FsYVEranB4MGs1czE5bDBqWXp2SSsyRnpJYXNvWHMvTXg4T0piblArUVRr
+      bVV2N0FPd3RaZlBSZzFWVm9MdEIxZUR5RXdER2pSOW5lRGdteElITEZhMUk5MTFENmZ5UjFMTC9q
+      cWp6MkhSTUlaQngxeDViSTVpcHBRTW5ldWFlWnE5WnBVOWVsM0pqOFV6eGtwbVAxZ3pUbmZsZDNC
+      U2lsMExMamdqVE9WMEhZdGI4aWZiL0xsaThySm9VcHljTWRaRjE5RFBuajBDWkthVGhWOWZHbE1t
+      OU1iZkVLK0VOSUtYWExtQzlrVjVwaXl6RjRxL09SR3lzYmVtb1cxRzhVdlBzeHlLT1dWZUFMS0Vk
+      d01YSnlaNEcrS2ZnZDV6TU1ySUdnOEM4eG9YNXdRM2tLSVZacWh1S21RVk0xdDdwTE91Sk54TkZt
+      dnpTLzA4dHJ1bHpQQk5LK1VER2docmkyVkJyUnJFOE5FbE5ic0REV25NTnRGM3V2bXlRTWExTWh5
+      VC83UDR2aVRkY1UxQzZXRjR5NUk2SzJ5U1gveDVVb3VraDB6Zk56c010M2h6ZVl5UURBc2NJNmdL
+      VXFxQWluRVVRV1lqMUVyVXNnejd1OHFGQWU3WkpFS3RWT1BXT3JHRU9uTWRKN1llUjVkbng5V1gr
+      czhVeTIrZ0ZKVk9HclduNlVRenovKytET00yQUg2b0Y2UUR3cFQ1MWZsU3pCTjVVaExsODh1dWJ0
+      Z283SkI2N1JKcEJDNGVaNk1qbmg4OGd0RW45THZhVVVwOHFWc1lFQ3JLNFBGM2tmR2JrbnUyeTJL
+      L3JQTWVsS3ZTR2lrUzJLSE1EUHBmNEhLc2h1SWxCMmhuOGZJbWNyTHltREN6a3FpU1Y3V2RjSzZE
+      Ly93blFFTFJrK3huN1NYSlUrU3RQR2ZjT25DMUhjbnN0bmgxN3c5RzRYSjlHc2I2a2JaUDdHcHkz
+      TDB2d0JSM1BVNFM4a2tPRXBCRUxpVFlocm1XSEJXeTV6UzloMlVNRTYvRWFlYnlva1ByenJEckYy
+      dGdrS0hWNG04NHBLUGZlQ3hBRUdzVW04SGdUVUJhTVMvWjB5UjUrQjdvYWM3eVp1aFJCdGVjREZz
+      Zy9BVnpzanlXQi8wUGJ3TUU2YlJRYmF1OHZKUlZDUzhOY3BiSlljd3pPbk9Fb08wR2pJZXMxdFlk
+      ZG1aWHg4SmwvVmV2cWVNdzJ1My9mSXRMQ3l4RHc4OTRmbEYydGJ4V0MvbEQ3WUdlVTdjbkFmc2Ny
+      S1hCTlV1SFpURHYybDFrMVI0R252bkZlcDRiY3ZPV0k5TWRwVjBPbW92NmRFQzh4MThSbWZ4V29m
+      aEFGVEh2ejFmaUk3bXlQWVJkQXh3aHhxa3NsS3VSSWNYOHpsdU9mMUw3UDNvNmdvSmZHZVRsais2
+      aUIxTjgydSt6RUNDLzM3YzZ2YXo0MEhJL2sraytLeXlLZTdGUXlyYmhlcHkvOGRzMU5NcHNHUG1x
+      c0p4cnZ5cjR2d0Rma0J6QmVTUGxPOGMwcjROQlNSRjNqT2pBTzJIMm14bkJTR3YrNHVMdHlQQ1R3
+      VmczSE9JZTZYVEl0V0NpVDBsZmZ1SnI1VWJTMFozWHFma283MFpWTXpuTG9vU2xldmJqSEtJN1pY
+      NUhJaldUOWhyS1lSVzJ4cmRmaEhFOHVPc09KZ1ZEUGtwYUJQQlR1N2wydmMrQ1FsVy9zMEhodUlj
+      blZVb0w4ZjJEUFZVSFdSTTVJOVlLcmxwbURFeU9jKzBFSHJFbWVWRDlIbTU3MEhnNGpDMU10UXZG
+      akJ4dWEydG1pRjd2S2gwT0xOOTdZL3RsTWVZZ1dESHVTS0NSelMxMUx1T1VZQVFQR3Y0clhXbzdT
+      QTRkU00zOVBCd3NROUJVREVsTUNNR0NTcUdTSWIzRFFFSkZURVdCQlNVMkhoTzBWVmpXM2Q2TC9n
+      TC82R3dodms4aGpBeE1DRXdDUVlGS3c0REFob0ZBQVFVbS83eFZRR0dxcHhDQ3AxVGMrNDhqdjZH
+      eGJrRUNGOFlrQzBuenF3ckFnSUlBQT09XG4iLCAiYXR0cmlidXRlcyI6IHsiZW5hYmxlZCI6IHRy
+      dWV9LCAicG9saWN5IjogeyJrZXlfcHJvcHMiOiB7Imt0eSI6ICJSU0EiLCAiZXhwb3J0YWJsZSI6
+      IHRydWUsICJrZXlfc2l6ZSI6IDIwNDgsICJyZXVzZV9rZXkiOiBmYWxzZX0sICJpc3N1ZXIiOiB7
+      Im5hbWUiOiAiU2VsZiJ9LCAic2VjcmV0X3Byb3BzIjogeyJjb250ZW50VHlwZSI6ICJhcHBsaWNh
+      dGlvbi94LXBrY3MxMiJ9fX0=
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMjU1NTcsIm5iZiI6MTQ3ODEyNTU1NywiZXhwIjoxNDc4MTI5NDU3LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.TZUoxJp7EMEpb-kycWpqD84JWY2-xLR6UQgiCFHMeYEn9o0AyZIbATjX8qFLOiRLIpkrJ67bLKtu1b5kKQWc0FtPCY9n5xkGcp0TL3khLaGQdYRhNBxfR0jV4aA17a_ISm5JqRsQFw4x3IM2tkE_lsAxiJP9wMezRUzUG4PNGOnkfzsHK5SruKitMYSVAcyw0vV4FzY7P6vPyFO9dm-oW-d3GWj3Apq7Hyj7GgD9UspGWQw1u0YlQBtnUEJ88wi4MqlRWUmISCZaPOaRxSo1iKc5bE3FvsrY3OrGRhh6dCx6TMbFXP-B9yFHZ55gjlH_m3-_lyaKPB085jDnRZYz2Q]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Length: ['3836']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [7f783cfa-a14e-11e6-8d02-a0b3ccf7272a]
+      x-ms-client-request-id: [53e3e1d8-a5fd-11e6-9cc6-a0b3ccf7272a]
     method: POST
     uri: https://cli-test-keyvault-cert.vault.azure.net/certificates/pfx-cert/import?api-version=2015-06-01
   response:
-    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pfx-cert/7143e9c324f643918d0509b02ff0c550","kid":"https://cli-test-keyvault-cert.vault.azure.net/keys/pfx-cert/7143e9c324f643918d0509b02ff0c550","sid":"https://cli-test-keyvault-cert.vault.azure.net/secrets/pfx-cert/7143e9c324f643918d0509b02ff0c550","x5t":"lNh4TtFVY1t3ei_4C_-hsIb5PIY","cer":"MIIERTCCAy2gAwIBAgIJALVCxh7S3lKsMA0GCSqGSIb3DQEBBQUAMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTAeFw0xNjEwMjYyMjM2NDRaFw0xNzEwMjYyMjM2NDRaMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANyYGOBFKSucBh9BTDZ9LOytCu9gjfds0KkzZ8bXMDY3E/N4VdxZfOuIRPw8Da20eMSZQSaAkCiJgwBLEsHWTyyae5sGXEWCwdRzgBk2W3U7FZ1/ymTg928R02GlQTNz8MHMGwk47nhyIXvRxvldqSg/0q28k/iC/BUkibL1No6JBloCzszktCuHH3sYrA9i62TOoPRnqflsshKVQHhh+VQsgUK/lu6qlgFrf12FMvwWsz9tCO03he6RMzhAk84aG+JYgF9pD1l0KU4dda1zfEVQ4K947WA/ghfBYopmZ/vRGAzHVoCSm5RyEDc9EyE2+NZx37Ng/I6keQy51Q2amI0CAwEAAaOB2TCB1jAdBgNVHQ4EFgQU+PapMyOAGd5G6GKBYVt8eIYPEwswgaYGA1UdIwSBnjCBm4AU+PapMyOAGd5G6GKBYVt8eIYPEwuheKR2MHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbYIJALVCxh7S3lKsMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAK7hpA3xfXaeg03xKNugcH/TkSPt2QAs89+trySNfMKaWZvei72XdkWBeC6ZyG/15hHjjpGF+NFzIMWVIeE8SnGQB6L5FiBH7+0lOQQrXpQOEnaPVz03R6y2rKROjrgROHmHL7JJRA93Zj9loVNNXOfpG228agLEOhYF0xXBPBms5V8LrcoWmmq4g8hRDz8xoS+VZBE5WJn8lnk4Hm1tKlwftHGcrhXIm4JpEqtj6WRqykrX6RpxeR/pqKl6qhZzRs3r3OOEdbHyH0iHR5/LlWh4THHeXIZOyI+3RZyYXvF0xJfZh0AZCRGjhrRETin8gIdA7kneMIYKI10JtLzw2nk=","attributes":{"enabled":true,"nbf":1477521404,"exp":1509057404,"created":1478126920,"updated":1478126920},"policy":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pfx-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"E=test@test.com,
-        CN=Test, OU=Test, O=Test, L=Test, S=WA, C=US","ekus":[],"key_usage":[],"validity_months":13,"basic_constraints":{"ca":true}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1478126920,"updated":1478126920}}}'}
+    body: {string: '{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pfx-cert/0178933632404bf59b638371c6be1f84","kid":"https://cli-test-keyvault-cert.vault.azure.net/keys/pfx-cert/0178933632404bf59b638371c6be1f84","sid":"https://cli-test-keyvault-cert.vault.azure.net/secrets/pfx-cert/0178933632404bf59b638371c6be1f84","x5t":"lNh4TtFVY1t3ei_4C_-hsIb5PIY","cer":"MIIERTCCAy2gAwIBAgIJALVCxh7S3lKsMA0GCSqGSIb3DQEBBQUAMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTAeFw0xNjEwMjYyMjM2NDRaFw0xNzEwMjYyMjM2NDRaMHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANyYGOBFKSucBh9BTDZ9LOytCu9gjfds0KkzZ8bXMDY3E/N4VdxZfOuIRPw8Da20eMSZQSaAkCiJgwBLEsHWTyyae5sGXEWCwdRzgBk2W3U7FZ1/ymTg928R02GlQTNz8MHMGwk47nhyIXvRxvldqSg/0q28k/iC/BUkibL1No6JBloCzszktCuHH3sYrA9i62TOoPRnqflsshKVQHhh+VQsgUK/lu6qlgFrf12FMvwWsz9tCO03he6RMzhAk84aG+JYgF9pD1l0KU4dda1zfEVQ4K947WA/ghfBYopmZ/vRGAzHVoCSm5RyEDc9EyE2+NZx37Ng/I6keQy51Q2amI0CAwEAAaOB2TCB1jAdBgNVHQ4EFgQU+PapMyOAGd5G6GKBYVt8eIYPEwswgaYGA1UdIwSBnjCBm4AU+PapMyOAGd5G6GKBYVt8eIYPEwuheKR2MHQxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJXQTENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbYIJALVCxh7S3lKsMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAK7hpA3xfXaeg03xKNugcH/TkSPt2QAs89+trySNfMKaWZvei72XdkWBeC6ZyG/15hHjjpGF+NFzIMWVIeE8SnGQB6L5FiBH7+0lOQQrXpQOEnaPVz03R6y2rKROjrgROHmHL7JJRA93Zj9loVNNXOfpG228agLEOhYF0xXBPBms5V8LrcoWmmq4g8hRDz8xoS+VZBE5WJn8lnk4Hm1tKlwftHGcrhXIm4JpEqtj6WRqykrX6RpxeR/pqKl6qhZzRs3r3OOEdbHyH0iHR5/LlWh4THHeXIZOyI+3RZyYXvF0xJfZh0AZCRGjhrRETin8gIdA7kneMIYKI10JtLzw2nk=","attributes":{"enabled":true,"nbf":1477521404,"exp":1509057404,"created":1478641813,"updated":1478641813},"policy":{"id":"https://cli-test-keyvault-cert.vault.azure.net/certificates/pfx-cert/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"E=test@test.com,
+        CN=Test, OU=Test, O=Test, L=Test, S=WA, C=US","ekus":[],"key_usage":[],"validity_months":13,"basic_constraints":{"ca":true}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1478641813,"updated":1478641813}}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['2519']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 22:48:40 GMT']
+      Date: ['Tue, 08 Nov 2016 21:50:14 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1930,6 +2181,6 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/recordings/test_keyvault_secret.yaml
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/recordings/test_keyvault_secret.yaml
@@ -1,27 +1,28 @@
 interactions:
 - request:
     body: !!binary |
-      eyJ2YWx1ZSI6ICJBQkMxMjMiLCAiYXR0cmlidXRlcyI6IHsiZW5hYmxlZCI6IHRydWV9fQ==
+      eyJ2YWx1ZSI6ICJBQkMxMjMiLCAidGFncyI6IHsiZmlsZS1lbmNvZGluZyI6ICJ1dGYtOCJ9LCAi
+      YXR0cmlidXRlcyI6IHsiZW5hYmxlZCI6IHRydWV9fQ==
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMTI1NTYsIm5iZiI6MTQ3ODExMjU1NiwiZXhwIjoxNDc4MTE2NDU2LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.YiXYcbk6VcghbG5fjq5R7XbaRD64YO-b3YQemB-zsIwPmwXJlJSlQZEKX270rXhjrdLpunu1tkvFF2ZnzBjAz43P98_tQ6b1tu9HBU0H-VET3ndPpv0k3pY0f7NsE1VBiteKzWye1SSzC9-fxyheoSr6rpZOTftYg2HncLC3NQgxRQlO_GPtf2odewMrKETK0q6aroV9_VzIbGHf3tVZ8i1JMJVtyDFlA1RHH1kl_zQ7_8WAhacEEYn7esIjqhHVutdnKUOh4A4W7m35zyE8BZRVZZbP_dI-AIvEiJUkYUUZI4N95DntQW5yoxWtoFlEiKAPxd0_w9cGfQIAnKD_yA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
-      Content-Length: ['52']
+      Content-Length: ['88']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [f2c4d14a-a133-11e6-8b47-a0b3ccf7272a]
+      x-ms-client-request-id: [a11d6458-a5f7-11e6-8d9d-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1?api-version=2015-06-01
   response:
-    body: {string: '{"value":"ABC123","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/82d81101b3864937ad2aa146cd0c727a","attributes":{"enabled":true,"created":1478115516,"updated":1478115516}}'}
+    body: {string: '{"value":"ABC123","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/7d0e32b469a049b4ae697814f8e38a5d","attributes":{"enabled":true,"created":1478639366,"updated":1478639366},"tags":{"file-encoding":"utf-8"}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['195']
+      Content-Length: ['228']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 19:38:35 GMT']
+      Date: ['Tue, 08 Nov 2016 21:09:25 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -30,29 +31,29 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMTI1NTYsIm5iZiI6MTQ3ODExMjU1NiwiZXhwIjoxNDc4MTE2NDU2LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.YiXYcbk6VcghbG5fjq5R7XbaRD64YO-b3YQemB-zsIwPmwXJlJSlQZEKX270rXhjrdLpunu1tkvFF2ZnzBjAz43P98_tQ6b1tu9HBU0H-VET3ndPpv0k3pY0f7NsE1VBiteKzWye1SSzC9-fxyheoSr6rpZOTftYg2HncLC3NQgxRQlO_GPtf2odewMrKETK0q6aroV9_VzIbGHf3tVZ8i1JMJVtyDFlA1RHH1kl_zQ7_8WAhacEEYn7esIjqhHVutdnKUOh4A4W7m35zyE8BZRVZZbP_dI-AIvEiJUkYUUZI4N95DntQW5yoxWtoFlEiKAPxd0_w9cGfQIAnKD_yA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [f3187d42-a133-11e6-ab03-a0b3ccf7272a]
+      x-ms-client-request-id: [a15086d2-a5f7-11e6-9c33-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets?api-version=2015-06-01
   response:
-    body: {string: '{"value":[{"id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1","attributes":{"enabled":true,"created":1478115516,"updated":1478115516}}],"nextLink":null}'}
+    body: {string: '{"value":[{"id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1","attributes":{"enabled":true,"created":1478639366,"updated":1478639366},"tags":{"file-encoding":"utf-8"}}],"nextLink":null}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['173']
+      Content-Length: ['206']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 19:38:36 GMT']
+      Date: ['Tue, 08 Nov 2016 21:09:26 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -61,32 +62,33 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
-      eyJ2YWx1ZSI6ICJERUY0NTYiLCAiYXR0cmlidXRlcyI6IHsiZW5hYmxlZCI6IHRydWV9LCAiY29u
-      dGVudFR5cGUiOiAidGVzdCB0eXBlIiwgInRhZ3MiOiB7InRlc3QiOiAiZm9vIn19
+      eyJjb250ZW50VHlwZSI6ICJ0ZXN0IHR5cGUiLCAidmFsdWUiOiAiREVGNDU2IiwgInRhZ3MiOiB7
+      InRlc3QiOiAiZm9vIiwgImZpbGUtZW5jb2RpbmciOiAidXRmLTgifSwgImF0dHJpYnV0ZXMiOiB7
+      ImVuYWJsZWQiOiB0cnVlfX0=
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMTI1NTYsIm5iZiI6MTQ3ODExMjU1NiwiZXhwIjoxNDc4MTE2NDU2LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.YiXYcbk6VcghbG5fjq5R7XbaRD64YO-b3YQemB-zsIwPmwXJlJSlQZEKX270rXhjrdLpunu1tkvFF2ZnzBjAz43P98_tQ6b1tu9HBU0H-VET3ndPpv0k3pY0f7NsE1VBiteKzWye1SSzC9-fxyheoSr6rpZOTftYg2HncLC3NQgxRQlO_GPtf2odewMrKETK0q6aroV9_VzIbGHf3tVZ8i1JMJVtyDFlA1RHH1kl_zQ7_8WAhacEEYn7esIjqhHVutdnKUOh4A4W7m35zyE8BZRVZZbP_dI-AIvEiJUkYUUZI4N95DntQW5yoxWtoFlEiKAPxd0_w9cGfQIAnKD_yA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
-      Content-Length: ['105']
+      Content-Length: ['131']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [f33d1182-a133-11e6-b0f1-a0b3ccf7272a]
+      x-ms-client-request-id: [a179e990-a5f7-11e6-ba8b-a0b3ccf7272a]
     method: PUT
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1?api-version=2015-06-01
   response:
-    body: {string: '{"value":"DEF456","contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/d29e9d2fc0bf452ebe8b065f2926ef93","attributes":{"enabled":true,"created":1478115516,"updated":1478115516},"tags":{"test":"foo"}}'}
+    body: {string: '{"value":"DEF456","contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/f8cdc374695040a2ad6770f965d8d507","attributes":{"enabled":true,"created":1478639367,"updated":1478639367},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['243']
+      Content-Length: ['267']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 19:38:36 GMT']
+      Date: ['Tue, 08 Nov 2016 21:09:27 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -95,30 +97,30 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMTI1NTYsIm5iZiI6MTQ3ODExMjU1NiwiZXhwIjoxNDc4MTE2NDU2LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.YiXYcbk6VcghbG5fjq5R7XbaRD64YO-b3YQemB-zsIwPmwXJlJSlQZEKX270rXhjrdLpunu1tkvFF2ZnzBjAz43P98_tQ6b1tu9HBU0H-VET3ndPpv0k3pY0f7NsE1VBiteKzWye1SSzC9-fxyheoSr6rpZOTftYg2HncLC3NQgxRQlO_GPtf2odewMrKETK0q6aroV9_VzIbGHf3tVZ8i1JMJVtyDFlA1RHH1kl_zQ7_8WAhacEEYn7esIjqhHVutdnKUOh4A4W7m35zyE8BZRVZZbP_dI-AIvEiJUkYUUZI4N95DntQW5yoxWtoFlEiKAPxd0_w9cGfQIAnKD_yA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [f387d822-a133-11e6-9ce7-a0b3ccf7272a]
+      x-ms-client-request-id: [a1b525b0-a5f7-11e6-9a1e-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/versions?api-version=2015-06-01
   response:
-    body: {string: '{"value":[{"id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/82d81101b3864937ad2aa146cd0c727a","attributes":{"enabled":true,"created":1478115516,"updated":1478115516}},{"contentType":"test
-        type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/d29e9d2fc0bf452ebe8b065f2926ef93","attributes":{"enabled":true,"created":1478115516,"updated":1478115516},"tags":{"test":"foo"}}],"nextLink":null}'}
+    body: {string: '{"value":[{"id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/7d0e32b469a049b4ae697814f8e38a5d","attributes":{"enabled":true,"created":1478639366,"updated":1478639366},"tags":{"file-encoding":"utf-8"}},{"contentType":"test
+        type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/f8cdc374695040a2ad6770f965d8d507","attributes":{"enabled":true,"created":1478639367,"updated":1478639367},"tags":{"test":"foo","file-encoding":"utf-8"}}],"nextLink":null}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['433']
+      Content-Length: ['490']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 19:38:37 GMT']
+      Date: ['Tue, 08 Nov 2016 21:09:27 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -127,29 +129,29 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMTI1NTYsIm5iZiI6MTQ3ODExMjU1NiwiZXhwIjoxNDc4MTE2NDU2LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.YiXYcbk6VcghbG5fjq5R7XbaRD64YO-b3YQemB-zsIwPmwXJlJSlQZEKX270rXhjrdLpunu1tkvFF2ZnzBjAz43P98_tQ6b1tu9HBU0H-VET3ndPpv0k3pY0f7NsE1VBiteKzWye1SSzC9-fxyheoSr6rpZOTftYg2HncLC3NQgxRQlO_GPtf2odewMrKETK0q6aroV9_VzIbGHf3tVZ8i1JMJVtyDFlA1RHH1kl_zQ7_8WAhacEEYn7esIjqhHVutdnKUOh4A4W7m35zyE8BZRVZZbP_dI-AIvEiJUkYUUZI4N95DntQW5yoxWtoFlEiKAPxd0_w9cGfQIAnKD_yA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [f3aaf586-a133-11e6-b036-a0b3ccf7272a]
+      x-ms-client-request-id: [a1de12e4-a5f7-11e6-8085-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/?api-version=2015-06-01
   response:
-    body: {string: '{"value":"DEF456","contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/d29e9d2fc0bf452ebe8b065f2926ef93","attributes":{"enabled":true,"created":1478115516,"updated":1478115516},"tags":{"test":"foo"}}'}
+    body: {string: '{"value":"DEF456","contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/f8cdc374695040a2ad6770f965d8d507","attributes":{"enabled":true,"created":1478639367,"updated":1478639367},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['243']
+      Content-Length: ['267']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 19:38:37 GMT']
+      Date: ['Tue, 08 Nov 2016 21:09:27 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -158,29 +160,29 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMTI1NTYsIm5iZiI6MTQ3ODExMjU1NiwiZXhwIjoxNDc4MTE2NDU2LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.YiXYcbk6VcghbG5fjq5R7XbaRD64YO-b3YQemB-zsIwPmwXJlJSlQZEKX270rXhjrdLpunu1tkvFF2ZnzBjAz43P98_tQ6b1tu9HBU0H-VET3ndPpv0k3pY0f7NsE1VBiteKzWye1SSzC9-fxyheoSr6rpZOTftYg2HncLC3NQgxRQlO_GPtf2odewMrKETK0q6aroV9_VzIbGHf3tVZ8i1JMJVtyDFlA1RHH1kl_zQ7_8WAhacEEYn7esIjqhHVutdnKUOh4A4W7m35zyE8BZRVZZbP_dI-AIvEiJUkYUUZI4N95DntQW5yoxWtoFlEiKAPxd0_w9cGfQIAnKD_yA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [f3cf7bf4-a133-11e6-b999-a0b3ccf7272a]
+      x-ms-client-request-id: [a206c3fe-a5f7-11e6-9a3b-a0b3ccf7272a]
     method: GET
-    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/82d81101b3864937ad2aa146cd0c727a?api-version=2015-06-01
+    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/7d0e32b469a049b4ae697814f8e38a5d?api-version=2015-06-01
   response:
-    body: {string: '{"value":"ABC123","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/82d81101b3864937ad2aa146cd0c727a","attributes":{"enabled":true,"created":1478115516,"updated":1478115516}}'}
+    body: {string: '{"value":"ABC123","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/7d0e32b469a049b4ae697814f8e38a5d","attributes":{"enabled":true,"created":1478639366,"updated":1478639366},"tags":{"file-encoding":"utf-8"}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['195']
+      Content-Length: ['228']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 19:38:37 GMT']
+      Date: ['Tue, 08 Nov 2016 21:09:26 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -189,7 +191,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: !!binary |
@@ -197,23 +199,23 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMTI1NTYsIm5iZiI6MTQ3ODExMjU1NiwiZXhwIjoxNDc4MTE2NDU2LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.YiXYcbk6VcghbG5fjq5R7XbaRD64YO-b3YQemB-zsIwPmwXJlJSlQZEKX270rXhjrdLpunu1tkvFF2ZnzBjAz43P98_tQ6b1tu9HBU0H-VET3ndPpv0k3pY0f7NsE1VBiteKzWye1SSzC9-fxyheoSr6rpZOTftYg2HncLC3NQgxRQlO_GPtf2odewMrKETK0q6aroV9_VzIbGHf3tVZ8i1JMJVtyDFlA1RHH1kl_zQ7_8WAhacEEYn7esIjqhHVutdnKUOh4A4W7m35zyE8BZRVZZbP_dI-AIvEiJUkYUUZI4N95DntQW5yoxWtoFlEiKAPxd0_w9cGfQIAnKD_yA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Length: ['34']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [f3efbc48-a133-11e6-8728-a0b3ccf7272a]
+      x-ms-client-request-id: [a231124a-a5f7-11e6-98d0-a0b3ccf7272a]
     method: PATCH
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/?api-version=2015-06-01
   response:
-    body: {string: '{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/d29e9d2fc0bf452ebe8b065f2926ef93","attributes":{"enabled":false,"created":1478115516,"updated":1478115518},"tags":{"test":"foo"}}'}
+    body: {string: '{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/f8cdc374695040a2ad6770f965d8d507","attributes":{"enabled":false,"created":1478639367,"updated":1478639367},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['227']
+      Content-Length: ['251']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 19:38:38 GMT']
+      Date: ['Tue, 08 Nov 2016 21:09:27 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -222,30 +224,30 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMTI1NTYsIm5iZiI6MTQ3ODExMjU1NiwiZXhwIjoxNDc4MTE2NDU2LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.YiXYcbk6VcghbG5fjq5R7XbaRD64YO-b3YQemB-zsIwPmwXJlJSlQZEKX270rXhjrdLpunu1tkvFF2ZnzBjAz43P98_tQ6b1tu9HBU0H-VET3ndPpv0k3pY0f7NsE1VBiteKzWye1SSzC9-fxyheoSr6rpZOTftYg2HncLC3NQgxRQlO_GPtf2odewMrKETK0q6aroV9_VzIbGHf3tVZ8i1JMJVtyDFlA1RHH1kl_zQ7_8WAhacEEYn7esIjqhHVutdnKUOh4A4W7m35zyE8BZRVZZbP_dI-AIvEiJUkYUUZI4N95DntQW5yoxWtoFlEiKAPxd0_w9cGfQIAnKD_yA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [f41d8714-a133-11e6-b4b5-a0b3ccf7272a]
+      x-ms-client-request-id: [a2673ea2-a5f7-11e6-8b03-a0b3ccf7272a]
     method: DELETE
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1?api-version=2015-06-01
   response:
-    body: {string: '{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/d29e9d2fc0bf452ebe8b065f2926ef93","attributes":{"enabled":false,"created":1478115516,"updated":1478115518},"tags":{"test":"foo"}}'}
+    body: {string: '{"contentType":"test type","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/secret1/f8cdc374695040a2ad6770f965d8d507","attributes":{"enabled":false,"created":1478639367,"updated":1478639367},"tags":{"test":"foo","file-encoding":"utf-8"}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['227']
+      Content-Length: ['251']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 19:38:37 GMT']
+      Date: ['Tue, 08 Nov 2016 21:09:27 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -254,20 +256,20 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0NzgxMTI1NTYsIm5iZiI6MTQ3ODExMjU1NiwiZXhwIjoxNDc4MTE2NDU2LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.YiXYcbk6VcghbG5fjq5R7XbaRD64YO-b3YQemB-zsIwPmwXJlJSlQZEKX270rXhjrdLpunu1tkvFF2ZnzBjAz43P98_tQ6b1tu9HBU0H-VET3ndPpv0k3pY0f7NsE1VBiteKzWye1SSzC9-fxyheoSr6rpZOTftYg2HncLC3NQgxRQlO_GPtf2odewMrKETK0q6aroV9_VzIbGHf3tVZ8i1JMJVtyDFlA1RHH1kl_zQ7_8WAhacEEYn7esIjqhHVutdnKUOh4A4W7m35zyE8BZRVZZbP_dI-AIvEiJUkYUUZI4N95DntQW5yoxWtoFlEiKAPxd0_w9cGfQIAnKD_yA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [f45cdba8-a133-11e6-9e19-a0b3ccf7272a]
+      x-ms-client-request-id: [a2c5b9a2-a5f7-11e6-a491-a0b3ccf7272a]
     method: GET
     uri: https://cli-test-keyvault-secret.vault.azure.net/secrets?api-version=2015-06-01
   response:
@@ -276,7 +278,7 @@ interactions:
       Cache-Control: [no-cache]
       Content-Length: ['28']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 02 Nov 2016 19:38:38 GMT']
+      Date: ['Tue, 08 Nov 2016 21:09:28 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -285,6 +287,402 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-keyvault-region: [westus]
-      x-ms-keyvault-service-version: [1.0.0.781]
+      x-ms-keyvault-service-version: [1.0.0.783]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJ2YWx1ZSI6ICJUZXN0U2VjcmV0VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0XG4iLCAi
+      dGFncyI6IHsiZmlsZS1lbmNvZGluZyI6ICJ1dGYtOCJ9LCAiYXR0cmlidXRlcyI6IHsiZW5hYmxl
+      ZCI6IHRydWV9fQ==
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
+      Connection: [keep-alive]
+      Content-Length: ['124']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [a2e80ee6-a5f7-11e6-b976-a0b3ccf7272a]
+    method: PUT
+    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-8?api-version=2015-06-01
+  response:
+    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-8/0b15119045cf428eba15c07d150a4120","attributes":{"enabled":true,"created":1478639369,"updated":1478639369},"tags":{"file-encoding":"utf-8"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['271']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 08 Nov 2016 21:09:28 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.783]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [a310a618-a5f7-11e6-97d8-a0b3ccf7272a]
+    method: GET
+    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-8/?api-version=2015-06-01
+  response:
+    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-8/0b15119045cf428eba15c07d150a4120","attributes":{"enabled":true,"created":1478639369,"updated":1478639369},"tags":{"file-encoding":"utf-8"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['271']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 08 Nov 2016 21:09:29 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.783]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJ2YWx1ZSI6ICJUZXN0U2VjcmV0VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0XG4iLCAi
+      dGFncyI6IHsiZmlsZS1lbmNvZGluZyI6ICJ1dGYtMTZsZSJ9LCAiYXR0cmlidXRlcyI6IHsiZW5h
+      YmxlZCI6IHRydWV9fQ==
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
+      Connection: [keep-alive]
+      Content-Length: ['127']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [a33ab438-a5f7-11e6-a17d-a0b3ccf7272a]
+    method: PUT
+    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16le?api-version=2015-06-01
+  response:
+    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16le/727b6111680643b89d7908a44c6e83e9","attributes":{"enabled":true,"created":1478639369,"updated":1478639369},"tags":{"file-encoding":"utf-16le"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['277']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 08 Nov 2016 21:09:28 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.783]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [a36de09e-a5f7-11e6-9ad3-a0b3ccf7272a]
+    method: GET
+    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16le/?api-version=2015-06-01
+  response:
+    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16le/727b6111680643b89d7908a44c6e83e9","attributes":{"enabled":true,"created":1478639369,"updated":1478639369},"tags":{"file-encoding":"utf-16le"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['277']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 08 Nov 2016 21:09:30 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.783]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJ2YWx1ZSI6ICJUZXN0U2VjcmV0VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0XG4iLCAi
+      dGFncyI6IHsiZmlsZS1lbmNvZGluZyI6ICJ1dGYtMTZiZSJ9LCAiYXR0cmlidXRlcyI6IHsiZW5h
+      YmxlZCI6IHRydWV9fQ==
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
+      Connection: [keep-alive]
+      Content-Length: ['127']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [a39513b6-a5f7-11e6-8f6b-a0b3ccf7272a]
+    method: PUT
+    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16be?api-version=2015-06-01
+  response:
+    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16be/a4533cc94f95410f9c00723baf7023a5","attributes":{"enabled":true,"created":1478639370,"updated":1478639370},"tags":{"file-encoding":"utf-16be"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['277']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 08 Nov 2016 21:09:30 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.783]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [a3faaab8-a5f7-11e6-b4f3-a0b3ccf7272a]
+    method: GET
+    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16be/?api-version=2015-06-01
+  response:
+    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-utf-16be/a4533cc94f95410f9c00723baf7023a5","attributes":{"enabled":true,"created":1478639370,"updated":1478639370},"tags":{"file-encoding":"utf-16be"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['277']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 08 Nov 2016 21:09:30 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.783]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJ2YWx1ZSI6ICJUZXN0U2VjcmV0VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0XG4iLCAi
+      dGFncyI6IHsiZmlsZS1lbmNvZGluZyI6ICJhc2NpaSJ9LCAiYXR0cmlidXRlcyI6IHsiZW5hYmxl
+      ZCI6IHRydWV9fQ==
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
+      Connection: [keep-alive]
+      Content-Length: ['124']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [a423d54a-a5f7-11e6-9ae1-a0b3ccf7272a]
+    method: PUT
+    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-ascii?api-version=2015-06-01
+  response:
+    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-ascii/076fd910fb90476e9f62b5d1ba29089d","attributes":{"enabled":true,"created":1478639371,"updated":1478639371},"tags":{"file-encoding":"ascii"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['271']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 08 Nov 2016 21:09:31 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.783]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [a4861330-a5f7-11e6-91eb-a0b3ccf7272a]
+    method: GET
+    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-ascii/?api-version=2015-06-01
+  response:
+    body: {string: '{"value":"TestSecretTestSecretTestSecretTestSecret\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-ascii/076fd910fb90476e9f62b5d1ba29089d","attributes":{"enabled":true,"created":1478639371,"updated":1478639371},"tags":{"file-encoding":"ascii"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['271']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 08 Nov 2016 21:09:31 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.783]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJ2YWx1ZSI6ICJWR1Z6ZEZObFkzSmxkRlJsYzNSVFpXTnlaWFJVWlhOMFUyVmpjbVYwVkdWemRG
+      TmxZM0psZEEwS1xuIiwgInRhZ3MiOiB7ImZpbGUtZW5jb2RpbmciOiAiYmFzZTY0In0sICJhdHRy
+      aWJ1dGVzIjogeyJlbmFibGVkIjogdHJ1ZX19
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
+      Connection: [keep-alive]
+      Content-Length: ['141']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [a4a9b764-a5f7-11e6-8c92-a0b3ccf7272a]
+    method: PUT
+    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-base64?api-version=2015-06-01
+  response:
+    body: {string: '{"value":"VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-base64/f2a5b856b51e4ab2b594df38a3682840","attributes":{"enabled":true,"created":1478639371,"updated":1478639371},"tags":{"file-encoding":"base64"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['289']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 08 Nov 2016 21:09:31 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.783]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [a4e46b4a-a5f7-11e6-a1c4-a0b3ccf7272a]
+    method: GET
+    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-base64/?api-version=2015-06-01
+  response:
+    body: {string: '{"value":"VGVzdFNlY3JldFRlc3RTZWNyZXRUZXN0U2VjcmV0VGVzdFNlY3JldA0K\n","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-base64/f2a5b856b51e4ab2b594df38a3682840","attributes":{"enabled":true,"created":1478639371,"updated":1478639371},"tags":{"file-encoding":"base64"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['289']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 08 Nov 2016 21:09:31 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.783]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJ2YWx1ZSI6ICI1NDY1NzM3NDUzNjU2MzcyNjU3NDU0NjU3Mzc0NTM2NTYzNzI2NTc0NTQ2NTcz
+      NzQ1MzY1NjM3MjY1NzQ1NDY1NzM3NDUzNjU2MzcyNjU3NDBkMGEiLCAidGFncyI6IHsiZmlsZS1l
+      bmNvZGluZyI6ICJoZXgifSwgImF0dHJpYnV0ZXMiOiB7ImVuYWJsZWQiOiB0cnVlfX0=
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
+      Connection: [keep-alive]
+      Content-Length: ['164']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [a50d5be4-a5f7-11e6-8a60-a0b3ccf7272a]
+    method: PUT
+    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-hex?api-version=2015-06-01
+  response:
+    body: {string: '{"value":"546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-hex/b8dff66d5bc946a3a114fff64631c187","attributes":{"enabled":true,"created":1478639372,"updated":1478639372},"tags":{"file-encoding":"hex"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['309']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 08 Nov 2016 21:09:32 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.783]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS8iLCJpYXQiOjE0Nzg2Mzg5MDksIm5iZiI6MTQ3ODYzODkwOSwiZXhwIjoxNDc4NjQyODA5LCJhY3IiOiIxIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImVfZXhwIjoxMDgwMCwiZmFtaWx5X25hbWUiOiJBZG1pbjIiLCJnaXZlbl9uYW1lIjoiQWRtaW4yIiwiZ3JvdXBzIjpbImU0YmIwYjU2LTEwMTQtNDBmOC04OGFiLTNkOGE4Y2IwZTA4NiIsIjZiOTc3NjFhLWQ3ZDAtNDhmNi1hZDU2LWYzOGQzMjdjODU1MyJdLCJpcGFkZHIiOiIxNjcuMjIwLjAuMTg2IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInBsYXRmIjoiMTQiLCJwdWlkIjoiMTAwM0JGRkQ5NTlGODQyMyIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbiIsInN1YiI6InB1QWlLRzRBMGE3VUE0ZHhZM1VNWEY4amtxZHRWSDhoMVAzY0tNMDJocWsiLCJ0aWQiOiI1NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEiLCJ1bmlxdWVfbmFtZSI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidXBuIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ2ZXIiOiIxLjAifQ.iF5O_wc9q7zatrMk-3Zl_e9zhHYcIu4uEuxzvJNnwuqHNoYIPA79206ZFF_FnG86SmGMNJ9sf7zVHenYqhprwOYp6JI7kKEuwpa0Fj_8AFrRcC83YXKQW2f6q1nImQkESrWPdSyzEY9m8Hf2mxGSm1qwnp0mxMDy-CIjG15_Jcj0i3E7O82GarmTr1ZDw35olvJ386fyl6gxuxjcpzlzze98sJL9RKQTySkivetYt1Rss3xzeTpT2sxDGOu_72QuFRVnZc3Y89R9TGBsQRWunkHFBgk7X1Cq1IUp-VZTpfbwlUYzmuqD8S2W3px3an1SuA8Csi-dbJKRJ-006v_sSQ]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 keyvaultclient/2015-06-01 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [a53d1c76-a5f7-11e6-8de1-a0b3ccf7272a]
+    method: GET
+    uri: https://cli-test-keyvault-secret.vault.azure.net/secrets/download-hex/?api-version=2015-06-01
+  response:
+    body: {string: '{"value":"546573745365637265745465737453656372657454657374536563726574546573745365637265740d0a","id":"https://cli-test-keyvault-secret.vault.azure.net/secrets/download-hex/b8dff66d5bc946a3a114fff64631c187","attributes":{"enabled":true,"created":1478639372,"updated":1478639372},"tags":{"file-encoding":"hex"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['309']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 08 Nov 2016 21:09:32 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000;includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-keyvault-region: [westus]
+      x-ms-keyvault-service-version: [1.0.0.783]
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/test_keyvault_commands.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/test_keyvault_commands.py
@@ -236,14 +236,14 @@ class KeyVaultSecretScenarioTest(ResourceGroupVCRTestBase):
         kv = self.keyvault_name
         secret_path = os.path.join(TEST_DIR, 'test_secret.txt')
         with open(secret_path, 'r') as f:
-            expected = f.read()
+            expected = f.read().replace('\r\n', '\n')
 
         def _test_set_and_download(encoding):
             self.cmd('keyvault secret set --vault-name {} -n download-{} --file "{}" --encoding {}'.format(kv, encoding, secret_path, encoding))
             dest_path = os.path.join(TEST_DIR, 'recover-{}'.format(encoding))
             self.cmd('keyvault secret download --vault-name {} -n download-{} --file "{}"'.format(kv, encoding, dest_path))
             with open(dest_path, 'r') as f:
-                actual = f.read()
+                actual = f.read().replace('\r\n', '\n')
             self.assertEqual(actual, expected)
             os.remove(dest_path)
 
@@ -419,7 +419,7 @@ class KeyVaultCertificateScenarioTest(ResourceGroupVCRTestBase):
                 downloaded_binary = base64.b64encode(f.read()).decode('utf-8')
 
             with open(dest_string, 'r') as f:
-                downloaded_string = f.read().replace('\n', '')
+                downloaded_string = f.read().replace('\r\n', '\n').replace('\n', '')
         finally:
             os.remove(dest_binary)
             os.remove(dest_string)

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/test_keyvault_commands.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/test_keyvault_commands.py
@@ -18,6 +18,7 @@ from azure.cli.core.test_utils.vcr_test_base import (ResourceGroupVCRTestBase, J
 from azure.cli.command_modules.keyvault.keyvaultclient import HttpBearerChallenge
 from azure.cli.command_modules.keyvault.keyvaultclient.key_vault_authentication import \
     (KeyVaultAuthBase)
+from azure.cli.command_modules.keyvault._params import secret_encoding_values
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
 
@@ -231,6 +232,24 @@ class KeyVaultSecretScenarioTest(ResourceGroupVCRTestBase):
     def test_keyvault_secret(self):
         self.execute()
 
+    def _test_download_secret(self):
+        kv = self.keyvault_name
+        secret_path = os.path.join(TEST_DIR, 'test_secret.txt')
+        with open(secret_path, 'r') as f:
+            expected = f.read()
+
+        def _test_set_and_download(encoding):
+            self.cmd('keyvault secret set --vault-name {} -n download-{} --file "{}" --encoding {}'.format(kv, encoding, secret_path, encoding))
+            dest_path = os.path.join(TEST_DIR, 'recover-{}'.format(encoding))
+            self.cmd('keyvault secret download --vault-name {} -n download-{} --file "{}"'.format(kv, encoding, dest_path))
+            with open(dest_path, 'r') as f:
+                actual = f.read()
+            self.assertEqual(actual, expected)
+            os.remove(dest_path)
+
+        for encoding in secret_encoding_values:
+            _test_set_and_download(encoding)
+
     def body(self):
         kv = self.keyvault_name
         # create a secret
@@ -244,9 +263,9 @@ class KeyVaultSecretScenarioTest(ResourceGroupVCRTestBase):
             checks=JMESPathCheck('length(@)', 1))
 
         # create a new secret version
-        secret = self.cmd('keyvault secret set --vault-name {} -n secret1 --value DEF456 --tags test=foo --content-type "test type"'.format(kv), checks=[
+        secret = self.cmd('keyvault secret set --vault-name {} -n secret1 --value DEF456 --tags test=foo --description "test type"'.format(kv), checks=[
             JMESPathCheck('value', 'DEF456'),
-            JMESPathCheck('tags', {'test':'foo'}),
+            JMESPathCheck('tags', {'file-encoding': 'utf-8', 'test':'foo'}),
             JMESPathCheck('contentType', 'test type')
         ])
         second_kid = secret['id']
@@ -274,8 +293,7 @@ class KeyVaultSecretScenarioTest(ResourceGroupVCRTestBase):
         self.cmd('keyvault secret list --vault-name {}'.format(kv),
             checks=NoneCheck())
 
-        # Round 4 COMMANDS
-        # TODO: download secret
+        self._test_download_secret()
 
 class KeyVaultCertificateScenarioTest(ResourceGroupVCRTestBase):
 
@@ -382,8 +400,37 @@ class KeyVaultCertificateScenarioTest(ResourceGroupVCRTestBase):
         self.cmd('keyvault certificate pending show --vault-name {} -n pending-cert'.format(kv),
             allowed_exceptions='Pending certificate not found')
 
+    def _test_certificate_download(self):
+        kv = self.keyvault_name
+        pem_file = os.path.join(TEST_DIR, 'import_pem_plain.pem')
+        pem_policy_path = os.path.join(TEST_DIR, 'policy_import_pem.json')
+        pem_cert = self.cmd('keyvault certificate import --vault-name {} -n pem-cert1 --file "{}" -p @"{}"'.format(kv, pem_file, pem_policy_path))
+        cert_data = pem_cert['cer']
+
+        dest_binary = os.path.join(TEST_DIR, 'download-binary')
+        dest_string = os.path.join(TEST_DIR, 'download-string')
+        self.cmd('keyvault certificate download --vault-name {} -n pem-cert1 --file "{}"'.format(kv, dest_binary))
+        self.cmd('keyvault certificate download --vault-name {} -n pem-cert1 --file "{}" -e string'.format(kv, dest_string))
+        self.cmd('keyvault certificate delete --vault-name {} -n pem-cert1'.format(kv))
+
+        try:
+            with open(dest_binary, 'rb') as f:
+                import base64
+                downloaded_binary = base64.b64encode(f.read()).decode('utf-8')
+
+            with open(dest_string, 'r') as f:
+                downloaded_string = f.read().replace('\n', '')
+        finally:
+            os.remove(dest_binary)
+            os.remove(dest_string)
+
+        self.assertEqual(cert_data, downloaded_string)
+        self.assertEqual(cert_data, downloaded_binary)
+
     def body(self):
         kv = self.keyvault_name
+
+        self._test_certificate_download()
 
         policy_path = os.path.join(TEST_DIR, 'policy.json')
         policy2_path = os.path.join(TEST_DIR, 'policy2.json')
@@ -446,6 +493,3 @@ class KeyVaultCertificateScenarioTest(ResourceGroupVCRTestBase):
         pfx_plain_file = os.path.join(TEST_DIR, 'import_pfx.pfx')
         pfx_policy_path = os.path.join(TEST_DIR, 'policy_import_pfx.json')
         self.cmd('keyvault certificate import --vault-name {} -n pfx-cert --file "{}" -p @"{}"'.format(kv, pfx_plain_file, pfx_policy_path))
-
-        # Round 4 COMMANDS
-        # TODO: download certificiate

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/test_secret.txt
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/test_secret.txt
@@ -1,0 +1,1 @@
+TestSecretTestSecretTestSecretTestSecret


### PR DESCRIPTION
Closes #885.

This PR updates the `secret set` command and adds the `secret download` and `certificate download` commands. With this, the entire KeyVault data plane functionality should be exposed.

Plan to defer merging this until #1059 is merged.