### PR TITLE
rename to --admin-enabled on update/create for acr operations

### DIFF
--- a/azure-cli.pyproj
+++ b/azure-cli.pyproj
@@ -81,6 +81,7 @@
     <Compile Include="command_modules\azure-cli-acr\azure\cli\command_modules\acr\credential.py" />
     <Compile Include="command_modules\azure-cli-acr\azure\cli\command_modules\acr\custom.py" />
     <Compile Include="command_modules\azure-cli-acr\azure\cli\command_modules\acr\repository.py" />
+    <Compile Include="command_modules\azure-cli-acr\azure\cli\command_modules\acr\tests\test_acr_commands.py" />
     <Compile Include="command_modules\azure-cli-acr\azure\cli\command_modules\acr\_constants.py" />
     <Compile Include="command_modules\azure-cli-acr\azure\cli\command_modules\acr\_factory.py" />
     <Compile Include="command_modules\azure-cli-acr\azure\cli\command_modules\acr\_format.py" />
@@ -724,6 +725,8 @@
     <Folder Include="command_modules\azure-cli-acr\azure\cli\" />
     <Folder Include="command_modules\azure-cli-acr\azure\cli\command_modules\" />
     <Folder Include="command_modules\azure-cli-acr\azure\cli\command_modules\acr\" />
+    <Folder Include="command_modules\azure-cli-acr\azure\cli\command_modules\acr\tests\" />
+    <Folder Include="command_modules\azure-cli-acr\azure\cli\command_modules\acr\tests\recordings\" />
     <Folder Include="command_modules\azure-cli-acs\" />
     <Folder Include="command_modules\azure-cli-acs\azure\" />
     <Folder Include="command_modules\azure-cli-acs\azure\cli\" />
@@ -911,6 +914,8 @@
     <Content Include="azure-cli\az.completion.sh" />
     <Content Include="azure-cli\setup.cfg" />
     <Content Include="command_modules\azure-cli-acr\azure\cli\command_modules\acr\template.json" />
+    <Content Include="command_modules\azure-cli-acr\azure\cli\command_modules\acr\tests\recordings\test_acr.yaml" />
+    <Content Include="command_modules\azure-cli-acr\azure\README.rst" />
     <Content Include="command_modules\azure-cli-acr\requirements.txt" />
     <Content Include="command_modules\azure-cli-acs\requirements.txt" />
     <Content Include="command_modules\azure-cli-appservice\azure\cli\command_modules\appservice\tests\recordings\test_appservice_error_polish.yaml" />

--- a/src/command_modules/azure-cli-acr/README.rst
+++ b/src/command_modules/azure-cli-acr/README.rst
@@ -14,24 +14,24 @@ Commands to manage Azure container registries
 
     Commands:
         check-name: Checks whether the container registry name is available for use.
-        create    : Creates or updates a container registry with the specified parameters.
+        create    : Creates a container registry.
         delete    : Deletes a container registry.
         list      : Lists all the available container registries under the current subscription.
         show      : Gets the properties of the specified container registry.
-        update    : Updates a container registry with the specified parameters.
+        update    : Updates a container registry.
 
 Create a container registry
 -------------
 ::
 
     Command
-        az acr create: Creates or updates a container registry with the specified parameters.
+        az acr create: Creates a container registry.
 
     Arguments
         --location -l       [Required]: Location.
         --name -n           [Required]: The name of the container registry.
         --resource-group -g [Required]: Name of resource group.
-        --admin-enabled               : The value that indicates whether the admin user is enabled.
+        --admin-enabled               : Indicates whether the admin user is enabled.
                                         Allowed values: false, true.  Default: false.
         --storage-account-name        : The name of an existing storage account.
 
@@ -84,12 +84,12 @@ Update a container registry
 ::
 
     Command
-        az acr update: Updates a container registry with the specified parameters.
+        az acr update: Updates a container registry.
 
     Arguments
         --name -n   [Required]: The name of the container registry.
-        --admin-enabled       : The value that indicates whether the admin user is enabled.  Allowed
-                                values: false, true.
+        --admin-enabled       : Indicates whether the admin user is enabled.
+		                        Allowed values: false, true.
         --resource-group -g   : Name of resource group.
         --storage-account-name: The name of an existing storage account.
         --tags                : Space separated tags in 'key[=value]' format. Use "" to clear existing

--- a/src/command_modules/azure-cli-acr/README.rst
+++ b/src/command_modules/azure-cli-acr/README.rst
@@ -9,46 +9,47 @@ Commands to manage Azure container registries
         az acr: Commands to manage Azure container registries.
 
     Subgroups:
-        credential: Manage admin user credential for Azure container registries.
+        credential: Manage administrator login credentials for Azure container registries.
         repository: Manage repositories for Azure container registries.
 
     Commands:
-        check-name: Check whether the container registry name is available.
-        create    : Create a container registry.
-        delete    : Delete a container registry.
-        list      : List container registries.
-        show      : Get a container registry.
-        update    : Update a container registry.
+        check-name: Checks whether the container registry name is available for use.
+        create    : Creates or updates a container registry with the specified parameters.
+        delete    : Deletes a container registry.
+        list      : Lists all the available container registries under the current subscription.
+        show      : Gets the properties of the specified container registry.
+        update    : Updates a container registry with the specified parameters.
 
 Create a container registry
 -------------
 ::
 
     Command
-        az acr create: Create a container registry.
+        az acr create: Creates or updates a container registry with the specified parameters.
 
     Arguments
         --location -l       [Required]: Location.
-        --name -n           [Required]: Name of container registry.
+        --name -n           [Required]: The name of the container registry.
         --resource-group -g [Required]: Name of resource group.
-        --enable-admin                : Enable admin user.
-        --storage-account-name -s     : Name of an existing storage account.
+        --admin-enabled               : The value that indicates whether the admin user is enabled.
+                                        Allowed values: false, true.  Default: false.
+        --storage-account-name        : The name of an existing storage account.
 
     Examples
         Create a container registry with a new storage account
             az acr create -n myRegistry -g myResourceGroup -l southcentralus
         Create a container registry with an existing storage account
-            az acr create -n myRegistry -g myResourceGroup -l southcentralus -s myStorageAccount
+            az acr create -n myRegistry -g myResourceGroup -l southcentralus --storage-account-name myStorageAccount
 
 Delete a container registry
 -------------
 ::
 
     Command
-        az acr delete: Delete a container registry.
+        az acr delete: Deletes a container registry.
 
     Arguments
-        --name -n [Required]: Name of container registry.
+        --name -n [Required]: The name of the container registry.
         --resource-group -g : Name of resource group.
 
 List container registries
@@ -56,7 +57,7 @@ List container registries
 ::
 
     Command
-        az acr list: List container registries.
+        az acr list: Lists all the available container registries under the current subscription.
 
     Arguments
         --resource-group -g: Name of resource group.
@@ -72,10 +73,10 @@ Get a container registry
 ::
 
     Command
-        az acr show: Get a container registry.
+        az acr show: Gets the properties of the specified container registry.
 
     Arguments
-        --name -n [Required]: Name of container registry.
+        --name -n [Required]: The name of the container registry.
         --resource-group -g : Name of resource group.
 
 Update a container registry
@@ -83,43 +84,43 @@ Update a container registry
 ::
 
     Command
-        az acr update: Update a container registry.
-    
+        az acr update: Updates a container registry with the specified parameters.
+
     Arguments
-        --name -n      [Required]: Name of container registry.
-        --admin-user-enabled -a  : Whether the admin user account is enabled.  Allowed values: false,
-                                   true.
-        --resource-group -g      : Name of resource group.
-        --storage-account-name -s: Name of an existing storage account.
-        --tags                   : Space separated tags in 'key[=value]' format. Use "" to clear
-                                   existing tags.
-    
+        --name -n   [Required]: The name of the container registry.
+        --admin-enabled       : The value that indicates whether the admin user is enabled.  Allowed
+                                values: false, true.
+        --resource-group -g   : Name of resource group.
+        --storage-account-name: The name of an existing storage account.
+        --tags                : Space separated tags in 'key[=value]' format. Use "" to clear existing
+                                tags.
+
     Generic Update Arguments
-        --add                    : Add an object to a list of objects by specifying a path and key value
-                                   pairs.  Example: --add property.listProperty <key=value, string or
-                                   JSON string>.
-        --remove                 : Remove a property or an element from a list.  Example: --remove
-                                   property.list <indexToRemove> OR --remove propertyToRemove.
-        --set                    : Update an object by specifying a property path and value to set.
-                                   Example: --set property1.property2=<value>.
-    
+        --add                 : Add an object to a list of objects by specifying a path and key value
+                                pairs.  Example: --add property.listProperty <key=value, string or JSON
+                                string>.
+        --remove              : Remove a property or an element from a list.  Example: --remove
+                                property.list <indexToRemove> OR --remove propertyToRemove.
+        --set                 : Update an object by specifying a property path and value to set.
+                                Example: --set property1.property2=<value>.
+
     Examples
         Update tags for a container registry
             az acr update -n myRegistry --tags key1=value1 key2=value2
         Update storage account for a container registry
             az acr update -n myRegistry --storage-account-name myStorageAccount
         Enable admin user for a container registry
-            az acr update -n myRegistry --admin-user-enabled true
+            az acr update -n myRegistry --admin-enabled true
 
 Get login credentials for a container registry
 -------------
 ::
 
     Command
-        az acr credential show: Get login credentials for a container registry.
+        az acr credential show: Gets the administrator login credentials for the specified container registry.
 
     Arguments
-        --name -n [Required]: Name of container registry.
+        --name -n [Required]: The name of the container registry.
         --resource-group -g : Name of resource group.
 
 Regenerate login credentials for a container registry
@@ -127,10 +128,10 @@ Regenerate login credentials for a container registry
 ::
 
     Command
-        az acr credential renew: Regenerate login credentials for a container registry.
+        az acr credential renew: Regenerates the administrator login credentials for the specified container registry.
 
     Arguments
-        --name -n [Required]: Name of container registry.
+        --name -n [Required]: The name of the container registry.
         --resource-group -g : Name of resource group.
 
 List repositories in a given container registry
@@ -138,12 +139,12 @@ List repositories in a given container registry
 ::
 
     Command
-        az acr repository list: List repositories in a given container registry.
+        az acr repository list: Lists repositories in the specified container registry.
 
     Arguments
-        --name -n [Required]: Name of container registry.
-        --password -p       : Password used to log into a container registry.
-        --username -u       : Username used to log into a container registry.
+        --name -n [Required]: The name of the container registry.
+        --password -p       : The password used to log into a container registry.
+        --username -u       : The username used to log into a container registry.
 
     Examples
         List repositories in a given container registry if admin user is enabled
@@ -156,17 +157,17 @@ Show tags of a given repository in a given container registry
 ::
 
     Command
-        az acr repository show-tags: Show tags of a given repository in a given container registry.
+        az acr repository show-tags: Shows tags of a given repository in the specified container
+        registry.
 
     Arguments
-        --name -n    [Required]: Name of container registry.
+        --name -n    [Required]: The name of the container registry.
         --repository [Required]: The repository to obtain tags from.
-        --password -p          : Password used to log into a container registry.
-        --username -u          : Username used to log into a container registry.
+        --password -p          : The password used to log into a container registry.
+        --username -u          : The username used to log into a container registry.
 
     Examples
         Show tags of a given repository in a given container registry if admin user is enabled
             az acr repository show-tags -n myRegistry --repository myRepository
         Show tags of a given repository in a given container registry with credentials
-            az acr repository show-tags -n myRegistry --repository myRepository -u myUsername -p
-            myPassword
+            az acr repository show-tags -n myRegistry --repository myRepository -u myUsername -p myPassword

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_help.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_help.py
@@ -46,7 +46,7 @@ helps['acr create'] = """
 
 helps['acr update'] = """
             type: command
-            short-summary: Updates a container registry with the specified parameters.
+            short-summary: Updates a container registry.
             examples:
                 - name: Update tags for a container registry
                   text:

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_help.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_help.py
@@ -14,7 +14,7 @@ helps['acr'] = """
 
 helps['acr credential'] = """
             type: group
-            short-summary: Manage admin user credential for Azure container registries.
+            short-summary: Manage administrator login credentials for Azure container registries.
             """
 
 helps['acr repository'] = """
@@ -41,12 +41,12 @@ helps['acr create'] = """
                     az acr create -n myRegistry -g myResourceGroup -l southcentralus
                 - name: Create a container registry with an existing storage account
                   text:
-                    az acr create -n myRegistry -g myResourceGroup -l southcentralus -s myStorageAccount
+                    az acr create -n myRegistry -g myResourceGroup -l southcentralus --storage-account-name myStorageAccount
             """
 
 helps['acr update'] = """
             type: command
-            short-summary: Update a container registry.
+            short-summary: Updates a container registry with the specified parameters.
             examples:
                 - name: Update tags for a container registry
                   text:
@@ -56,7 +56,7 @@ helps['acr update'] = """
                     az acr update -n myRegistry --storage-account-name myStorageAccount
                 - name: Enable admin user for a container registry
                   text:
-                    az acr update -n myRegistry --admin-user-enabled true
+                    az acr update -n myRegistry --admin-enabled true
             """
 
 helps['acr repository list'] = """

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_params.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_params.py
@@ -21,26 +21,27 @@ from ._validators import (
 
 register_cli_argument('acr', 'registry_name',
                       options_list=('--name', '-n'),
-                      help='Name of container registry',
+                      help='The name of the container registry',
                       completer=get_resource_name_completion_list(ACR_RESOURCE_TYPE))
 register_cli_argument('acr', 'storage_account_name',
-                      help='Name of an existing storage account',
+                      help='The name of an existing storage account',
                       completer=get_resource_name_completion_list(STORAGE_RESOURCE_TYPE))
 
 register_cli_argument('acr', 'resource_group_name', resource_group_name_type)
 register_cli_argument('acr', 'location', location_type)
 register_cli_argument('acr', 'tags', tags_type)
-register_cli_argument('acr', 'admin_user_enabled',
-                      help='Whether the admin user account is enabled.',
+register_cli_argument('acr', 'admin_enabled',
+                      help='The value that indicates whether the admin user is enabled',
                       choices=['true', 'false'])
 
 register_cli_argument('acr', 'username',
                       options_list=('--username', '-u'),
-                      help='Username used to log into a container registry')
+                      help='The username used to log into a container registry')
 register_cli_argument('acr', 'password',
                       options_list=('--password', '-p'),
-                      help='Password used to log into a container registry')
+                      help='The password used to log into a container registry')
 
 register_cli_argument('acr create', 'registry_name', completer=None)
 register_cli_argument('acr create', 'resource_group_name',
                       validator=validate_resource_group_name)
+register_cli_argument('acr check-name', 'registry_name', completer=None)

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_params.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/_params.py
@@ -31,7 +31,7 @@ register_cli_argument('acr', 'resource_group_name', resource_group_name_type)
 register_cli_argument('acr', 'location', location_type)
 register_cli_argument('acr', 'tags', tags_type)
 register_cli_argument('acr', 'admin_enabled',
-                      help='The value that indicates whether the admin user is enabled',
+                      help='Indicates whether the admin user is enabled',
                       choices=['true', 'false'])
 
 register_cli_argument('acr', 'username',

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/credential.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/credential.py
@@ -10,7 +10,7 @@ import azure.cli.core._logging as _logging
 logger = _logging.get_az_logger(__name__)
 
 def acr_credential_show(registry_name, resource_group_name=None):
-    '''Get login credentials for a container registry.
+    '''Gets the administrator login credentials for the specified container registry.
     :param str registry_name: The name of container registry
     :param str resource_group_name: The name of resource group
     '''
@@ -22,7 +22,7 @@ def acr_credential_show(registry_name, resource_group_name=None):
     return client.get_credentials(resource_group_name, registry_name)
 
 def acr_credential_renew(registry_name, resource_group_name=None):
-    '''Regenerate login credentials for a container registry.
+    '''Regenerates the administrator login credentials for the specified container registry.
     :param str registry_name: The name of container registry
     :param str resource_group_name: The name of resource group
     '''

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/custom.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/custom.py
@@ -5,9 +5,7 @@
 
 import uuid
 
-from azure.cli.core.commands import (
-    LongRunningOperation
-)
+from azure.cli.core.commands import LongRunningOperation
 
 from azure.mgmt.containerregistry.models import (
     Registry,
@@ -26,7 +24,7 @@ import azure.cli.core._logging as _logging
 logger = _logging.get_az_logger(__name__)
 
 def acr_check_name(registry_name):
-    '''Check whether the container registry name is available.
+    '''Checks whether the container registry name is available for use.
     :param str registry_name: The name of container registry
     '''
     client = get_acr_service_client().registries
@@ -34,7 +32,7 @@ def acr_check_name(registry_name):
     return client.check_name_availability(registry_name)
 
 def acr_list(resource_group_name=None):
-    '''List container registries.
+    '''Lists all the available container registries under the current subscription.
     :param str resource_group_name: The name of resource group
     '''
     client = get_acr_service_client().registries
@@ -48,15 +46,16 @@ def acr_create(registry_name, #pylint: disable=too-many-arguments
                resource_group_name,
                location,
                storage_account_name=None,
-               enable_admin=False):
-    '''Create a container registry.
+               admin_enabled='false'):
+    '''Creates or updates a container registry with the specified parameters.
     :param str registry_name: The name of container registry
     :param str resource_group_name: The name of resource group
     :param str location: The name of location
     :param str storage_account_name: The name of storage account
-    :param bool enable_admin: Enable admin user
+    :param str admin_enabled: The value that indicates whether the admin user is enabled
     '''
     client = get_acr_service_client().registries
+    admin_user_enabled = admin_enabled == 'true'
 
     if storage_account_name is None:
         storage_account_name = str(uuid.uuid4()).replace('-', '')[:24]
@@ -65,7 +64,7 @@ def acr_create(registry_name, #pylint: disable=too-many-arguments
                                 registry_name,
                                 location,
                                 storage_account_name,
-                                enable_admin)
+                                admin_user_enabled)
         )
         registry = client.get_properties(resource_group_name, registry_name)
     else:
@@ -78,7 +77,7 @@ def acr_create(registry_name, #pylint: disable=too-many-arguments
                     storage_account_name,
                     storage_account_key
                 ),
-                admin_user_enabled=enable_admin
+                admin_user_enabled=admin_user_enabled
             )
         )
 
@@ -94,7 +93,7 @@ def acr_create(registry_name, #pylint: disable=too-many-arguments
     return registry
 
 def acr_delete(registry_name, resource_group_name=None):
-    '''Delete a container registry.
+    '''Deletes a container registry.
     :param str registry_name: The name of container registry
     :param str resource_group_name: The name of resource group
     '''
@@ -106,7 +105,7 @@ def acr_delete(registry_name, resource_group_name=None):
     return client.delete(resource_group_name, registry_name)
 
 def acr_show(registry_name, resource_group_name=None):
-    '''Get a container registry.
+    '''Gets the properties of the specified container registry.
     :param str registry_name: The name of container registry
     :param str resource_group_name: The name of resource group
     '''
@@ -132,11 +131,11 @@ def acr_update_get(client,
     )
 
 def acr_update_custom(instance,
-                      admin_user_enabled=None,
+                      admin_enabled=None,
                       storage_account_name=None,
                       tags=None):
-    if admin_user_enabled is not None:
-        instance.admin_user_enabled = admin_user_enabled == 'true'
+    if admin_enabled is not None:
+        instance.admin_user_enabled = admin_enabled == 'true'
 
     if tags is not None:
         instance.tags = tags

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/custom.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/custom.py
@@ -47,12 +47,12 @@ def acr_create(registry_name, #pylint: disable=too-many-arguments
                location,
                storage_account_name=None,
                admin_enabled='false'):
-    '''Creates or updates a container registry with the specified parameters.
+    '''Creates a container registry.
     :param str registry_name: The name of container registry
     :param str resource_group_name: The name of resource group
     :param str location: The name of location
     :param str storage_account_name: The name of storage account
-    :param str admin_enabled: The value that indicates whether the admin user is enabled
+    :param str admin_enabled: Indicates whether the admin user is enabled
     '''
     client = get_acr_service_client().registries
     admin_user_enabled = admin_enabled == 'true'

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/repository.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/repository.py
@@ -69,7 +69,7 @@ def _validate_user_credentials(registry_name, path, resultIndex, username=None, 
     return _obtain_data_from_registry(login_server, path, resultIndex, username, password)
 
 def acr_repository_list(registry_name, username=None, password=None):
-    '''List repositories in a given container registry.
+    '''Lists repositories in the specified container registry.
     :param str registry_name: The name of container registry
     :param str username: The username used to log into the container registry
     :param str password: The password used to log into the container registry
@@ -78,7 +78,7 @@ def acr_repository_list(registry_name, username=None, password=None):
     return _validate_user_credentials(registry_name, path, 'repositories', username, password)
 
 def acr_repository_show_tags(registry_name, repository, username=None, password=None):
-    '''Show tags of a given repository in a given container registry.
+    '''Shows tags of a given repository in the specified container registry.
     :param str registry_name: The name of container registry
     :param str repository: The repository to obtain tags from
     :param str username: The username used to log into the container registry

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/tests/test_acr_commands.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/tests/test_acr_commands.py
@@ -61,7 +61,7 @@ class ACRTest(ResourceGroupVCRTestBase):
             JMESPathCheck('adminUserEnabled', False)
         ])
         # enable admin user
-        self.cmd('acr update -n {} -g {} --admin-user-enabled true'.format(registry_name, resource_group), checks=[
+        self.cmd('acr update -n {} -g {} --admin-enabled true'.format(registry_name, resource_group), checks=[
             JMESPathCheck('name', registry_name),
             JMESPathCheck('location', location),
             JMESPathCheck('adminUserEnabled', True)
@@ -82,7 +82,7 @@ class ACRTest(ResourceGroupVCRTestBase):
         assert login_server
         self.cmd('acr repository list -n {}'.format(registry_name), checks=NoneCheck())
         # test acr update
-        self.cmd('acr update -n {} -g {} --tags foo=bar cat --admin-user-enabled false --storage-account-name {}'.format(registry_name, resource_group, storage_account_for_update), checks=[
+        self.cmd('acr update -n {} -g {} --tags foo=bar cat --admin-enabled false --storage-account-name {}'.format(registry_name, resource_group, storage_account_for_update), checks=[
             JMESPathCheck('name', registry_name),
             JMESPathCheck('location', location),
             JMESPathCheck('tags', {'cat':'', 'foo':'bar'}),


### PR DESCRIPTION
This PR renames --admin-user-enabled to --admin-enabled on create and update operations.

Usage:
- az acr update -n ... [--admin-enabled true/false]
- az acr create ... [--admin-enabled true/false]

Also removed short flags -a and -s in readme for update operation. Additionally, updates descriptions to match new swagger file.