### PR TITLE
[DO NOT MERGE] Fix issues with NIC create help

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/template_create.py
+++ b/src/azure-cli-core/azure/cli/core/commands/template_create.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 import argparse
 import platform
 
+import azure.cli.core._logging as _logging
 from azure.cli.core._util import CLIError
 from azure.cli.core.commands import register_cli_argument
 from azure.cli.core.commands.arm import (
@@ -17,10 +18,10 @@ from azure.cli.core.commands.arm import (
     make_camel_case)
 
 def register_folded_cli_argument(scope, base_name, resource_type, parent_name=None, # pylint: disable=too-many-arguments
-                                 parent_type=None, type_field=None,
+                                 parent_option_flag=None, parent_type=None, type_field=None,
                                  existing_id_flag_value='existingId', new_flag_value='new',
                                  none_flag_value='none', default_value_flag='new',
-                                 **kwargs):
+                                 base_required=True, **kwargs):
     type_field_name = type_field or base_name + '_type'
 
     fold_validator = _name_id_fold(base_name,
@@ -30,8 +31,11 @@ def register_folded_cli_argument(scope, base_name, resource_type, parent_name=No
                                    new_flag_value,
                                    none_flag_value,
                                    parent_name,
-                                   parent_type)
+                                   parent_option_flag,
+                                   parent_type,
+                                   base_required)
     custom_validator = kwargs.pop('validator', None)
+    custom_help = kwargs.pop('help', None)
     if custom_validator:
         def wrapped(namespace):
             fold_validator(namespace)
@@ -40,22 +44,27 @@ def register_folded_cli_argument(scope, base_name, resource_type, parent_name=No
     else:
         validator = fold_validator
 
-    quotes = '""' if platform.system() == 'Windows' else "''"
-    quote_text = '  Use {} for none.'.format(quotes) if none_flag_value else ''
-    flag_texts = {
-        new_flag_value: '  Creates new by default.{}'.format(quote_text),
-        existing_id_flag_value: '  Uses existing resource.{}'
-                                .format(quote_text),
-        none_flag_value: '  None by default.'
-    }
-    help_text = 'Name or ID of the resource.' + flag_texts[default_value_flag]
+    if not custom_help:
+        quotes = '""' if platform.system() == 'Windows' else "''"
+        quote_text = ' Use {} for none.'.format(quotes) if none_flag_value else ''
+        parent_text = ' If name specified, must also specify {}.'.format(
+            parent_option_flag or parent_name) if parent_name else ''
+        flag_texts = {
+            new_flag_value: '  Creates new by default.{}'.format(quote_text),
+            existing_id_flag_value: '  Uses existing resource.{}{}'
+                                    .format(quote_text, parent_text),
+            none_flag_value: '  None by default.'
+        }
+        help_text = 'Name or ID of the resource.' + flag_texts[default_value_flag]
+    else:
+        help_text = custom_help
 
     register_cli_argument(scope, base_name, validator=validator, help=help_text, **kwargs)
     register_cli_argument(scope, type_field_name, help=argparse.SUPPRESS, default=None)
 
 def _name_id_fold(base_name, resource_type, type_field, #pylint: disable=too-many-arguments
                   existing_id_flag_value, new_flag_value, none_flag_value,
-                  parent_name=None, parent_type=None):
+                  parent_name=None, parent_option_flag=None, parent_type=None, base_required=True):
     def handle_folding(namespace):
         base_name_val = getattr(namespace, base_name)
         type_field_val = getattr(namespace, type_field)
@@ -79,6 +88,9 @@ def _name_id_fold(base_name, resource_type, type_field, #pylint: disable=too-man
             if is_valid_resource_id(base_name_val):
                 resource_id_parts = parse_resource_id(base_name_val)
             elif has_parent:
+                if not parent_name_val and base_required:
+                    raise CLIError("Must specify '{}' when specifying '{}' name.".format(
+                        parent_option_flag or parent_name, base_name))
                 resource_id_parts = dict(
                     name=parent_name_val,
                     resource_group=namespace.resource_group_name,
@@ -110,3 +122,117 @@ def _name_id_fold(base_name, resource_type, type_field, #pylint: disable=too-man
 
     return handle_folding
 
+# NEW STYLE
+
+def get_folded_parameter_help_string(
+    display_name, allow_none=False, allow_new=False, other_required_option=None):
+    """ Assembles a parameterized help string for folded parameters. """
+    quotes = '""' if platform.system() == 'Windows' else "''"
+
+    if not allow_none and not allow_new:
+        help_text = 'Name or ID of an existing {}.'.format(display_name)
+    elif not allow_new and allow_none:
+        help_text = 'Name or ID of an existing {}, or {} for none.'.format(display_name, quotes)
+    elif allow_new and not allow_none:
+        help_text = 'Name or ID of the {}. Will create resource if it does not exist.'.format(display_name)
+    elif allow_new and allow_none:
+        help_text = 'Name or ID of the {}, or {} for none. Will create resource if it does not exist.'.format(display_name, quotes)
+
+    # add parent name option string (if applicable)
+    if other_required_option:
+        help_text = '{} If name specified, also specify {}'.format(help_text, other_required_option)
+    return help_text
+
+def _validate_name_or_id(
+    resource_group_name, property_value, property_type, parent_value, parent_type):
+    from azure.cli.core.commands.client_factory import get_subscription_id
+    has_parent = parent_type is not None
+    if is_valid_resource_id(property_value):
+        resource_id_parts = parse_resource_id(property_value)
+        value_supplied_was_id = True
+    elif has_parent:
+        resource_id_parts = dict(
+            name=parent_value,
+            resource_group=resource_group_name,
+            namespace=parent_type.split('/')[0],
+            type=parent_type.split('/')[1],
+            subscription=get_subscription_id(),
+            child_name=property_value,
+            child_type=property_type)
+        value_supplied_was_id = False
+    else:
+        resource_id_parts = dict(
+            name=property_value,
+            resource_group=resource_group_name,
+            namespace=property_type.split('/')[0],
+            type=property_type.split('/')[1],
+            subscription=get_subscription_id())
+        value_supplied_was_id = False
+    return (resource_id_parts, value_supplied_was_id)
+
+def get_folded_parameter_validator(
+    property_name, property_type, property_option,
+    parent_name=None, parent_type=None, parent_option=None,
+    allow_none=False, allow_new=False):
+
+    # Ensure that all parent parameters are specified if any are
+    parent_params = [parent_name, parent_type, parent_option]
+    has_parent = any(parent_params)
+    if has_parent and not all(parent_params):
+        raise CLIError('All parent parameters must be specified (name, type, option) if any are.')
+
+    # construct the validator
+    def validator(namespace):
+        type_field_name = '{}_type'.format(property_name)
+        property_val = getattr(namespace, property_name, None)
+        parent_val = getattr(namespace, parent_name, None) if parent_name else None
+
+        # Check for the different scenarios (order matters)
+        # 1) provided value indicates None (pair of empty quotes)
+        if property_val in ('', '""', "''") or not property_val:
+            if not allow_none:
+                raise CLIError('{} cannot be None.'.format(property_option))
+            setattr(namespace, type_field_name, 'none')
+            setattr(namespace, property_name, None)
+            if parent_name and parent_val:
+                logger = _logging.get_az_logger(__name__)
+                logger.info('Ignoring: {} {}'.format(parent_option, parent_val))
+                setattr(namespace, parent_name, None)
+            return # SUCCESS
+
+        # Create a resource ID we can check for existence.
+        (resource_id_parts, value_was_id) = _validate_name_or_id(
+            namespace.resource_group_name, property_val, property_type, parent_val, parent_type)
+
+        # 2) resource exists
+        if resource_exists(**resource_id_parts):
+            setattr(namespace, type_field_name, 'existingId')
+            setattr(namespace, property_name, resource_id(**resource_id_parts))
+            if parent_val:
+                if value_was_id:
+                    logger = _logging.get_az_logger(__name__)
+                    logger.info('Ignoring: {} {}'.format(parent_option, parent_val))
+                setattr(namespace, parent_name, None)
+            return # SUCCESS
+
+        # if a parent name was required but not specified, raise a usage error
+        if has_parent and not value_was_id and not parent_val:
+            raise ValueError('incorrect usage: {} ID | {} NAME {} NAME'.format(
+                property_option, property_option, parent_option))
+
+        # if non-existent ID was supplied, throw error depending on whether a new resource can
+        # be created.
+        if value_was_id:
+            usage_message = '{} NAME'.format(property_option) if not has_parent \
+                else '{} NAME [{} NAME]'.format(property_option, parent_option)
+            action_message = 'Specify ( {} ) to create a new resource.'.format(usage_message) if \
+                allow_new else 'Create the required resource and try again.'
+            raise CLIError('{} {} does not exist. {}'.format(property_name, property_val, action_message))
+
+        # 3) try to create new resource
+        if allow_new:
+            setattr(namespace, type_field_name, 'new')
+        else:
+            raise CLIError('{} {} does not exist. Create the required resource and try again.'.format(property_name, property_val))
+
+    return validator

--- a/src/azure-cli-core/azure/cli/core/commands/template_create.py
+++ b/src/azure-cli-core/azure/cli/core/commands/template_create.py
@@ -124,8 +124,9 @@ def _name_id_fold(base_name, resource_type, type_field, #pylint: disable=too-man
 
 # NEW STYLE
 
+# pylint: disable=line-too-long
 def get_folded_parameter_help_string(
-    display_name, allow_none=False, allow_new=False, other_required_option=None):
+        display_name, allow_none=False, allow_new=False, other_required_option=None):
     """ Assembles a parameterized help string for folded parameters. """
     quotes = '""' if platform.system() == 'Windows' else "''"
 
@@ -144,7 +145,7 @@ def get_folded_parameter_help_string(
     return help_text
 
 def _validate_name_or_id(
-    resource_group_name, property_value, property_type, parent_value, parent_type):
+        resource_group_name, property_value, property_type, parent_value, parent_type):
     from azure.cli.core.commands.client_factory import get_subscription_id
     has_parent = parent_type is not None
     if is_valid_resource_id(property_value):
@@ -170,10 +171,10 @@ def _validate_name_or_id(
         value_supplied_was_id = False
     return (resource_id_parts, value_supplied_was_id)
 
-def get_folded_parameter_validator(
-    property_name, property_type, property_option,
-    parent_name=None, parent_type=None, parent_option=None,
-    allow_none=False, allow_new=False):
+def get_folded_parameter_validator( # pylint: disable=too-many-arguments
+        property_name, property_type, property_option,
+        parent_name=None, parent_type=None, parent_option=None,
+        allow_none=False, allow_new=False):
 
     # Ensure that all parent parameters are specified if any are
     parent_params = [parent_name, parent_type, parent_option]
@@ -196,7 +197,7 @@ def get_folded_parameter_validator(
             setattr(namespace, property_name, None)
             if parent_name and parent_val:
                 logger = _logging.get_az_logger(__name__)
-                logger.info('Ignoring: {} {}'.format(parent_option, parent_val))
+                logger.info('Ignoring: %s %s', parent_option, parent_val)
                 setattr(namespace, parent_name, None)
             return # SUCCESS
 
@@ -211,7 +212,7 @@ def get_folded_parameter_validator(
             if parent_val:
                 if value_was_id:
                     logger = _logging.get_az_logger(__name__)
-                    logger.info('Ignoring: {} {}'.format(parent_option, parent_val))
+                    logger.info('Ignoring: %s %s', parent_option, parent_val)
                 setattr(namespace, parent_name, None)
             return # SUCCESS
 
@@ -227,12 +228,15 @@ def get_folded_parameter_validator(
                 else '{} NAME [{} NAME]'.format(property_option, parent_option)
             action_message = 'Specify ( {} ) to create a new resource.'.format(usage_message) if \
                 allow_new else 'Create the required resource and try again.'
-            raise CLIError('{} {} does not exist. {}'.format(property_name, property_val, action_message))
+            raise CLIError('{} {} does not exist. {}'.format(
+                property_name, property_val, action_message))
 
         # 3) try to create new resource
         if allow_new:
             setattr(namespace, type_field_name, 'new')
         else:
-            raise CLIError('{} {} does not exist. Create the required resource and try again.'.format(property_name, property_val))
+            raise CLIError(
+                '{} {} does not exist. Create the required resource and try again.'.format(
+                    property_name, property_val))
 
     return validator

--- a/src/azure-cli-core/azure/cli/core/test_utils/vcr_test_base.py
+++ b/src/azure-cli-core/azure/cli/core/test_utils/vcr_test_base.py
@@ -6,6 +6,7 @@
 from __future__ import print_function
 
 import json
+import logging
 import os
 import collections
 import shlex
@@ -13,6 +14,8 @@ from random import choice
 import re
 from string import digits
 import sys
+from six.moves.urllib.parse import urlparse, parse_qs # pylint: disable=import-error
+
 import unittest
 try:
     import unittest.mock as mock
@@ -168,6 +171,30 @@ def _search_result_by_jmespath(json_data, query):
         json_val,
         jmespath.Options(collections.OrderedDict))
 
+def _custom_request_matcher(r1, r2):
+    """ Ensure method, path, and query parameters match. """
+    if r1.method != r2.method:
+        return False
+
+    url1 = urlparse(r1.uri)
+    url2 = urlparse(r2.uri)
+
+    if url1.path != url2.path:
+        return False
+
+    q1 = parse_qs(url1.query)
+    q2 = parse_qs(url2.query)
+    shared_keys = set(q1.keys()).union(set(q2.keys()))
+
+    if len(shared_keys) != len(q1) or len(shared_keys) != len(q2):
+        return False
+
+    for key in shared_keys:
+        if q1[key][0].lower() != q2[key][0].lower():
+            return False
+
+    return True
+
 # MAIN CLASS
 
 class VCRTestBase(unittest.TestCase):#pylint: disable=too-many-instance-attributes
@@ -204,11 +231,17 @@ class VCRTestBase(unittest.TestCase):#pylint: disable=too-many-instance-attribut
         if not self.playback and ('--buffer' in sys.argv) and not run_live:
             self.exception = CLIError('No recorded result provided for {}.'.format(self.test_name))
 
+        if debug:
+            logging.basicConfig()
+            vcr_log = logging.getLogger('vcr')
+            vcr_log.setLevel(logging.INFO)
         self.my_vcr = vcr.VCR(
             cassette_library_dir=self.recording_dir,
             before_record_request=VCRTestBase._before_record_request,
             before_record_response=VCRTestBase._before_record_response,
         )
+        self.my_vcr.register_matcher('custom', _custom_request_matcher)
+        self.my_vcr.match_on = ['custom']
 
     def _track_executed_commands(self, command):
         if not self.track_commands:

--- a/src/azure-cli-core/azure/cli/core/tests/test_vcr_security.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_vcr_security.py
@@ -35,7 +35,7 @@ class Test_vcr_security(unittest.TestCase):
                     continue
                 with open(os.path.join(path_to_recordings, name), 'r') as f:
                     for line in f:
-                        if 'grant_type=refresh_token' in line or '/oauth2/token' in line:
+                        if 'grant_type=refresh_token' in line.lower() or '/oauth2/token' in line.lower():
                             insecure_cassettes.append(name)
         self.assertFalse(insecure_cassettes, 'The following cassettes contain refresh tokens: {}'.format(insecure_cassettes))
 

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
@@ -179,7 +179,7 @@ def get_public_ip_validator(has_type_field=False, allow_none=False, allow_new=Fa
 
     def complex_validator_with_type(namespace):
         get_folded_parameter_validator(
-            'public_ip_address', 'Microsoft.Network/publicIpAddresses', '--public-ip-address',
+            'public_ip_address', 'Microsoft.Network/publicIPAddresses', '--public-ip-address',
             allow_none=allow_none, allow_new=allow_new)(namespace)
 
     return complex_validator_with_type if has_type_field else simple_validator

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
@@ -10,6 +10,7 @@ import os
 
 from azure.cli.core.commands.arm import is_valid_resource_id, resource_id
 from azure.cli.core._util import CLIError
+from azure.cli.core.commands.template_create import get_folded_parameter_validator
 from azure.cli.core.commands.validators import SPECIFIED_SENTINEL
 from azure.cli.core.commands.client_factory import get_subscription_id
 
@@ -137,6 +138,7 @@ def validate_inbound_nat_rule_name_or_id(namespace):
         namespace.inbound_nat_rule = _generate_lb_subproperty_id(
             namespace, 'inboundNatRules', rule_name)
 
+# TODO This will go away
 def validate_nsg_name_or_id(namespace):
     """ Validates a NSG ID or, if a name is provided, formats it as an ID. """
     if namespace.network_security_group:
@@ -160,35 +162,77 @@ def validate_private_ip_address(namespace):
     if namespace.private_ip_address:
         namespace.private_ip_address_allocation = 'static'
 
-def validate_public_ip_name_or_id(namespace):
-    """ Validates a public IP ID or, if a name is provided, formats it as an ID. """
-    if namespace.public_ip_address:
-        # determine if public_ip_address is name or ID
-        is_id = is_valid_resource_id(namespace.public_ip_address)
-        if not is_id:
-            namespace.public_ip_address = resource_id(
-                subscription=get_subscription_id(),
-                resource_group=namespace.resource_group_name,
-                namespace='Microsoft.Network',
-                type='publicIPAddresses',
-                name=namespace.public_ip_address)
-
-def validate_public_ip_type(namespace): # pylint: disable=unused-argument
-    if namespace.public_ip_address_type == 'none' and not namespace.subnet:
-        raise argparse.ArgumentError(None, '--subnet is required if not using --public-ip-address')
-
-    if namespace.subnet:
-        namespace.public_ip_address_type = 'none'
+def get_public_ip_validator(has_type_field=False, allow_none=False, allow_new=False):
+    """ Retrieves a validator for public IP address. Accepting all defaults will perform a check
+    for an existing name or ID with no ARM-required -type parameter. """
+    def simple_validator(namespace):
         if namespace.public_ip_address:
-            raise argparse.ArgumentError(
-                None, 'Cannot specify --subnet and --public-ip-address when creating a '
-                      'load balancer.')
+            # determine if public_ip_address is name or ID
+            is_id = is_valid_resource_id(namespace.public_ip_address)
+            if not is_id:
+                namespace.public_ip_address = resource_id(
+                    subscription=get_subscription_id(),
+                    resource_group=namespace.resource_group_name,
+                    namespace='Microsoft.Network',
+                    type='publicIPAddresses',
+                    name=namespace.public_ip_address)
 
-    if namespace.public_ip_address:
-        if namespace.public_ip_dns_name and namespace.public_ip_address_type != 'new':
-            raise argparse.ArgumentError(
-                None, 'Can only specify --public-ip-dns-name when creating a new public '
-                      'IP address.')
+    def complex_validator_with_type(namespace):
+        get_folded_parameter_validator(
+            'public_ip_address', 'Microsoft.Network/publicIpAddresses', '--public-ip-address',
+            allow_none=allow_none, allow_new=allow_new)(namespace)
+
+    return complex_validator_with_type if has_type_field else simple_validator
+
+def get_subnet_validator(has_type_field=False, allow_none=False, allow_new=False):
+
+    def simple_validator(namespace):
+        if namespace.virtual_network_name is None and namespace.subnet is None:
+            return
+        if namespace.subnet == '':
+            return
+        usage_error = ValueError('incorrect usage: ( --subnet ID | --subnet NAME --vnet-name NAME)')
+        # error if vnet-name is provided without subnet
+        if namespace.virtual_network_name and not namespace.subnet:
+            raise usage_error
+
+        # determine if subnet is name or ID
+        is_id = is_valid_resource_id(namespace.subnet)
+
+        # error if vnet-name is provided along with a subnet ID
+        if is_id and namespace.virtual_network_name:
+            raise usage_error
+        elif not is_id and not namespace.virtual_network_name:
+            raise usage_error
+
+    def complex_validator_with_type(namespace):
+        get_folded_parameter_validator(
+            'subnet', 'subnets', '--subnet',
+            'virtual_network_name', 'Microsoft.Network/virtualNetworks', '--vnet-name',
+            allow_none=allow_none, allow_new=allow_new)(namespace)
+
+    return complex_validator_with_type if has_type_field else simple_validator
+
+def get_nsg_validator(has_type_field=False, allow_none=False, allow_new=False):
+
+    def simple_validator(namespace):
+        if namespace.network_security_group:
+            # determine if network_security_group is name or ID
+            is_id = is_valid_resource_id(namespace.network_security_group)
+            if not is_id:
+                namespace.network_security_group = resource_id(
+                    subscription=get_subscription_id(),
+                    resource_group=namespace.resource_group_name,
+                    namespace='Microsoft.Network',
+                    type='networkSecurityGroups',
+                    name=namespace.network_security_group)
+
+    def complex_validator_with_type(namespace):
+        get_folded_parameter_validator(
+            'network_security_group', 'Microsoft.Network/networkSecurityGroups', '--nsg',
+            allow_none=allow_none, allow_new=allow_new)(namespace)
+
+    return complex_validator_with_type if has_type_field else simple_validator
 
 def validate_servers(namespace):
     from azure.mgmt.network.models import ApplicationGatewayBackendAddress
@@ -201,8 +245,10 @@ def validate_servers(namespace):
             servers.append(ApplicationGatewayBackendAddress(fqdn=item))
     namespace.servers = servers
 
+# TODO DEPRECATE AND REMOVE
 def validate_subnet_name_or_id(namespace):
     """ Validates a subnet ID or, if a name is provided, formats it as an ID. """
+
     if namespace.virtual_network_name is None and namespace.subnet is None:
         return
     if namespace.subnet == '':
@@ -216,10 +262,10 @@ def validate_subnet_name_or_id(namespace):
 
     # error if vnet-name is provided along with a subnet ID
     if is_id and namespace.virtual_network_name:
-        raise argparse.ArgumentError(None, 'Please omit --vnet-name when specifying a subnet ID')
+        raise argparse.ArgumentError(None, 'Omit --vnet-name when specifying a subnet ID')
     elif not is_id and not namespace.virtual_network_name:
         raise argparse.ArgumentError(None,
-                                     'Please specify --vnet-name when specifying a subnet name')
+                                     'You must specify --vnet-name when specifying a subnet name')
     if not is_id:
         namespace.subnet = resource_id(
             subscription=get_subscription_id(),
@@ -304,6 +350,27 @@ def process_auth_create_namespace(namespace):
     namespace.authorization_parameters = ExpressRouteCircuitAuthorization()
 
 def process_lb_create_namespace(namespace):
+
+    def _validate_public_ip_type(): # pylint: disable=unused-argument
+        if namespace.public_ip_address_type == 'none' and not namespace.subnet:
+            raise argparse.ArgumentError(
+                None, '--subnet is required if not using --public-ip-address')
+
+        if namespace.subnet:
+            namespace.public_ip_address_type = 'none'
+            if namespace.public_ip_address:
+                raise argparse.ArgumentError(
+                    None, 'Cannot specify --subnet and --public-ip-address when creating a '
+                          'load balancer.')
+
+        if namespace.public_ip_address:
+            if namespace.public_ip_dns_name and namespace.public_ip_address_type != 'new':
+                raise argparse.ArgumentError(
+                    None, 'Can only specify --public-ip-dns-name when creating a new public '
+                          'IP address.')
+
+    _validate_public_ip_type()
+
     if namespace.public_ip_dns_name:
         namespace.dns_name_type = 'new'
 
@@ -312,14 +379,14 @@ def process_lb_create_namespace(namespace):
             None, 'Must specify a subnet OR a public IP address, not both.')
 
 def process_nic_create_namespace(namespace):
+
+    # process folded parameters
+    get_subnet_validator(has_type_field=True)(namespace)
+    get_public_ip_validator(has_type_field=True, allow_none=True)(namespace)
+    get_nsg_validator(has_type_field=True, allow_none=True)(namespace)
+
     if namespace.internal_dns_name_label:
         namespace.use_dns_settings = 'true'
-
-    if not namespace.public_ip_address:
-        namespace.public_ip_address_type = 'none'
-
-    if not namespace.network_security_group:
-        namespace.network_security_group_type = 'none'
 
 def process_public_ip_create_namespace(namespace):
     if namespace.dns_name:

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_nic.yaml
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_nic.yaml
@@ -1,49 +1,49 @@
 interactions:
 - request:
-    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateVnet_2016-09-07/azuredeploy.json"},
-      "mode": "Incremental", "parameters": {"subnetName": {"value": "mysubnet"}, "virtualNetworkPrefix":
-      {"value": "10.0.0.0/16"}, "virtualNetworkName": {"value": "myvnet"}, "subnetPrefix":
-      {"value": "10.0.0.0/24"}}}}'
+    body: '{"properties": {"mode": "Incremental", "templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateVnet_2016-09-07/azuredeploy.json"},
+      "parameters": {"subnetName": {"value": "mysubnet"}, "virtualNetworkPrefix":
+      {"value": "10.0.0.0/16"}, "subnetPrefix": {"value": "10.0.0.0/24"}, "virtualNetworkName":
+      {"value": "myvnet"}}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
       Connection: [keep-alive]
       Content-Length: ['348']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 vnetcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [20c4dbf0-a7aa-11e6-8b83-a0b3ccf7272a]
+      x-ms-client-request-id: [7feb4f36-a853-11e6-a18d-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478825981.7443243","name":"azurecli1478825981.7443243","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVnet_2016-09-07/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"dnsServers":{"type":"Array","value":[]},"location":{"type":"String","value":"westus"},"subnetName":{"type":"String","value":"mysubnet"},"subnetPrefix":{"type":"String","value":"10.0.0.0/24"},"tags":{"type":"Object","value":{}},"virtualNetworkName":{"type":"String","value":"myvnet"},"virtualNetworkPrefix":{"type":"String","value":"10.0.0.0/16"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-11-11T00:59:43.0921644Z","duration":"PT0.5826551S","correlationId":"de90eccd-93c2-4a4d-b600-8d4a21b3ee61","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]}]}],"dependencies":[]}}'}
+    body: {string: '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/azurecli1478898726.31033128040","name":"azurecli1478898726.31033128040","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVnet_2016-09-07/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"dnsServers":{"type":"Array","value":[]},"location":{"type":"String","value":"westus"},"subnetName":{"type":"String","value":"mysubnet"},"subnetPrefix":{"type":"String","value":"10.0.0.0/24"},"tags":{"type":"Object","value":{}},"virtualNetworkName":{"type":"String","value":"myvnet"},"virtualNetworkPrefix":{"type":"String","value":"10.0.0.0/16"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-11-11T21:12:07.9944458Z","duration":"PT0.4639888S","correlationId":"f1cd4ab6-1e67-4e84-9032-61505920afbf","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]}]}],"dependencies":[]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478825981.7443243/operationStatuses/08587227809029681539?api-version=2015-11-01']
-      cache-control: [no-cache]
-      content-length: ['1043']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 00:59:42 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/azurecli1478898726.31033128040/operationStatuses/08587227081579472319?api-version=2015-11-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['1050']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:12:07 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 vnetcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [20c4dbf0-a7aa-11e6-8b83-a0b3ccf7272a]
+      x-ms-client-request-id: [7feb4f36-a853-11e6-a18d-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587227809029681539?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587227081579472319?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -51,104 +51,104 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['141']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:00:13 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['141']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:12:38 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 vnetcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [20c4dbf0-a7aa-11e6-8b83-a0b3ccf7272a]
+      x-ms-client-request-id: [7feb4f36-a853-11e6-a18d-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
         o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXenZfH7t3nT/v7LYvr7N9N8mdVFtXt3VVeXxSyvm7tfFNO6aqrzdvxK32zuzvJVWV0v
-        8mXb3M1+sK5zgrK7/+DgYO/+w4Pd8YP9/Xt7+/c+Gn20zBY54bmxDXW1yuu2yJuPHv3ij9p8sSqz
-        Nn9eLN/i73VdEIB5266aR3els2b2dlqMJ2U1GU+rOh9fFctZddWMl3l717w+r5r27kmd068/SZ//
-        /ns7u59u7zzc3nkgMGQE459uqiWhMK2WLQ3mJ2m8REjqb3e8g/8++iWEXlbTIFr6CujMls3rvL7U
-        v9rrFYZ3XNfZNYG5zMo1/f2979NrZTXNMCtes9dtXSwvXLuProju6wad0DwSli8yUGu4/eJa2rk3
-        Xtb5efFu0zu7NAz8d3dvH6+12YWP+ZeTn86nrWv+i38Jtbks6nadlS/y9qqq396M1CUhAtjhe++B
-        2u6nH6HfRTXDx2fLaZ2Dt7KSGhN3XBaYFXr3dUvTSS1er6fTnKZwRt+3xYKomC1W9DlP8i6x/+6b
-        nd1HOzuPdvbHuw8/Pfj0/v2foqazda1T8tHLN3u7408PHty7/+nea/qK+KjOiW/o2zMI1ix/uJNP
-        p7Pth/eme9v72f5se/Lpzs72wWw/29ud3MvzT3fpNUYOUkKT/ouZ2ZtVNgWKTmqUHNSaOJfl5w3R
-        Q97wP6GXQgI29IrhIjQ37PL9X0L/0WjyVb6c5cspC8736JNq3a7WLf1BqORXP0lg8KtSvzfTgvwG
-        yhrkPl+zrpncv3c///Te+fbB9Dzb3s/z8+2Hn+7n27N8+nCSHRCJ9g/orWw2oxeb10KHX2z+Fm5g
-        TIN5h6jM5tPVl6LC8IYvYixKwur4iwaWgRuJ6eRD6pCRu0t//vAUIVEWE3S3M193RRTuEi70A3/K
-        b4RkTnJHaH737u/70c69B3u7D+9n23sH00+39/f3d7az2S4R897+5MHeg918Z2//9/2I3qGePb1I
-        f22crYDO9J0lMuSeOAYCJgxi1TgTlMl326F9BED/DwI4IWd8BgAA
+        p/nndbVeNXenZfH7t3nT/v7LYvr7N9N8mdVFdXdVV5fFLK+bu18U07pqqvN2/EpfbO7O8lVZXS/y
+        ZdvczX6wrnMCsrv/4ODg4cGDvU/H93Z37t3b3TvY2d/5aPTRMlvkhOqN7ajLVV63Rd589OgXf9Tm
+        i1WZtfnzYvkWf6/rgoDM23bVPLornTazt9NiPCmryXha1fn4qljOqqtmvMzbu+b1edW0d0/qnH79
+        Sfr899/b2f10e+fh9s4DgSEjGf90Uy0JhWm1bGlQP0njJnpSf7vjHfz30S8h9LKaBtLSV0Bntmxe
+        5/Wl/tVerzDE47rOrgnMZVau6e/vfZ9eK6tphsnxmr1u62J54dp9dEXkXzfohKaTsHyRgWLD7RfX
+        0s698bLOz4t3m97ZpWHgv7t7+3itzS58zL+c/HQ+bV3zX/xLqM1lUbfrrHyRt1dV/fZmpC4JEcAO
+        33sP1HY//Qj9LqoZPj5bTuscPJaV1Ji447LArNC7r1uaTmrxej2d5jSFM/q+LRZExWyxos95kndJ
+        Cnbf7O0+2t17tLc/3tn/9OH9Bw9/iprO1rVOyUcv3+x+Or6/++n9nZ2Hr+kr4qM6J76hb88gX+e7
+        09l+NiFo+acPtvfzg/3thzv39rY/3b2/c//h3k52Pjmn1xg5SAtN+i9mhm9W2RQoOulRclBr4lyW
+        ozdED3nD/4ReCgnY0CuGi9DcsMv3fwn9R6PJV/lyli+nLDjfo0+qdbtat/QHoZJf/SSBwa9K/d5M
+        C/IbKGuQ+3zNKid/OPv0wSTb2yZy7m/v782m25N798+3Z7NP9w92ds738/MJvZXNZvRi81ro8IvN
+        38INjGkw7xCV2Xy6+lI0Gd7wRYxFSVgdf9HAMnAjMZ18SB0ycnfpzx+aPiTCYn7udqbrrkjCXUKF
+        fuBP+Y1wzEnsCMvv3v19Pzp4mB3cO9+9t33+YJc468GD6fbBw4cPtx9Md/bPd88f7O082P99P6J3
+        qGdPLdJfGycrIDN9Z2kMsSeGgXwJf1htzvRk6t12aB8B0P8DJl8wwYIGAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['951']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:00:13 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['956']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:12:38 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateNsg_2016-07-18/azuredeploy.json"},
-      "mode": "Incremental", "parameters": {"name": {"value": "mynsg"}}}}'
+    body: '{"properties": {"mode": "Incremental", "templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateNsg_2016-07-18/azuredeploy.json"},
+      "parameters": {"name": {"value": "mynsg"}}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
       Connection: [keep-alive]
       Content-Length: ['203']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 nsgcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [34ac12f0-a7aa-11e6-9425-a0b3ccf7272a]
+      x-ms-client-request-id: [93d56bca-a853-11e6-a345-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478826015.1370549","name":"azurecli1478826015.1370549","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateNsg_2016-07-18/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"mynsg"},"tags":{"type":"Object","value":{}}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-11-11T01:00:16.389236Z","duration":"PT0.4313961S","correlationId":"8b0727f5-289d-47d8-b9b2-320a99980290","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[]}}'}
+    body: {string: '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/azurecli1478898759.722316739456","name":"azurecli1478898759.722316739456","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateNsg_2016-07-18/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"mynsg"},"tags":{"type":"Object","value":{}}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-11-11T21:12:41.4797907Z","duration":"PT0.4519806S","correlationId":"9aca68e9-5af7-4164-9040-352e51f963bf","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478826015.1370549/operationStatuses/08587227808695198121?api-version=2015-11-01']
-      cache-control: [no-cache]
-      content-length: ['823']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:00:16 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/azurecli1478898759.722316739456/operationStatuses/08587227081244498556?api-version=2015-11-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['833']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:12:41 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 nsgcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [34ac12f0-a7aa-11e6-9425-a0b3ccf7272a]
+      x-ms-client-request-id: [93d56bca-a853-11e6-a345-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587227808695198121?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587227081244498556?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -156,157 +156,157 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['141']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:00:45 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['141']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:13:11 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 nsgcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [34ac12f0-a7aa-11e6-9425-a0b3ccf7272a]
+      x-ms-client-request-id: [93d56bca-a853-11e6-a345-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
         o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXenZfH7t3nT/v7LYvr7N9N8mdVFtXt3VVeXxSyvm7tfFNO6aqrzdvxK32zuzvJVWV0v
-        8mXb3M1+sK5zgrK7/+DgYO/Tnd374917D3bu7z/8aPTRMlvkhOfGNtTVKq/bIm8+evSLP2rzxarM
-        2vx5sXyLv9d1QQDmbbtqHt2VzprZ22kxnpTVZDyt6nx8VSxn1VUzXubtXfP6vGrauyd1Tr++aC5+
-        /72d3U+3dx5s7x4ICBnA+KebakkYTKtlS2P5SRou0ZG62x3v4L+Pfglhl9U0hpa+AjZlNc1Aa/ze
-        Xq8wttdtXSwvCMplVq7xwRVRc93gXRn9cMvF9bK5QMM2u2Dw2vDLyU/n09Y1/MW/5JdQo0U1o98/
-        OltO6xykz0pqQcS7LIA1QX7d0mipxev1dJrTEGf0fVssCJ1ssaLPmQi7xB27b3Z2H+3sPLr3YPzp
-        w0/v7396/6eo6Wxd69g+evlmb3f84N7Bg51PP31NXxGZ65zISt+ege8OJjsP9h6c39/eO3g4295/
-        MDvYnjyc7G3f29vJHj58eLCz93CHXmPkwEQfPfreL2ZqNKtsChQdU73I26uqfkutaWKZvd4QEeQN
-        /xN6ieYXTV/nU2KK9loYmF40k4KXDPW//0voPxpTvsqXs3w5Ze76Hn1SrdvVuqU/CKH86sXrz/Hb
-        EN1lBBvIazD8fM3yuLe3M7v36W6+nT14eL69f57vbT/cod/yT/N7D2YPHmQ79/bprUZH8GpdGrRm
-        +Xm2LlszNvMNIZmBhz46Lsvq6ieJAmfLJ9V6ib65x7s/VA2gk3WX8MBPg60CYnYm3dAfyd0I+jkx
-        PQ3gu3d/34+mn2a7+b3zbHsvAzvtZ/e3H57f39n+dO/eg/v3Hx6c55/Oft+P6B3CyVMV9NfGyZnl
-        ljL0DaOQFssJ+k/bOjs/L6bpeV0t0qws05/8oqEv0598cfqGXiXQbTWtSnrvW/Sn0OtlVbevsuUF
-        +sGnBL8tlsx63a/khePZjGjdvKzz8+IdffOTRd2us1KpSM08CDe2zWhgDY1bBkIfrGiaQOGPHn16
-        f2dnh6AVpGQBixqdyTg/IsUR8tAx1N/zKps9ycpsOc1rNyP/n2OoDWP5fxN3Acu0JDTTieJJrxP4
-        nwUO61GEWnpAus0B6Aa+2iUAN/DV03x5TS874v9/iZF6yP+wOQcIsAYqhLSGeaghAfpZ4BF8470U
-        +9ryBJCjv32WIJ6g929gCaKo6Psv160h7P+XuCKG/w+bMRiHlPwVJq9hC9UpxC+wWG1lf/3/kfEi
-        ovOY+yx1Ro56HU7L/+fYKjKG/5eylsGU3if4Pws8hW+8l7pfe/3fwEAdK0Wk5ZEFDARdRm/Td4bs
-        /19inT72P2ymAQbMHV2+oZYE6YfPHvja8gWwo799tiC+oPfjbPF9DqlpJBQM2rwGB1zMFO81YR8B
-        2v8DT+JUaJIRAAA=
+        p/nndbVeNXenZfH7t3nT/v7LYvr7N9N8mdVFdXdVV5fFLK+bu18U07pqqvN2/EpfbO7O8lVZXS/y
+        ZdvczX6wrnMCsrv/4ODg4cGD+w/HD/b27u1++uDew/37n340+miZLXLC9eaG1Okqr9sibz569Is/
+        avPFqsza/HmxfIu/13VBUOZtu2oe3ZVum9nbaTGelNVkPK3qfHxVLGfVVTNe5u1d8/q8atq7J3VO
+        v75oLn7/vZ3dT7d3HmzvHggIGcr4p5tqSRhMq2VLo/pJGjgRlLrbHe/gv49+CWGX1TSQlr4CNmU1
+        zUB0/N5erzDA121dLC8IymVWrvHBFZF13eBdIcFwy8X1srlAwza7YPDa8MvJT+fT1jX8xb/kl1Cj
+        RTWj3z86W07rHJOQldSCiHdZAGuC/Lql0VKL1+vpNKchzuj7tlgQOtliRZ8zEXaJTXbf7O0+2r33
+        aGd3fHBvf/fBg3s/RU1n61rH9tHLN3s744OdT+99+mDvNX1FZK5zIit9ewYGfJhNs08P8ofb97Pz
+        B9v7u5/ubz/c2d/Zvnd/L7+/e/7w03uTc3qNkQM7ffToe7+YqdGssilQdOz1Im+vqvottaaJZUZ7
+        Q0SQN/xP6CWaXzR9nU+JKdpr4WR60UwKXjLU//4vof9oTPkqX87y5ZS563v0SbVuV+uW/iCE8qsX
+        rz/Hb0N0lxFsIK/B8PM1C2b24PzT8/uf3t/emR3sbu/fy7Ptg4P797ez6d757uz8PH94D3RpdASv
+        1qVBa5afZ+uyNWMz3xCSGXjoo+OyrK5+kihwtnxSrZfom3u8+8NUBTpXdwkN/DTIKhzmZlIS/YHc
+        jWCfE88T/t+9+/t+tLN/8CDPH+xv7z64P93efzAhbnpwb3f74OHDh7NZnu8fTB/+vh/RO4STpyno
+        r41zM8stYegbRiEtlhP0n7Z1dn5eTNPzulqkWVmmP/lFQ1+mP/ni9A29SqDbalqV9N636E8h18uq
+        bl9lywv0g08JflssmfO6X8kLx7MZkbp5WefnxTv65ieLul1npVKRmnkQbmyb0cAaGrcMhD5Y0SyB
+        wh89+vT+zs4OQStI0QIWNTqTcX5EeiNkoWNov+dVNnuSldlymtduRv6/xk8bhvL/JuYClmlJaKYT
+        xZNeJ/A/CwzWowi19IB0mwPQDWy1SwBuYKun+fKaXnbE//8QH/Vw/2EzDhBg/VMIZQ3vUEMC9LPA
+        IvjGeyn2tWUJIEd/+xxBLEHv38ARRFHR9l+uW0PY/w8xRQz9HzZfMA4p+SpMXcMVqlGIXWCu2sr+
+        +v8jy0VE5zH3OeqMnPQ6nJb/r3FVZAj/L+Usgym9T/B/FlgK33gvdb/2+r+BfzomikjLIwv4B5qM
+        3qbvDNn/P8Q5feR/2DwDDJg5umxDLQnSD5878LVlC2BHf/tcQWxB78e54vscTNNIKAy0uQ0OtZgn
+        3mvCPgK0/wfvZqO2lREAAA==
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['1265']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:00:47 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['1270']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:13:11 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [488da4a1-a7aa-11e6-95ac-a0b3ccf7272a]
+      x-ms-client-request-id: [a7babc00-a853-11e6-a65d-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkSecurityGroups/mynsg?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/networkSecurityGroups/mynsg?api-version=2016-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9aHG9bC4+GvFnxQyf3G3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb
-        08nDvQd75zsP7z/cuVvnTbWup/nndbVeNXenZfH7t3nT/v7LYvr7N9N8mdVFtXt3VVeXxSyvm7tf
-        FNO6aqrzdvwib6+q+u3dpfx8nU/XddFeKyAfu7zNLoDfd+/+vh9NP81283vn2fZe9nC2vb+f3d9+
-        eH5/Z/vTvXsP7t9/eHCefzr7fT/SF9vrFQ/1lp3qW2U1zUABvHlFY1mbLwiNhj78xb9E/qRBrfK6
-        LXL+EB/Jh5dFQ28Xy4vXbdZy/6/X02mez/KZAKJmlmxrIf3e3s7s3qe7+Xb24OH59v55vrf9cId+
-        yz/N7z2YPXiQ7dzbty83ivWrdcl9f+/75ptZfp6ty9YMyzaQr1ODJR7LB8dlWV39JBHkbPmkWi8t
-        jnj+38oYd2MDvbtxJF+XieTBvPYmWx58dYspl4dmyBISzRjltFhOgG/a1tn5eTFNz+tqkWZlmf7k
-        Fw19mf7ki9M3HTjUaVtNqxJAvtX5Tgj/sqrbV9nygtHpNiE02mLJbL6xnYA6ns1oOpuXdX5evEOz
-        nyzqdp2VOlOddzzY7/diRiRrQF8hS+fbFTEM5pq+//T+zs5O+O2sqPMpuqSvPzoTen7kWvwS86vI
-        Lh5vEkNZOP7Bus6fV9nsSVZmy2lex9jp/3uCcath/X9PSjCqtKRhpRMdVwcWdfxzKCk9qnde88D3
-        3u128V7ysRt++83Ix9N8eU19xzjn/1MCsWEc/++UACDMFqGQqTNC0HmLuvg55PVuMw/cjW0db2Oo
-        nS8D1ibeDr/9Zlib2EGchy/XbZ8r/j/F3ZuH8v9OBmec02rd8vQZ9lYdT3wPT6it7K8/cor4oRF7
-        krHZKSJmYNp+TdE4W7Z5PcRT/98Tj43D+f+0iJiRdYBRzz+HstFt5oHrtR0YwHsJwibvh6acKfj+
-        ggDTRJ0TgD7P/H9KBDYN5P+dzA+Mmcu7/N95jfr4/wibd9s6/sZYO18G7E38HX57e/aWX76PH/T7
-        L/l/ADGeOUASFAAA
+        08nDvQd75zsP7z/cuVvnTbWup/nndbVeNXenZfH7t3nT/v7LYvr7N9N8mdVFdXdVV5fFLK+bu18U
+        07pqqvN2/CJvr6r67d2l/HydT9d10V4rHB+5vM0ugN537/6+H+3sHzzI8wf727sP7k+39x9M9rcf
+        Pri3u33w8OHD2SzP9w+mD3/fj/TF9nrFI71lp/pWWU0zEABvXtFQ1uYLQqOhD3/xL5E/aVCrvG6L
+        nD/ER/LhZdHQ28Xy4nWbtdz/6/V0muezfCaAqJml2loonz04//T8/qf3t3dmB7vb+/fybPvg4P79
+        7Wy6d747Oz/PH947ty83ivWrdcl9f+/75ptZfp6ty9YMyzaQr1ODJR7LBsdlWV39JBHkbPmkWi8t
+        jnj+X8oXd2PjvLtxIF+Xh+TBtPbmWh58dYsZl4cmyNIRzRjltFhOgG/a1tn5eTFNz+tqkWZlmf7k
+        Fw19mf7ki9M3HTjUaVtNqxJAvtX5Tuj+sqrbV9nygtHpNiE02mLJXL6xnYA6ns1oNpuXdX5evEOz
+        nyzqdp2VOlOddzzY7/diRiRrQF8hS+fbFfEL5pq+//T+zs5O+O2sqPMpuqSvPzoTen7kWvwS86uI
+        Lh5vEkNROP7Bus6fV9nsSVZmy2lex9jp/3NycatR/X9PSDCqtKRhpRMdVwcWdfxzKCg9qnde88D3
+        3u128V7isRt++82Ix9N8eU19xzjn/0vysGEY/+8UACDM9qCQmTMy0HmLuvg5ZPVuMw/cjW0da2Oo
+        nS8DzibWDr/9Zjib2EFchy/XbZ8r/r/E3JtH8v9O/mac02rd8uwZ7lYNT2wPN6it7K8/8oj4oRF7
+        grHZIyJmYNp+Tck4W7Z5PcRT/5+Tjo2j+f+0hJiRdYBRzz+HotFt5oHrtR0YwHvJwSbXh6acKfj+
+        cgDDRJ0TgD7P/H9JAjaN4/+dvA+Mmcm77N95jfr4/wiXd9s69sZYO18G3E3sHX57e+6WX76PH/T7
+        L/l/AMtyVIILFAAA
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:00:47 GMT']
-      etag: [W/"c6a1e3fa-2a9d-44a5-9f50-62375598fe6d"]
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:13:12 GMT']
+      ETag: [W/"0487ee74-175c-47b4-9731-8999ddee48c9"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateNsg_2016-07-18/azuredeploy.json"},
-      "mode": "Incremental", "parameters": {"name": {"value": "myothernsg"}}}}'
+    body: '{"properties": {"mode": "Incremental", "templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateNsg_2016-07-18/azuredeploy.json"},
+      "parameters": {"name": {"value": "myothernsg"}}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
       Connection: [keep-alive]
       Content-Length: ['208']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 nsgcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [49096451-a7aa-11e6-b4db-a0b3ccf7272a]
+      x-ms-client-request-id: [a81f2e5a-a853-11e6-97bc-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478826049.2911366","name":"azurecli1478826049.2911366","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateNsg_2016-07-18/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"myothernsg"},"tags":{"type":"Object","value":{}}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-11-11T01:00:50.5768411Z","duration":"PT0.5252519S","correlationId":"a9826e4d-8116-4f3e-ad88-e57114cad5f8","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[]}}'}
+    body: {string: '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/azurecli1478898793.76014312363","name":"azurecli1478898793.76014312363","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateNsg_2016-07-18/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"myothernsg"},"tags":{"type":"Object","value":{}}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-11-11T21:13:15.1849313Z","duration":"PT0.515621S","correlationId":"2f2411ec-af12-4bb4-8401-e1222aa14c63","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478826049.2911366/operationStatuses/08587227808354260746?api-version=2015-11-01']
-      cache-control: [no-cache]
-      content-length: ['829']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:00:49 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/azurecli1478898793.76014312363/operationStatuses/08587227080908083475?api-version=2015-11-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['835']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:13:14 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 nsgcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [49096451-a7aa-11e6-b4db-a0b3ccf7272a]
+      x-ms-client-request-id: [a81f2e5a-a853-11e6-97bc-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587227808354260746?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587227080908083475?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -314,115 +314,115 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['141']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:01:19 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['141']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:13:45 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 nsgcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [49096451-a7aa-11e6-b4db-a0b3ccf7272a]
+      x-ms-client-request-id: [a81f2e5a-a853-11e6-97bc-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
         o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXenZfH7t3nT/v7LYvr7N9N8mdVFtXt3VVeXxSyvm7tfFNO6aqrzdvxK32zuzvJVWV0v
-        8mXb3M1+sK5zgrK7/+DgYO/Tnf2H472Hu7v3Pv30o9FHy2yRE54b21BXq7xui7z56NEv/qjNF6sy
-        a/PnxfIt/l7XBQGYt+2qeXRXOmtmb6fFeFJWk/G0qvPxVbGcVVfNeJm3d83r86pp757UOf36orn4
-        /fd2dj/d3nmwvXsgIGQA459uqiVhMK2WLY3lJ2m4REfqbne8g/8++iWEXVbTGFr6CtiU1TQDrfF7
-        e73C2F63dbG8ICiXWbnGB1dEzXWDd2X0wy0X11U7z+tlc4HWbXbBfWjrLyc/nU9b1/oX/5JfQo0W
-        1Yx+/+hsOa1z0D8rqQVR8LIA6gT+dUtDphav19NpTuOc0fdtsSCcssWKPmdK7BKL7L7Z2X2E/z0Y
-        7+3e/3Tn4YOfoqazda0D/Ojlm90H491P93f2du6/pq+I1nVOtKVvz8B82UOaynx/tn2wSyD3z+/l
-        29ns4GA7v/9gd3d/ms3unx/Qa4wcOOmjR9/7xUySZpVNgaLjrBd5e1XVb6k1zS7z2Bsigrzhf0Iv
-        0SSj6et8SpzRXgsX04tmZvCSmYLv/xL6j8aUr/LlLF9OmcW+R59U63a1bukPQii/evH6c/w2RHcZ
-        wQbyGgw/X7NQHkwf5tPz2cPt7NPd8+39+3ufEl12ZtuTT6eTLH+wM92b7NNbjY7g1bo0aM3y82xd
-        tmZs5htCMgMjfXRcltXVTxIFzpZPqvUSfXOPd3+oakAn6y7hgZ8GWwXkeJq0RH84dyNjyInzaRTf
-        vfv7fpTdn872H967t30/28u293fy+9sH9/aJYXc+zXZ2Z/fOD6a7v+9H9A4h5ikN+mvjDM1ySx76
-        hlFIi+UE/adtnZ2fF9P0vK4WaVaW6U9+0dCX6U++OH1DrxLotppWJb33LfpTiPayqttX2fIC/eBT
-        gt8WS+a/7lfywvFsRgRvXtb5efGOvvnJom7XWamkpGYehBvbZjSwhsYtA6EPVjRXoPBHjz69v7Oz
-        Q9AKUreARY3OZJwfkfYIGekYivB5lc2eZGW2nOa1m5H/b3LVhgH9v4nFgGVaEprpRPGk1wn8zwKb
-        9ShCLT0g3eYAdANz7RKAG5jrab68ppcd8f8/x029Efyw2QcIsC4qhL6Gg6ghAfpZYBR8470U+9oy
-        BpCjv32+IMag92/gC6KoaP4v160h7P/nWCM2iB82dzAOKfkwTGPDG6pdiGlgwNrK/vr/I1tGROcx
-        9/nqjDz4OpyW/2/yVmQg/y/lL4MpvU/wfxYYC994L3W/9vq/gYs6RotIyyMLuAhajd6m7wzZ/z/H
-        P/0h/LA5Bxgwi3SZh1oSpB8+j+BryxzAjv72eYOYg96P88b3OeCmkVCoaFMfHI4xZ7z/rH0EkP8P
-        CIPI97oRAAA=
+        p/nndbVeNXenZfH7t3nT/v7LYvr7N9N8mdVFdXdVV5fFLK+bu18U07pqqvN2/EpfbO7O8lVZXS/y
+        ZdvczX6wrnMCsrv/4ODg4cGDh/fGDz7d2d2/t7t379N7H40+WmaLnFC9sR11ucrrtsibjx794o/a
+        fLEqszZ/Xizf4u91XRCQeduumkd3pdNm9nZajCdlNRlPqzofXxXLWXXVjJd5e9e8Pq+a9u5JndOv
+        L5qL339vZ/fT7Z0H27sHAkIGMv7pploSBtNq2dKYfpKGTeSk7nbHO/jvo19C2GU1jaOlr4BNWU0z
+        kBy/t9crjO91WxfLC4JymZVrfHBFRF03eFcoMNxycV2187xeNhdo3WYX3Ie2/nLy0/m0da1/8S/5
+        JdRoUc3o94/OltM6xzxkJbUgCl4WQJ3Av25pyNTi9Xo6zWmcM/q+LRaEU7ZY0edMiV3ilN03e7uP
+        du89urc7JibZ39998FPUdLaudYAfvXyz+2C8d/9g997u/mv6imhd50Rb+vYMPLh3vre/u5tPt7Pz
+        3b3t/clkf/tgf2d3O9/d29vLst39qZle4aiPHn3vFzNJmlU2BYqOw17k7VVVv6XWNLvMa2+ICPKG
+        /wm9RJOMpq/zKXFGey3MTC+amcFLZgq+/0voPxpTvsqXs3w5ZRb7Hn1SrdvVuqU/CKH86sXrz/Hb
+        EN1lBBvIazD8fM2yOZ3u38vvP5hs379/78H2/nT6cPvhw52D7SkRZe/BbLY73d2ntxodwat1adCa
+        5efZumzN2Mw3hGQGRvrouCyrq58kCpwtn1TrJfrmHu/+MLWBztVdQgM/DbIKx7E0KYv+aO5GhpAT
+        49Mgvnv39/0oP88fEMNNtyefHnxKLPXg/vbB3vn+9vneTvbw00939h7u3vt9P6J3CDFPZ9BfGydo
+        llvq0DeMQlosJ+g/bevs/LyYpud1tUizskx/8ouGvkx/8sXpG3qVQLfVtCrpvW/Rn0Kzl1XdvsqW
+        F+gHnxL8tlgy+3W/kheOZzOid/Oyzs+Ld/TNTxZ1u85KJSU18yDc2DajgTU0bhkIfbCiqQKFP3r0
+        6f2dnR2CVpDGBSxqdCbj/IiUR8hHx9CDz6ts9iQrs+U0r92M/H+SqTaM5/9NHAYs05LQTCeKJ71O
+        4H8WuKxHEWrpAek2B6AbeGuXANzAW0/z5TW97Ij//zVm6g3gh809QIA1USHkNQxEDQnQzwKf4Bvv
+        pdjXli+AHP3tswXxBb1/A1sQRUXvf7luDWH/v8YZsTH8sJmDcUjJf2ESG9ZQ3UI8A+vVVvbX/x8Z
+        MiI6j7nPVmfkvdfhtPx/krUi4/h/KXsZTOl9gv+zwFf4xnup+7XX/w1M1LFYRFoeWcBE0Gn0Nn1n
+        yP7/Nfbpj+CHzTjAgDmkyzvUkiD98FkEX1veAHb0t88axBv0fpw1vs+hNo2EgkSb/OBAjBnj/Wft
+        I4D8fwB0gXl7uxEAAA==
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['1262']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:01:21 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['1267']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:13:45 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreatePublicIp_2016-09-14/azuredeploy.json"},
-      "mode": "Incremental", "parameters": {"allocationMethod": {"value": "dynamic"},
-      "version": {"value": "ipv4"}, "name": {"value": "publicip1"}, "_artifactsLocation":
-      {"value": "https://azuresdkci.blob.core.windows.net/templatehost/CreatePublicIp_2016-09-14"},
-      "dnsNameType": {"value": "none"}, "idleTimeout": {"value": 4}}}}'
+    body: '{"properties": {"mode": "Incremental", "templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreatePublicIp_2016-09-14/azuredeploy.json"},
+      "parameters": {"allocationMethod": {"value": "dynamic"}, "dnsNameType": {"value":
+      "none"}, "_artifactsLocation": {"value": "https://azuresdkci.blob.core.windows.net/templatehost/CreatePublicIp_2016-09-14"},
+      "name": {"value": "publicip1"}, "version": {"value": "ipv4"}, "idleTimeout":
+      {"value": 4}}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
       Connection: [keep-alive]
       Content-Length: ['463']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 publicipcreationclient/2015-11-01 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [5d831751-a7aa-11e6-8b5b-a0b3ccf7272a]
+      x-ms-client-request-id: [bc03ea86-a853-11e6-92ae-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478826083.659178","name":"azurecli1478826083.659178","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreatePublicIp_2016-09-14/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreatePublicIp_2016-09-14"},"allocationMethod":{"type":"String","value":"dynamic"},"dnsName":{"type":"String","value":""},"dnsNameType":{"type":"String","value":"none"},"idleTimeout":{"type":"Int","value":4},"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"publicip1"},"reverseFqdn":{"type":"String","value":""},"tags":{"type":"Object","value":{}},"version":{"type":"String","value":"ipv4"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-11-11T01:01:24.6663342Z","duration":"PT0.3646618S","correlationId":"16abc600-e7c7-448b-a73c-399b134db286","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]}]}],"dependencies":[]}}'}
+    body: {string: '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/azurecli1478898827.135890228171","name":"azurecli1478898827.135890228171","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreatePublicIp_2016-09-14/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreatePublicIp_2016-09-14"},"allocationMethod":{"type":"String","value":"dynamic"},"dnsName":{"type":"String","value":""},"dnsNameType":{"type":"String","value":"none"},"idleTimeout":{"type":"Int","value":4},"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"publicip1"},"reverseFqdn":{"type":"String","value":""},"tags":{"type":"Object","value":{}},"version":{"type":"String","value":"ipv4"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-11-11T21:13:48.8394814Z","duration":"PT0.6440235S","correlationId":"200590f5-957a-4f7a-b484-37b32d736f66","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]}]}],"dependencies":[]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478826083.659178/operationStatuses/08587227808011760038?api-version=2015-11-01']
-      cache-control: [no-cache]
-      content-length: ['1222']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:01:24 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/azurecli1478898827.135890228171/operationStatuses/08587227080572822158?api-version=2015-11-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['1233']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:13:48 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 publicipcreationclient/2015-11-01 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [5d831751-a7aa-11e6-8b5b-a0b3ccf7272a]
+      x-ms-client-request-id: [bc03ea86-a853-11e6-92ae-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587227808011760038?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587227080572822158?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -430,148 +430,178 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['141']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:01:54 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['141']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:14:18 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 publicipcreationclient/2015-11-01 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [5d831751-a7aa-11e6-8b5b-a0b3ccf7272a]
+      x-ms-client-request-id: [bc03ea86-a853-11e6-92ae-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
         o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXenZfH7t3nT/v7LYvr7N9N8mdVFtXt3VVeXxSyvm7tfFNO6aqrzdvxK32zuzvJVWV0v
-        8mXb3M1+sK5zgrK7/+DgYO/TnYN740/vP9x9cPDR6KNltsgJzU1NqKNVXrdF3nz06Bd/1OaLVZm1
-        +fNi+RZ/r+uC3p+37ap5dFe6amZvp8V4UlaT8bSq8/FVsZxVV814mbd3zevzqmnvntQ5/fpyPSmL
-        6dnq99/b2f10e+fh9u6+wJExjH+6qZaExrRatjScn6QREympz93xDv776JcQillN42jpK6D0+2eE
-        7Xk2bZvn1TQD4fFpe73CSF+3dbG8IHiXWbnGB98w6kAnK0vt+Iu8nVfEB8Pdz65pCoopXpstmxcZ
-        pmO4tdfsDTcZbrqsljmaF7Myf1Ms8mrdes3Plq1ru0/NDMZemx7IK+LCdQOghDN9MNxyxYQpVrto
-        XOeXNDP5s1802wgdTdvsgqdQ23w5+el86iH6i38JtQGwGxAtVpc0EdR2Uc3w99lyWucQhqykVsTQ
-        lwVA0EuvW5pGavF6PZ3mxHEz+r4lajVttljR5zyxuySvu292dh/R//Z3xvsPd3ce/hQ1nK1rpdlH
-        L9/sfjrePXi4v/vg09f0FXFPnRO30LdnNP8f7X6aTaaf7uxs5w+mD7b39w8m29mDe9Ptew8fTnbv
-        7c8mewef0muMGoT6o0ff+8VM5WaVTYGgE/IXeXtV1W+pNfEriztYQd7wP6GXZBrOXh7PZvRNQ43c
-        ROMFM6Pf/yX0H40nX+XLWb6csqx/jz4hplmtW/rjFxtYRBRL9970CP4bSEtYMH6fr1k73n84uzf7
-        9GG+/XD68GB7/97uw+3s/v2d7Yf38tnu3s7+zr38Ib2lXb887snVR09VfAI+P1t+USzXpDPB2mAD
-        +oyGYbUjjU3Vc4+qd21fhmT6CfPy93/JL/l/AFHmFzbYBQAA
+        p/nndbVeNXenZfH7t3nT/v7LYvr7N9N8mdVFdXdVV5fFLK+bu18U07pqqvN2/EpfbO7O8lVZXS/y
+        ZdvczX6wrnMCsrv/4ODg4cHB3oPx7r37Bw939vYOdh/sfjT6aJktcsL15obU6Sqv2yJvPnr0iz9q
+        88WqzNr8ebF8i7/XdUFQ5m27ah7dlW6b2dtpMZ6U1WQ8rep8fFUsZ9VVM17m7V3z+rxq2rsndU6/
+        vlxPymJ6tvr993Z2P93eebi9uy9wZDzjn26qJaExrZYtDe0nafREVepzd7yD/z76JYRiVtNoWvoK
+        KP3+GWF7nk3b5nk1zTAH+LS9XmG8r9u6WF4QvMusXOODbxh1oJOVpXb8Rd7OK2KJ4e5n1zQRxRSv
+        zZbNiwyTMtzaa/aGmww3XVbLHM2LWZm/KRZ5tW695mfL1rXdp2YGY69ND+QVMeS6AVDCmT4Ybrli
+        whSrXTSu80uamfzZL5pthI6mbXbBU6htvpz8dD71EP3Fv4TaANgNiBarS5oIaruoZvj7bDmtcwhG
+        VlIrYujLAiDopdctTSO1eL2eTnPiuBl93xK1mjZbrOhznthdEt3dN3u7j3b3H+08GD/c3yXhePhT
+        1HS2rpVqH718s/tw/GD//oMHu6/pG2KfOid2oS/PiAEI0A6J+fn97Yf3H2Tb++f0z2T/YH/73oPJ
+        vb3Zg3ufnn/6Kb3GuEHCP3r0vV/MZG5W2RQYOol/kbdXVf2WWhPDsuyDF+QN/xN6Sebh7OXxbEbf
+        NNTIzTReMFP6/V9C/9Fw8lW+nOXLKQv79+gT4prVuqU/frGBRVSxhO/Nj+C/gbaEBeP3+Zo15c50
+        mt3bzfe2z3f2Jtv7pCm3JwfT3e2H071P89m9+zuT6Q69pV2/PO4J1kdPVX4CRj9bflEs16Q/wdvg
+        A/qMhmFVJY1NVXWPqndtX4Zk+gkz8/d/yS/5fwCKa+H85AUAAA==
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['891']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:01:55 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['892']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:14:19 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [716aea8f-a7aa-11e6-be20-a0b3ccf7272a]
+      x-ms-client-request-id: [cfeeacd2-a853-11e6-b1f4-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/publicIPAddresses/publicip1?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/publicIPAddresses/publicip1?api-version=2016-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9aLWelMW0WO1+NOLPixk+vdusJ820LlZtUS2buzuT3fNP9x/sbu9Ozne292ezbDvL
-        p/e2p5OHew/2znce3n+4c7fOm2pdT/PP62q9au5Oy+L3b/Om/f2XxfT3b6b5MquLavfuqq4ui1le
-        N3e/KKZ11VTn7fhF3l5V9du7gsvZy+PZjIA1eaOfOOzyNrsAft+9+/t+tDfb/fR8/+HO9t7Bzn1C
-        an+6PXlwkG/f/3QyeTA9yO/fP5/8vh/pi+31iod7i071jbKaZhg93rqicazNF4RCQx/+4l8if9KA
-        VnndFvQifYiP5MPLoqG3i+XF6zZrue/X6+k0z2f5TABRM+pQSLYWst9/OLs3+/Rhvv1w+vBge//e
-        7sPt7P79ne2H9/LZ7t7O/s69/KF9uYP4TxJNqUOAOXt5ud9vVpoRfZG384r7e3pNbFBMbdtiVuZv
-        ikVerduz5RfFck0TSO328fUv+Y2TX/L/AN8iVXs7AgAA
+        p/e2p5OHew/2znce3n+4c7fOm2pdT/PP62q9au5Oy+L3b/Om/f2XxfT3b6b5MquL6u6qri6LWV43
+        d78opnXVVOft+EXeXlX127uCytnL49mMYDV5o5845PI2uwB63737+340yz7d3ds72Nu+N93fI5x2
+        d7cPHh482D64N907eJB/+mDn/OHv+5G+2F6veLS36FTfKKtphsHjrSsaxtp8QSg09OEv/iXyJw1o
+        lddtQS/Sh/hIPrwsGnq7WF68brOW+369nk7zfJbPBBA1ow6FYmuh+s50mt3bzfe2z3f2Jtv7RPXt
+        ycF0d/vhdO/TfHbv/s5kumNf7iD+k0RT6hBgzl5e7veblWZEX+TtvOL+nl4TFxRT27aYlfmbYpFX
+        6/Zs+UWxXNP8Ubt9fP1LfuPkl/w/xAlDXzoCAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:01:56 GMT']
-      etag: [W/"2d16f490-2805-4d4c-b78e-56bb7c8e55fb"]
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:14:20 GMT']
+      ETag: [W/"da612282-3c42-4d11-8987-83c287e670f9"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-07-19/azuredeploy.json"},
-      "mode": "Incremental", "parameters": {"dnsNameType": {"value": "none"}, "publicIpAddressAllocation":
-      {"value": "dynamic"}, "loadBalancerName": {"value": "mylb"}, "vnetAddressPrefix":
-      {"value": "10.0.0.0/16"}, "privateIpAddressAllocation": {"value": "dynamic"},
-      "_artifactsLocation": {"value": "https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-07-19"},
-      "frontendIpName": {"value": "LoadBalancerFrontEnd"}, "subnetAddressPrefix":
-      {"value": "10.0.0.0/24"}}}}'
+    body: '{"properties": {"mode": "Incremental", "templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-07-19/azuredeploy.json"},
+      "parameters": {"privateIpAddressAllocation": {"value": "dynamic"}, "dnsNameType":
+      {"value": "none"}, "vnetAddressPrefix": {"value": "10.0.0.0/16"}, "subnetAddressPrefix":
+      {"value": "10.0.0.0/24"}, "_artifactsLocation": {"value": "https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-07-19"},
+      "publicIpAddressAllocation": {"value": "dynamic"}, "loadBalancerName": {"value":
+      "mylb"}, "frontendIpName": {"value": "LoadBalancerFrontEnd"}}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
       Connection: [keep-alive]
       Content-Length: ['609']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 lbcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [71db86b0-a7aa-11e6-805c-a0b3ccf7272a]
+      x-ms-client-request-id: [d04f7b76-a853-11e6-95c4-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478826117.7823163","name":"azurecli1478826117.7823163","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-07-19/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-07-19"},"backendPoolName":{"type":"String","value":"mylbbepool"},"dnsNameType":{"type":"String","value":"none"},"frontendIpName":{"type":"String","value":"LoadBalancerFrontEnd"},"loadBalancerName":{"type":"String","value":"mylb"},"location":{"type":"String","value":"westus"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddress":{"type":"String","value":"PublicIPmylb"},"publicIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddressType":{"type":"String","value":"new"},"publicIpDnsName":{"type":"String","value":""},"subnet":{"type":"String","value":""},"subnetAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetType":{"type":"String","value":"none"},"tags":{"type":"Object","value":{}},"virtualNetworkName":{"type":"String","value":""},"vnetAddressPrefix":{"type":"String","value":"10.0.0.0/16"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-11-11T01:01:59.331743Z","duration":"PT0.7842205S","correlationId":"bdaf6804-a337-4f67-b5b5-8b2d2436313b","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/IPmylb","resourceType":"Microsoft.Resources/deployments","resourceName":"IPmylb"},{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/Subnetmylb","resourceType":"Microsoft.Resources/deployments","resourceName":"Subnetmylb"}],"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"mylb"}]}}'}
+    body: {string: '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/azurecli1478898861.18755417327","name":"azurecli1478898861.18755417327","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-07-19/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-07-19"},"backendPoolName":{"type":"String","value":"mylbbepool"},"dnsNameType":{"type":"String","value":"none"},"frontendIpName":{"type":"String","value":"LoadBalancerFrontEnd"},"loadBalancerName":{"type":"String","value":"mylb"},"location":{"type":"String","value":"westus"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddress":{"type":"String","value":"PublicIPmylb"},"publicIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddressType":{"type":"String","value":"new"},"publicIpDnsName":{"type":"String","value":""},"subnet":{"type":"String","value":""},"subnetAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetType":{"type":"String","value":"none"},"tags":{"type":"Object","value":{}},"virtualNetworkName":{"type":"String","value":""},"vnetAddressPrefix":{"type":"String","value":"10.0.0.0/16"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-11-11T21:14:22.9339848Z","duration":"PT0.5966945S","correlationId":"a043bea8-3959-4525-90f9-16e260c6ac1e","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/IPmylb","resourceType":"Microsoft.Resources/deployments","resourceName":"IPmylb"},{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/Subnetmylb","resourceType":"Microsoft.Resources/deployments","resourceName":"Subnetmylb"}],"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"mylb"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478826117.7823163/operationStatuses/08587227807669301773?api-version=2015-11-01']
-      cache-control: [no-cache]
-      content-length: ['2495']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:01:59 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/azurecli1478898861.18755417327/operationStatuses/08587227080231404043?api-version=2015-11-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['2500']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:14:22 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 lbcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [71db86b0-a7aa-11e6-805c-a0b3ccf7272a]
+      x-ms-client-request-id: [d04f7b76-a853-11e6-95c4-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587227807669301773?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587227080231404043?api-version=2015-11-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
+        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['140']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:14:53 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 lbcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [d04f7b76-a853-11e6-95c4-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587227080231404043?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -579,558 +609,281 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
         tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['141']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:02:29 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['141']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:15:23 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 lbcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [71db86b0-a7aa-11e6-805c-a0b3ccf7272a]
+      x-ms-client-request-id: [d04f7b76-a853-11e6-95c4-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
         o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXenZfH7t3nT/v7LYvr7N9N8mdVFtXt3VVeXxSyvm7tfFNO6aqrzdvxK32zuzvJVWV0v
-        8mXb3M1+sK5zgrK7/+DgYO/T3d0H4wcHe/d2P7330eijZbbICc+NbairVV63Rd589OgXf9Tmi1WZ
-        tfnzYvkWf6/rggDM23bVPLornTWzt9NiPCmryXha1fn4qljOqqtmvMzbu+b1edW0d0/qnH59Pvn9
-        93Z2P93eebC9+1AgCP7jn26qJSEwrZYtDeUnabRERuptd7yD/z76JYRcVtMQWvoKyPz+GeF5nk3b
-        5nk1zUB0fNperzDI121dLC8I3mVWrvHBN4Y0EJlk07f5cvayqsoXGYg63O/iupxM8hW1xIuzZYMX
-        3nDj4ZeW1TJH8/OaqTE7W+GtTW88r7LZk6zMltO8foa3TpczQCi9z2+CAVTlnZvJeUVcum7QelUX
-        l0Sjs9XxbEaU5akZeivW/ri8TX+za+LeYsoA1pOymNr3N731Upq+NCPrvPqhXd84jfmV/9ZTmfxN
-        b6A5qRHiw9u1UkRe1vl58W7TK7skQvjv7t6+e/tG/JUN2+zCJ/OXk5/Op61r94t/CbW5LOp2nZUv
-        8vaqqt/eZpyXhMH747/76UfoblHN8PHZclrnUH1ZSY1JeV0WUBv07uuWmIxavF5PpznpmBl93xYL
-        YttssaLPWaB3STvvvtnZfbSz92jv3vj+7v1PP909+ClqOlvXyhgfvXyztz9++OnB7r2H917TV6Qx
-        6pw0BH17Br0/mWXnnx7s7G9n9+492N4///TB9uT+5P72wWRvtrd/79N7u/cm9BojByX+0aPv/WLW
-        xc0qmwJFp9SVetSaqMLqHVMkb/if0Eu+YDf0guFkNDbS+f1f8v1fMhrqyxoQetmHDQC93kRHg9Bo
-        7ve1XJcl+vk+0Sxfka7Kl1O2HgREPmi+JCrSX/+vMZKqD8JhE243vOe9IOz9kQICjf9fM7jXLNmM
-        l8P36w7QA4YJ/jkYpErE3YDd7zJGDtve8KJveS/o8BgMBlat29WaCEAKyH8Ff6tC6uk8kecNysb0
-        9fmayba//3D3/Hy2v/3gwaczaImD7YP9yXT73kGe3zs/vz+7P8Vb1uK/PKmW58WFqiFCjSQIgkyg
-        orb+/2Wzc3doIHcHsM/JyBD+3737+3706ex+9mB2kG9nn+59ur2/c/98O7u/+3A7//Th/uz8Qf6A
-        /v19P6J3CCXPWaW/Nk6IcTxeOrP/Rd7OK5Dtqdp4aiXG+qVaJgD+OSRsBxuS19Cl+SXgXvVGtQ2c
-        UkLbsQtaqgf6/zYmiWDOX1h0f7a5gunnEKM2r9YlXvwefU6vTszvxXJSrZezF1nrNSC1EfnUNeUB
-        4UOaJ25NSsZqXvpcWes2pHJGpt/6Jib5/i/5Jf8P4oADKqMOAAA=
+        p/nndbVeNXenZfH7t3nT/v7LYvr7N9N8mdVFdXdVV5fFLK+bu18U07pqqvN2/EpfbO7O8lVZXS/y
+        ZdvczX6wrnMCsrv/4ODg4cHBp7vj3YMH9+/v7z64t/fgo9FHy2yRE6o3tqMuV3ndFnnz0aNf/FGb
+        L1Zl1ubPi+Vb/L2uCwIyb9tV8+iudNrM3k6L8aSsJuNpVefjq2I5q66a8TJv75rX51XT3j2pc/r1
+        +eT339vZ/XR758H27kOBIOMY/3RTLQmBabVsaUg/SaMmalJvu+Md/PfRLyHkspqG0dJXQOb3zwjP
+        82zaNs+raQba49P2eoWBvm7rYnlB8C6zco0PvjGkgcgkm77Nl7OXVVW+yEDY4X4X1+Vkkq+oJV6c
+        LRu88IYbD7+0rJY5mp/XTI3Z2QpvbXrjeZXNnmRltpzm9TO8dbqcAULpfX4TDKAq79xMziti1nWD
+        1qu6uCQana2OZzOiLE/N0Fux9sflbfqbXRMHF1MGsJ6UxdS+v+mtl9L0pRlZ59UP7frGacyv/Lee
+        yuRvegPNSZsQH96ulSLyss7Pi3ebXtklEcJ/d/f23ds34q9s2GYXPpm/nPx0Pm1du1/8S6jNZVG3
+        66x8kbdXVf32NuO8JAzeH//dTz9Cd4tqho/PltM6hwrMSmpMyuuygNqgd1+3xGTU4vV6Os1Jx8zo
+        +7ZYENtmixV9zgK9S0p6983e7qPd/Uf3Px3f39/fvf/w4Keo6WxdK2N89PLNvf3x3s6nB58+vP+a
+        viKNUeekIejbM6j/bGf/3iTPDrbvkWbf3r+/d3/74c75w+3dT/O9T3emn2bT3ZxeY+SgzD969L1f
+        zPq4WWVToOiUu1KPWhNVWM1jiuQN/xN6yRfshl4wnIzGRjq//0u+/0tGQ31ZQ0Iv+7ABoNeb6GgQ
+        Gs39vpbrskQ/3yea5SvSVflyytaDgMgHzZdERfrr/y22UtVBOGpC7Yb3vBeEuz9SQCDx/1vG9prl
+        mtFy6H7d8XnAML0//DGqONwNeP0uI+SQ7Y0u+pb3go6OwWBc1bpdrWn8pH38V/C3aqOewhNh3qBp
+        TF+fr5lq985n9/fu7e5t7+Y797b3p/f3trPZg/Pth9n+pw8mDw4m+/d36S1r7l+eVMvz4kJ1EKFG
+        4gMpJlBRQ///rsm5OzSOuwPI52RgCP3v3v19P8rOd7Is251sP/gUyvRePtvOPs3ub2cPd/PJ/b38
+        fDJ7+Pt+RO8QSp6jSn9tnA/jdLx0Jv+LvJ1XoNpTte/USgz1S7VKAPxzR9cOMiSsoTfzS8C76ohq
+        G/ijhLVjFrRU5/P/ZSwSQZy/sNj+bPMEk88hRm1erUu8+D36nF6dmN+L5aRaL2cvstZrQDoj8qlr
+        ygPChzRN3Jo0jNW69Lky1m1I5exLv/VNPPL9X/JL/h9piceWpA4AAA==
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['1235']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:02:29 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['1237']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:15:24 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [85c46b61-a7aa-11e6-900c-a0b3ccf7272a]
+      x-ms-client-request-id: [f6b80d78-a853-11e6-960c-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9aHFdTj4a8UfFDB/cbdaTZloXq7aols3dncnu+af7D3a3dyfnO9v7s1m2neXTe9vT
-        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edP+/sti+vs303yZ1UW1e3dVV5fFLK+bu18U
-        07pqqvN2/CJvr6r67d2yymZPsjJbTvG9h1TeZhdA67t3f9+PPp3dzx7MDvLt7NO9T7f3d+6fb2f3
-        dx9u558+3J+dP8gf0L+/70f6Ynu94gHe0Je2LqtphgHjjStCfW2+oO4b+vAX/xL5k8awyuu2yPlD
-        fCQfXhYNvV0sL163Wcv9vl5Pp3k+y2cCiJpZKq2F0vv7D3fPz2f72w8efDrb3j//9GD7YH8y3b53
-        kOf3zs/vz+5P3cvndbVs8+Xs7OVJtTwvLtY14ws0vidNUoMPHju/z73BPgOM06UFiuf/ZbN+d2ic
-        d28cyNflFHkwib2ZlQdf3WJ+5aHGxSU1OXt5XBqm+iJv5xWT+ek1zUsx7b6ynpTFlN6YzYimvf6p
-        xc/lJHWwy5u7L/UTTNhHPqa/xP1hf9Vfvq9D/miSTd/S/Cq0l1VVYsAbeRj9TPIVNfUJ93NKlAjn
-        RgbGX0Qw/zljVddWp8X+YufHjYxAvFqX3Mn37NfUwaTzUbGcVOvl7EXW9ptX63b4S/ciU4u/w1eE
-        0i/5fwA8Vtg9pgYAAA==
+        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edP+/sti+vs303yZ1UV1d1VXl8Usr5u7XxTT
+        umqq83b8Im+vqvrt3bLKZk+yMltO8b2HU95mF8Dqu3d/34+y850sy3Yn2w8+vf9we/9ePtvOPs3u
+        b2cPd/PJ/b38fDJ7+Pt+pC+21yse3w19aeuymmYYL964IszX5gvqvqEPf/EvkT9pDKu8boucP8RH
+        8uFl0dDbxfLidZu13O/r9XSa57N8JoComSXSWgh973x2f+/e7t72br5zb3t/en9vO5s9ON9+mO1/
+        +mDy4GCyf3/XvnxeV8s2X87OXp5Uy/PiYl0zvkDje9IkNfjgsdP73BvsM8A4XVqM8Py/a9LvDg3z
+        7o3j+LqMIg/msDex8uCrW0yvPNS4uKQmZy+PS8NTX+TtvGIqP72maSmm3VfWk7KY0huzGZG01z+1
+        +Dmcow5yeXP3pX6C+frIR/SXuD/sr/rL93XEH02y6VuaXoX2sqpKjHcjB6OfSb6ipj7dfi5pEuHb
+        yLj4iwjiP2eM6trqrNhf7PS4kRGIV+uSO/me/Zo6mHQ+KpaTar2cvcjafvNq3Q5/6V5kavF3+IpQ
+        +iX/D7ekTGCiBgAA
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:02:31 GMT']
-      etag: [W/"6d5a7d8e-a626-405f-a519-e694df7e74df"]
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:15:25 GMT']
+      ETag: [W/"af0aaa1b-7659-43ed-a6a5-a91eb52efbd9"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb",
-      "etag": "W/\"6d5a7d8e-a626-405f-a519-e694df7e74df\"", "location": "westus",
-      "properties": {"inboundNatRules": [{"properties": {"protocol": "Tcp", "backendPort":
-      100, "frontendIPConfiguration": {"etag": "W/\"6d5a7d8e-a626-405f-a519-e694df7e74df\"",
-      "properties": {"privateIPAllocationMethod": "Dynamic", "provisioningState":
-      "Succeeded", "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/publicIPAddresses/PublicIPmylb"}},
-      "name": "LoadBalancerFrontEnd", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"},
-      "enableFloatingIP": false, "frontendPort": 100}, "name": "rule1"}], "resourceGuid":
-      "4491ffd4-776d-4f68-84bc-38ee3ff5d5cd", "frontendIPConfigurations": [{"etag":
-      "W/\"6d5a7d8e-a626-405f-a519-e694df7e74df\"", "properties": {"privateIPAllocationMethod":
-      "Dynamic", "provisioningState": "Succeeded", "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/publicIPAddresses/PublicIPmylb"}},
-      "name": "LoadBalancerFrontEnd", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"}],
-      "outboundNatRules": [], "loadBalancingRules": [], "inboundNatPools": [], "backendAddressPools":
-      [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mylbbepool",
-      "etag": "W/\"6d5a7d8e-a626-405f-a519-e694df7e74df\"", "name": "mylbbepool",
-      "properties": {"provisioningState": "Succeeded"}}], "provisioningState": "Succeeded",
-      "probes": []}, "tags": {}}'
+    body: '{"etag": "W/\"af0aaa1b-7659-43ed-a6a5-a91eb52efbd9\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb",
+      "location": "westus", "properties": {"inboundNatPools": [], "resourceGuid":
+      "3fd52312-1e03-4c52-ad7f-9a467b78b451", "frontendIPConfigurations": [{"etag":
+      "W/\"af0aaa1b-7659-43ed-a6a5-a91eb52efbd9\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd",
+      "name": "LoadBalancerFrontEnd", "properties": {"provisioningState": "Succeeded",
+      "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/publicIPAddresses/PublicIPmylb"},
+      "privateIPAllocationMethod": "Dynamic"}}], "loadBalancingRules": [], "backendAddressPools":
+      [{"etag": "W/\"af0aaa1b-7659-43ed-a6a5-a91eb52efbd9\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mylbbepool",
+      "name": "mylbbepool", "properties": {"provisioningState": "Succeeded"}}], "provisioningState":
+      "Succeeded", "inboundNatRules": [{"name": "rule1", "properties": {"protocol":
+      "Tcp", "backendPort": 100, "enableFloatingIP": false, "frontendPort": 100, "frontendIPConfiguration":
+      {"etag": "W/\"af0aaa1b-7659-43ed-a6a5-a91eb52efbd9\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd",
+      "name": "LoadBalancerFrontEnd", "properties": {"provisioningState": "Succeeded",
+      "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/publicIPAddresses/PublicIPmylb"},
+      "privateIPAllocationMethod": "Dynamic"}}}}], "probes": [], "outboundNatRules":
+      []}, "tags": {}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
       Connection: [keep-alive]
-      Content-Length: ['2055']
+      Content-Length: ['2049']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [85f4ca30-a7aa-11e6-9783-a0b3ccf7272a]
+      x-ms-client-request-id: [f7068ccc-a853-11e6-a546-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9aHFdTj4a8UfFDB/cbdaTZloXq7aols3dncnu+af7D3a3dyfnO9v7s1m2neXTe9vT
-        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edP+/sti+vs303yZ1UW1e3dVV5fFLK+bu18U
-        07pqqvN2/CJvr6r67d2yymZPsjJbTvG9h1TeZhdA67t3f9+P8r17exPqcPvT2c7D7f1sNt3OHkzv
-        b0+mD3cODvZ29mcH2e/7kb7YXq94gDf0pa3LapphwHjjilBfmy+o+4Y+/MW/RP6kMazyui1y/hAf
-        yYeXRUNvF8uL123Wcr+v19Npns/ymQCiZpZKa6H0/v7D3fPz2f72gwefzrb3zz892D7Yn0y37x3k
-        +b3z8/uz+1P38nldLdt8OTt7eVItz4uLdc34Ao3vSZPU4IPHzu9zb7DPAON0aYHi+X/ZrN8dGufd
-        GwfydTlFHkxib2blwVe3mF95qHFxSU3OXh6Xhqm+yNt5xWR+ek3zUky7r6wnZTGlN2Yzommvf2rx
-        czlJHezy5u5L/QQT9pGPqQiJeT4qlpNqvZy9yNpX65LpallVns4w8crP4UAj3NgZwd2a/t0NhkyD
-        9v/8vvvDfq6/fF+J89Ekm74lDld6vqyqMiCNRxQrxUBmkq+oqc86/2+jVmRg/EUE858zYXVtdVrs
-        L3Z+3MgIBM87gfie/Zo6mHQ+6rAJvpNv4rMpXKQv4/l/20R2xqNs7yP8czZ/HhRqPGAt6JUAKLX8
-        fxmFBxAfMHP+WDo61gB6WdUtjXB3Zyf8XmVy6GtCf1LmzwjDluh99pLanGdlk4etilmZvykWebVu
-        z5ZfFMs1EYBa7oetiARtNSVBJ0K/ma48rFXC7C9WcAhgwGn0akyqWJXwd/iKgPyS/wdAOKBSxQoA
-        AA==
+        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edP+/sti+vs303yZ1UV1d1VXl8Usr5u7XxTT
+        umqq83b8Im+vqvrt3bLKZk+yMltO8b2HU95mF8Dqu3d/34/yvZ3z+7PzbPvT3XvT7f2He/vbkwfZ
+        p9sP8+ns4cH9vek0y37fj/TF9nrF47uhL21dVtMM48UbV4T52nxB3Tf04S/+JfInjWGV122R84f4
+        SD68LBp6u1hevG6zlvt9vZ5O83yWzwQQNbNEWguh753P7u/d293b3s137m3vT+/vbWezB+fbD7P9
+        Tx9MHhxM9u/v2pfP62rZ5svZ2cuTanleXKxrxhdofE+apAYfPHZ6n3uDfQYYp0uLEZ7/d0363aFh
+        3r1xHF+XUeTBHPYmVh58dYvplYcaF5fU5OzlcWl46ou8nVdM5afXNC3FtPvKelIWU3pjNiOS9vqn
+        Fj+Hc9RBLm/uvtRPMF8f+YiKiJjno2I5qdbL2YusfbUumayWUeXpjBKv/NyNM8KLnQHcrenf3WDE
+        NGb/z++7P+zn+sv3lTYfTbLpW+JvJefLqioDyng0sSIMZCb5ipr6jPP/MmJFxsVfRBD/OZNU11Zn
+        xf5ip8eNjEDwtBOI79mvqYNJ56MOl+A7+SY+mcJE+jKe/5fNY2c4yvQ+vj9n0+dBocYDloJeCYBS
+        y/93EXgA7wEL5w+lo18NoJdV3dIAd3d2wu9VIoe+JuwnZf6MMGyJ3Gcvqc15VjZ52KqYlfmbYpFX
+        6/Zs+UWxXNP4qeV+2IpI0FZTEnOi85vpysNa5cv+YsWGAAaMRq/GZIoVCX+HrwjIL/l/AJK/d2G+
+        CgAA
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/9248b76a-94db-4be5-bfbc-9bf60cf429e0?api-version=2016-06-01']
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:02:30 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/8eb02308-face-41de-8b0c-fff0e3435238?api-version=2016-06-01']
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:15:26 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [8661bccf-a7aa-11e6-ae41-a0b3ccf7272a]
+      x-ms-client-request-id: [f7a2ad98-a853-11e6-81ce-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9aHFdTj4a8UfFDB/cbdaTZloXq7aols3dncnu+af7D3a3dyfnO9v7s1m2neXTe9vT
-        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edP+/sti+vs303yZ1UW1e3dVV5fFLK+bu18U
-        07pqqvN2/CJvr6r67d2yymZPsjJbTvG9h1TeZhdA67t3f9+P8r17exPqcPvT2c7D7f1sNt3OHkzv
-        b0+mD3cODvZ29mcH2e/7kb7YXq94gDf0pa3LapphwHjjilBfmy+o+4Y+/MW/RP6kMazyui1y/hAf
-        yYeXRUNvF8uL123Wcr+v19Npns/ymQCiZpZKa6H0/v7D3fPz2f72gwefzrb3zz892D7Yn0y37x3k
-        +b3z8/uz+1P38nldLdt8OTt7eVItz4uLdc34Ao3vSZPU4IPHzu9zb7DPAON0aYHi+X/ZrN8dGufd
-        GwfydTlFHkxib2blwVe3mF95qHFxSU3OXh6Xhqm+yNt5xWR+ek3zUky7r6wnZTGlN2Yzommvf2rx
-        czlJHezy5u5L/QQT9pGPqQiJeT4qlpNqvZy9yNpX65LpallVns4w8crP4UAj3NgZwd2a/t0NhkyD
-        9v/8vvvDfq6/fF+J89Ekm74lDld6vqyqMiCNRxQrxUBmkq+oqc86/2+jVmRg/EUE858zYXVtdVrs
-        L3Z+3MgIBM87gfie/Zo6mHQ+6rAJvpNv4rMpXKQv4/l/20R2xqNs7yP8czZ/HhRqPGAt6JUAKLX8
-        fxmFBxAfMHP+WDo61gB6WdUtjXB3Zyf8XmVy6GtCf1LmzwjDluh99pLanGdlk4etilmZvykWebVu
-        z5ZfFMs1EYBa7oetiARtNSVBJ0K/ma48rFXC7C9WcAhgwGn0akyqWJXwd/iKgPyS/wdAOKBSxQoA
-        AA==
+        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edP+/sti+vs303yZ1UV1d1VXl8Usr5u7XxTT
+        umqq83b8Im+vqvrt3bLKZk+yMltO8b2HU95mF8Dqu3d/34/yvZ3z+7PzbPvT3XvT7f2He/vbkwfZ
+        p9sP8+ns4cH9vek0y37fj/TF9nrF47uhL21dVtMM48UbV4T52nxB3Tf04S/+JfInjWGV122R84f4
+        SD68LBp6u1hevG6zlvt9vZ5O83yWzwQQNbNEWguh753P7u/d293b3s137m3vT+/vbWezB+fbD7P9
+        Tx9MHhxM9u/v2pfP62rZ5svZ2cuTanleXKxrxhdofE+apAYfPHZ6n3uDfQYYp0uLEZ7/d0363aFh
+        3r1xHF+XUeTBHPYmVh58dYvplYcaF5fU5OzlcWl46ou8nVdM5afXNC3FtPvKelIWU3pjNiOS9vqn
+        Fj+Hc9RBLm/uvtRPMF8f+YiKiJjno2I5qdbL2YusfbUumayWUeXpjBKv/NyNM8KLnQHcrenf3WDE
+        NGb/z++7P+zn+sv3lTYfTbLpW+JvJefLqioDyng0sSIMZCb5ipr6jPP/MmJFxsVfRBD/OZNU11Zn
+        xf5ip8eNjEDwtBOI79mvqYNJ56MOl+A7+SY+mcJE+jKe/5fNY2c4yvQ+vj9n0+dBocYDloJeCYBS
+        y/93EXgA7wEL5w+lo18NoJdV3dIAd3d2wu9VIoe+JuwnZf6MMGyJ3Gcvqc15VjZ52KqYlfmbYpFX
+        6/Zs+UWxXNP4qeV+2IpI0FZTEnOi85vpysNa5cv+YsWGAAaMRq/GZIoVCX+HrwjIL/l/AJK/d2G+
+        CgAA
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:02:31 GMT']
-      etag: [W/"e232b959-6d09-4adc-a7c5-bc9088204d8a"]
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:15:27 GMT']
+      ETag: [W/"e20f5dfa-613c-4924-b7a6-9ecd9852ccaa"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb",
-      "etag": "W/\"e232b959-6d09-4adc-a7c5-bc9088204d8a\"", "location": "westus",
-      "properties": {"inboundNatRules": [{"etag": "W/\"e232b959-6d09-4adc-a7c5-bc9088204d8a\"",
-      "properties": {"frontendIPConfiguration": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"},
-      "protocol": "Tcp", "frontendPort": 100, "backendPort": 100, "enableFloatingIP":
-      false, "idleTimeoutInMinutes": 4, "provisioningState": "Succeeded"}, "name":
-      "rule1", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule1"},
-      {"properties": {"protocol": "Tcp", "backendPort": 200, "frontendIPConfiguration":
-      {"etag": "W/\"e232b959-6d09-4adc-a7c5-bc9088204d8a\"", "properties": {"privateIPAllocationMethod":
-      "Dynamic", "provisioningState": "Succeeded", "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/publicIPAddresses/PublicIPmylb"}},
-      "name": "LoadBalancerFrontEnd", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"},
-      "enableFloatingIP": false, "frontendPort": 200}, "name": "rule2"}], "resourceGuid":
-      "4491ffd4-776d-4f68-84bc-38ee3ff5d5cd", "frontendIPConfigurations": [{"etag":
-      "W/\"e232b959-6d09-4adc-a7c5-bc9088204d8a\"", "properties": {"privateIPAllocationMethod":
-      "Dynamic", "provisioningState": "Succeeded", "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/publicIPAddresses/PublicIPmylb"}},
-      "name": "LoadBalancerFrontEnd", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"}],
-      "outboundNatRules": [], "loadBalancingRules": [], "inboundNatPools": [], "backendAddressPools":
-      [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mylbbepool",
-      "etag": "W/\"e232b959-6d09-4adc-a7c5-bc9088204d8a\"", "name": "mylbbepool",
-      "properties": {"provisioningState": "Succeeded"}}], "provisioningState": "Succeeded",
-      "probes": []}, "tags": {}}'
+    body: '{"etag": "W/\"e20f5dfa-613c-4924-b7a6-9ecd9852ccaa\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb",
+      "location": "westus", "properties": {"inboundNatPools": [], "resourceGuid":
+      "3fd52312-1e03-4c52-ad7f-9a467b78b451", "frontendIPConfigurations": [{"etag":
+      "W/\"e20f5dfa-613c-4924-b7a6-9ecd9852ccaa\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd",
+      "name": "LoadBalancerFrontEnd", "properties": {"provisioningState": "Succeeded",
+      "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/publicIPAddresses/PublicIPmylb"},
+      "privateIPAllocationMethod": "Dynamic"}}], "loadBalancingRules": [], "backendAddressPools":
+      [{"etag": "W/\"e20f5dfa-613c-4924-b7a6-9ecd9852ccaa\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mylbbepool",
+      "name": "mylbbepool", "properties": {"provisioningState": "Succeeded"}}], "provisioningState":
+      "Succeeded", "inboundNatRules": [{"etag": "W/\"e20f5dfa-613c-4924-b7a6-9ecd9852ccaa\"",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule1",
+      "name": "rule1", "properties": {"idleTimeoutInMinutes": 4, "protocol": "Tcp",
+      "backendPort": 100, "frontendPort": 100, "provisioningState": "Succeeded", "enableFloatingIP":
+      false, "frontendIPConfiguration": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"}}},
+      {"name": "rule2", "properties": {"protocol": "Tcp", "backendPort": 200, "enableFloatingIP":
+      false, "frontendPort": 200, "frontendIPConfiguration": {"etag": "W/\"e20f5dfa-613c-4924-b7a6-9ecd9852ccaa\"",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd",
+      "name": "LoadBalancerFrontEnd", "properties": {"provisioningState": "Succeeded",
+      "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/publicIPAddresses/PublicIPmylb"},
+      "privateIPAllocationMethod": "Dynamic"}}}}], "probes": [], "outboundNatRules":
+      []}, "tags": {}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
       Connection: [keep-alive]
-      Content-Length: ['2681']
+      Content-Length: ['2673']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [8693f05e-a7aa-11e6-b0c5-a0b3ccf7272a]
+      x-ms-client-request-id: [f7e6ca02-a853-11e6-89dd-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9aHFdTj4a8UfFDB/cbdaTZloXq7aols3dncnu+af7D3a3dyfnO9v7s1m2neXTe9vT
-        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edP+/sti+vs303yZ1UW1e3dVV5fFLK+bu18U
-        07pqqvN2/CJvr6r67d2yymZPsjJbTvG9h1TeZhdA67t3f9+PpvsPd3fu3Xuwvbezd769v793f/vg
-        YPf+9r3zg+nuw/sPHu5ln/6+H+mL7fWKB3hDX9q6rKYZBow3rgj1tfmCum/ow1/8S+RPGsMqr9si
-        5w/xkXx4WTT0drG8eN1mLff7ej2d5vksnwkgamaptBZK79Nwzs9n+9sPHnw6294///Rg+2B/Mt2+
-        d5Dn987P78/uT93L53W1bPPl7OzlSbU8Ly7WNeMLNL4nTVKDDx47v8+9wT4DjNOlBYrn/2Wzfndo
-        nHdvHMjX5RR5MIm9mZUHX91ifuWhxsUlNTl7eVwapvoib+cVk/npNc1LMe2+sp6UxZTemM2Ipr3+
-        qcXP5SR1sMubuy/1E0zYRz6mIiTm+ahYTqr1cvYia1+tS6arZVV5OsPEKz+HA41wY2cEd2v6dzcY
-        cnfQ/x8d1F53UP6f33d/2M/1l+/r4D+aZNO3JLbKJC+rqgzm2yOKVU1AZpKvqKkvD/9vo1ZkYPxF
-        BPOfMw3k2uq02F/s/LiREQiedwLxPfs1dTDpfNRhE3wn38RnE1y0G4zn/2UT2RkPs32I8M/Z/HlQ
-        qPGACaRXAqDU8v9lFB5AfMB2+2MJdailwMuqbmmEuzs74fcqk0NfE/qTMn9GGLZE77OX1OY8K5s8
-        bFXMyvxNscirdXu2/KJYrokA1HI/bEUkaKspCToR+s105WGtEka/2De8+QnkYs+fYeoYn9/9f8us
-        xeQiRPhHcvFhFB5A/IPlYq/L+KFc9L4m9H+ociG/WINCAANOo1dj1oZNLH+HrwjIL/l/ALwlywey
+        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edP+/sti+vs303yZ1UV1d1VXl8Usr5u7XxTT
+        umqq83b8Im+vqvrt3bLKZk+yMltO8b2HU95mF8Dqu3d/34/2Ht6fZTvTT7cfTM+n2/vns9n2QbY3
+        3f40u7dz/8H+g/OdBw9/34/0xfZ6xeO7oS9tXVbTDOPFG1eE+dp8Qd039OEv/iXyJ41hlddtkfOH
+        +Eg+vCwaertYXrxus5b7fb2eTvN8ls8EEDWzRFoLoe+dz+7v3dvd297Nd+5t70/v721nswfn2w+z
+        /U8fTB4cTPbv79qXz+tq2ebL2dnLk2p5Xlysa8YXaHxPmqQGHzx2ep97g30GGKdLixGe/3dN+t2h
+        Yd69cRxfl1HkwRz2JlYefHWL6ZWHGheX1OTs5XFpeOqLvJ1XTOWn1zQtxbT7ynpSFlN6YzYjkvb6
+        pxY/h3PUQS5v7r7UTzBfH/mIioiY56NiOanWy9mLrH21LpmsllHl6YwSr/zcjTPCi50B3K3p391g
+        xN0x/39zTHvdMfl/ft/9YT/XX76vY/9okk3fkswqi7ysqjKYbY8mVi0BmUm+oqa+MPy/jFiRcfEX
+        EcR/zrSPa6uzYn+x0+NGRiB42gnE9+zX1MGk81GHS/CdfBOfTDCRtVR4/l82j53hMNOH+P6cTZ8H
+        hRoPWD96JQBKLf/fReABvAestj+UUH9aArys6pYGuLuzE36vEjn0NWE/KfNnhGFL5D57SW3Os7LJ
+        w1bFrMzfFIu8Wrdnyy+K5ZrGTy33w1ZEgraakpgTnd9MVx7WKl/0i33Dm55AKvb8CaaO8fnd/5dM
+        WkwqQnx/JBUfROABvD9YKva6bB9KRe9rwv6HKhXyizUmBDBgNHo1ZmnYvPJ3+IqA/JL/B+DmTDSo
         DgAA
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/aa05ac15-5c73-4251-a1a1-334fb8f2dc28?api-version=2016-06-01']
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:02:31 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
-      Connection: [keep-alive]
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/09351327-bb17-45d3-a386-393299f6df63?api-version=2016-06-01']
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [87043e61-a7aa-11e6-8fe0-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9aHFdTj4a8UfFDB/cbdaTZloXq7aols3dncnu+af7D3a3dyfnO9v7s1m2neXTe9vT
-        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edP+/sti+vs303yZ1UW1e3dVV5fFLK+bu18U
-        07pqqvN2/CJvr6r67d2yymZPsjJbTvG9h1TeZhdA67t3f9+PpvsPd3fu3Xuwvbezd769v793f/vg
-        YPf+9r3zg+nuw/sPHu5ln/6+H+mL7fWKB3hDX9q6rKYZBow3rgj1tfmCum/ow1/8S+RPGsMqr9si
-        5w/xkXx4WTT0drG8eN1mLff7ej2d5vksnwkgamaptBZK79Nwzs9n+9sPHnw6294///Rg+2B/Mt2+
-        d5Dn987P78/uT93L53W1bPPl7OzlSbU8Ly7WNeMLNL4nTVKDDx47v8+9wT4DjNOlBYrn/2Wzfndo
-        nHdvHMjX5RR5MIm9mZUHX91ifuWhxsUlNTl7eVwapvoib+cVk/npNc1LMe2+sp6UxZTemM2Ipr3+
-        qcXP5SR1sMubuy/1E0zYRz6mIiTm+ahYTqr1cvYia1+tS6arZVV5OsPEKz+HA41wY2cEd2v6dzcY
-        cnfQ/x8d1F53UP6f33d/2M/1l+/r4D+aZNO3JLbKJC+rqgzm2yOKVU1AZpKvqKkvD/9vo1ZkYPxF
-        BPOfMw3k2uq02F/s/LiREQiedwLxPfs1dTDpfNRhE3wn38RnE1y0G4zn/2UT2RkPs32I8M/Z/HlQ
-        qPGACaRXAqDU8v9lFB5AfMB2+2MJdailwMuqbmmEuzs74fcqk0NfE/qTMn9GGLZE77OX1OY8K5s8
-        bFXMyvxNscirdXu2/KJYrokA1HI/bEUkaKspCToR+s105WGtEka/2De8+QnkYs+fYeoYn9/9f8us
-        xeQiRPhHcvFhFB5A/IPlYq/L+KFc9L4m9H+ociG/WINCAANOo1dj1oZNLH+HrwjIL/l/ALwlywey
-        DgAA
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:02:32 GMT']
-      etag: [W/"c4910337-202f-4425-8815-3f8c195792a6"]
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [87657130-a7aa-11e6-88f2-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9aHFdTj4a8UfFDB/cbdaTZloXq7aols3dncnu+af7D3a3dyfnO9v7s1m2neXTe9vT
-        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edP+/sti+vs303yZ1UW1e3dVV5fFLK+bu18U
-        07pqqvN2/CJvr6r67d2yymZPsjJbTvG9h1TeZhdA67t3f9+PpvsPd3fu3Xuwvbezd769v793f/vg
-        YPf+9r3zg+nuw/sPHu5ln/6+H+mL7fWKB3hDX9q6rKYZBow3rgj1tfmCum/ow1/8S+RPGsMqr9si
-        5w/xkXx4WTT0drG8eN1mLff7ej2d5vksnwkgamaptBZK79Nwzs9n+9sPHnw6294///Rg+2B/Mt2+
-        d5Dn987P78/uT93L53W1bPPl7OzlSbU8Ly7WNeMLNL4nTVKDDx47v8+9wT4DjNOlBYrn/2Wzfndo
-        nHdvHMjX5RR5MIm9mZUHX91ifuWhxsUlNTl7eVwapvoib+cVk/npNc1LMe2+sp6UxZTemM2Ipr3+
-        qcXP5SR1sMubuy/1E0zYRz6mIiTm+ahYTqr1cvYia1+tS6arZVV5OsPEKz+HA41wY2cEd2v6dzcY
-        cnfQ/x8d1F53UP6f33d/2M/1l+/r4D+aZNO3JLbKJC+rqgzm2yOKVU1AZpKvqKkvD/9vo1ZkYPxF
-        BPOfMw3k2uq02F/s/LiREQiedwLxPfs1dTDpfNRhE3wn38RnE1y0G4zn/2UT2RkPs32I8M/Z/HlQ
-        qPGACaRXAqDU8v9lFB5AfMB2+2MJdailwMuqbmmEuzs74fcqk0NfE/qTMn9GGLZE77OX1OY8K5s8
-        bFXMyvxNscirdXu2/KJYrokA1HI/bEUkaKspCToR+s105WGtEka/2De8+QnkYs+fYeoYn9/9f8us
-        xeQiRPhHcvFhFB5A/IPlYq/L+KFc9L4m9H+ociG/WINCAANOo1dj1oZNLH+HrwjIL/l/ALwlywey
-        DgAA
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:02:33 GMT']
-      etag: [W/"c4910337-202f-4425-8815-3f8c195792a6"]
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: '{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb",
-      "etag": "W/\"c4910337-202f-4425-8815-3f8c195792a6\"", "location": "westus",
-      "properties": {"inboundNatRules": [{"etag": "W/\"c4910337-202f-4425-8815-3f8c195792a6\"",
-      "properties": {"frontendIPConfiguration": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"},
-      "protocol": "Tcp", "frontendPort": 100, "backendPort": 100, "enableFloatingIP":
-      false, "idleTimeoutInMinutes": 4, "provisioningState": "Succeeded"}, "name":
-      "rule1", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule1"},
-      {"etag": "W/\"c4910337-202f-4425-8815-3f8c195792a6\"", "properties": {"frontendIPConfiguration":
-      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"},
-      "protocol": "Tcp", "frontendPort": 200, "backendPort": 200, "enableFloatingIP":
-      false, "idleTimeoutInMinutes": 4, "provisioningState": "Succeeded"}, "name":
-      "rule2", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule2"}],
-      "resourceGuid": "4491ffd4-776d-4f68-84bc-38ee3ff5d5cd", "frontendIPConfigurations":
-      [{"etag": "W/\"c4910337-202f-4425-8815-3f8c195792a6\"", "properties": {"privateIPAllocationMethod":
-      "Dynamic", "provisioningState": "Succeeded", "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/publicIPAddresses/PublicIPmylb"}},
-      "name": "LoadBalancerFrontEnd", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"}],
-      "outboundNatRules": [], "loadBalancingRules": [], "inboundNatPools": [], "backendAddressPools":
-      [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mylbbepool",
-      "etag": "W/\"c4910337-202f-4425-8815-3f8c195792a6\"", "name": "mylbbepool",
-      "properties": {"provisioningState": "Succeeded"}}, {"name": "bap1"}], "provisioningState":
-      "Succeeded", "probes": []}, "tags": {}}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
-      Connection: [keep-alive]
-      Content-Length: ['2627']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [878f675e-a7aa-11e6-9c71-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9aHFdTj4a8UfFDB/cbdaTZloXq7aols3dncnu+af7D3a3dyfnO9v7s1m2neXTe9vT
-        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edP+/sti+vs303yZ1UW1e3dVV5fFLK+bu18U
-        07pqqvN2/CJvr6r67d2yymZPsjJbTvG9h1TeZhdA67t3f9+P9j/99ME02/t0e3ae72/v708/3T7Y
-        27m//fDhg73Z+eQg353t/L4f6Yvt9YoHeENf2rqsphkGjDeuCPW1+YK6b+jDX/xL5E8awyqv2yLn
-        D/GRfHhZNPR2sbx43WYt9/t6PZ3m+SyfCSBqZqm0Fkrv7z/cPT+f7W8/ePDpbHv//NOD7YP9yXT7
-        3kGe3zs/vz+7P3Uvn9fVss2Xs7OXJ9XyvLhY14wv0PieNEkNPnjs/D73BvsMME6XFiie/5fN+t2h
-        cd69cSBfl1PkwST2ZlYefHWL+ZWHGheX1OTs5XFpmOqLvJ1XTOan1zQvxbT7ynpSFlN6YzYjmvb6
-        pxY/l5PUwS5v7r7UTzBhH/mYipCY56NiOanWy9mLrH21LpmullXl6QwTr/wcDjTCjZ0R3K3p391g
-        yN1B/390UHvdQfl/ft/9YT/XX76vg/9okk3fktgqk7ysqjKYb48oVjUBmUm+oqa+PPy/jVqRgfEX
-        Ecx/zjSQa6vTQr9YyB4kS/pJttoN+v7/ANF7OP+/itzyixUHNyYCwWJGIL5nv6YOJp2POlKJ7+Sb
-        +AxCaENy/L9sCjvjYS0TIvxzNn8eFGo84HHQKwFQavn/MgoPID7gKvljccoBj6XAy6puaYS7Ozvh
-        9yqNQ18T+pMyf0YYtkTvs5fU5jwrmzxsVczK/E2xyKt1e7b8oliuiQDUcj9sRSRoqynpVSL0m+nK
-        w1oljH6xb3jzE8jFnj/D1DE+v/v/llmLyUWI8I/k4sMoPID4B8vFXpfxQ7nofU3o/1DlQn6xBoUA
-        BpxGr8asDRtX/g5fEZBf8v8AZx+mOyEQAAA=
-    headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/ac6c134a-2660-4036-b3c8-435b4f039c5c?api-version=2016-06-01']
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:02:34 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [8820d1f0-a7aa-11e6-b9fe-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9aHFdTj4a8UfFDB/cbdaTZloXq7aols3dncnu+af7D3a3dyfnO9v7s1m2neXTe9vT
-        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edP+/sti+vs303yZ1UW1e3dVV5fFLK+bu18U
-        07pqqvN2/CJvr6r67d2yymZPsjJbTvG9h1TeZhdA67t3f9+P9j/99ME02/t0e3ae72/v708/3T7Y
-        27m//fDhg73Z+eQg353t/L4f6Yvt9YoHeENf2rqsphkGjDeuCPW1+YK6b+jDX/xL5E8awyqv2yLn
-        D/GRfHhZNPR2sbx43WYt9/t6PZ3m+SyfCSBqZqm0Fkrv7z/cPT+f7W8/ePDpbHv//NOD7YP9yXT7
-        3kGe3zs/vz+7P3Uvn9fVss2Xs7OXJ9XyvLhY14wv0PieNEkNPnjs/D73BvsMME6XFiie/5fN+t2h
-        cd69cSBfl1PkwST2ZlYefHWL+ZWHGheX1OTs5XFpmOqLvJ1XTOan1zQvxbT7ynpSFlN6YzYjmvb6
-        pxY/l5PUwS5v7r7UTzBhH/mYipCY56NiOanWy9mLrH21LpmullXl6QwTr/wcDjTCjZ0R3K3p391g
-        yN1B/390UHvdQfl/ft/9YT/XX76vg/9okk3fktgqk7ysqjKYb48oVjUBmUm+oqa+PPy/jVqRgfEX
-        Ecx/zjSQa6vTQr9YyB4kS/pJttoN+v7/ANF7OP+/itzyixUHNyYCwWJGIL5nv6YOJp2POlKJ7+Sb
-        +AxCaENy/L9sCjvjYS0TIvxzNn8eFGo84HHQKwFQavn/MgoPID7gKvljccoBj6XAy6puaYS7Ozvh
-        9yqNQ18T+pMyf0YYtkTvs5fU5jwrmzxsVczK/E2xyKt1e7b8oliuiQDUcj9sRSRoqynpVSL0m+nK
-        w1oljH6xb3jzE8jFnj/D1DE+v/v/llmLyUWI8I/k4sMoPID4B8vFXpfxQ7nofU3o/1DlQn6xBoUA
-        BpxGr8asDRtX/g5fEZBf8v8AZx+mOyEQAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:02:34 GMT']
-      etag: [W/"4667ca26-dfe4-44c6-8205-9972dfb8e1d0"]
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: '{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb",
-      "etag": "W/\"4667ca26-dfe4-44c6-8205-9972dfb8e1d0\"", "location": "westus",
-      "properties": {"inboundNatRules": [{"etag": "W/\"4667ca26-dfe4-44c6-8205-9972dfb8e1d0\"",
-      "properties": {"frontendIPConfiguration": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"},
-      "protocol": "Tcp", "frontendPort": 100, "backendPort": 100, "enableFloatingIP":
-      false, "idleTimeoutInMinutes": 4, "provisioningState": "Succeeded"}, "name":
-      "rule1", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule1"},
-      {"etag": "W/\"4667ca26-dfe4-44c6-8205-9972dfb8e1d0\"", "properties": {"frontendIPConfiguration":
-      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"},
-      "protocol": "Tcp", "frontendPort": 200, "backendPort": 200, "enableFloatingIP":
-      false, "idleTimeoutInMinutes": 4, "provisioningState": "Succeeded"}, "name":
-      "rule2", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule2"}],
-      "resourceGuid": "4491ffd4-776d-4f68-84bc-38ee3ff5d5cd", "frontendIPConfigurations":
-      [{"etag": "W/\"4667ca26-dfe4-44c6-8205-9972dfb8e1d0\"", "properties": {"privateIPAllocationMethod":
-      "Dynamic", "provisioningState": "Succeeded", "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/publicIPAddresses/PublicIPmylb"}},
-      "name": "LoadBalancerFrontEnd", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"}],
-      "outboundNatRules": [], "loadBalancingRules": [], "inboundNatPools": [], "backendAddressPools":
-      [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mylbbepool",
-      "etag": "W/\"4667ca26-dfe4-44c6-8205-9972dfb8e1d0\"", "name": "mylbbepool",
-      "properties": {"provisioningState": "Succeeded"}}, {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/bap1",
-      "etag": "W/\"4667ca26-dfe4-44c6-8205-9972dfb8e1d0\"", "name": "bap1", "properties":
-      {"provisioningState": "Succeeded"}}, {"name": "bap2"}], "provisioningState":
-      "Succeeded", "probes": []}, "tags": {}}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
-      Connection: [keep-alive]
-      Content-Length: ['2920']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [886d9261-a7aa-11e6-9529-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9aHFdTj4a8UfFDB/cbdaTZloXq7aols3dncnu+af7D3a3dyfnO9v7s1m2neXTe9vT
-        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edP+/sti+vs303yZ1UW1e3dVV5fFLK+bu18U
-        07pqqvN2/CJvr6r67d2yymZPsjJbTvG9h1TeZhdA67t3f9+PHuzMptNPzx9sTz69/5BwuT/bznZm
-        B9vZ+WR39/79e1n+6cPf9yN9sb1e8QBv6Etbl9U0w4DxxhWhvjZfUPcNffiLf4n8SWNY5XVb5Pwh
-        PpIPL4uG3i6WF6/brOV+X6+n0zyf5TMBRM0sldZC6f39h7vn57P97QcPPp1t759/erB9sD+Zbt87
-        yPN75+f3Z/en7uXzulq2+XJ29vKkWp4XF+ua8QUa35MmqcEHj53f595gnwHG6dICxfP/slm/OzTO
-        uzcO5OtyijyYxN7MyoOvbjG/8lDj4pKanL08Lg1TfZG384rJ/PSa5qWYdl9ZT8piSm/MZkTTXv/U
-        4udykjrY5c3dl/oJJuwjH1MREvN8VCwn1Xo5e5G1r9Yl09WyqjydYeKVn8OBRrixM4K7Nf27Gwy5
-        O+j/jw5qrzso/8/vuz/s5/rL93XwH02y6VsSW2WSl1VVBvPtEcWqJiAzyVfU1JeH/7dRKzIw/iKC
-        +c+ZBnJtdVroFwvZg2RJP8lWu0Hf/x8geg/n/0+Rey/o+/8b5A5x/n8VueUXq33cmAgEazUC8T37
-        NXUw6XzUUYL4Tr6JzyB0ZMh9/y+bws54WKmHCP+czZ8HhRoPOHj0SgCUWv6/jMIDiA94pv5YnHLA
-        YynwsqpbGuHuzk74vUrj0NeE/qTMnxGGLdH77CW1Oc/KJg9bFbMyf1Ms8mrdni2/KJZrIgC13A9b
-        EQnaakpmjAj9ZrrysFYJo1/sG978BHIRqon/l81aTC5ChH8kFx9G4QHEP1gu9rqMH8pF72tC/4cq
-        F/KLNSgEMOA0ejVmbdi48nf4ioD8kv8H69hlcJARAAA=
-    headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/31aef007-ec8c-4894-ace5-b1cdbc3b7922?api-version=2016-06-01']
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:02:35 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Date: ['Fri, 11 Nov 2016 21:15:27 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
@@ -1138,815 +891,1085 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [88f7a9f0-a7aa-11e6-adb8-a0b3ccf7272a]
+      x-ms-client-request-id: [f88dc4a8-a853-11e6-8a92-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9aHFdTj4a8UfFDB/cbdaTZloXq7aols3dncnu+af7D3a3dyfnO9v7s1m2neXTe9vT
-        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edP+/sti+vs303yZ1UW1e3dVV5fFLK+bu18U
-        07pqqvN2/CJvr6r67d2yymZPsjJbTvG9h1TeZhdA67t3f9+PHuzMptNPzx9sTz69/5BwuT/bznZm
-        B9vZ+WR39/79e1n+6cPf9yN9sb1e8QBv6Etbl9U0w4DxxhWhvjZfUPcNffiLf4n8SWNY5XVb5Pwh
-        PpIPL4uG3i6WF6/brOV+X6+n0zyf5TMBRM0sldZC6f39h7vn57P97QcPPp1t759/erB9sD+Zbt87
-        yPN75+f3Z/en7uXzulq2+XJ29vKkWp4XF+ua8QUa35MmqcEHj53f595gnwHG6dICxfP/slm/OzTO
-        uzcO5OtyijyYxN7MyoOvbjG/8lDj4pKanL08Lg1TfZG384rJ/PSa5qWYdl9ZT8piSm/MZkTTXv/U
-        4udykjrY5c3dl/oJJuwjH1MREvN8VCwn1Xo5e5G1r9Yl09WyqjydYeKVn8OBRrixM4K7Nf27Gwy5
-        O+j/jw5qrzso/8/vuz/s5/rL93XwH02y6VsSW2WSl1VVBvPtEcWqJiAzyVfU1JeH/7dRKzIw/iKC
-        +c+ZBnJtdVroFwvZg2RJP8lWu0Hf/x8geg/n/0+Rey/o+/8b5A5x/n8VueUXq33cmAgEazUC8T37
-        NXUw6XzUUYL4Tr6JzyB0ZMh9/y+bws54WKmHCP+czZ8HhRoPOHj0SgCUWv6/jMIDiA94pv5YnHLA
-        YynwsqpbGuHuzk74vUrj0NeE/qTMnxGGLdH77CW1Oc/KJg9bFbMyf1Ms8mrdni2/KJZrIgC13A9b
-        EQnaakpmjAj9ZrrysFYJo1/sG978BHIRqon/l81aTC5ChH8kFx9G4QHEP1gu9rqMH8pF72tC/4cq
-        F/KLNSgEMOA0ejVmbdi48nf4ioD8kv8H69hlcJARAAA=
+        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edP+/sti+vs303yZ1UV1d1VXl8Usr5u7XxTT
+        umqq83b8Im+vqvrt3bLKZk+yMltO8b2HU95mF8Dqu3d/34/2Ht6fZTvTT7cfTM+n2/vns9n2QbY3
+        3f40u7dz/8H+g/OdBw9/34/0xfZ6xeO7oS9tXVbTDOPFG1eE+dp8Qd039OEv/iXyJ41hlddtkfOH
+        +Eg+vCwaertYXrxus5b7fb2eTvN8ls8EEDWzRFoLoe+dz+7v3dvd297Nd+5t70/v721nswfn2w+z
+        /U8fTB4cTPbv79qXz+tq2ebL2dnLk2p5Xlysa8YXaHxPmqQGHzx2ep97g30GGKdLixGe/3dN+t2h
+        Yd69cRxfl1HkwRz2JlYefHWL6ZWHGheX1OTs5XFpeOqLvJ1XTOWn1zQtxbT7ynpSFlN6YzYjkvb6
+        pxY/h3PUQS5v7r7UTzBfH/mIioiY56NiOanWy9mLrH21LpmsllHl6YwSr/zcjTPCi50B3K3p391g
+        xN0x/39zTHvdMfl/ft/9YT/XX76vY/9okk3fkswqi7ysqjKYbY8mVi0BmUm+oqa+MPy/jFiRcfEX
+        EcR/zrSPa6uzYn+x0+NGRiB42gnE9+zX1MGk81GHS/CdfBOfTDCRtVR4/l82j53hMNOH+P6cTZ8H
+        hRoPWD96JQBKLf/fReABvAestj+UUH9aArys6pYGuLuzE36vEjn0NWE/KfNnhGFL5D57SW3Os7LJ
+        w1bFrMzfFIu8Wrdnyy+K5ZrGTy33w1ZEgraakpgTnd9MVx7WKl/0i33Dm55AKvb8CaaO8fnd/5dM
+        WkwqQnx/JBUfROABvD9YKva6bB9KRe9rwv6HKhXyizUmBDBgNHo1ZmnYvPJ3+IqA/JL/B+DmTDSo
+        DgAA
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:02:36 GMT']
-      etag: [W/"70dcc6f7-b659-4d5d-a0d8-afb11553ae69"]
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:15:28 GMT']
+      ETag: [W/"295da0c6-7cfc-4fdd-8a2c-6a305747f079"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 resourcemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [895cd45e-a7aa-11e6-9db0-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27cli_test_nic_scenario1%27%20and%20name%20eq%20%27myvnet%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FvirtualNetworks%27
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
-        zsP7D3fu1nlTretp/nldrVfN3WlZ/P5t3rS//7KY/v7NNF9mdVHt3l3V1WUxy+vm7hfFtK6a6rwd
-        v8jbq6p+e/eyqNt1Vuqfzd3F9eUybz8afbTMFoTcR/bv9nqFv2+EQE3LapphENT8irBZ47M2u2g+
-        evSLf8kv+f4v+X8Agm88D/oAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['305']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:02:37 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateNic_2016-08-01/azuredeploy.json"},
-      "mode": "Incremental", "parameters": {"subnet": {"value": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},
-      "publicIpAddressType": {"value": "none"}, "subnetType": {"value": "existingId"},
-      "networkSecurityGroupType": {"value": "none"}, "privateIpAddressAllocation":
-      {"value": "dynamic"}, "useDnsSettings": {"value": "false"}, "enableIpForwarding":
-      {"value": false}, "networkInterfaceName": {"value": "cli-test-nic"}, "privateIpAddressVersion":
-      {"value": "ipv4"}}}}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
-      Connection: [keep-alive]
-      Content-Length: ['712']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [89960ccf-a7aa-11e6-9752-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
-  response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478826157.5960859","name":"azurecli1478826157.5960859","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateNic_2016-08-01/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"enableIpForwarding":{"type":"Bool","value":false},"internalDnsNameLabel":{"type":"String","value":""},"loadBalancerBackendAddressPoolIds":{"type":"Array","value":[]},"loadBalancerInboundNatRuleIds":{"type":"Array","value":[]},"location":{"type":"String","value":"westus"},"networkInterfaceName":{"type":"String","value":"cli-test-nic"},"networkSecurityGroup":{"type":"String","value":""},"networkSecurityGroupType":{"type":"String","value":"none"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"privateIpAddressVersion":{"type":"String","value":"ipv4"},"publicIpAddress":{"type":"String","value":""},"publicIpAddressType":{"type":"String","value":"none"},"subnet":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},"subnetType":{"type":"String","value":"existingId"},"tags":{"type":"Object","value":{}},"useDnsSettings":{"type":"String","value":"false"},"virtualNetworkName":{"type":"String","value":""}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-11-11T01:02:39.1089747Z","duration":"PT0.5269914S","correlationId":"85fddf64-1f2b-4b4e-9fe5-bb43ffe62710","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["westus"]}]}],"dependencies":[]}}'}
-    headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478826157.5960859/operationStatuses/08587227807268956965?api-version=2015-11-01']
-      cache-control: [no-cache]
-      content-length: ['1804']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:02:38 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 201, message: Created}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [89960ccf-a7aa-11e6-9752-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587227807268956965?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['141']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:03:08 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [89960ccf-a7aa-11e6-9752-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXenZfH7t3nT/v7LYvr7N9N8mdVFtXt3VVeXxSyvm7tfFNO6aqrzdvxK32zuzvJVWV0v
-        8mXb3M1+sK5zgrK7/+DgYO/T3fsPxvcffrpzcP/hR6OPltkiJzw3tqGuVnndFnnz0aNf/FGbL1Zl
-        1ubPi+Vb/L2uCwIwb9tV8+iudNbM3k6L8aSsJuNpVefjq2I5q66a8TJv75rX51XT3j2pc/r1BQ1s
-        b2f30+2dg+2dXQEhAxj/dFMtCYNptWxpLD9JwyU6Une74x3899EvIeyymsbQ0lfAhsgzKfOz1bOq
-        vsrqWbG8wKft9QqjfFJVJUG7zMo1/XmelU1OAAqCXS+z8umyeZEt8ufZJC+9l163NaDY1z5Cp2WV
-        zZ5kZbac5vWTbPo2X86OZzMaefOS+jibMS4K4Lius2v3/ve+33n/bDmp1svZi6x9tSbUb/HuNAM7
-        ec16OF4Rw6wbYEo0v6rqt2cY5Hk2zTHETW8SE2yD3baJ3bz3X+dTmuj2mply0/tD77zh9sPvLatl
-        jndXdXFJPHG2UnpueifW/ri8DX1m18T4MsAuAMtkw28Xq8t9fnU9KYupfXPTK5Hmt6UIqRAi6KaW
-        d6nJD0/LvJDZvXtZ1O06K/XP5u7i+pLwvEu40A/8Kb+5Idw04Pxd0bT00dkM77TZhU/RLyc/nU9b
-        1/oX/xJqs25yktrXeYvX/NY92CzsABtifZM0fIReFtUMv58tp3UOlZpBiTBlwCj0wuuWGIhavF5P
-        pzmprhl93xYLIme2IGH5iJXbLs3H7pud3Uc7e4/2d8af3vv03oPdhz9FTWfrWhn2o5dv9sY79/fv
-        HRx8+pq+Ie1Z56Qt6UsiyqOPDu6fz2Y0t9u753uT7f3Jfr798Dy/vz2Z7N87P88/3Xuwu0OvMW6Y
-        NdIYv5hVfLMi0ScAvVmk1oYTMD3yhv8JvURTh6ZWhTT0khEyvGC0zfd/Cf1Hw8lXpA7z5ZQNxvfo
-        k2rdrtYt/UHI5Fcvzk7wm5K8N6+C/QbKGuw+X7OJvXeQP5jeP59uPzg/2Nvef7g32z7Y2bu3/emn
-        2ad7e/n9nYf7U3qrWJ1Uy/PiQmlNyNBAQRoCUazIwNB3u2gHmGDiH75A9egMIFYZ3+2OgD5waOck
-        LoT4d+/+vh/tf/rpQZ5PHm5Ppw/3Cdt7e4Rtnm9Ppp/u3M+zB7PdvfPf9yN6h3Dx7Dr9tZHsRk++
-        VPVFX++SCab/9oNvrf79Im/nFaj5VJWt0QPo7eeQzKEGgKIa1Fs0qkVWX3/0qK3X+S9h5g7VDf9Z
-        X1JHxE/0dbZalUU+Y6VkPyZAhBfckpe+W8Iq6ZdAwYh8WO+N3lEC9ZEnxPBzgEc+Ign8Jf8PHXG+
-        HXsKAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['1202']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:03:09 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 resourcemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9d777770-a7aa-11e6-b99f-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27cli_test_nic_scenario1%27%20and%20name%20eq%20%27myvnet%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FvirtualNetworks%27
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
-        zsP7D3fu1nlTretp/nldrVfN3WlZ/P5t3rS//7KY/v7NNF9mdVHt3l3V1WUxy+vm7hfFtK6a6rwd
-        v8jbq6p+e/eyqNt1Vuqfzd3F9eUybz8afbTMFoTcR/bv9nqFv2+EQE3LapphENT8irBZ47M2u2g+
-        evSLf8kv+f4v+X8Agm88D/oAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['305']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:03:10 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 resourcemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9d9a68c0-a7aa-11e6-aea1-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27cli_test_nic_scenario1%27%20and%20name%20eq%20%27publicip1%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FpublicIpAddresses%27
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
-        zsP7D3fu1nlTretp/nldrVfN3WlZ/P5t3rS//7KY/v7NNF9mdVHt3l3V1WUxy+vm7hfFtK6a6rwd
-        v8jbq6p+e3e1npTF9Ozl8WxGwJq80U+K1e5Ho4+W2YIw/Mj/qL1e4aNbQKLGZTXNMBx64YrwWuOz
-        NrtoPnr0i3/JL/n+L/l/ALWYEcMEAQAA
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['309']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:03:10 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateNic_2016-08-01/azuredeploy.json"},
-      "mode": "Incremental", "parameters": {"subnet": {"value": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},
-      "useDnsSettings": {"value": "true"}, "loadBalancerInboundNatRuleIds": {"value":
-      [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule1"},
-      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule2"}]},
-      "internalDnsNameLabel": {"value": "test"}, "privateIpAddress": {"value": "10.0.0.15"},
-      "publicIpAddressType": {"value": "existingId"}, "privateIpAddressVersion": {"value":
-      "ipv4"}, "publicIpAddress": {"value": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/publicIpAddresses/publicip1"},
-      "networkSecurityGroupType": {"value": "none"}, "privateIpAddressAllocation":
-      {"value": "static"}, "loadBalancerBackendAddressPoolIds": {"value": [{"id":
-      "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mylbbepool"},
-      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/bap1"},
-      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/bap2"}]},
-      "enableIpForwarding": {"value": true}, "networkInterfaceName": {"value": "cli-test-nic"},
-      "subnetType": {"value": "existingId"}}}}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
-      Connection: [keep-alive]
-      Content-Length: ['1942']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9db67c40-a7aa-11e6-8f45-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
-  response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478826191.3543586","name":"azurecli1478826191.3543586","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateNic_2016-08-01/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"enableIpForwarding":{"type":"Bool","value":true},"internalDnsNameLabel":{"type":"String","value":"test"},"loadBalancerBackendAddressPoolIds":{"type":"Array","value":[{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mylbbepool"},{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/bap1"},{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/bap2"}]},"loadBalancerInboundNatRuleIds":{"type":"Array","value":[{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule1"},{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule2"}]},"location":{"type":"String","value":"westus"},"networkInterfaceName":{"type":"String","value":"cli-test-nic"},"networkSecurityGroup":{"type":"String","value":""},"networkSecurityGroupType":{"type":"String","value":"none"},"privateIpAddress":{"type":"String","value":"10.0.0.15"},"privateIpAddressAllocation":{"type":"String","value":"static"},"privateIpAddressVersion":{"type":"String","value":"ipv4"},"publicIpAddress":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/publicIpAddresses/publicip1"},"publicIpAddressType":{"type":"String","value":"existingId"},"subnet":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},"subnetType":{"type":"String","value":"existingId"},"tags":{"type":"Object","value":{}},"useDnsSettings":{"type":"String","value":"true"},"virtualNetworkName":{"type":"String","value":""}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-11-11T01:03:12.7404036Z","duration":"PT0.3505533S","correlationId":"74cb4312-aabf-400d-9a76-1b3ae8466865","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["westus"]}]}],"dependencies":[]}}'}
-    headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478826191.3543586/operationStatuses/08587227806930878620?api-version=2015-11-01']
-      cache-control: [no-cache]
-      content-length: ['2818']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:03:12 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 201, message: Created}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9db67c40-a7aa-11e6-8f45-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587227806930878620?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['141']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:03:42 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [9db67c40-a7aa-11e6-8f45-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXenZfH7t3nT/v7LYvr7N9N8mdVFtXt3VVeXxSyvm7tfFNO6aqrzdvxK32zuzvJVWV0v
-        8mXb3M1+sK5zgrK7/+DgYO/T3Ye743v39+/dP/j0o9FHy2yRE54b21BXq7xui7z56NEv/qjNF6sy
-        a/PnxfIt/l7XBQGYt+2qeXRXOmtmb6fFeFJWk/G0qvPxVbGcVVfNeJm3d83r86pp757UOf36gga2
-        t7P76fbOwfbOroCQAYx/uqmWhMG0WrY0lp+k4RIdqbvd8Q7+++iXEHZZTWNo6StgQ+SZlPnZ6llV
-        X2X1rFhe4NP2eoVRPqmqkqBdZuWa/mzrdU7vFwS6Xmbl02XzIlvkz7NJXnrvvG5rALFv0fibFv2W
-        VTZ7kpXZcprXT7Lp23w5O57NaPDNS+rmbMboKJDjus6uHYzv/Zxwx4u8varqt3d9xJu7i+tycnfS
-        w1++mOQr+p1G+/8FhCfZavf/O6juffRLvt/horPlpFovZy+y9tWaePj/UxxUBLg3d2v69/+NsxHD
-        007FNAN6HtV7wn9FCKwbGtdHpMvQxxm0x3k2zaE7Nr1J6G8D/W1C33v/dT4lBdpe8yA3vT/0zhtu
-        P/zeslrmeHdVF5eka89Wyoib3tkl1Ur/7d6PvXhc3oZQTUtNeKDd960SH365WF3u86vrSVlM7Zub
-        Xrn7c8JgHQSJn+STgjVRF/+bpip/VzQtfXQ2w8s0IJrvTe3vUpMf/pgvi7pdZ6X+CbG6JDzvEi70
-        A3/Kb24I7zfsNrvwJ/rLyU/n09a1/sW/hNqsm5ys9eu8xWt+6x5s2HhADZG+SVY/QieLaobfz5bT
-        OocjlcF1YMKAfemF18TiaPF6PZ3m5LDM6Pu2WBA1swWJ8kfs0uzSdOy+2dl9tHPv0e6D8acPH+wd
-        fHrwU9R0tq5JRCAIH718c398b+fB/r1P77+mb8hnqnPykehLosmjjx7sTyf793b3trNscr69v7Mz
-        236YPSDYk3tZfrD/6acHn96n1xg3TBqbBzh2zYoUEwHoTSK1NoyA2ZE3/E/oJZo5NLUKrqGXjOTj
-        BaMLv0/K8/s0nHxFVi5fTtlN/B59Uq3b1bqlPwiZ/OrF2Ql+U5L3plWw30BZg93nazYo9w7yB9P7
-        59PtB+cHe9v7D/dm2wc7e/e2P/00+3RvL7+/83B/Sm8Vq5NqeV5cKK0JGRooSEMgihW5lfTdLtoB
-        Jnj4hy9PPToDiDUVd7sjoA8c2jlJCyH+3bu/70cPDnaIUlm+/WDn4GB7/0Geb08+JWz3H54fTIlS
-        +7Pdye/7Eb1DuHjePP21kexGe79UHUZfO+vgf22twhd5O69AToAjE0CNRA06ED+nTkEHG6K3fKI6
-        m3CiGfk5xjFUV1CqgzqWZmCR1dcSzkBCncvTj0qI9sT/P4cD89HDOMgji/nH+OJHscfPGqpweENW
-        CUOP/zeyScxx/38jyWN4gt6/BCSfhV4L/1lf0rtEcPo6W63KIp+xb+N9HM9QSCLCffvsF83gS+DT
-        8fx+OyuXq526fbe+d95Uu7v57uW0Wf50Np69G5s3xtOyWs+oUyRmiJQmefLST55ArfwS+ENizm2K
-        iVBT0vfJQuDwc8CkMTH+HwMLCjUgEwAA
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['1392']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:03:43 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 resourcemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [b1a15cc0-a7aa-11e6-99b2-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27cli_test_nic_scenario1%27%20and%20name%20eq%20%27myvnet%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FvirtualNetworks%27
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
-        zsP7D3fu1nlTretp/nldrVfN3WlZ/P5t3rS//7KY/v7NNF9mdVHt3l3V1WUxy+vm7hfFtK6a6rwd
-        v8jbq6p+e/eyqNt1Vuqfzd3F9eUybz8afbTMFoTcR/bv9nqFv2+EQE3LapphENT8irBZ47M2u2g+
-        evSLf8kv+f4v+X8Agm88D/oAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['305']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:03:44 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 resourcemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [b1baff40-a7aa-11e6-88fd-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27cli_test_nic_scenario1%27%20and%20name%20eq%20%27mynsg%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FnetworkSecurityGroups%27
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
-        zsP7D3fu1nlTretp/nldrVfN3WlZ/P5t3rS//7KY/v7NNF9mdVHt3l3V1WUxy+vm7hfFtK6a6rwd
-        v8jbq6p+e3cpP1/n03VdtNcKaHG9bC4+Gn20zBaE4Ufmz/Z6hT9vCYVeKKtphuHQS1eE1xqftdlF
-        89GjX/xLfsn3f8n/A+h0coUEAQAA
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['306']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:03:44 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateNic_2016-08-01/azuredeploy.json"},
-      "mode": "Incremental", "parameters": {"subnet": {"value": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},
-      "networkSecurityGroup": {"value": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkSecurityGroups/mynsg"},
-      "publicIpAddressType": {"value": "none"}, "subnetType": {"value": "existingId"},
-      "networkSecurityGroupType": {"value": "existingId"}, "privateIpAddressAllocation":
-      {"value": "dynamic"}, "useDnsSettings": {"value": "false"}, "enableIpForwarding":
-      {"value": false}, "networkInterfaceName": {"value": "cli-test-nic"}, "privateIpAddressVersion":
-      {"value": "ipv4"}}}}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
-      Connection: [keep-alive]
-      Content-Length: ['902']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [b1f3e991-a7aa-11e6-9699-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
-  response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478826225.3191808","name":"azurecli1478826225.3191808","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateNic_2016-08-01/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"enableIpForwarding":{"type":"Bool","value":false},"internalDnsNameLabel":{"type":"String","value":""},"loadBalancerBackendAddressPoolIds":{"type":"Array","value":[]},"loadBalancerInboundNatRuleIds":{"type":"Array","value":[]},"location":{"type":"String","value":"westus"},"networkInterfaceName":{"type":"String","value":"cli-test-nic"},"networkSecurityGroup":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkSecurityGroups/mynsg"},"networkSecurityGroupType":{"type":"String","value":"existingId"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"privateIpAddressVersion":{"type":"String","value":"ipv4"},"publicIpAddress":{"type":"String","value":""},"publicIpAddressType":{"type":"String","value":"none"},"subnet":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},"subnetType":{"type":"String","value":"existingId"},"tags":{"type":"Object","value":{}},"useDnsSettings":{"type":"String","value":"false"},"virtualNetworkName":{"type":"String","value":""}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-11-11T01:03:47.0165899Z","duration":"PT0.3798726S","correlationId":"9b2a0b79-1637-45db-8058-c70829b2982c","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["westus"]}]}],"dependencies":[]}}'}
-    headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478826225.3191808/operationStatuses/08587227806588409688?api-version=2015-11-01']
-      cache-control: [no-cache]
-      content-length: ['1955']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:03:46 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
-    status: {code: 201, message: Created}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [b1f3e991-a7aa-11e6-9699-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587227806588409688?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['141']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:04:16 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [b1f3e991-a7aa-11e6-9699-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXenZfH7t3nT/v7LYvr7N9N8mdVFtXt3VVeXxSyvm7tfFNO6aqrzdvxK32zuzvJVWV0v
-        8mXb3M1+sK5zgrK7/+DgYO/Tvb3743u7D3cPdg4+Gn20zBY54bmxDXW1yuu2yJuPHv3ij9p8sSqz
-        Nn9eLN/i73VdEIB5266aR3els2b2dlqMJ2U1GU+rOh9fFctZddWMl3l717w+r5r27kmd068vaGB7
-        O7ufbu8cbO/sCggZwPinm2pJGEyrZUtj+UkaLtGRutsd7+C/j34JYZfVNIaWvgI2RJ5JmZ+tnlX1
-        VVbPiuUFPm2vVxjlk6oqCdplVq7pz/OsbHICUBDsepmVT5fNi2yRP88meem99LqtAcW+9hE6Lats
-        9iQrs+U0r59k07f5cnY8m9HIm5fUx9mMcVEAx3WdXbv3v/f9zvtny0m1Xs5eZO2rNaF+i3enGdjJ
-        a9bD8YoYZt0AU6L5VVW/PcMgz7NpjiFuepOYYBvstk3s5r3/Op/SRLfXzJSb3r/7Q+X4F4Ld3RiW
-        zd3F9bK5GBrEGx7A8EDyd0XT0kdnM0BY1cUlserZSqd505ux9sflbaZtdk3yKHTvArC8P/x2sbrc
-        51fXk7KY2jc3vRJpfhNdltUyx2s0z0TWTS3vUpMfPitcFnW7zkr9E0xwSXjeJVzoB/6U39wQbhpw
-        yAhtduFT9MvJT+fT1rX+xb+E2qybnJTJ67zFa37rHmzWQQAbYn2TkH6EXhbVDL+fLad1Dk2fQbcx
-        ZcAo9MLrlhiIWrxeT6c5adQZfd8WCyJntiAZ/oh17i7Nx+6bnd1HO/ce7T8c36fn4f7BT1HT2bpW
-        hv3o5Zu9MVmDgwcP7r+mb0ip1zkpcfqSiPLoo4eTvWxn8uDh9u6n9x5s79+fTbYPdu4fbE8f7Bzs
-        0ZcPD/am9BrjhlkjRfaL2fI0K9JIBKA3i9TacAKmR97wP6GXaOrQ1Gq2hl4yQoYXjBL8/i+h/2g4
-        +Yq0dL6csh37Hn1SrdvVuqU/CJn86sXZCX5TkvfmVbDfQFmD3edrtvz3DvIH0/vn0+0H5wd72/sP
-        92ZEk717259+mpF5ze/vPNwHTYrVSbU8Ly6U1oQMDRSkIRDFiuwefbeLdoAJJv7hC1SPzgBibcTd
-        7gjoA4d2TuJCiH/37u/70XT24N7O3oNse5bvErb39x9uZw+nD7bzh/kkp8/z8/2D3/cjeodw8dwN
-        +msj2Y2efKnqi77eJc+A/tu9H3xtFfAXeTuvQM6nqm2NIkB3P4d0DlUANNWg4qJRLbL6+qNHbb3O
-        fwlzd6hv+M/6kjoihqKvs9WqLPIZayX7MQEivOAuvfTdJdZJcZsJ0D+HFIqhBMKwlafHiLT1g2mU
-        ivAgsAG2/oiUxi/5fwBnMcV6xQsAAA==
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['1219']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:04:16 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 resourcemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [c5d469cf-a7aa-11e6-bf81-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27cli_test_nic_scenario1%27%20and%20name%20eq%20%27myvnet%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FvirtualNetworks%27
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
-        zsP7D3fu1nlTretp/nldrVfN3WlZ/P5t3rS//7KY/v7NNF9mdVHt3l3V1WUxy+vm7hfFtK6a6rwd
-        v8jbq6p+e/eyqNt1Vuqfzd3F9eUybz8afbTMFoTcR/bv9nqFv2+EQE3LapphENT8irBZ47M2u2g+
-        evSLf8kv+f4v+X8Agm88D/oAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['305']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:04:18 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 resourcemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [c5ef92ee-a7aa-11e6-94b4-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27cli_test_nic_scenario1%27%20and%20name%20eq%20%27publicip1%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FpublicIPAddresses%27
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
-        zsP7D3fu1nlTretp/nldrVfN3WlZ/P5t3rS//7KY/v7NNF9mdVHt3l3V1WUxy+vm7hfFtK6a6rwd
-        v8jbq6p+e3e1npTF9Ozl8WxGwJq80U+K1e5Ho4+W2YIw/Mj/qL1e4aNbQKLGZTXNMBx64YrwWuOz
-        NrtoPnr0i3/JL/n+L/l/ALWYEcMEAQAA
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['309']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:04:18 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 resourcemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [c62262c0-a7aa-11e6-b2ca-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27cli_test_nic_scenario1%27%20and%20name%20eq%20%27mynsg%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FnetworkSecurityGroups%27
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
-        zsP7D3fu1nlTretp/nldrVfN3WlZ/P5t3rS//7KY/v7NNF9mdVHt3l3V1WUxy+vm7hfFtK6a6rwd
-        v8jbq6p+e3cpP1/n03VdtNcKaHG9bC4+Gn20zBaE4Ufmz/Z6hT9vCYVeKKtphuHQS1eE1xqftdlF
-        89GjX/xLfsn3f8n/A+h0coUEAQAA
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['306']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:04:18 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateNic_2016-08-01/azuredeploy.json"},
-      "mode": "Incremental", "parameters": {"subnet": {"value": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},
-      "networkSecurityGroup": {"value": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkSecurityGroups/mynsg"},
-      "privateIpAddressVersion": {"value": "ipv4"}, "publicIpAddressType": {"value":
-      "existingId"}, "subnetType": {"value": "existingId"}, "publicIpAddress": {"value":
-      "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/publicIPAddresses/publicip1"},
-      "networkSecurityGroupType": {"value": "existingId"}, "privateIpAddressAllocation":
-      {"value": "dynamic"}, "enableIpForwarding": {"value": false}, "networkInterfaceName":
-      {"value": "cli-test-nic"}, "useDnsSettings": {"value": "false"}}}}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
-      Connection: [keep-alive]
-      Content-Length: ['1087']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [c6592a30-a7aa-11e6-a223-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
-  response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478826259.5333579","name":"azurecli1478826259.5333579","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateNic_2016-08-01/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"enableIpForwarding":{"type":"Bool","value":false},"internalDnsNameLabel":{"type":"String","value":""},"loadBalancerBackendAddressPoolIds":{"type":"Array","value":[]},"loadBalancerInboundNatRuleIds":{"type":"Array","value":[]},"location":{"type":"String","value":"westus"},"networkInterfaceName":{"type":"String","value":"cli-test-nic"},"networkSecurityGroup":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkSecurityGroups/mynsg"},"networkSecurityGroupType":{"type":"String","value":"existingId"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"privateIpAddressVersion":{"type":"String","value":"ipv4"},"publicIpAddress":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/publicIPAddresses/publicip1"},"publicIpAddressType":{"type":"String","value":"existingId"},"subnet":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},"subnetType":{"type":"String","value":"existingId"},"tags":{"type":"Object","value":{}},"useDnsSettings":{"type":"String","value":"false"},"virtualNetworkName":{"type":"String","value":""}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-11-11T01:04:20.7553458Z","duration":"PT0.5349857S","correlationId":"21e5ebd4-248d-47cb-9110-187980ce1d27","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["westus"]}]}],"dependencies":[]}}'}
-    headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478826259.5333579/operationStatuses/08587227806252573224?api-version=2015-11-01']
-      cache-control: [no-cache]
-      content-length: ['2106']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:04:20 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
-    status: {code: 201, message: Created}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [c6592a30-a7aa-11e6-a223-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587227806252573224?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['141']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:04:51 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [c6592a30-a7aa-11e6-a223-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXenZfH7t3nT/v7LYvr7N9N8mdVFtXt3VVeXxSyvm7tfFNO6aqrzdvxK32zuzvJVWV0v
-        8mXb3M1+sK5zgrK7/+DgYO/TvfsPx/fv3bt3/8HDj0YfLbNFTnhubENdrfK6LfLmo0e/+KM2X6zK
-        rM2fF8u3+HtdFwRg3rar5tFd6ayZvZ0W40lZTcbTqs7HV8VyVl0142Xe3jWvz6umvXtS5/TrCxrY
-        3s7up9s7B9s7uwJCBjD+6aZaEgbTatnSWH6Shkt0pO52xzv476NfQthlNY2hpa+ADZFnUuZnq2dV
-        fZXVs2J5gU/b6xVG+aSqSoJ2mZVr+vM8K5ucABQEu15m5dNl8yJb5M+zSV56L71ua0Cxr32ETssq
-        mz3Jymw5zesn2fRtvpwdz2Y08uYl9XE2Y1wUwHFdZ9fu/e99v/P+2XJSrZezF1n7ak2o3+LdaQZ2
-        8pr1cLwihlk3wJRoflXVb88wyPNsmmOIm94kJtgGu20Tu3nvv86nNNHtNTPlpvfv/lA5/oVgdzeG
-        ZXN3cb1sLoYG8YYHMDyQ/F3RtPTR2QwQVnVxSax6ttJp3vRmrP1xeZtpm12TPArduwAs7w+/Xawu
-        9/nV9aQspvbNTa/c/TmZLUXwpSJI+ko+KVa7Efzfb6JoQDTbm9rfpSY//DFfFnW7zkr9E7x5SXje
-        JVzoB/6U39wQ3m/YbXbhT/SXk5/Op61r/Yt/CbVZNznpuNd5i9f81j3YrBoBNsT6Jt3xEXpZVDP8
-        frac1jkMUAaVy5QB/9ILr1via2rxej2d5qToZ/R9WyyInNmCVMtHbAp2aT523+zsPtrZf7S3O374
-        YOfg4f39n6Kms3WtcvTRyze74wf3d+7fu3/vNX1DtqbOybbQl0QUArSb388ns/3tvf2D2fb+g+lk
-        ++Hu7s727sGDhwc703x3tveAXmPcMGukX38xG8RmRYqSAPRmkVobTsD0yBv+J/QSTR2aWoXb0EtG
-        9vGC0c3f/yX0Hw0nX5HxyJdTNq/fo0+qdbtat/QHIZNfvTg7wW9K8t68CvYbKGuw+3zNDsm9g/zB
-        9P75dPvB+cHe9v7Dvdn2wc7eve1PP80+3dvL7+883J/SW8XqpFqeFxdKa0KGBgrSEIhiReaYvttF
-        O8AEE//wBapHZwCxputudwT0gUM7J3EhxL979/f9KLv/6YPJZOfe9vlOfr69PzmYbmf7+5Ptg0/P
-        d+4/OM/uPZjt/r4f0TuEi+cF0V8byW7Ut9Fx9PUuOSz03+794GtrF77I23kFcj5VI0CtRBE6GD8n
-        XqUheAcbIrh8olqbcKIp+TnGMdRXUKuDWpamYJHV1x89aut1/ktYFEPlyH/Wl9QRcT99na1WZZHP
-        WIXajwkQ4QWX86XvcrICjfsdAP1zSKEYSiAMe0r0GP1jYwkapSI8CGxABj8iDfdL/h+pjMHHCQ0A
-        AA==
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['1255']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:04:51 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [da42840f-a7aa-11e6-aa8c-a0b3ccf7272a]
+      x-ms-client-request-id: [f917ced2-a853-11e6-a54c-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9aHFdTj4a8UfFDB/cbdaTZloXq7aols3dncnu+af7D3a3dyfnO9v7s1m2neXTe9vT
+        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edP+/sti+vs303yZ1UV1d1VXl8Usr5u7XxTT
+        umqq83b8Im+vqvrt3bLKZk+yMltO8b2HU95mF8Dqu3d/34/2Ht6fZTvTT7cfTM+n2/vns9n2QbY3
+        3f40u7dz/8H+g/OdBw9/34/0xfZ6xeO7oS9tXVbTDOPFG1eE+dp8Qd039OEv/iXyJ41hlddtkfOH
+        +Eg+vCwaertYXrxus5b7fb2eTvN8ls8EEDWzRFoLoe+dz+7v3dvd297Nd+5t70/v721nswfn2w+z
+        /U8fTB4cTPbv79qXz+tq2ebL2dnLk2p5Xlysa8YXaHxPmqQGHzx2ep97g30GGKdLixGe/3dN+t2h
+        Yd69cRxfl1HkwRz2JlYefHWL6ZWHGheX1OTs5XFpeOqLvJ1XTOWn1zQtxbT7ynpSFlN6YzYjkvb6
+        pxY/h3PUQS5v7r7UTzBfH/mIioiY56NiOanWy9mLrH21LpmsllHl6YwSr/zcjTPCi50B3K3p391g
+        xN0x/39zTHvdMfl/ft/9YT/XX76vY/9okk3fkswqi7ysqjKYbY8mVi0BmUm+oqa+MPy/jFiRcfEX
+        EcR/zrSPa6uzYn+x0+NGRiB42gnE9+zX1MGk81GHS/CdfBOfTDCRtVR4/l82j53hMNOH+P6cTZ8H
+        hRoPWD96JQBKLf/fReABvAestj+UUH9aArys6pYGuLuzE36vEjn0NWE/KfNnhGFL5D57SW3Os7LJ
+        w1bFrMzfFIu8Wrdnyy+K5ZrGTy33w1ZEgraakpgTnd9MVx7WKl/0i33Dm55AKvb8CaaO8fnd/5dM
+        WkwqQnx/JBUfROABvD9YKva6bB9KRe9rwv6HKhXyizUmBDBgNHo1ZmnYvPJ3+IqA/JL/B+DmTDSo
+        DgAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:15:29 GMT']
+      ETag: [W/"295da0c6-7cfc-4fdd-8a2c-6a305747f079"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"etag": "W/\"295da0c6-7cfc-4fdd-8a2c-6a305747f079\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb",
+      "location": "westus", "properties": {"inboundNatPools": [], "resourceGuid":
+      "3fd52312-1e03-4c52-ad7f-9a467b78b451", "frontendIPConfigurations": [{"etag":
+      "W/\"295da0c6-7cfc-4fdd-8a2c-6a305747f079\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd",
+      "name": "LoadBalancerFrontEnd", "properties": {"provisioningState": "Succeeded",
+      "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/publicIPAddresses/PublicIPmylb"},
+      "privateIPAllocationMethod": "Dynamic"}}], "loadBalancingRules": [], "backendAddressPools":
+      [{"etag": "W/\"295da0c6-7cfc-4fdd-8a2c-6a305747f079\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mylbbepool",
+      "name": "mylbbepool", "properties": {"provisioningState": "Succeeded"}}, {"name":
+      "bap1"}], "provisioningState": "Succeeded", "inboundNatRules": [{"etag": "W/\"295da0c6-7cfc-4fdd-8a2c-6a305747f079\"",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule1",
+      "name": "rule1", "properties": {"idleTimeoutInMinutes": 4, "protocol": "Tcp",
+      "backendPort": 100, "frontendPort": 100, "provisioningState": "Succeeded", "enableFloatingIP":
+      false, "frontendIPConfiguration": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"}}},
+      {"etag": "W/\"295da0c6-7cfc-4fdd-8a2c-6a305747f079\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule2",
+      "name": "rule2", "properties": {"idleTimeoutInMinutes": 4, "protocol": "Tcp",
+      "backendPort": 200, "frontendPort": 200, "provisioningState": "Succeeded", "enableFloatingIP":
+      false, "frontendIPConfiguration": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"}}}],
+      "probes": [], "outboundNatRules": []}, "tags": {}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
+      Connection: [keep-alive]
+      Content-Length: ['2619']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [f966fe5c-a853-11e6-80a8-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9aHFdTj4a8UfFDB/cbdaTZloXq7aols3dncnu+af7D3a3dyfnO9v7s1m2neXTe9vT
+        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edP+/sti+vs303yZ1UV1d1VXl8Usr5u7XxTT
+        umqq83b8Im+vqvrt3bLKZk+yMltO8b2HU95mF8Dqu3d/348ODrLpvWw22z7fe3h/ez/P9rcnkweT
+        7Z39Bzv3Pp3u3d+fzH7fj/TF9nrF47uhL21dVtMM48UbV4T52nxB3Tf04S/+JfInjWGV122R84f4
+        SD68LBp6u1hevG6zlvt9vZ5O83yWzwQQNbNEWguh753P7u/d293b3s137m3vT+/vbWezB+fbD7P9
+        Tx9MHhxM9u/v2pfP62rZ5svZ2cuTanleXKxrxhdofE+apAYfPHZ6n3uDfQYYp0uLEZ7/d0363aFh
+        3r1xHF+XUeTBHPYmVh58dYvplYcaF5fU5OzlcWl46ou8nVdM5afXNC3FtPvKelIWU3pjNiOS9vqn
+        Fj+Hc9RBLm/uvtRPMF8f+YiKiJjno2I5qdbL2YusfbUumayWUeXpjBKv/NyNM8KLnQHcrenf3WDE
+        3TH/f3NMe90x+X9+3/1hP9dfvq9j/2iSTd+SzCqLvKyqMphtjyZWLQGZSb6ipr4w/L+MWJFx8RcR
+        xH/OtI9rq7NCv1jIHiRL+Um2slYFz/8HaN5D+f9V1JZfrDC4MREIFjIC8T37NXUw6XzUkUl8J9/E
+        JxAiG5Lj/10z2BkOq5gQ35+z6fOgUOMBX4NeCYBSy/93EXgA7wEfyR+K0wx4LAFeVnVLA9zd2Qm/
+        V1kc+pqwn5T5M8KwJXKfvaQ251nZ5GGrYlbmb4pFXq3bs+UXxXJN46eW+2ErIkFbTUmpEp3fTFce
+        1ipf9It9w5ueQCr2/AmmjvH53f+XTFpMKkJ8fyQVH0TgAbw/WCr2umwfSkXva8L+hyoV8os1JgQw
+        YDR6NWZp2LDyd/iKgPyS/wdUY5A0FhAAAA==
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/de176b9e-4cb3-4013-b3ae-e141c2e2cb90?api-version=2016-06-01']
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:15:29 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [fa11cd2e-a853-11e6-87b3-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9aHFdTj4a8UfFDB/cbdaTZloXq7aols3dncnu+af7D3a3dyfnO9v7s1m2neXTe9vT
+        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edP+/sti+vs303yZ1UV1d1VXl8Usr5u7XxTT
+        umqq83b8Im+vqvrt3bLKZk+yMltO8b2HU95mF8Dqu3d/348ODrLpvWw22z7fe3h/ez/P9rcnkweT
+        7Z39Bzv3Pp3u3d+fzH7fj/TF9nrF47uhL21dVtMM48UbV4T52nxB3Tf04S/+JfInjWGV122R84f4
+        SD68LBp6u1hevG6zlvt9vZ5O83yWzwQQNbNEWguh753P7u/d293b3s137m3vT+/vbWezB+fbD7P9
+        Tx9MHhxM9u/v2pfP62rZ5svZ2cuTanleXKxrxhdofE+apAYfPHZ6n3uDfQYYp0uLEZ7/d0363aFh
+        3r1xHF+XUeTBHPYmVh58dYvplYcaF5fU5OzlcWl46ou8nVdM5afXNC3FtPvKelIWU3pjNiOS9vqn
+        Fj+Hc9RBLm/uvtRPMF8f+YiKiJjno2I5qdbL2YusfbUumayWUeXpjBKv/NyNM8KLnQHcrenf3WDE
+        3TH/f3NMe90x+X9+3/1hP9dfvq9j/2iSTd+SzCqLvKyqMphtjyZWLQGZSb6ipr4w/L+MWJFx8RcR
+        xH/OtI9rq7NCv1jIHiRL+Um2slYFz/8HaN5D+f9V1JZfrDC4MREIFjIC8T37NXUw6XzUkUl8J9/E
+        JxAiG5Lj/10z2BkOq5gQ35+z6fOgUOMBX4NeCYBSy/93EXgA7wEfyR+K0wx4LAFeVnVLA9zd2Qm/
+        V1kc+pqwn5T5M8KwJXKfvaQ251nZ5GGrYlbmb4pFXq3bs+UXxXJN46eW+2ErIkFbTUmpEp3fTFce
+        1ipf9It9w5ueQCr2/AmmjvH53f+XTFpMKkJ8fyQVH0TgAbw/WCr2umwfSkXva8L+hyoV8os1JgQw
+        YDR6NWZp2LDyd/iKgPyS/wdUY5A0FhAAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:15:30 GMT']
+      ETag: [W/"88ac3add-f295-4ea4-bb7b-047036c254bd"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"etag": "W/\"88ac3add-f295-4ea4-bb7b-047036c254bd\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb",
+      "location": "westus", "properties": {"inboundNatPools": [], "resourceGuid":
+      "3fd52312-1e03-4c52-ad7f-9a467b78b451", "frontendIPConfigurations": [{"etag":
+      "W/\"88ac3add-f295-4ea4-bb7b-047036c254bd\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd",
+      "name": "LoadBalancerFrontEnd", "properties": {"provisioningState": "Succeeded",
+      "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/publicIPAddresses/PublicIPmylb"},
+      "privateIPAllocationMethod": "Dynamic"}}], "loadBalancingRules": [], "backendAddressPools":
+      [{"etag": "W/\"88ac3add-f295-4ea4-bb7b-047036c254bd\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mylbbepool",
+      "name": "mylbbepool", "properties": {"provisioningState": "Succeeded"}}, {"etag":
+      "W/\"88ac3add-f295-4ea4-bb7b-047036c254bd\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/bap1",
+      "name": "bap1", "properties": {"provisioningState": "Succeeded"}}, {"name":
+      "bap2"}], "provisioningState": "Succeeded", "inboundNatRules": [{"etag": "W/\"88ac3add-f295-4ea4-bb7b-047036c254bd\"",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule1",
+      "name": "rule1", "properties": {"idleTimeoutInMinutes": 4, "protocol": "Tcp",
+      "backendPort": 100, "frontendPort": 100, "provisioningState": "Succeeded", "enableFloatingIP":
+      false, "frontendIPConfiguration": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"}}},
+      {"etag": "W/\"88ac3add-f295-4ea4-bb7b-047036c254bd\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule2",
+      "name": "rule2", "properties": {"idleTimeoutInMinutes": 4, "protocol": "Tcp",
+      "backendPort": 200, "frontendPort": 200, "provisioningState": "Succeeded", "enableFloatingIP":
+      false, "frontendIPConfiguration": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"}}}],
+      "probes": [], "outboundNatRules": []}, "tags": {}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
+      Connection: [keep-alive]
+      Content-Length: ['2911']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [fa6ae5d0-a853-11e6-84cf-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9aHFdTj4a8UfFDB/cbdaTZloXq7aols3dncnu+af7D3a3dyfnO9v7s1m2neXTe9vT
+        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edP+/sti+vs303yZ1UV1d1VXl8Usr5u7XxTT
+        umqq83b8Im+vqvrt3bLKZk+yMltO8b2HU95mF8Dqu3d/34+m+c75vcm9g+3p7nR/e//B/f3tg3zy
+        YPv8fGdysL+7d//e7v3f9yN9sb1e8fhu6Etbl9U0w3jxxhVhvjZfUPcNffiLf4n8SWNY5XVb5Pwh
+        PpIPL4uG3i6WF6/brOV+X6+n0zyf5TMBRM0skdZC6Hvns/t793b3tnfznXvb+9P7e9vZ7MH59sNs
+        /9MHkwcHk/37u/bl87patvlydvbypFqeFxfrmvEFGt+TJqnBB4+d3ufeYJ8BxunSYoTn/12Tfndo
+        mHdvHMfXZRR5MIe9iZUHX91ieuWhxsUlNTl7eVwanvoib+cVU/npNU1LMe2+sp6UxZTemM2IpL3+
+        qcXP4Rx1kMubuy/1E8zXRz6iIiLm+ahYTqr1cvYia1+tSyarZVR5OqPEKz9344zwYmcAd2v6dzcY
+        cXfM/98c0153TP6f33d/2M/1l+/r2D+aZNO3JLPKIi+rqgxm26OJVUtAZpKvqKkvDP8vI1ZkXPxF
+        BPGfM+3j2uqs0C8WsgfJUn6SraxVwfP/AZr3UP7/FLX3gr7/P0HtEOX/V1FbfrGqx42JQLBKIxDf
+        s19TB5PORx0NiO/km/gEQkGGzPf/rhnsDIcVeojvz9n0eVCo8YBnR68EQKnl/7sIPID3gEfqD8Vp
+        BjyWAC+ruqUB7u7shN+rLA59TdhPyvwZYdgSuc9eUpvzrGzysFUxK/M3xSKv1u3Z8otiuabxU8v9
+        sBWRoK2mZMKIzm+mKw9rlS/6xb7hTU8gFaGS+H/XpMWkIsT3R1LxQQQewPuDpWKvy/ahVPS+Jux/
+        qFIhv1hjQgADRqNXY5aGDSt/h68IyC/5fwD24MQ/hBEAAA==
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/78b897f9-aecd-4b85-ba37-3e5f87f7a92e?api-version=2016-06-01']
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:15:31 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [fb27a0ae-a853-11e6-ab03-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
+        6UfLbJF/9Cj9aHFdTj4a8UfFDB/cbdaTZloXq7aols3dncnu+af7D3a3dyfnO9v7s1m2neXTe9vT
+        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edP+/sti+vs303yZ1UV1d1VXl8Usr5u7XxTT
+        umqq83b8Im+vqvrt3bLKZk+yMltO8b2HU95mF8Dqu3d/34+m+c75vcm9g+3p7nR/e//B/f3tg3zy
+        YPv8fGdysL+7d//e7v3f9yN9sb1e8fhu6Etbl9U0w3jxxhVhvjZfUPcNffiLf4n8SWNY5XVb5Pwh
+        PpIPL4uG3i6WF6/brOV+X6+n0zyf5TMBRM0skdZC6Hvns/t793b3tnfznXvb+9P7e9vZ7MH59sNs
+        /9MHkwcHk/37u/bl87patvlydvbypFqeFxfrmvEFGt+TJqnBB4+d3ufeYJ8BxunSYoTn/12Tfndo
+        mHdvHMfXZRR5MIe9iZUHX91ieuWhxsUlNTl7eVwanvoib+cVU/npNU1LMe2+sp6UxZTemM2IpL3+
+        qcXP4Rx1kMubuy/1E8zXRz6iIiLm+ahYTqr1cvYia1+tSyarZVR5OqPEKz9344zwYmcAd2v6dzcY
+        cXfM/98c0153TP6f33d/2M/1l+/r2D+aZNO3JLPKIi+rqgxm26OJVUtAZpKvqKkvDP8vI1ZkXPxF
+        BPGfM+3j2uqs0C8WsgfJUn6SraxVwfP/AZr3UP7/FLX3gr7/P0HtEOX/V1FbfrGqx42JQLBKIxDf
+        s19TB5PORx0NiO/km/gEQkGGzPf/rhnsDIcVeojvz9n0eVCo8YBnR68EQKnl/7sIPID3gEfqD8Vp
+        BjyWAC+ruqUB7u7shN+rLA59TdhPyvwZYdgSuc9eUpvzrGzysFUxK/M3xSKv1u3Z8otiuabxU8v9
+        sBWRoK2mZMKIzm+mKw9rlS/6xb7hTU8gFaGS+H/XpMWkIsT3R1LxQQQewPuDpWKvy/ahVPS+Jux/
+        qFIhv1hjQgADRqNXY5aGDSt/h68IyC/5fwD24MQ/hBEAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:15:32 GMT']
+      ETag: [W/"ce0f3b38-c1c4-4754-8eb7-ff0b84125315"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [fb972eee-a853-11e6-aa5b-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-09-01&$filter=resourceGroup%20eq%20%27cli_test_nic_scenario%27%20and%20name%20eq%20%27myvnet%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FvirtualNetworks%27
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
+        zsP7D3fu1nlTretp/nldrVfN3WlZ/P5t3rS//7KY/v7NNF9mdVHdXdXVZTHL6+buF8W0rprqvB2/
+        yNurqn5797Ko23VW6p/N3cX15TJvPxp9tMwWhNtH9u/2eoW/b4RATctqmmEM1PyKkFnjsza7aD56
+        9It/yS/5/i/5fwCjXD5a+QAAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['304']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:15:33 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"mode": "Incremental", "templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateNic_2016-08-01/azuredeploy.json"},
+      "parameters": {"useDnsSettings": {"value": "false"}, "privateIpAddressAllocation":
+      {"value": "dynamic"}, "privateIpAddressVersion": {"value": "ipv4"}, "networkSecurityGroupType":
+      {"value": "none"}, "subnet": {"value": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},
+      "networkInterfaceName": {"value": "cli-test-nic"}, "enableIpForwarding": {"value":
+      false}, "subnetType": {"value": "existingId"}, "publicIpAddressType": {"value":
+      "none"}}}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
+      Connection: [keep-alive]
+      Content-Length: ['711']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [fbd31fb0-a853-11e6-85a3-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+  response:
+    body: {string: '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/azurecli1478898933.797942952087","name":"azurecli1478898933.797942952087","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateNic_2016-08-01/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"enableIpForwarding":{"type":"Bool","value":false},"internalDnsNameLabel":{"type":"String","value":""},"loadBalancerBackendAddressPoolIds":{"type":"Array","value":[]},"loadBalancerInboundNatRuleIds":{"type":"Array","value":[]},"location":{"type":"String","value":"westus"},"networkInterfaceName":{"type":"String","value":"cli-test-nic"},"networkSecurityGroup":{"type":"String","value":""},"networkSecurityGroupType":{"type":"String","value":"none"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"privateIpAddressVersion":{"type":"String","value":"ipv4"},"publicIpAddress":{"type":"String","value":""},"publicIpAddressType":{"type":"String","value":"none"},"subnet":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},"subnetType":{"type":"String","value":"existingId"},"tags":{"type":"Object","value":{}},"useDnsSettings":{"type":"String","value":"false"},"virtualNetworkName":{"type":"String","value":""}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-11-11T21:15:36.3421587Z","duration":"PT0.7800408S","correlationId":"d8ac860c-0355-46d5-9a93-be1a26e938cb","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["westus"]}]}],"dependencies":[]}}'}
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/azurecli1478898933.797942952087/operationStatuses/08587227079499155724?api-version=2015-11-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['1812']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:15:36 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [fbd31fb0-a853-11e6-85a3-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587227079499155724?api-version=2015-11-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
+        tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['141']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:16:06 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [fbd31fb0-a853-11e6-85a3-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
+        p/nndbVeNXenZfH7t3nT/v7LYvr7N9N8mdVFdXdVV5fFLK+bu18U07pqqvN2/EpfbO7O8lVZXS/y
+        ZdvczX6wrnMCsrv/4ODg4cHDe/fGDx4+eLi/9/D+3s7Bg49GHy2zRU643tyQOl3ldVvkzUePfvFH
+        bb5YlVmbPy+Wb/H3ui4IyrxtV82ju9JtM3s7LcaTspqMp1Wdj6+K5ay6asbLvL1rXp9XTXv3pM7p
+        1xc0wr2d3U+3dw62d3YFhAxl/NNNtSQMptWypVH9JA2cCErd7Y538N9Hv4Swy2oaSEtfARui06TM
+        z1bPqvoqq2fF8gKfttcrDPVJVZUE7TIr1/TneVY2OQEoCHa9zMqny+ZFtsifZ5O89F563daAYl/7
+        CJ2WVTZ7kpXZcprXT7Lp23w5O57NaOTNS+rjbMa4KIDjus6u3fvf+37n/bPlpFovZy+y9tWaUL/F
+        u9MMfOU16+F4RZyzboAp0fyqqt+eYZDn2TTHEDe9SZywDb7bJr7z3n+dT2mi22vmzk3vD73zhtsP
+        v7esljneXdXFJfHE2UrpuemdWPvj8jb0mV0T98sAuwAskw2/Xawu9/nV9aQspvbNTa9Emt+WIqRL
+        iKCbWt6lJj80dfNCJvfuZVG366zUP5u7i+tLQvMuoUI/8Kf85kZw03jzd0XT0kdnM7zTZhc+Qb+c
+        /HQ+bV3rX/xLqM26yUloX+ctXvNb92CzrANsiPVNwvARellUM/x+tpzWOXRrBh3ClAGf0AuvW+If
+        avF6PZ3mpLlm9H1bLIia2YJk5SPWbbs0Hbtv9nYf7d5/dO9gvHuwf3Dv4U9Ry9m6Vnb96OWbvfGn
+        ezRHu7uv6RvSnXVOupK+JJoQ0x5k04NPd6bbO/fu39/e/3R2f/th9vDe9iTfzfY+zR/eO5hO6DVG
+        DZNG+uIXs5ZvViT4BKA3idTa8AFmR97wP6GXaObQ1CqQhl4yIoYXjK75/i+h/2g4+YqUYb6csrn4
+        Hn1SrdvVuqU/CJn86sXZCX5TivemVbDfQFiD3edrtrTn2YOHs2yXiDB5+JB4Pb+3fTA9uE+8fj8/
+        mOxN9nYe5vRWsTqplufFhdKakKGBgjQEoliReaHvdtEOMMHDP3Rx6pEZMKwmvtsdAH3gsM5JWAjv
+        7979fT96SDww+fR8tn1/cj/b3s/3drcfTvbvEcb5w92D7N69/dnD3/cjeodw8Yw6/bWR6kZJvlTd
+        RV/vkv2l//aDb63y/SJv5xWI+VQ1rdEC6O3njsqh+ENLDSotGtQiq68/etTW6/yXMGuHuob/rC+p
+        I+Im+jpbrcoin7FGsh8TIEILLslL3yVhffRLoF1EOqwPR+8offrIE2L4OcAiH5H8/ZL/B8wnpcKA
+        CgAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['1200']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:16:07 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [1053dab4-a854-11e6-96e8-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-09-01&$filter=resourceGroup%20eq%20%27cli_test_nic_scenario%27%20and%20name%20eq%20%27myvnet%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FvirtualNetworks%27
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
+        zsP7D3fu1nlTretp/nldrVfN3WlZ/P5t3rS//7KY/v7NNF9mdVHdXdXVZTHL6+buF8W0rprqvB2/
+        yNurqn5797Ko23VW6p/N3cX15TJvPxp9tMwWhNtH9u/2eoW/b4RATctqmmEM1PyKkFnjsza7aD56
+        9It/yS/5/i/5fwCjXD5a+QAAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['304']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:16:08 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [107510ae-a854-11e6-a047-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-09-01&$filter=resourceGroup%20eq%20%27cli_test_nic_scenario%27%20and%20name%20eq%20%27publicip1%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FpublicIPAddresses%27
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
+        zsP7D3fu1nlTretp/nldrVfN3WlZ/P5t3rS//7KY/v7NNF9mdVHdXdXVZTHL6+buF8W0rprqvB2/
+        yNurqn57d7WelMX07OXxbEawmrzRT4rV7kejj5bZghD8yP+ovV7ho1tAosZlNc0wGnrhitBa47M2
+        u2g+evSLf8kv+f4v+X8AIc36RwMBAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['308']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:16:09 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"mode": "Incremental", "templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateNic_2016-08-01/azuredeploy.json"},
+      "parameters": {"useDnsSettings": {"value": "true"}, "publicIpAddress": {"value":
+      "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/publicIPAddresses/publicip1"},
+      "subnetType": {"value": "existingId"}, "networkInterfaceName": {"value": "cli-test-nic"},
+      "enableIpForwarding": {"value": true}, "loadBalancerBackendAddressPoolIds":
+      {"value": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mylbbepool"},
+      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/bap1"},
+      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/bap2"}]},
+      "internalDnsNameLabel": {"value": "test"}, "loadBalancerInboundNatRuleIds":
+      {"value": [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule1"},
+      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule2"}]},
+      "privateIpAddressVersion": {"value": "ipv4"}, "networkSecurityGroupType": {"value":
+      "none"}, "subnet": {"value": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},
+      "privateIpAddressAllocation": {"value": "static"}, "publicIpAddressType": {"value":
+      "existingId"}, "privateIpAddress": {"value": "10.0.0.15"}}}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
+      Connection: [keep-alive]
+      Content-Length: ['1935']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [10b6cca2-a854-11e6-94fb-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+  response:
+    body: {string: '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/azurecli1478898968.588888433738","name":"azurecli1478898968.588888433738","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateNic_2016-08-01/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"enableIpForwarding":{"type":"Bool","value":true},"internalDnsNameLabel":{"type":"String","value":"test"},"loadBalancerBackendAddressPoolIds":{"type":"Array","value":[{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mylbbepool"},{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/bap1"},{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/bap2"}]},"loadBalancerInboundNatRuleIds":{"type":"Array","value":[{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule1"},{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule2"}]},"location":{"type":"String","value":"westus"},"networkInterfaceName":{"type":"String","value":"cli-test-nic"},"networkSecurityGroup":{"type":"String","value":""},"networkSecurityGroupType":{"type":"String","value":"none"},"privateIpAddress":{"type":"String","value":"10.0.0.15"},"privateIpAddressAllocation":{"type":"String","value":"static"},"privateIpAddressVersion":{"type":"String","value":"ipv4"},"publicIpAddress":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/publicIPAddresses/publicip1"},"publicIpAddressType":{"type":"String","value":"existingId"},"subnet":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},"subnetType":{"type":"String","value":"existingId"},"tags":{"type":"Object","value":{}},"useDnsSettings":{"type":"String","value":"true"},"virtualNetworkName":{"type":"String","value":""}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-11-11T21:16:11.0230034Z","duration":"PT0.5135413S","correlationId":"b3f0c484-aaa1-4246-9d24-439c68c80248","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["westus"]}]}],"dependencies":[]}}'}
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/azurecli1478898968.588888433738/operationStatuses/08587227079149682236?api-version=2015-11-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['2820']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:16:11 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [10b6cca2-a854-11e6-94fb-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587227079149682236?api-version=2015-11-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
+        tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['141']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:16:40 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [10b6cca2-a854-11e6-94fb-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
+        p/nndbVeNXenZfH7t3nT/v7LYvr7N9N8mdVFdXdVV5fFLK+bu18U07pqqvN2/EpfbO7O8lVZXS/y
+        ZdvczX6wrnMCsrv/4ODg4cHDTw/G9w/w7N+79+DewUejj5bZIidcb25Ina7yui3y5qNHv/ijNl+s
+        yqzNnxfLt/h7XRcEZd62q+bRXem2mb2dFuNJWU3G06rOx1fFclZdNeNl3t41r8+rpr17Uuf06wsa
+        4d7O7qfbOwfbO7sCQoYy/ummWhIG02rZ0qh+kgZOBKXudsc7+O+jX0LYZTUNpKWvgA3RaVLmZ6tn
+        VX2V1bNieYFP2+sVhvqkqkqCdpmVa/qzrdc5vV8Q6HqZlU+XzYtskT/PJnnpvfO6rQHEvkXjb1r0
+        W1bZ7ElWZstpXj/Jpm/z5ex4NqPBNy+pm7MZo6NAjus6u3YwvvdzwSYv8vaqqt/e9fFu7i6uy8nd
+        SQ99+WKSr+h3Guz/B/CdZKvd/89guvfRL/l+h4XOlpNqvZy9yNpXa2Lg/y+xTxGg3tyt6d//F85F
+        DE07EdMM2Hk078n9FfW/bmhYH5EaQx9nUBzn2TSH2tj0JmG/Dey3CXvv/df5lHRne81j3PT+0Dtv
+        uP3we8tqmePdVV1ckpo9Wykbbnpnl7Qq/bd7P/bicXkbQjUtNeGBdt+3+nv45WJ1uc+vridlMbVv
+        bnrl7s8Ffyl+LxU/Yif5pGAt1EX/ppnK3xVNSx+dzfAyjYeme1P7u9Tkhz7ky6Ju11mpf0KoLgnN
+        u4QK/cCf8psbwfuNus0u/Gn+cvLT+bR1rX/xL6E26yYnM/06b/Ga37oHG8YdUEOkb5LUj9DJoprh
+        97PltM7hS2XwGZgwYF564TUxOFq8Xk+nOXkqM/q+LRZEzGxBgvwR+zK7NBu7b/Z2H+1++mj3/vjh
+        w4P7u/d/ilrO1jXJB6Tgo5dv7o/3Dx7u3N97+Jq+IV+pzsk3oi+JJI8+mtw735nuH+xvZ1m2u72/
+        t//p9sPZ3v72/r2H008Ppgc7e/vqnsmcsWWAV9esSCsRgN4cUmvDBpgcecP/hF6iiUNTq90aesmI
+        PV4wivD7pDm/T8PJV2Tg8uWU3cPv0SfVul2tW/qDkMmvXpyd4DeleG9WBfsNhDXYfb5mY3KePXg4
+        y3bvbU8mDx8Sq+f3tokS94nV7+cHk73J3s7DnN4qVifV8ry4UFoTMjRQkIZAFCtyJ+m7XbQDTLDw
+        D12aemQGDGsm7nYHQB84rHOSFcL7u3d/348+3ZkQTsQZ9+9N97b38zwXymT57qfnu+cHOwf72e/7
+        Eb1DuHhOPP21kepGcxv9Rl87y+B/bS3CF3k7r0BNgCP1T41EBzoQP5f+QAcZIrd8ovqaUKIJ+blF
+        MVRVUKiD+pXov8jqa4lhIJ7O2emHIkR5Yv6fu3H52GEY5IrF3GJ88aOA42cJU/i5IZ+E8cb/C3kk
+        5q7/v5DgMTRB7V8Cgs9CZ4X/rC/pXSI3fZ2tVmWRz9il8T6OZyQk8eC+ffaLZvAh8Ol4/dP37i13
+        ynXzrsrPFzv3dy+bIpvtVPdn49m7sXljPC2r9Yw6RSKGKGmSJS/9ZAk0yi+BGyRm3CaXCDWlfJ8s
+        BA4/B2wZE+P/AfZPpuQZEwAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['1386']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:16:41 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [24a4306c-a854-11e6-b4f8-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-09-01&$filter=resourceGroup%20eq%20%27cli_test_nic_scenario%27%20and%20name%20eq%20%27myvnet%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FvirtualNetworks%27
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
+        zsP7D3fu1nlTretp/nldrVfN3WlZ/P5t3rS//7KY/v7NNF9mdVHdXdXVZTHL6+buF8W0rprqvB2/
+        yNurqn5797Ko23VW6p/N3cX15TJvPxp9tMwWhNtH9u/2eoW/b4RATctqmmEM1PyKkFnjsza7aD56
+        9It/yS/5/i/5fwCjXD5a+QAAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['304']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:16:42 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [24e080b6-a854-11e6-afd6-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-09-01&$filter=resourceGroup%20eq%20%27cli_test_nic_scenario%27%20and%20name%20eq%20%27mynsg%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FnetworkSecurityGroups%27
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
+        zsP7D3fu1nlTretp/nldrVfN3WlZ/P5t3rS//7KY/v7NNF9mdVHdXdXVZTHL6+buF8W0rprqvB2/
+        yNurqn57dyk/X+fTdV201wpncb1sLj4afbTMFoTgR+bP9nqFP28JhV4oq2mG0dBLV4TWGp+12UXz
+        0aNf/Et+yfd/yf8DfCGZAQMBAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['305']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:16:42 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"mode": "Incremental", "templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateNic_2016-08-01/azuredeploy.json"},
+      "parameters": {"useDnsSettings": {"value": "false"}, "publicIpAddressType":
+      {"value": "none"}, "privateIpAddressAllocation": {"value": "dynamic"}, "privateIpAddressVersion":
+      {"value": "ipv4"}, "networkSecurityGroupType": {"value": "existingId"}, "subnet":
+      {"value": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},
+      "networkInterfaceName": {"value": "cli-test-nic"}, "enableIpForwarding": {"value":
+      false}, "subnetType": {"value": "existingId"}, "networkSecurityGroup": {"value":
+      "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/networkSecurityGroups/mynsg"}}}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
+      Connection: [keep-alive]
+      Content-Length: ['900']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [24ff3694-a854-11e6-9578-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+  response:
+    body: {string: '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/azurecli1478899002.669802448387","name":"azurecli1478899002.669802448387","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateNic_2016-08-01/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"enableIpForwarding":{"type":"Bool","value":false},"internalDnsNameLabel":{"type":"String","value":""},"loadBalancerBackendAddressPoolIds":{"type":"Array","value":[]},"loadBalancerInboundNatRuleIds":{"type":"Array","value":[]},"location":{"type":"String","value":"westus"},"networkInterfaceName":{"type":"String","value":"cli-test-nic"},"networkSecurityGroup":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/networkSecurityGroups/mynsg"},"networkSecurityGroupType":{"type":"String","value":"existingId"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"privateIpAddressVersion":{"type":"String","value":"ipv4"},"publicIpAddress":{"type":"String","value":""},"publicIpAddressType":{"type":"String","value":"none"},"subnet":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},"subnetType":{"type":"String","value":"existingId"},"tags":{"type":"Object","value":{}},"useDnsSettings":{"type":"String","value":"false"},"virtualNetworkName":{"type":"String","value":""}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-11-11T21:16:44.7095054Z","duration":"PT0.4702085S","correlationId":"6bf4af61-d5f1-4b18-8cf4-111a2f87cbb7","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["westus"]}]}],"dependencies":[]}}'}
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/azurecli1478899002.669802448387/operationStatuses/08587227078812384039?api-version=2015-11-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['1962']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:16:43 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [24ff3694-a854-11e6-9578-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587227078812384039?api-version=2015-11-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
+        tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['141']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:17:15 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [24ff3694-a854-11e6-9578-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
+        p/nndbVeNXenZfH7t3nT/v7LYvr7N9N8mdVFdXdVV5fFLK+bu18U07pqqvN2/EpfbO7O8lVZXS/y
+        ZdvczX6wrnMCsrv/4ODg4cOdnb3xp58+PNjZ298/uHfw4KPRR8tskROuNzekTld53RZ589GjX/xR
+        my9WZdbmz4vlW/y9rguCMm/bVfPornTbzN5Oi/GkrCbjaVXn46tiOauumvEyb++a1+dV0949qXP6
+        9QWNcG9n99PtnYPtnV0BIUMZ/3RTLQmDabVsaVQ/SQMnglJ3u+Md/PfRLyHsspoG0tJXwIboNCnz
+        s9Wzqr7K6lmxvMCn7fUKQ31SVSVBu8zKNf15npVNTgAKgl0vs/LpsnmRLfLn2SQvvZdetzWg2Nc+
+        Qqdllc2eZGW2nOb1k2z6Nl/OjmczGnnzkvo4mzEuCuC4rrNr9/73vt95/2w5qdbL2YusfbUm1G/x
+        7jQDX3nNejheEeesG2BKNL+q6rdnGOR5Ns0xxE1vEidsg++2ie+891/nU5ro9pq5c9P7d3+YrP9C
+        kLsbQ7K5u7heNhdDY3jD+A+PI39XNC19dDYDhFVdXBKnnq10lje9GWt/XN5m1mbXJJNC9i4Ay/rD
+        bxery31+dT0pi6l9c9MrkeY30WVZLXO8RtNMZN3U8i41+aFzwmVRt+us1D/BA5eE5l1ChX7gT/nN
+        jeCm8YZ80GYXPkG/nPx0Pm1d61/8S6jNuslJlbzOW7zmt+7BZg0EsCHWN4noR+hlUc3w+9lyWufQ
+        +Bk0G1MGfEIvvG6Jf6jF6/V0mpM+ndH3bbEgamYLkuCPWOPu0nTsvtnbfbT76aP9T8e7+3sH93bv
+        /RQ1na1r5dePXr7ZHT/cuXf/3v7+a/qGVHqdkwqnL4kojz76dHK+n51/urs9u3++u70/2T3YPpie
+        7xPg3Wzv/ODBdDJRKyKzRmrsF7PxaVakjwhAbxaptWEETI+84X9CL9HUoanVaw29ZGQMLxgV+P1f
+        Qv/RcPIV6eh8OWUr9j36pFq3q3VLfxAy+dWLsxP8piTvzatgv4GyBrvP1+wAnGcPHs6y3Xvbk8nD
+        h8Ts+T2iycF9Yvb7+cFkb7K38zCnt4rVSbU8Ly6U1oQMDRSkIRDFiqwefbeLdoAJJv6hy1OPzIBh
+        DcTd7gDoA4d1TtJCeH/37u/70f2Dg/xhvrO7/XC6O9nefzj7dHuyRzyS78yI4x7szx5+uvv7fkTv
+        EC6er0F/baS60ZIvVXnR17vkFtB/u/eDr636/SJv5xWo+VR1rdED6O7njsyhAoCeGlRbNKhFVl9/
+        9Kit1/kvYd4OtQ3/WV9SR8RO9HW2WpVFPmOdZD8mQIQWXKWXvqvEGiluMAH6545AMYxAF7bw9Bh5
+        ts4wDVLxHQQ2wNQfkcb4Jf8P4yDg0MkLAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['1223']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:17:14 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [38e30a80-a854-11e6-8edc-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-09-01&$filter=resourceGroup%20eq%20%27cli_test_nic_scenario%27%20and%20name%20eq%20%27myvnet%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FvirtualNetworks%27
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
+        zsP7D3fu1nlTretp/nldrVfN3WlZ/P5t3rS//7KY/v7NNF9mdVHdXdXVZTHL6+buF8W0rprqvB2/
+        yNurqn5797Ko23VW6p/N3cX15TJvPxp9tMwWhNtH9u/2eoW/b4RATctqmmEM1PyKkFnjsza7aD56
+        9It/yS/5/i/5fwCjXD5a+QAAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['304']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:17:15 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [3902ba02-a854-11e6-b501-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-09-01&$filter=resourceGroup%20eq%20%27cli_test_nic_scenario%27%20and%20name%20eq%20%27publicip1%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FpublicIPAddresses%27
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
+        zsP7D3fu1nlTretp/nldrVfN3WlZ/P5t3rS//7KY/v7NNF9mdVHdXdXVZTHL6+buF8W0rprqvB2/
+        yNurqn57d7WelMX07OXxbEawmrzRT4rV7kejj5bZghD8yP+ovV7ho1tAosZlNc0wGnrhitBa47M2
+        u2g+evSLf8kv+f4v+X8AIc36RwMBAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['308']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:17:16 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [3923c8da-a854-11e6-b07e-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-09-01&$filter=resourceGroup%20eq%20%27cli_test_nic_scenario%27%20and%20name%20eq%20%27mynsg%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FnetworkSecurityGroups%27
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
+        zsP7D3fu1nlTretp/nldrVfN3WlZ/P5t3rS//7KY/v7NNF9mdVHdXdXVZTHL6+buF8W0rprqvB2/
+        yNurqn57dyk/X+fTdV201wpncb1sLj4afbTMFoTgR+bP9nqFP28JhV4oq2mG0dBLV4TWGp+12UXz
+        0aNf/Et+yfd/yf8DfCGZAQMBAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['305']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:17:16 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"mode": "Incremental", "templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateNic_2016-08-01/azuredeploy.json"},
+      "parameters": {"useDnsSettings": {"value": "false"}, "publicIpAddressType":
+      {"value": "existingId"}, "privateIpAddressAllocation": {"value": "dynamic"},
+      "privateIpAddressVersion": {"value": "ipv4"}, "publicIpAddress": {"value": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/publicIPAddresses/publicip1"},
+      "networkSecurityGroupType": {"value": "existingId"}, "subnet": {"value": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},
+      "networkInterfaceName": {"value": "cli-test-nic"}, "enableIpForwarding": {"value":
+      false}, "subnetType": {"value": "existingId"}, "networkSecurityGroup": {"value":
+      "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/networkSecurityGroups/mynsg"}}}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
+      Connection: [keep-alive]
+      Content-Length: ['1084']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [3942663e-a854-11e6-b59c-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+  response:
+    body: {string: '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/azurecli1478899036.636140616679","name":"azurecli1478899036.636140616679","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateNic_2016-08-01/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"enableIpForwarding":{"type":"Bool","value":false},"internalDnsNameLabel":{"type":"String","value":""},"loadBalancerBackendAddressPoolIds":{"type":"Array","value":[]},"loadBalancerInboundNatRuleIds":{"type":"Array","value":[]},"location":{"type":"String","value":"westus"},"networkInterfaceName":{"type":"String","value":"cli-test-nic"},"networkSecurityGroup":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/networkSecurityGroups/mynsg"},"networkSecurityGroupType":{"type":"String","value":"existingId"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"privateIpAddressVersion":{"type":"String","value":"ipv4"},"publicIpAddress":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/publicIPAddresses/publicip1"},"publicIpAddressType":{"type":"String","value":"existingId"},"subnet":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},"subnetType":{"type":"String","value":"existingId"},"tags":{"type":"Object","value":{}},"useDnsSettings":{"type":"String","value":"false"},"virtualNetworkName":{"type":"String","value":""}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-11-11T21:17:19.1553151Z","duration":"PT0.548086S","correlationId":"813a6f83-f8bc-4db5-8c4b-e5521f119c4a","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["westus"]}]}],"dependencies":[]}}'}
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/azurecli1478899036.636140616679/operationStatuses/08587227078468704581?api-version=2015-11-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['2111']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:17:18 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [3942663e-a854-11e6-b59c-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587227078468704581?api-version=2015-11-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
+        tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['141']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:17:48 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [3942663e-a854-11e6-b59c-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
+        p/nndbVeNXenZfH7t3nT/v7LYvr7N9N8mdVFdXdVV5fFLK+bu18U07pqqvN2/EpfbO7O8lVZXS/y
+        ZdvczX6wrnMCsrv/4ODg4cOde5+OP7336e7+zqe7n3764OFHo4+W2SInXG9uSJ2u8rot8uajR7/4
+        ozZfrMqszZ8Xy7f4e10XBGXetqvm0V3ptpm9nRbjSVlNxtOqzsdXxXJWXTXjZd7eNa/Pq6a9e1Ln
+        9OsLGuHezu6n2zsH2zu7AkKGMv7pploSBtNq2dKofpIGTgSl7nbHO/jvo19C2GU1DaSlr4AN0WlS
+        5merZ1V9ldWzYnmBT9vrFYb6pKpKgnaZlWv68zwrm5wAFAS7Xmbl02XzIlvkz7NJXnovvW5rQLGv
+        fYROyyqbPcnKbDnN6yfZ9G2+nB3PZjTy5iX1cTZjXBTAcV1n1+79732/8/7ZclKtl7MXWftqTajf
+        4t1pBr7ymvVwvCLOWTfAlGh+VdVvzzDI82yaY4ib3iRO2AbfbRPfee+/zqc00e01c+em9+/+MFn/
+        hSB3N4Zkc3dxvWwuhsbwhvEfHkf+rmha+uhsBgirurgkTj1b6SxvejPW/ri8zazNrkkmhexdAJb1
+        h98uVpf7/Op6UhZT++amV+7+XEyW4vdS8SO9JZ8Uq90I+u83TzQemuxN7e9Skx/6kC+Lul1npf4J
+        zrwkNO8SKvQDf8pvbgTvN+o2u/Cn+cvJT+fT1rX+xb+E2qybnBTc67zFa37rHmzWiwAbYn2T4vgI
+        vSyqGX4/W07rHHYog75lyoB76YXXLXE1tXi9nk5z0vIz+r4tFkTNbEF65SO2A7s0Hbtv9nYf7T54
+        tLc/fnCwu/fw4e5PUdPZulYp+ujlm0/Huw/2dx68ps/JzNQ5mRX6ikjy6KOD3XvZp+cH97bPDyZT
+        mtbJ/e2D6f5kO79/f2/3fHf34XQ/o9cYM8wZqdZfzAaxWZGOJAC9OaTWhg0wOfKG/wm9RBOHplbX
+        NvSSkXu8YNTy938J/UeDyVdkN/LllC3r9+iTat2u1i39QcjkVy/OTvCbErw3q4L9Broa7D5fs1Ny
+        nj14OMt2721PJg8fEk3ye0STg/vE6vfzg8neZG/nYU5vFauTanleXCilCRkaKEhDIIoVWWL6bhft
+        ABMs/EOXph6ZAcMarbvdAdAHDuucZIXw/u7d3/ejB7vTBw92zyfbe5Mp8QjxxXY2PXiwPbm384D+
+        d/5p9vDT3/cjeodw8fwf+msj1Y3mNvqNvt4lV4X+270ffG1Nwhd5O69Azaeq/6mVKEEH4+fCsTT0
+        7iBD9JZPVGETSjQjP7cohqoKGnVQwdIELLL6+qNHbb3OfwnLYagX+c/6kjoi1qevs9WqLPIZa0/7
+        MQEitOBqvvRdTdadcYcDoH/uCBTDCHRhD4keo3tsMEGDVHwHgQ0I4Eek3X7J/wNDluDuCQ0AAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['1252']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:17:50 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [4dc8f870-a854-11e6-b1ec-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/networkInterfaces?api-version=2016-06-01
   response:
@@ -1955,222 +1978,222 @@ interactions:
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
         uc4/evS9X/zRMlvQLx9Ny2K7zZt2e1lMPxp9VMzos7vNetJM62LVFtWyubsz2T3/dP/B7vbu5Hxn
-        e382y7azfHpvezp5uPdg73zn4f2HO3frvKnW9TT/vK7Wq+Yugf39Afb3J7C/fzPNl1ldVLt3V3V1
-        Wczyurn7RTGtq6Y6b8cv8vaqqt/eXcrPs2Wb1+fZNGcgPm55m10Qdt+9+/t+lN3/9MFksnNv+3wn
-        P9/enxxMt7P9/cn2wafnO/cfnGf3Hsx2f9+P6J2ymmYYBb13RZDWDX1GYJqPHv3iXzL6iNBZ5XVb
-        5Pgbf10WDTUulhev26wFeV6vp9M8n+Uzes8Occ1UuneQP5jeP59uPzg/2Nvef7g32z7Y2bu3/emn
-        2ad7e/n9nYf7wLpYnVTL8+JiXTMi1JMjfrGa8ne7aAeYd/9fSPm73RHQBw7trzMphMt7kH1VF5f0
-        6dnL49mMxkrvfLS7M8Z/u/eDr0sz2V/k7bwCOZ9eE6GZd1brSVlMqZGB8Yt/LgnewYYILp8Uq92P
-        iC0JJ5qSn2McL4u6XWel/tncXVxfElJ3CRf6gT/lN+BLU7DI6uuPHrX1Ouc/dUZkeD9JHRDmNJKz
-        l5f7H/2SX/L90UezZfM6b1uacp4L/rO+pIYkHvR1tlqVRT572vm4AIcus/JptciK5QsSotfr8/Pi
-        HYGe329n5XK1U7fv1vfOm2p3N9+9nDbLn87Gs3dj8+J4WlbrGUEfK+pEiUlJqD6r6qusnhE+Hz06
-        z8qGhkEtMPLX+XRdF+01UxK4/hzOSQwlTMWyuSCykma7XkF6Bl90Ek5jt1oo+8H2tFqsqmW+bFnq
-        f/KLFyw039RIZ/kkf1vltxqbQ/HuIF6eztm/v5vf398ndB5MZ9v7+e759sPzSb5NyuP+ZH/y8Hxv
-        P2edY3QDvfdNG4Lp7P7O7GGWEyH2723v79+/tz25Ryhl59mn+TTLHjzMH9BbXTVKLG2nwGjU3pDx
-        Hvq4+/+yWSAbEI6GPhgewteZMMLyPaakq3PoazUSB8G3P0c2YnYb2nf6j9H+pTYh8f2IsKLZ+qFj
-        2bULqzpfFOvF9uVie/cnX5y+uUt4EF7hF6/5M2BNU/Fzbyvy1W6dLyd7y+m6LK/2Fvfv7+xMZ5fl
-        ZluxyKaKJcHY2dneebp973j73u720yfbz9gX+rkzJrP8FlMXQyLCZC9ef47h0tT4M6Xz/kU2nRdL
-        Er8fEu4nhNq6zQ3bafcRrIlXSKN/XQO4uFztsmKjafyhjGsQMYzMx8bTndPzB/d3J5/Otu89+PTB
-        9v7ujHTnZPdge2/y6U5+kGc79w/us+40So7e+6aN3e7u/Z3dySTbJk+fcJjln25nnx483M6n092D
-        ndn5w/29Cb3VNQ8kk5bcnqXAQNEakO/+v4LiZMdCzOmDLrpfZ0oIo/cgOsleoBbpazVnu0DAff3/
-        OXsGEv7Iiv2/z4rtbx/sb+8fE9v8f9aKgbX+v2K7gCvxBanlr2uxrorlrLpqtvdYbdG8/VCGNIgd
-        BtVDyVOUD873H0weksm4f/Dp7vb+gwcTSg59em9778Fs58Gnu9nD2bn4/Uah0XvftO16eP/eQXZw
-        MNl+MH2Qbe9Pdx5uZ/cme8T8O/vZdO9g92D3Hr3VtQAkiZbwnjGwo8UrAH/3/z20J6MVjoE+iCL+
-        dWaIcHuPOSBRDHQjfa2mDEGx+/b/c5bMkvFH5uz/jebsybPt033inf/PmjPLX/9fsWkWYeIQ0tkf
-        aNhYj9H8/VBGNYibNy6DkK8y793LH+zn0+2DvR0yKA/O71Myi4KB6SS/9+m9h5/emz6csMo0uo3e
-        +6aN2vnDvXt7B/n+dvZwNyejdk602J19un2+l08eHswOsvs5sO4aBJJHS/S+bcALAH73/y10J/sV
-        4k8fRJD+OnNDeL0H9UkKA91IX6s5+zT49v+r5uxHxuz/fcbs3vYD+h/46wON2c/61NE48HPQmP1/
-        zJQRd5Ce/lqGbFVm1xeExHLG2UlJLtEM/lBGNojh3SG0PMVJK/j7s0/zB4TN7h5hszPbPng43due
-        fnr/wd7Op5PsXrbPitNoOHrvmzZq0+m9B/sPIQH7E6JIdm9nezKbPNi+d//+bDK5t/dgcv+2Wcbu
-        iPEaurj7/645IHsWjoU+GBzA15ktwvE95oMkNNCa9LWauYfBt//fMnNdUv7I2P2/z9jtbD98sP1g
-        h/jn/5vGrstj/58weV2kiVNIl38Thk/yUTSbP5TxDWLYHaFFy1Ol+b179x5MJufb+xRFbe/n2e72
-        QTa7v/3p+cN7pEuzT/fzXValRufRe9+04TuY7ny6P6HsJEVtpM7v7T6guO5evn0v3z2/t5fT0luO
-        tF3XWJCM2gkYsBv8Grq4+/+uOSA7F46FPhgcwNeZLcLxPeaD5DTQoPS1Gr5d6CT39f+nLd+PcpY0
-        Wv7TM3Fkm35OLR8l3U+2nyAr/v8Ly/f/jbxlF2niFFLmX8/yeXzKqo1m8ocytkHsqHUfJU+HZjsP
-        sxkte23fu3f+gMKsh9n2w4eUMrt3cE52aHfn/u7+OetQo+vovW/a4mV7u9nOg/MZ0QA47FEA8/B8
-        /x7RZW/ycPbg3iTPkcbvWgmSTUt4azC80eIVgL/7/x7ak2ELx0AfRBH/OjNEuL3HHJBMBtqSvlYr
-        B1q7b/8/ZuQ8Mv7IwP2/z8Dd2366t316QLzz/1ED583T/zeMm4cwcQjp7A81bOKz0wz+UMY1iB21
-        7qPkqc2D/exgMj24t33//gFhcm/v3vbBwe5se+8827n3YDab5dkDVptGv9F737hhe/BgJ8vvZduf
-        7og5o8zGfQpVZju7+d7u7u75fo6IomsUSCYt4SP2AVEQg7/7/x7akx0Lx0AfRBH/OjNEuL3HHJA8
-        BlqSvlbDdj/49v+zhu1HkRuNlv/0LBiZnp9Tw7a/ff8hLVUQ7/x/3rD9fyRq8xAmDiGd/bUM21Ve
-        X5zPGlZiNHk/lCENIna3g42nLPd3Z+d7u3uUF599ur+9f7A72X64v7tDyfKD2aeExv79Sc7K0mg1
-        eu8bN2ezjCIyWmjayWeUbzufkcLeP/90e2/nfP9gNvt090GO1EXXFJAkWnIbq6ADRWtAvvv/CoqT
-        zQoxpw+66H6dKSGM3oPoJHaBMqSv1X7twoC6r6MG7CYD9kMidN+AKQl/ZLv+32e7KG3+lFwvYq7/
-        b9ouZa3/T5gtxZX4gtTy17JY86yaXi7u36Pp+qZGApD1RXQcgyjxS4qHpxQP7k3vPchnn27P9vcp
-        W3Xv4Wx7crBD6vF8mu3vfZrf353ssFKM2SlC4D0UpR2EWqfd3clsd0aJsfOHB6SOP93dfrhHScX8
-        3s6n5wcUfD3Yv611QgaOYd79OaYtGaAQW/rAofh1yE54vAeJSZYC5UZfky3aJVv0/4pYCmS6gbad
-        3pW2P/kFSdRHhACR/ptE6Hp9kS0vrjZipBpB/7TvbF8SLncJBfrhPpS/gSwR21dr9KfSXgb2QzE7
-        7dW7+3uz6qez3Z/Of0AmaLbKp5Pmp7Odr2l2nu5vP/g5NjvghhtYKIaCvChsRFPhz4zOr2r8HxKu
-        Q+YGrwBLQvPrWZv1ZL1st1lDb+/uPHywv797f39/e8mi/U0NrCwu83lekmKKDm4Q0bsbsfPU4zQ/
-        38n2sa60O324vX8/+5Rc9Z1se7p7Pp3s5eeTgwdTVo9Gj9F7DPWDrdL+/d2D+/m9yfbk4X2ySvnD
-        8+2H0/3724TMwXR2vpvdm942Bbi7/+nB3r39e/v7D3f4HcC/+/9K6pOZCsdDH8QH8XUmibAkZG87
-        ISSegaakr8mGwYohW+O+/TmyYbekfgeDYeqvihXJ70eEGE3YzwGiqoH0z0E0A2s30KahLzEWmiNf
-        wdKfOmVCi2/K9FFPg4aIvvt6+jP7wfaqzK4viIbL2fbicsWZBmKpb2paCGSzXiyKdpsmJCdG2TA3
-        PUzvDqLnyWW2t7/7YPaQMpwH96fkWO/eIxV2MNvef7CfZbQGfX7v3kOWSyNA9B7PJZQngSHifnDq
-        6eFeNsl28sn2+YNzwuHTg93t7P69g+3p+X1aH89nuw934BF31Q5Nq50Jo4F6Q8Z76OPu/zsng1Rn
-        OCj6YHgkX2feCMv3mJmu+NHXrE93/t+hT4kMt56CDhqxKfjZzVdRB7dGtqtYe6gGuavet//vSmBl
-        k92LWfmL1vdml/mszPbWO8WiaWY/3Z5/nUhib/ves+2nJ8RYgwr8Zz+SIBrfei5juETm7Ied0aIu
-        bxzCUKTRQ544h9T/1zKa5EGyNv+GhkXgBsKmQWzwDlDw1OnD3ezh5P75LmVXzimxsruXbR9kB7QO
-        QqvYB2SQJnszUadG79F737QZ/DRDT8T4DzNabtwnTLcfPnhwvr3z6W6WPdibZvd3M3qrazFIHC1t
-        jfHA6Bjm3Z87ApMlCxGlDxx2X4f2hMN7UJcEK1B99PV7mzKiHg0Ovf3wqKmyp382d+FM796lnuln
-        oz93SaAwBF9z0J86IhnvD0XVt7NftCx+EamGZje/v/hF9+6t2yJbzGfnm5NGg5qcvvu6WmWZXS72
-        Pn34kKbtm5qsFwT0YnNE1EOKZtjDxGPzBzuTbPc+8fX9bEZsfv7wwfbBZOfe9qfk+j48v3f+4P59
-        iYANP9J7VsUQCu/B+nYYoljuUc/39/bz7fuUl9jefzij/PHug/3te5N7+wc7O5RYfwCR6MorTb4l
-        ry+6DPPuzzl1SZ2E+NIHDsmvQ3jC5D2I3JU3+nr3wd549wFpmP9XJNBvQd9O70RfvET03f7ZSjQA
-        /g1IXXYUoLwSJhVm+Xm2LlmXEJ1/ztXg+XU+v7d3Xs53ivzdTy/nF9Nlfr2aF79otlENDni8O9v3
-        P91+ygm0IT0Z93gxmB/iRNEo8LPj6OLFS+KgZXOBMdJ8+NNzKZOrnuUPCeEhtxavXC72iCk+zOwc
-        PIDA/xAGMoiT6kVBxNN9n96bPqTF0b3tT/P8U/Kopp9uT6b7B9sHBw/u7d6fTSgFe491n1FR9N43
-        Y3SmpAwnOw8/3d67f3APWney/fD8/vn2wfm9nb384OF0Zx96uqvESdQscX19zjDv/lwTl0xMiC59
-        4HD8OnQnRN6DxiRMgXKjr4nMYnNgwt33/9+zOT8yOT+HJmd3+8m97SefEnP8f9fk/H/H4hBLfF2D
-        s7h+cYZc2Dc1hvqibrL2/s7Op/d27z3MSEd9Gh3QIHJ3DUae9tv5lFRWlj3cfvDpbELaj2L7hzt7
-        k+1deuMBGYB72YP7rP2MkqL3vhmrc/5pvj+h7Pf25MGEciifTmiZ8Zy8qfN8d3KPej/YOQCTd9U4
-        SZulsK/RGebd/9dQmaxNiDd94JD9OhNASLwHsUmyAkVHX793SqWj/tHtzxWVO6gwlX92lwTeF0NV
-        H/on8AvWASTtv/3/mmzQ2+n0/qytz4v2Xb786bpq8531vevy7WrydWzSfTJI2zvHxDMbbBKN0x+2
-        Ekz1LUb1w566Ic1PU/cFkf3r6n3KG/JvRP9vaEAtKdz6YnfvIDqMQaTIGTaYeAqHMkmzfJKRj5/f
-        o8ztg918+2A6OdjO92fZwZQ83vuf7rHCMZqB3rMan8DQzP/ij97mNI8fXWblOqeh09S+j26yoxND
-        QM56PjmnJBfNGCV97u2RIdjL6Ld8mn863b1HQ0F+rqtQicUtyc13/Cc1Bdi7zfrnmO6k8gUtg7L9
-        AN8Snl9nVgiT9yA1yVygW+jr/zeZgdsRuIMAEVg+KVaEIvNfw9r1h4+Zag79UxYAgNPdhhEyawD4
-        CGgSvX0NSH8q+WVgPxTFn+/v7K7e7e7vlKt8tVy+a3bfNj/4Rfllm29U/IN6nb77emrykhaarz5t
-        8iuSFuKyb2riAHZg2Sau719PszInGsurnS8Jh/4ouKGHuifGu/v7O+c7uw+396bTbHt/52BvO3sw
-        fbBNKf17nx7c2z2fPPz0a4ixHaNozPv703uTB7N8eze7D59x9/725NNPp/Tbzv3Z3u6D/NMM6sVo
-        G6N+iDf61DduKdoD9t3/702BVatmoO5bb3Q/+7PUlWf6+r2VLVGfBovefgizYeRUCa5/yiuB94oP
-        xIMlCcZI3kONwZHIZk+yMltO8/pJNn2bL2fa9GVVlUQmYssf4mh9dOSFcnJ30seLv5rkK/r9I6hi
-        /72z5aRaL2cvsvbVugR3/L9gCEWIE3+8zFrgP96hEfzs2JNs+W6ev/vBTv7Txfresl7dW1/9dFHO
-        f/BuutGeDAQSu9snx9unnKMYMjjMcD7/KfequsCofggz8fUUGdn0/+9ZwN2b9C/h7inXvZxc+PuE
-        aH7+6Wx7f//ePfJpDyi/kZ+TIzu5n2UPZl9DudpBigk8mDx8OHuY72zvZhMyfPuf3t8+eEDhw252
-        Pvk025tkD2fAq2sZiJ375C+ckWDYd/8/OAfvbQN/lqaJZDMwBvS12kAk89y3P7KBga1hvvwhjtZH
-        R14gA/L/cxu4S+r3GzOCH2oEmYkGjOD+9pPT7b1nxDX/fzSCmIb/L1rB3Rs0MOHuqdfZvd2984cP
-        c4rJJqRe788ebmcH9x9u55/e25/u7s12J9Ovo17tIMUKzvY+/TQ7p7XrHVop2N4/oETswcOH90mn
-        T+/vnN97+PD84f+fAsEb5+C9reDP0jSRcAbmgL5WK/gg+PZHVjCwNsyXP8TR+ujIC2RC/v9uBWkJ
-        6v8rVvDZ9qenxDX/v7SCNA3/X7SCezdoYMLdU697D6cP7h3k2fb5gymtany6k1GUtpdt04pO/nA6
-        Od/L8vxrqFc7SLGCBwezvf3dT8+3D3aRzsseTrcPJvv59r3z+5P7+fnuZGd20wKSHULhzATDvvv/
-        wTl4byv4szRNJJyBOaCv1QoeBN/+yAoG1ob58oc4Wh8deYFMyP/freAeDeH/I1bwdPvB/29jQZqG
-        /y9awRsUMKHuadcJac/zh7sPtvPJOQUaO+ekXc93KFI7//ThvdmD/fzh18q02TGKEaRhZ58ePDzY
-        fvAw29/e3917uP1w+uk+KfJ8cvDwwfn+QbZDb3VNA7Fzn/qFsxIM++7/96bgvW3gz9IskWgGxoC+
-        Vht4P/j2RzYwsDXMlj/E0froyAtkQP7/bgNpBP8fMYEH2w/vEdP8/9IE/n/SAt4UghDqnm7d/XTn
-        frbzgOKLTx882N4/z2fb2acPzrd3d3N6c//e7uThztfQrXaMYgHv7e6fn9/bOd+eHexTFLM/u79N
-        Sv3h9vn+/U8n0/v5/u7OHr3VNQzEzX3qF85GMOy7/9+bgve2gD9Ls0SSGZgC+lot4O5u8PWPTGBg
-        apgvf4ij9dGRF8h+/P/cBFL48f8VE0grgsia/P/RBNIs/H/QBN67Qf8S6p5y3dm7v7PzYC/fnuzv
-        kXI92L+//XAvO9ie5NPdaX7+YJLtffo1lKsdo5jAnXzv4f7O/sH27MHeLqnw/XuUCb3/YDubHOze
-        e5g9eDDbg87tWgbi5j71C2ckGPbd/+9NwXubwJ+lWSLJDEzBR48+MiYQHon7+kcmMDA1zJc/xNH6
-        6MgLZD/+f24C79EI/j9iAp9snxwT0/z/0QTSLPx/0ATev0H/Euqecp3uzvb39+/nlKE8n23vT2eU
-        ocwPdrbv3T+fPHiwv3Mw+1oZNjtGMYEHB9Pp+YNsj7T3vYf0z2yfrB9ZxJ1sZ+/8/P6DyWwCndu1
-        DMTNfeoXzkgw7Lv/35uC9zaBP0uzRJIZmAL62phAGAL39Y9MYGBqmC9/iKP10ZEXyH78/9wE3qcR
-        /H/EBJ5sH/z/dS2QZuH/gybw0xv0L6HuKdf83r1P811aWtr9lEzS/t6MQrOdvU+3dx+c0wpddn6e
-        f/rwayhXO0Yxgef3JucPJw8m26TLP93ez6aUPp9MJtuf7t7PZ58+2CElPqG3upaBuLlP/cIZCYZ9
-        9/97U/DeJvBnaZZIMgNTQF8bE/ijtUCjsH9kAn/WhrDJBH5KI/j/iAl8sL13Qkzz/0cTSLPw/0ET
-        +OAG/Uuoe8r13u7DvXuz3fPtfO8+BWm7Dyfbk4fZ+fbe/vn9PJ/Q/x7e/xrK1Y5RTOD9nVm+t//g
-        3vaDyQ73cr79cJeIs/fw4b3Jzqe7Dx8+hObpWgbi5j71C2ckGPbd/+9NwXubwJ+lWSLJDEwBfW1M
-        4KfB1z8ygYGpYb78IY7WR0deIPvx/3MT+IBG8P8ZE3j8lJjm/48mkGbh/4Mm8OAG/Uuoe8r1PPv0
-        4S7p0e0H5/dIuebZDq0y3SOMH9w7n96/N33wcJp9DeVqxygmcHqe3Z892N3d3tndI7qckzHMPt2h
-        KCbbzw4OPr13f+feA3qraxmIm/vUL5yRYNh3/783Be9tAn+WZokkMzAF9LUxgZgO9/WPTGBgapgv
-        f4ij9dGRF8h+/P/cBB7QCP4/YgLvb7P2+lkzgd/MTAxrsk2a7P+TJvDhDfqXUPeU687eZH9vuvvp
-        dp49JIz383vbD+/tHWzn+aeT/fPJOQVsB19Dudoxigm8d757b7r/abb96f5utr2/u7NLa4EP8u18
-        Mv30/NPdnfO9GfDqWgbi5j71C2ckGPbd/+9NwXubwJ+lWeqaAvramMCD4OsfmcDA1DBf/hBH66Mj
-        L5D9+P+5CXxII/j/iAnc2366Q0zz/0cTSLPgm8Dr9UW2vLja3v3JL16w8H9TeCvgKOKGhWge8NPT
-        qfqWQ8dTmfnk4PxB/un59gOKsGjt7Xy6/XCWP9j+9P4O4Xawe3A/m7DKNKqN3rvKm3bd0GcEhmb5
-        F9OsE0LvoVDtqMTsHcx29+7l96fbs51PiRJ7B9Pt7Pzh/vb9nfOcosL9KVGD3upaA+JgS/FC7YEd
-        KtoD9t3/dxC9b8piGH+deSGs3oPyJGGBSqevyZTtkimDPnffbrJkq/WkLKbUyID45uRSibGR1J3u
-        fVK/1K+ghwgZmpQfNnKqGPRP+872JeFyl1CgH+5D+RvIEuF9xUd/6jzIGDuG92dH37dX7+7vzaqf
-        znZ/Ov9BvtqdrfLppPnpbCf7Ovr+3vb+k+2dh8QuG/Q9gQCZXufTdV2010xnDOaHOWMxHOyb27sv
-        Xn+OUdKM+BOk06z6/4eFctw02XdIhZAR+qi9XhFGH7nXOiN1OooGZhXobFo124usoe+2nz65f+/Z
-        k4cPt8kH32bN+80OLps20fENInp3I3ae1ty7TxjNzmcUNu3OKADY39nOHuwfbB/sTz89uH+QzWaT
-        fdaaRr3Re9aaEUrvoUnt0MSGPdzZJ5V8/un29P7kgHr+dLY92T/Y3X6Y7X66c/88e/BgD7qzawZI
-        Ku0UmO9eVLMcTQH27v8riU7GS1A1w7AfKO5fZ0oIufcgPwlkoCLp690He7QsR6bsfvB935QBHlsy
-        Ii4NG939kImtEqx/KqlhIyyh7xIu9Ld+JbPw/41A7ZYk8FEKRrldThwVYtGb3xYxkG1NoVA41J/N
-        YO4bHWY3wnv9+tvbflvTkPQddPb/V8bwsqrbvb3BkfwsBa677fqnq8v9H6zXdV5PFk22WhTn6/3L
-        txdfx5HZ3X62u/3gGQnRz70jc9NExdAIJ2zZXNgpwKBJc/iKRPWSehY/xBEMuTY+7gZvsA6h/g37
-        OYi/fkiDHUQ0PlyDnWdUpwf7+cH+zmR79975Q1orJXuanc8m25PZzmQn2723v7/7kI2qsX303jfj
-        59w7nz34dDaZbO/cyz7d3t+5T+SYAIcH9OGn+f69+1M4/cYfMA4CCa2dAvOd+goM9u7/K4lu3Roz
-        DPuB4v51poSQew/yk4AGpp2+tn7Op8H3P/JzwO7OUv3Iz/l/3zAjPkLcO6BQ9v8r3sHB9pMbVnYJ
-        BGgUmGUM5oc8RTE0wqn6/4V3QKxDqH/D3sEezfAPabCDiMaHa7DzTFH+6e75g4eUNt6593CyvX9A
-        rQ5mGVaVZ9mntLw8u3dvxqbIWAx67ybvgPgZ5gRE8s2THZp4B5SWfvBwmu1u793LqOcZdf/wAf15
-        sPPwYZ5ne5OHBxN6y1hRY1ZJaO0UmO/UwjLYu/+vJLp1Bsww7AeK+9eZEkLuG/IOoJTc9z/yDsDu
-        zkb9yDv4f98wb+0d7NEY/z/iHTzYvn9KrPcj7+BnbwTv5R0Q6xDqX887yC7yZftStAxUPK3r0tT+
-        nI7y9TQrcxIBHS1juE0TAxTdoC8XTbPTeZOQ7I/2LgPoDdEzZA8+3b3/4NMs357k9/e29ye0ap9l
-        tEyd7+xN9h/cn07PH97/GobM0kL8iGzn3v7ep7v7tI5473x7/975ve2D/ODe9vnDyaf7k70H051P
-        keQ39tYYYBJvO1lkos0SO1oC6t3//06SdT0MKe6G4//Zn0Edj7W+9PXuzvjeHnkisL3u674n8vSa
-        5owZjSaIhovufkgTZuReya5/6kRtcEX8Kfi6Dsn/FyzY3vbOs+0dTOAGC0bj9IettFQWxqh+SJP5
-        syB9NEn//zUAe7fTLTRET32cf/rg3nR3/8H2g9neLo1sQuu5Dye72+dTygCfP9w7n+7sfA31YWkh
-        BuDT/ft7s2z6YPvT+ztkAPY+3dvO9s+JnPf3Pj3Pdx/cz/dvSjOHCpCh3v3/7yS9hwH4WZpBHY/V
-        dvS1MQA3Jap/ZAD+32wA9rafYAJ/XhoAhAv//zUA926nW2iInvo4OM9nu5+eTymzt79PI3tAa1yk
-        SbazT+9NZg8/ne2f7xx8DfVhaSEGYP/+p/u7u/d2th/uHMy29x/unm8/pMziNi04kq462H2YP8jo
-        ra7WI+mwkxUqQIZ69/+/k/QeBuBnaQZ1PFbb0dfGANyUi/yRAfh/swHY2T74eWsA7tEkdQ2AShyR
-        5P+Fw1pPSlqcuGFUg1kFNzRPX0zOH9yfnB882N7fySljcJDtbz+8P/t0O59klI75dOfhwezB19AX
-        lgai8Xc+/XQy2TvY2b6HxM9+NpltTw6mtGLy4AFRdH+2N92BGumqORIHOzuhxmOod///Nznvoel/
-        lmZOZceqNfqaND3+Q6bAffv/I0XPM/d19Xy4HvP/3qUnHmqwJDO48iRNuwtP/x8xaCfbnz6jSfn/
-        kkETplUd8SHK5Wvas2+UBb9xlTmYJFGVicl2WvHT+/d2H+5PaQn+wU6+TdL1kDLgBwfbs/ufHuTZ
-        g/PznZ3J19CKlgZiz/bu3/v0/H5OEcz0gHTv9H62/ZAgb+89fPhp9mDvIHs4vUdvdZU5ScP/z+zZ
-        TZPzHvbsZ2nmuuqbvlZ7Br/Xffsje/YjeyZ/eoaLLM7PtT0jcj6hSfn5aM9iCTrVK0SR/6+OajDn
-        44bmacVplu9me5OD7Qfkz5Orj8WSg/NPKXDfPycddzDZuTf9GlrR0kDs2acH2WT66f0H27uz2YR6
-        mT3Yntx7SPZs+pCCien+/nQP2rKrzEka7OyEep2h3v3/3+S8hz37WZo5kvZAfdPXas8QQbtvf2TP
-        fmTP5E/PcJHF+bm2Z8fb93doUn4+2rNOvpE0x8He7oODezt797Nzosk3Na764uTLL34yv5ffo5Tb
-        /Yf3oqMzrEgThp+evuvh5Sm1nb0H00+p1fb5w31SavcnhM79CXnqn96b7WeU4pvl+6zUjPah9/Ks
-        adcNfUZgiB1+MbEHIfQeKs8OT4zVg3uT3f2D2XQ7n1L3+/fvf7qdPaDs1yybHCD82t3LbjJWhsWo
-        FSDe/X8ZzftWxiH8dSaDcHkPclNfgUKlr9XCQJu6b3+4Fua9CKySp382d2FiDvb29u7v7R/s5XcJ
-        G/qg0Z+7UFg0LCawKh36U0cpNOgYla+ta6mnuGrcvb/94P72pw+JdoOqkV5ur1eYrv6IaRz46ViK
-        BmXZnbhrd3/v4cGn9/cOpvnuvd371M03NzHLfNE8uDcD+AcUpk/3Ns5ND1Mw/24PPY/P9x+c7+3s
-        3n9Iawbnu5QZmN2jbMv92TalCChDMD0/3z3ImM8NQ9J737TSmX167+H5g5297V1aYCXKZPe3H376
-        gJy73U9J4exO7x8cQFV2BZfm3M4C8RSzGLUCxLv/7yT9LXXPreeE8HkPqlNfgdzR17sP9sa7n453
-        30P7iDmmRgbIN6mG3o/kHVSI5Kti9eDB/gFFVp+SjH5EKNG0/FyiGFOWD853+O2D+xQAnt8lpOjD
-        5u6zuiJvh5xSYE5zwXzxs6wySVzAr+RlRtzTrMnv3b+/2Lv86eX6cnKxt/OLZu29dvKL9rPxZIN7
-        GlOxMgpqACq8zqfrumivmaRA9edqcmL4NHfP82Vzce88YyAP9imUJPqSrvta1uHdqsxaUgSziuKN
-        +t7BAQLJb2q8DPxN3rSf/+QXT7mDvYf3d28zZIesAOli6Cmj2WTv4e7Ow+n2To710P29+9uTTx/u
-        bR9kB/fzh1Oi00NxhIzOoPesgSBU3kNB2eGJWTg4IG9kRlacUCA1SPnr7YP72cH2vZ18d/qQMirU
-        Nb3V1anE15b8JnuwS57swe7up3ufHhzAADL8u/+vnYG+nRgayNeZKMLuPSalq3ro6/8XeKxMs/cj
-        fFcVMwihObTywf6nLkHifScfPXxwj1YAebw/53p5b3n/3vr87Sp7d72+rK6q7BfNJ+Uv2l2uN+vl
-        Ad+YKH6wvX9CsxRT3Owb8zj9YSspNfjGqH4O5jWeQlAQl4sZv/3wYP8+TcM3o753d3agHH/2xvrp
-        g5370bEOIitAuhh6WuHB+YOHM4rMtvfyPfKt9zPyJQ8m+fYDso/E0w8fZjs5awUjvvTeN6O+s/zB
-        7r2c0rN5du+cIuj7+fbBvXvZ9qe7lLzNJ/sPHz68aR3X03qfklt3f/fg03vQOgz/7v9rZ4C0tR2T
-        IDc0kK8zUYTde0wKSW6goejr91bfHT8b3f4czkAHGzMDQv5idW/nwQMS4Y8IN5qrn2NcVTfpnwpC
-        MIXN2T3Yv3eXEKNfg+/ko0/v3yfdReQPlS/9qXMmBPjh2Jzi3b295e783sU0/+nV+Wz9i3ba83f3
-        92f5RpszaFLouw/QyC1NAkncpwec0/nZmN+TOica36Nn4/z2UBUgIX6ekN+b3Nu7t/8g2z7Id/e2
-        9/fy8+2D851se+dgf+c+MRMtat1nITfSSO8Rju0cKjlrioy+InzeQ/7tGFUp70+y/V2ixuTBg3x7
-        Pz8gVCbntDZ5vrf76fThvXuTh3AruwqM+MPOgNNlnz74lIj54MFDsrH0DuDf/X/pNJAGDkdEH8SH
-        8XVmi3B7jynpCjB9/f9WlXxL+new8elfrD492NkjCf6IMKN5+jnGNKqQgSfU8f7uwe5dQot+9b6R
-        D+7de/D/GmW8367v7a/LIrv/0+vJxWox351fVLPsvDkfFxuUcTwAON7Zvvdwew+u2KC25nH6w1Yy
-        qs+NUf0czOkNAcC93T1yMD/Q998m5Nr5NuVxKSzfJQ2xTQqFSPWND/cnv3j9Wsa79yA62kGcBcYQ
-        op46u3/w4F6+k3+6/WB2nxIEn+bZ9sOd80+3Hz54mM+mDx7uzPJPWZ0ZvUPvMdRvyvg8JOQe5A8p
-        sX9+7z7lte/Nth9Odw+2pzktrX16fn5v735Ob3VVNcmDnRSntR9Qcmj3wb3dTyk/R+8A/t3/t88H
-        GZ1waPRBfDxfZ9oIy/eYG5LoQHPR12yF/l+yFsBEfK+J6CAzPBG0SEBy/hHhSHP3c4uzqi79UyH0
-        MYZxukv40Y/BNg19iWHRzPmamv7UiRSy/FAMFHUwv67aZbW8yO+XdV1dLxdXV1l5b7OBGrQ/9N2H
-        6/D7D+7vkJjdP4AkEvP+3M16D2WBMYCnpwpm9x7uP7yX7W7nlECgvF0+2c4me/e29yfk0+9N7u3c
-        y6asCozM0nsM9BvT4PcJsene+fZ5PiH65AcHpIY+3ds+n5BDfG96MN17iD66ao4Yxk5JR+Pt7u7v
-        3t/DO4B/9//l00H6OhwZfRAfzteZNULyPaamK9n09f+fFbibh/+P6G+H8KD6dk0a+g6Domn7Odfe
-        RJ11sXc/e/uDy/X5T08vzverd+9mWTH7YWvvxfWLMyxMfFPz+9PZZTZtFvVFPJ4YxOmuQcQT6ns7
-        k+zgfD8nTbg7IVEmoX64uzcFJtN88nCyMzmYsVAb6aP3CJl2Ps2XbZ2VH55f//TB/d2H04eT7U8f
-        PKB+D6az7YOHk2z7PvHUwe7e+cHDc3iSXY1F028JbJUX2gHm3Z9rIpM+DdGlDxyOX4f+hMR70Lgr
-        cPQ1K9X/l+RmbkncDgZM3Jf6GQnYR4QI0f/nALGuvlxc/+SL0zd3qX/Cp7n7mn9u7wJHovXPuSZc
-        n8+uf1H1jlZWf1E+L6rpfHUxmS/mF9fZ+Kc3aMJ4ouXB3va9ne1PnxCHDKpKHqc/bCWY5jYwqh/S
-        jA0lV2jGviBqv59K//4v+X8AegYGVwc7AQA=
+        e382y7azfHpvezp5uPdg73zn4f2HO3frvKnW9TT/vK7Wq+Yugf39Afb3J7C/fzPNl1ldVHdXdXVZ
+        zPK6uftFMa2rpjpvxy/y9qqq395dys+zZZvX59k0Zxg+anmbXRBy3737+370YHf64MHu+WR7bzKd
+        bu/v7Z5vZ9ODB9uTezsP6H/nn2YPP/19P6J3ymqaYRD03hVBWjf0GYFpPnr0i3/J6CNCZ5XXbZHj
+        b/x1WTTUuFhevG6zFtR5vZ5O83yWz+g9O8I1E+k8e/Bwlu3e255MHj4kquT3tg+mB/eJKvfzg8ne
+        ZG/nYU5vFauTanleXKxrRoR6crQvVlP+bhftAPPu//sIf7c7APrAYf115oRweQ+qr+rikj49e3k8
+        m9FQ6Z2PdnfG+G/3fvB1aeb6i7ydV6Dm02uiM7POaj0piyk1MjB+8c8hvTvIEL3lk2K1+xExJaFE
+        M/Jzi+JlUbfrrNQ/m7uL60vC6S6hQj/wp/wGdGkCFll9/dGjtl7n/KfOh4zuJ6kDQpwGcvbycv+j
+        X/JLvj/6aLZsXudtSxPOM8F/1pfUkGSDvs5Wq7LIZ087Hxfgz2VWPq0WWbF8QRL0en1+Xrwj0Ouf
+        vndvuVOum3dVfr7Yub972RTZbKe6PxvP3o3Ni+NpWa1nBH2sqBMhJiWh+qyqr7J6Rvh89Og8Kxsa
+        BrXAyF/n03VdtNdMSOD6czclMYwwE8vmgqhKWu16BdEZfNGJNw3daqDsB9vTarGqlvmyZZH/yS9e
+        sMR8UwOd5ZP8bZXv3mZsDsW7g3h5Cmf//m5+f3+f0HkwnW3v56RwHp5P8m3SHPcn+5OH53v7OSsc
+        oxjovW/aCExn93dmD7OcCLF/b3t//z6Zg3uEUnaefZpPMzIR+QN6q6tDiaPtFBh12hsy3kMfd/9f
+        NgtkAMLR0AfDQ/g6E0ZYvseUdFUOfa0W4iD49ufIQMxuQ/tO/zHav9QmJL4fEVY0Wz90LLtmYVXn
+        i2K92L5cbO/+5IvTN3cJD8Ir/OI1fwasaSp+zk3FPF/t1vlysrecrsvyam9x//7OznR2WWYbTcUi
+        myqWBGNnZ3vn6fa94+17u9tPn2w/Y0fo586WzPJbTF0MiQiTvXj9OYZLU+PPlM77F9l0XixJ/H5I
+        uJ8Qaus2N2yn3UewJl4hjf51DeDicrXLio2m8YcyrkHEMDIfG093Ts8f3N+dfDrbvvfg0wfb+7sz
+        0p2T3QNytj/dyQ/ybOf+wX3WnUbJ0XvftLHb3b2/szuZZBTx7BAOs/zT7ezTg4fb+XS6e7AzO3+4
+        vzeht7rmgWTSktuzFBgoWgPy3f9XUJzsWIg5fdBF9+tMCWH0HkQn2QvUIn2t5mwXCLiv/z9nz0DC
+        H1mx//dZsf3tg/3t/WNim//PWjGw1v9XbBdwJb4gtfx1LdZVsZxVV832HqstmrcfypAGscOgeih5
+        ivLB+f6DyUMyGfcPPt3d3n/wYLKd7X96b3vvwWznwae72cPZufj9RqHRe9+07Xp4/95BdnAw2X4w
+        fZBt7093Hm5n9yZ7xPw7+9l072D3YPcevdW1ACSJlvCeMbCjxSsAf/f/PbQnoxWOgT6IIv51Zohw
+        e485IFEMdCN9raYMQbH79v9zlsyS8Ufm7P+N5uzJs+3TfeKd/8+aM8tf/1+xaRZh4hDS2R9o2FiP
+        0fz9UEY1iJs3LoOQrzLv3csf7OfT7YO9HTIoD87vUzKLgoHpJL/36b2Hn96bPpywyjS6jd77po3a
+        +cO9e3sH+f529nA3J6N2TrTYnX26fb6XTx4ezA6y+zmw7hoEkkdL9L5twAsAfvf/LXQn+xXiTx9E
+        kP46c0N4vQf1SQoD3Uhfqzn7NPj2/6vm7EfG7P99xuze9gP6H/jrmzBmP5tTR+PAz0Fj9v8xU0bc
+        QXr6axmyVZldXxASyxlnJyW5RDP4QxnZIIZ3h9DyFOdk597+7NP8AWGzu0fY7My2Dx5O97ann95/
+        sLfz6SS7l+2z4jQajt77po3adHrvwf5DSMD+hCiS3dvZnswmD7bv3b8/m0zu7T2Y3L9tlrE7YryG
+        Lu7+v2sOyJ6FY6EPBgfwdWaLcHyP+SAJDbQmfa1m7mHw7f+3zFyXlD8ydv/vM3Y72w8fbD/YIf75
+        /6ax6/LY/ydMXhdp4hTS5d+E4ZN8FM3mD2V8gxh2R2jR8lRpfu/evQeTyfn2PkVR2/t5trt9kM3u
+        b396/vAe6dLs0/18l1Wp0Xn03jdt+A6mO5/uTyg7SVEbqfN7uw8orruXb9/Ld8/v7eW09JYjbdc1
+        FiSjdgIG7Aa/hi7u/r9rDsjOhWOhDwYH8HVmi3B8j/kgOQ00KH2thm8XOsl9/f9py/ejnCWNlv/0
+        TBzZpp9Ty0dJ95PtJ8iK///C8v1/I2/ZRZo4hZT517N8Hp+yaqOZ/KGMbRA7at1HydOh2c7DbEbL
+        Xtv37p0/oDDrYbb98CGlzO4dnJMd2t25v7t/zjrU6Dp675u2eNnebrbz4HxGNAAOexTAPDzfv0d0
+        2Zs8nD24N8lzpPG7VoJk0xLeGgxvtHgF4O/+v4f2ZNjCMdAHUcS/zgwRbu8xBySTgbakr9XKgdbu
+        2/+PGTmPjD8ycP/vM3D3tp/ubZ8eEO/8f9TAefP0/w3j5iFMHEI6+0MNm/jsNIM/lHENYket+yh5
+        avNgPzuYTA/ubd+/f0CY3Nu7t31wsDvb3jvPdu49mM1mefaA1abRb/TeN27YHjzYyfJ72fanO2LO
+        KLNxn0KV2c5uvre7u3u+nyOi6BoFkklL+Ih9QBTE4O/+v4f2ZMfCMdAHUcS/zgwRbu8xBySPgZak
+        r9Ww3Q++/f+sYftR5Eaj5T89C0am5+fUsO1v339ISxXEO/+fN2z/H4naPISJQ0hnfy3DdpXXF+ez
+        hpUYTd4PZUiDiN3tYOMpy/3d2fne7h7lxWef7m/vH+xOth/u7+5Qsvxg9imhsX9/krOyNFqN3vvG
+        zdkso4iMFpp28hnl285npLD3zz/d3ts53z+YzT7dfZAjddE1BSSJltzGKuhA0RqQ7/6/guJks0LM
+        6YMuul9nSgij9yA6iV2gDOlrtV+7MKDu62EDRq3URFgYgbT+7BO6078j9I9s1//7bBelzZ+S60XM
+        9f9N26Ws9f8Js6W4El+QWv5aFmueVdPLxf17NF3f1EgAsr6IjmMQJX5J8fCU4sG96b0H+ezT7dn+
+        PmWr7j2cbU8Odkg9nk+z/b1P8/u7kx1WijE7RQi8h6K0g1DrtLs7me3OKDF2/vCA1PGnu9sP9yip
+        mN/b+fT8gIKvB/u3tU7IwDHMuz/HtCUDFGJLHzgUvw7ZCY/3IDHJUqDc6GuyRbtki/5fEUuBTDfQ
+        ttO70vYnvyCJ+ogQINJ/kwhdry+y5cXVRoxUI+if9p3tS8LlLqFAP9yH8jeQJWL7ao3+VNrLwH4o
+        Zqe9end/b1b9dLb70/kPyATNVvl00vx0tvM1zc7T/e0HP8dmB9xwAwvFUJAXhY1oKvyZ0flVjf9D
+        wnXI3OAVYElofj1rs56sl+02a+jt3Z2HD/b3d+/v728vWbS/qYGVxWU+z0tSTNHBDSJ6dyN2nnqc
+        5uc72T7WlXanD7f372efkqu+k21Pd8+nk738fHLwYMrq0egxeo+hfrBV2r+/e3A/vzfZnjy8T1Yp
+        f3i+/XC6f3+bkDmYzs53s3vT26YAd/c/Pdi7t39vf//hDr8D+Hf/X0l9MlPheOiD+CC+ziQRloTs
+        bSeExDPQlPQ12TBYMWRr3Lc/RzbsltTvYDBM/VWxIvn9iBCjCfs5QFQ1kP45iGZg7QbaNPQlxkJz
+        5CtY+lOnTGjxTZk+6mnQENF3X09/Zj/YXpXZ9QXRcDnbXlyuONNALPVNTQuBbNaLRdFu04TkxCgb
+        5qaH6d1B9Dy5zPb2dx/MHlKG8+D+lBzr3Xukwg5m2/sP9rOM1qDP7917yHJpBIje47mE8iQwRNwP
+        Tj093Msm2U4+2T5/cE44fHqwu53dv3ewPT2/T+vj+Wz34Q484q7aoWm1M2E0UG/IeA993P1/52SQ
+        6gwHRR8Mj+TrzBth+R4z0xU/+pr16c7/O/QpkeHWU9BBIzYFP7v5Kurg1sh2FWsP1SB31fv2/10J
+        rGyyezErf9H63uwyn5XZ3nqnWDTN7Kfb868TSext33u2/fSEGGtQgf/sRxJE41vPZQyXyJz9sDNa
+        1OWNQxiKNHrIE+eQ+v9aRpM8SNbm39CwCNxA2DSIDd4BCp46nT04oLz+vYfbu/fyfHufsvvbtBZy
+        TibowXm2d//B/sGDjNWp0Xv03jdtBj/NDsj0EeM/zGi5cZ8w3X74gHDY+XQ3yx7sTbP7uxm91bUY
+        JI6WtsZ4YHQM8+7PHYHJkoWI0gcOu69De8LhPahLghWoPvr6vU0ZUY8Gh95+eNRU2dM/m7twpnfv
+        Us/0s9GfuyRQGIKvOehPHZGM94ei6tvZL1oWv4hUQ7Ob31/8onv31m2RLeaz881Jo0FNTt99Xa2y
+        zC4Xe58+fEjT9k1N1gsCerE5IuohRTPsYeKx+YOdSbZ7/+B8+342Q+724YPtg8nOve1PyfV9eH7v
+        /MH9+xIBG36k96yKIRTeg/XtMESx3KOe7+/t59v3KS+xvf9wRvnj3Qf72/cm9/YPdnYosf4AItGV
+        V5p8S15fdBnm3Z9z6pI6CfGlDxySX4fwhMl7ELkrb/T17oO98e4D0jD/r0ig34K+nd6JvniJ6Lv9
+        s5VoAPwbkLrsKEB5JUwqzPLzbF2yLiE6/5yrwfPrfH5v77yc7xT5u59ezi+my/x6NS9+0WyjGhzw
+        eHe273+6/ZQTaEN6coPH+8ObKBoFfnYcXbx4SRy0bC4wRpoPf3ouZXLVswT1fwicNeTW4pXLxR4x
+        xYeZnYMHEPgfwkAGcVK9KIh4uu/Te9OHtDi6t/1pnn8Kn/LT7cl0/2D74ODBvd37swmlYO+x7jMq
+        it77ZozOlJThZOfhp9t79w/uQetOth+e3z/fPji/t7OXHzyc7uxDT3eVOImaJa6vzxnm3Z9r4pKJ
+        CdGlDxyOX4fuhMh70JiEKVBu9DWRWWwOTLj7/v97NudHJufn0OTsbj+5t/3kU2KO/++anP/vWBxi
+        ia9rcBbXL86QC/umxlBf1E3W3t/Z+fTe7r2HGemoT6MDGkTursHI0347n5LKyrKH2w8+nU1I+53v
+        bj/c2Zts79IbD8gA3Mse3GftZ5QUvffNWJ3zT/P9CWW/tycPJpRD+XRCy4zn5E2d57uTe9T7wc4B
+        mLyrxknaLIV9jc4w7/6/hspkbUK86QOH7NeZAELiPYhNkhUoOvr6vVMqHfWPbn+uqNxBhan8s7sk
+        8L4YqvrQP4FfsA4gaf/t/9dkg95Op/dnbX1etO/y5U/XVZvvrO9dl29Xk69jk+6TQdreOSae2WCT
+        aJz+sJVgqm8xqh/21A1pfpq6L4jsX1fvU96QfyP6f0MDaknh1he7ewfRYQwiRc6wwcRTOJRJmuWT
+        jHz8/N45LULu5tsH08nBdr4/yw6m5PHe/3SPFY7RDPSe1fgEhmb+F3/0Nqd5/OgyK9c5DZ2m9n10
+        kx2dGAJy1vPJOSW5aMYo6XNvjwzBXka/5dP80+nuPRoK8nNdhUosbkluvuM/qSnA3m3WP8d0J5Uv
+        aBmU7Qf4lvD8OrNCmLwHqUnmAt1CX/+/yQzcjsAdBIjA8kmxIhSZ/xrWrj98zFRz6J+yAACc7jaM
+        kFkDwEdAk+jta0D6U8kvA/uhKP58f2d39W53f6dc5avl8l2z+7b5wS/KL9t8o+If1Ov03ddTk5e0
+        0Hz1aZNfkbQQl31TEwewA8s2cX3/epqVOdFYXu18STj0R8ENPdQ9Md7d398539l9uL03nWbb+zsH
+        e9vZg+mDbUrp3/v04N7u+eThp19DjO0YRWPe35/emzyY5du7Ga3A7VPKfHvy6adT+m3n/mxv90H+
+        aQb1YrSNUT/EG33qG7cU7QH77v/3psCqVTNQ9603up/9WerKM3393sqWqE+DRW8/hNkwcqoE1z/l
+        lcB7xQfiwZIEYyTvocbgSGSzJ1mZLad5/SSbvs2XM236sqpKIhOx5Q9xtD468kI5uTvp48VfTfIV
+        /f4RVLH/3tlyUq2XsxdZ+2pdgjv+XzCEIsSJP15mLfAf79AIfnbsSbZ8N8/f/WAn/+lifW9Zr+6t
+        r366KOc/eDfdaE8GAond7ZPj7VPOUQwZHGY4n/+Ue1VdYFQ/hJn4eoqMbPr/9yzg7k36l3D3lOte
+        Ti78fUI0P/90tr2/f+8e+bQHlN/Iz8mRndzPsgezr6Fc7SDFBB5MHj6cPcx3tnezCRm+/U/vbx88
+        oPBhNzuffJrtTbKHM+DVtQzEzn3yF85IMOy7/x+cg/e2gT9L00SyGRgD+lptIJJ57tsf2cDA1jBf
+        /hBH66MjL5AB+f+5Ddwl9fvNGsEPNYIDRnB/+8np9t4z4pr/PxpBTMP/F63g7g0amHD31Ovs3u7e
+        +cOHOcVkE1Kv92cPt7OD+w+380/v7U9392a7k+nXUa92kGIFZ3uffpqd09r1Dq0UbO8fUCL24OHD
+        +6TTp/d3zu89fHj+8P9PgeCNc/DeVvBnaZpIOANzQF+rFXwQfPsjKxhYG+bLH+JofXTkBTIh/3+3
+        grQE9f8VK/hs+9NT4pr/X1pBmob/L1rBvRs0MOHuqde9h9MH9w7ybPv8wZRWNT7dyShK28u2aUUn
+        fzidnO9lef411KsdpFjBg4PZ3v7up+fbB7tI52UPp9sHk/18+975/cn9/Hx3sjO7aQHJDqFwZoJh
+        3/3/4By8txX8WZomEs7AHNDXagUPgm9/ZAUDa8N8+UMcrY+OvEAm5P/vVnCPhvD/ESt4uv3g/7ex
+        IE3D/xet4A0KmFD3tOuEtOf5w90H2/nknAKNnXPSruc7FKmdf/rw3uzBfv7wa2Xa7BjFCNKws08P
+        Hh5sP3iY7W/v7+493H44/XSfFHk+OXj44Hz/INuht7qmgdi5T/3CWQmGfff/e1Pw3jbwZ2mWSDQD
+        Y0Bfqw28H3z7IxsY2Bpmyx/iaH105AUyIP9/t4E0gv+PmMCD7Yf3iGn+f2kC/z9pAW8KQQh1T7fu
+        frpzP9t5QPHFpw8ebO+f57Pt7NMH59u7uzm9uX9vd/Jw52voVjtGsYD3dvfPz+/tnG/PDvYpitmf
+        3d8mpf5w+3z//qeT6f18f3dnj97qGgbi5j71C2cjGPbd/+9NwXtbwJ+lWSLJDEwBfa0WcHc3+PpH
+        JjAwNcyXP8TR+ujIC2Q//n9uAin8+P+KCaQVQWRN/v9oAmkW/j9oAu/doH8JdU+57uzd39l5sJdv
+        T/b3SLke7N/ffriXHWxP8unuND9/MMn2Pv0aytWOUUzgTr73cH9n/2B79mBvl1T4/j3KhN5/sJ1N
+        DnbvPcwePJjtQed2LQNxc5/6hTMSDPvu//em4L1N4M/SLJFkBqaAvmYTSCYQHon7+kcmMDA1zJc/
+        xNH66MgLZD/+f24C79EI/j9iAp9snxwT0/z/0QTSLPx/0ATev0H/Euqecp3uzvb39+/nlKE8n23v
+        T2eUocwPdrbv3T+fPHiwv3Mw+1oZNjtGMYEHB9Pp+YNsj7T3vYf0z2yfrB9ZxJ1sZ+/8/P6DyWwC
+        ndu1DMTNfeoXzkgw7Lv/35uC9zaBP0uzRJIZmAL62phAGAL39Y9MYGBqmC9/iKP10ZEXyH78/9wE
+        3qcR/H/EBJ5sH/z/dS2QZuH/gybw0xv0L6HuKdf83r1P811aWtr9lEzS/t6MQrOdvU+3dx+c0wpd
+        dn6ef/rwayhXO0Yxgef3JucPJw8m26TLP93ez6aUPp9MJtuf7t7PZ58+2CElPqG3upaBuLlP/cIZ
+        CYZ99/97U/DeJvBnaZZIMgNTQF8bE/ijtUCjsH9kAn/WhrDJBH5KI/j/iAl8sL13Qkzz/0cTSLPw
+        /0ET+OAG/Uuoe8r13u7DvXuz3fPtfO8+BWm7Dyfbk4fZ+fbe/vn9PJ/Q/x7e/xrK1Y5RTOD9nVm+
+        t//g3vaDyQ73cr79cJeIs/fw4b3Jzqe7Dx8+hObpWgbi5j71C2ckGPbd/+9NwXubwJ+lWSLJDEwB
+        fW1M4KfB1z8ygYGpYb78IY7WR0deIPvx/3MT+IBG8P8ZE3j8lJjm/48mkGbh/4Mm8OAG/Uuoe8r1
+        PPv04S7p0e0H5/dIuebZDq0y3SOMH9w7n96/N33wcJp9DeVqxygmcHqe3Z892N3d3tndI7qckzHM
+        Pt2hKCbbzw4OPr13f+feA3qraxmIm/vUL5yRYNh3/783Be9tAn+WZokkMzAF9LUxgZgO9/WPTGBg
+        apgvf4ij9dGRF8h+/P/cBB7QCP4/YgLvb7P2+tk1gR88EzdoMn7VyJXTZP+fNIEPb9C/hLqnXHf2
+        Jvt7091Pt/PsIWG8n9/bfnhv72A7zz+d7J9PzilgO/gaytWOUUzgvfPde9P9T7PtT/d3s+393Z1d
+        Wgt8kG/nk+mn55/u7pzvzYBX1zIQN/epXzgjwbDv/n9vCt7bBP4szVLXFNDXxgQeBF//yAQGpob5
+        8oc4Wh8deYHsx//PTeBDGsH/R0zg3vbTHWKa/z+aQJoF3wRery+y5cXV9u5PfvGChf+bwlsBRxE3
+        LETzgJ+eTtW3HDqeyswnB+cP8k/Ptx9QhEVrb+fT7Yez/MH2p/d3CLeD3YP72YRVplFt9N5V3rTr
+        hj4jMDTLv5hmnRB6D4VqRyVm72C2u3cvvz/dnu18SpTYO5huZ+cP97fv75znFBXuT4ka9FbXGhAH
+        W4oXag/sUNEesO/+v4PofVMWw/jrzAth9R6UJwkLVDp9TaZsl0wZ9Ln7dpMlW60nZTGlRgbENyeX
+        SoyNpO5075P6pX4FPUTI0KT8sJFTxaB/2ne2LwmXu4QC/XAfyt9AlgjvKz76U+dBxtgxvD87+r69
+        end/b1b9dLb70/kP8tXubJVPJ81PZzvZ19H397b3n2zvPCR22aDvCQTI9DqfruuivWY6YzA/zBmL
+        4WDf3N598fpzjJJmxJ8gnWbV/z8slOOmyb5DKoSM0Eft9Yow+si91hmp01E0MKtAZ9Oq2V5kDX23
+        /fTJ/XvPnjx8uE0++DZr3m92cNm0iY5vENG7G7HztObefcJodj6jsGl3RgHA/s529mD/YPtgf/rp
+        wf2DbDab7LPWNOqN3rPWjFB6D01qhyY27OHOPqnk80+3p/cnB9Tzp7Ptyf7B7vbDbPfTnfvn2YMH
+        e9CdXTNAUmmnwHz3oprlaAqwd/9fSXQyXoKqGYb9QHH/OlNCyL0H+UkgAxVJX+8+2KNlOTJl94Pv
+        +6YM8NiSEXFp2Ojuh0xslWD9U0kNG2EJfZdwob/1K5mF/28EarckgY9SMMrtcuKoEIve/LaIgWxr
+        CoXCof5sBnPf6DC7Ed7r19/e9tuahqTvoLP/vzKGl1Xd7u0NjuRnKXDdbdc/XV3u/2C9rvN6smiy
+        1aI4X+9fvr34Oo7M7vaz3e0Hz0iIfu4dmZsmKoZGOGHL5sJOAQZNmsNXJKqX1LP4IY5gyLXxcTd4
+        g3UI9W/Yz0H89UMa7CCi8eEa7DyjOj3Yzw/2dybbu/fOH9JaKdnT7Hw22Z7MdiY72e69/f3dh2xU
+        je2j974ZP+fe+ezBp7PJZHvnXvbp9v7OfSLHBDg8oA8/zffv3Z/C6Tf+gHEQSGjtFJjv1FdgsHf/
+        X0l069aYYdgPFPevMyWE3HuQnwQ0MO30tfVzPg2+/5GfA3Z3lupHfs7/+4YZ8RHi3gGFsv9f8Q4O
+        tp/csLJLIECjwCxjMD/kKYqhEU7V/y+8A2IdQv0b9g72aIZ/SIMdRDQ+XIOdZ4ryT3fPHzyktPHO
+        vYeT7f0DanUwy7CqPMs+peXl2b17MzZFxmLQe7fyDkj3UlPfPNmhiXdAaekHD6fZ7vbevYx6nlH3
+        Dx/Qnwc7Dx/mebY3eXgwobeMFTVmlYTWToH5Ti0sg737/0qiW2fADMN+oLh/nSkh5L4h7wBKyX3/
+        I+8A7O5s1I+8g//3DfPW3sEejfH/I97Bg+37p8R6P/IOfvZG8F7eAbEOof71vIPsIl+2L0XLQMXT
+        ui5N7c/pKF9PszInEdDRMobbNDFA0Q36ctE0O503Ccn+aO8ygN4QPUP24NPd+w8+zfLtSX5/b3t/
+        Qqv2WUbL1PnO3mT/wf3p9Pzh/a9hyCwtxI/Idu7t7326u0/riPfOt/fvnd/bPsgP7m2fP5x8uj/Z
+        ezDd+RRJfmNvjQEm8baTRSbaLLGjJaDe/f/vJFnXw5Dibjj+n/0Z1PFY60tf7+6M7+2RJwLb677u
+        eyJPr2nOmNFogmi46O6HNGFG7pXs+qdO1AZXxJ+Cr+uQ/H/Bgu1t7zzb3sEEbrBgNE5/2EpLZWGM
+        6oc0mT8L0keT9P9fA7B3O91CQ/TUx/mnD+5Nd/cfbD+Y7e3SyCa0nvtwsrt9PqUM8PnDvfPpzs7X
+        UB+WFmIAPt2/vzfLpg+2P72/QwZg79O97Wz/nMh5f+/T83z3wf18/6Y0c6gAGerd//9O0nsYgJ+l
+        GdTxWG1HXxsDcFOi+kcG4P/NBmBv+wkm8OelAUC48P9fA3DvdrqFhuipj4PzfLb76fmUMnv7+zSy
+        B7TGRZpkO/v03mT28NPZ/vnOwddQH5YWYgD273+6v7t7b2f74c7BbHv/4e759kPKLG7TgiPpqoPd
+        h/mDjN7qaj2SDjtZoQJkqHf//ztJ72EAfpZmUMdjtR19bQzATbnIHxmA/zcbgJ3tg5+3BuAeTVLX
+        AKjEEUn+Xzis9aSkxYkbRjWYVXBD8/TF5PzB/cn5wYPt/Z2cMgYH2f72w/uzT7fzSUbpmE93Hh7M
+        HnwNfWFpIBp/59NPJ5O9g53te0j87GeT2fbkYEorJg8eEEX3Z3vTHaiRrpojcbCzE2o8hnr3/3+T
+        8x6a/mdp5lR2rFqjr0nT4z9kCty3/z9S9DxzX1fPh+sx/+9deuKhBksygytP0rS78PT/EYN2sv3p
+        M5qU/88ZNKMjPkS5fIg9+6ZY8BtXmYNJElWZmGynFT+9f2/34f6UluAf7OTbJF0PKQN+cLA9u//p
+        QZ49OD/f2Zl8Da1oaSD2bO/+vU/P7+cUwUwPSPdO72fbDwny9t7Dh59mD/YOsofTe/RWV5mTNPz/
+        zJ7dNDnvYc9+lmauq77pa7Vn8Hvdtz+yZz+yZ/KnZ7jI4vxc2zMi5xOalJ+P9iyWoFO9QhT5/+qo
+        BnM+bmieVpxm+W62NznYfkD+PLn6WCw5OP+UAvf9c9JxB5Ode9OvoRUtDcSefXqQTaaf3n+wvTub
+        TaiX2YPtyb2HZM+mDymYmO7vT/egLbvKnKTBzk6o1xnq3f//Tc572LOfpZkjaQ/UN32t9gwRtPv2
+        R/bsR/ZM/vQMF1mcn2t7drx9f4cm5eejPevkG0lzHOztPji4t7N3PzsnmnxT46ovTr784ifze/k9
+        Srndf3gvOjrDijRh+Onpux5enlLb2Xsw/ZRabZ8/3Celdn9C6NyfkKf+6b3ZfkYpvlm+z0rNaB96
+        L8+adt3QZwSG2OEXE3sQQu+h8uzwxFg9uDfZ3T+YTbfzKXW/f//+p9vZA8p+zbLJAcKv3b3sJmNl
+        WIxaAeLd/5fRvG9lHMJfZzIIl/cgN/UVKFT6Wi0MtKn79odrYd6LwCp5+mdzFybmYG9v7/7e/sFe
+        fpewoQ8a/bkLhUXDYgKr0qE/dZRCg45R+dq6lnqKq8bd+9sP7m9/+pBoN6ga6eX2eoXp6o+YxoGf
+        jqVoUJbdibt29/ceHnx6f+9gmu/e271P3XxzE7PMF82DezOAf0Bh+nRv49z0MAXz7/bQ8/h8/8H5
+        3s7u/Ye0ZnC+S5mB2T3KttyfbVOKgDIE0/Pz3YOM+dwwJL33TSud2af3Hp4/2Nnb3qUFVqJMdn/7
+        4acPyLnb/ZQUzu70/sEBVGVXcGnO7SwQTzGLUStAvPv/TtLfUvfcek4In/egOvUVyB19vftgb7z7
+        6Xj3PbSPmGNqZIB8k2ro/UjeQYVIvipWDx7sH1Bk9SnJ6EeEEk3LzyWKMWX54HyH3z64TwHg+V1C
+        ij5s7j6rK/J2yCkF5jQXzBc/yyqTxAX8Sl5mxD3Nmvze/fuLvcufXq4vJxd7O79o1t5rJ79oPxtP
+        NrinMRUro6AGoMLrfLqui/aaSQpUf64mJ4ZPc/c8XzYX984zBvJgn0JJoi/puq9lHd6tyqwlRTCr
+        KN6o7x0cIJD8psbLwN/kTfv5T37xlDvYe3h/9zZDdsgKkC6GnjKaTfYe7u48nG7v5FgP3d+7vz35
+        9OHe9kF2cD9/OCU6PRRHyOgMes8aCELlPRSUHZ6YhYMD8kZmZMUJBVKDlL/ePrifHWzf28l3pw8p
+        o0Jd01tdnUp8bclvsge75Mke7O5+uvfpwQEMIMO/+//aGejbiaGBfJ2JIuzeY1K6qoe+/n+Bx8o0
+        ez/Cd1UxgxCaQysf7H/qEiTed/LRwwf3aAWQx/tzrpf3lvfvrc/frrJ31+vL6qrKftF8Uv6i3eV6
+        s14e8I2J4gfb+yc0SzHFzb4xj9MftpJSg2+M6udgXuMpBAVxuZjx2w8P9u/TNHwz6nt3ZwfK8Wdv
+        rJ8+2LkfHesgsgKki6GnFR6cP3g4o8hsey/fI996PyNf8mCSbz8g+0g8/fBhtpOzVjDiS+99M+o7
+        yx/s3sspPZtn984pgr6fbx/cu5dtf7pLydt8sv/w4cOb1nE9rfcpuXX3dw8+vQetw/Dv/r92Bkhb
+        h2OiD+ID+ToTRdi9x6SQ5AYair5+b/Xd8bPR7c/hDHSwMTMg5C9W93YePCAR/ohwo7n6OcZVdZP+
+        qSAEU9ic3YP9e3cJMfo1+E4++vT+fdJdRP5Q+dKfOmdCgB+OzSne3dtb7s7vXUzzn16dz9a/aKc9
+        f3d/f5ZvtDmDJoW++wCN3NIkkMR9esA5nZ+N+T2pc6LxPXo2zm8PVQES4ucJ+b3Jvb17+w+y7YN8
+        d297fy8/3z4438m2dw72d+4TM9Gi1n0WciON9B7h2M6hkrOmyOgrwuc95N+OUZXy/iTb3yVqTB48
+        yLf38wNCZXJOa5Pne7ufTh/euzd5CLeyq8CIP+wMOF326YNPiZgPHjwkG0vvAP7d/5dOA2ngcET0
+        QXwYX2e2CLf3mJKuANPX/29Vybekfwcbn/7F6tODnT2S4I8IM5qnn2NMowoZeEId7+8e7N4ltOhX
+        7xv54N69B/+vUcb77fre/rossvs/vZ5crBbz3flFNcvOm/NxsUEZxwOA453tew+39+CKDWprHqc/
+        bCWj+twY1c/BnN4QANzb3SMH8wN9/21Crp1vUx6XwvJd0hDbpFCIVN/4cH/yi9evZbx7D6KjHcRZ
+        YAwh6qmz+wcP7uU7+afbD2b3KUHwaZ5tP9w5/3T74YOH+Wz64OHOLP+U1ZnRO/QeQ/2mjM9DQu5B
+        /pAS++f37lNe+95s++F092B7mtPS2qfn5/f27uf0VldVkzzYSXFa+wElh3Yf3Nv9lPJz9A7g3/1/
+        +3yQ0QmHRh/Ex/N1po2wfI+5IYkONBd9zVbo/yVrAUzE95qIDjLDE0GLBCTnHxGONHc/tzir6tI/
+        FUIfYxinu4Qf/Rhs09CXGBbNnK+p6U+dSCHLD8VAUQfz66pdVsuL/H5Z19X1cnF1lZX3NhuoQftD
+        3324Dr//4P4Oidn9A0giMe/P3az3UBYYA3h6qmB27+H+w3vZ7nZOCQTK2+WT7Wyyd297f0I+/d7k
+        3s69bMqqwMgsvcdAvzENfp8Qm+6db5/nE6JPfnBAaujTve3zCTnE96YH072H6KOr5ohh7JR0NN7u
+        7v7u/T28A/h3/18+HaSvw5HRB/HhfJ1ZIyTfY2q6kk1f//9Zgbt5+P+I/nYID6pv16Sh7zAomraf
+        c+1N1FkXe/eztz+4XJ//9PTifL96926WFbMftvZeXL84w8LENzW/P51dZtNmUV/E44lBnO4aRDyh
+        vrczyQ7O93PShLsTEmUS6oe7e1NgMs0nDyc7k4MZC7WRPnqPkGnn03zZ1ln54fn1Tx/c3304fTjZ
+        /vTBA+r3YDrbPng4ybbvE08d7O6dHzw8hyfZ1Vg0/ZbAVnmhHWDe/bkmMunTEF36wOH4dehPSLwH
+        jbsCR1+zUv1/SW7mlsTtYMDEfamfkYB9RIgQ/X8OEOvqy8X1T744fXOX+id8mruv+ef2LnAkWv+c
+        a8L1+ez6F1XvaGX1F+XzoprOVxeT+WJ+cZ2Nf3qDJownWh7sbd/b2f70CXHIoKrkcfrDVoJpbgOj
+        +iHN2FByhWbsC6L2+6n07/+S/wfvTec4AjsBAA==
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['10856']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:04:53 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-ms-original-request-ids: [95b16910-477c-4ece-b28a-20f3e1f744e1, 5528f9b5-56c9-42dc-a303-cae296d637b9,
-        2a1d0f6c-672d-4509-96e1-296a52aaaaff, c9aff889-132e-45e4-a981-d43b14bcf4b1]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['10858']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:17:52 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-original-request-ids: [e2bd1a3b-e9b9-487f-a9aa-c549c26a23fe, 1a6339bc-65e6-4796-a161-2cd24b5414d2,
+        1c8d06b5-c349-4626-a90a-702d072e7e70, 2700b7c1-95af-42ca-9534-f53703e6b67a]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [db5553a1-a7aa-11e6-9e7e-a0b3ccf7272a]
+      x-ms-client-request-id: [4eda3910-a854-11e6-85b7-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkInterfaces?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/networkInterfaces?api-version=2016-06-01
   response:
     body:
       string: !!binary |
@@ -2178,276 +2201,278 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UeXWbnOP3qUfg9/pSl/iOejZbbA5x9Ny2K7zZt2e1lMPxrZr4sZvrzbrCfNtC5WbVEtm7s7k93z
         T/cf7G7vTs53tvdns2w7y6f3tqeTh3sP9s53Ht5/uHO3zptqXU/zz+tqvWruEvzfH/B/f4L/+zfT
-        fJnVRbV7d1VXl8Usr5u7XxTTumqq83b8Im+vqvrt3aX8PFu2eX2eTXMGEkMyb7MLoPndu7/vR9n9
-        Tx9MJjv3ts938vPt/cnBdDvb359sH3x6vnP/wXl278Fs9/f9yHu5rKYZhgUAVwR73XhfEuCGvvjF
-        v8R9RBiv8rotcv7CfCxfXBYNQSqWF6/brGWyvl5Pp3k+y2cOKDW1tFkLfe8d5A+m98+n2w/OD/a2
-        9x/uzbYPdvbubX/6afbp3l5+f+fhvjdeAlCsTqrleXGxrhl3oKIzK4+HFx47y8Vqyu/t+tDw/L94
-        ou92B0sfDI3iQzhBHkxjdH7lwde3nGV56IXikpqdvTyezYhUgPrR7s4Y/+3e39i+NKz5Rd7OK56f
-        p9c0kz7vm+ej1XpSFlN6y/bSw51a/VzOcgdDmmX5pFjtftRF1cmbeT4inIlPCP3/t43rsqjbdVbq
-        n83dxfUlIXqXcKEf+FN+u80Yae4XWX1NY2nrdR79XnlDaPiThBENldp/dPbycr/TxS/x//T++L4H
-        +KPZsnmdty1xc49n5Lv6kjqhr77nv0ZfZqtVWeSzp5vaFJDoZVY+rRZZsXxBSuj1+vy8eEdNP5rf
-        b2flcrVTt+/W986banc3372cNsufzsazd2Pz5nhaVusZ9TUOSegT7yOapUlJVHlW1VdZPaOxUAfn
-        Wdn4JPyIAGCCXufTdV201zzh1C4c8s8lI8UQBP8smwt/5OZXR4KP2usV66FBmE61KiSG8v3fOPkl
-        /w9WI/v+HwgAAA==
+        fJnVRXV3VVeXxSyvm7tfFNO6aqrzdvwib6+q+u3dpfw8W7Z5fZ5Nc4YRwzFvswtg+d27v+9HD3an
+        Dx7snk+29ybT6fb+3u75djY9eLA9ubfzgP53/mn28NPf9yPv5bKaZhgVAFwR7HXjfUmAG/riF/8S
+        9xFhvMrrtsj5C/OxfHFZNASpWF68brOWqfp6PZ3m+SyfOaDU1JJmLeQ9zx48nGW797Ynk4cPiZ75
+        ve2D6cF9ouf9/GCyN9nbeZgHAIrVSbU8Ly7WNeMOVHRi5fHwwmMnuVhN+b1dHxqe//fO893uWOmD
+        oUF8CCPIg1mMTq88+PqWkywPvVBcUrOzl8ezGVEKUD/a3Rnjv937G9uXhjO/yNt5xdPz9Jom0md9
+        83y0Wk/KYkpv2V56uFOrn8NJ7iBIkyyfFKvdj7qYOmkzz0eEMrEJYf//smFdFnW7zkr9s7m7uL4k
+        PO8SKvQDf8pvtxkizfwiq69pKG29zqPfK2cICX+SMKKRUvuPzl5e7ne6+CX+n94f3/cAfzRbNq/z
+        tiVe7nGMfFdfUif01ff81+jLbLUqi3z2dFObAvK8zMqn1SIrli9IA71en58X76jpR+ufvndvuVOu
+        m3dVfr7Yub972RTZbKe6PxvP3o3Nm+NpWa1n1Nc4JKFPvI9okiYlUeVZVV9l9YzGQh2cZ2Xjk/Aj
+        AoAJep1P13XRXvN8U7twyD+HfBTDD+yzbC78gZtfHQU+aq9XrIQGYTq9qpAYyvd/4+SX/D+eAI5A
+        GggAAA==
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:04:54 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:17:53 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [dbd3844f-a7aa-11e6-92c2-a0b3ccf7272a]
+      x-ms-client-request-id: [4f39f69e-a854-11e6-b10b-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkInterfaces/cli-test-nic?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/networkInterfaces/cli-test-nic?api-version=2016-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9aFoW223etNvLYvrRiL8qZvjibrOeNNO6WLVFtWzu7kx2zz/df7C7vTs539nen82y
-        7Syf3tueTh7uPdg733l4/+HO3TpvqnU9zT+vq/WquUuwf3/A/v0J9u/fTPNlVhfV7t1VXV0Ws7xu
-        7n5RTOuqqc7b8Yu8varqt3eX8vNs2eb1eTbNGUgXwbzNLoDid+/+vh9l9z99MJns3Ns+38nPt/cn
-        B9PtbH9/sn3w6fnO/Qfn2b0Hs93f9yN9saymGYaDl68I5rrRLwhgQx/+4l8ifxKGq7xui5w/xEfy
-        4WXR0NvF8uJ1m7VMvtfr6TTPZ/lMAFEzS4O10PHeQf5gev98uv3g/GBve//h3mz7YGfv3vann2af
-        7u3l93ce7uu46OVidVItz4uLdc14ovvvyVepwQOPnb1iNeX2uwYCnv8XT+Dd7gDpg9gIvu4My4Op
-        6s2fPPjqFrMoDzUuLqnJ2cvj2YxIA2gf7e6M8d/u/cG2pWGzL/J2XvFcPL2mGTP8a56PVutJWUzp
-        DQs9wJVa/FzOZAc7mkn5pFjtfuSjKTJjno8IV+IBQvv/TWO5LOp2nZX6Z3N3cX1JSN4lXOgH/pTf
-        No2L5neR1dc0hrZe573vdO6FVj9JWNDwqO1HZy8v9z2wv8T8qr98XwF9NFs2r/O2Ja4M+EA+ry8J
-        IH38PdOcvshWq7LIZ0+Hvi8ggcusfFotsmL5ghTG6/X5efGOmn00v9/OyuVqp27fre+dN9Xubr57
-        OW2WP52NZ+/G5s3xtKzWM+pn7EhjiPIRUX1S0oifVfVVVs8IbwJ8npWNIc1H9BKI/TqfruuivebJ
-        ozZuaD+XDBFDDnywbC7MSPFDhvtRe71iPTEIx6k7evuX/D/DXtFJYgcAAA==
+        7Syf3tueTh7uPdg733l4/+HO3TpvqnU9zT+vq/WquUuwf3/A/v0J9u/fTPNlVhfV3VVdXRazvG7u
+        flFM66qpztvxi7y9quq3d5fy82zZ5vV5Ns0ZRhe/vM0ugOF37/6+Hz3YnT54sHs+2d6bTKfb+3u7
+        59vZ9ODB9uTezgP63/mn2cNPf9+P9MWymmYYDV6+IpjrRr8ggA19+It/ifxJGK7yui1y/hAfyYeX
+        RUNvF8uL123WMvVer6fTPJ/lMwFEzSwJ1kLG8+zBw1m2e297Mnn4kOiW39s+mB7cJ7rdzw8me5O9
+        nYe5fblYnVTL8+JiXTOe6P578lVq8MBjJ69YTbn9roGA5/+983e3Oz76IDaArzvB8mCmetMnD766
+        xSTKQ42LS2py9vJ4NiPKANpHuztj/Ld7f7Btabjsi7ydVzwVT69pwgz7muej1XpSFlN6w0IPcKUW
+        P4cT2UGOJlI+KVa7H/lYisSY5yNClViAsP5/0VAui7pdZ6X+2dxdXF8SjncJFfqBP+W3TcOi2V1k
+        9TUNoa3Xee87nXkh1U8SFjQ6avvR2cvLfQ/sLzG/6i/fV0AfzZbN67xtiScDLpDP60sCSB9/zzSn
+        L7LVqizy2dOh7wvI3zIrn1aLrFi+IG3xen1+XryjZh+tf/reveVOuW7eVfn5Yuf+7mVTZLOd6v5s
+        PHs3Nm+Op2W1nlE/Y0caQ5SPiOiTkkb8rKqvsnpGeBPg86xsDGk+opdA7Nf5dF0X7TXPHbVxQ/s5
+        5IcYbmCDZXNhBoofMtqP2usVK4lBOE7X0du/5P8B7OiU6V0HAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:04:55 GMT']
-      etag: [W/"a567bb03-f0ef-4b8c-a44b-86f057fa37d1"]
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:17:53 GMT']
+      ETag: [W/"71c771fb-2bcc-421f-ac87-b307307f6a96"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [dc4de470-a7aa-11e6-a504-a0b3ccf7272a]
+      x-ms-client-request-id: [4fbcae1a-a854-11e6-9448-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkInterfaces/cli-test-nic?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/networkInterfaces/cli-test-nic?api-version=2016-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9aFoW223etNvLYvrRiL8qZvjibrOeNNO6WLVFtWzu7kx2zz/df7C7vTs539nen82y
-        7Syf3tueTh7uPdg733l4/+HO3TpvqnU9zT+vq/WquUuwf3/A/v0J9u/fTPNlVhfV7t1VXV0Ws7xu
-        7n5RTOuqqc7b8Yu8varqt3eX8vNs2eb1eTbNGUgXwbzNLoDid+/+vh9l9z99MJns3Ns+38nPt/cn
-        B9PtbH9/sn3w6fnO/Qfn2b0Hs93f9yN9saymGYaDl68I5rrRLwhgQx/+4l8ifxKGq7xui5w/xEfy
-        4WXR0NvF8uJ1m7VMvtfr6TTPZ/lMAFEzS4O10PHeQf5gev98uv3g/GBve//h3mz7YGfv3vann2af
-        7u3l93ce7uu46OVidVItz4uLdc14ovvvyVepwQOPnb1iNeX2uwYCnv8XT+Dd7gDpg9gIvu4My4Op
-        6s2fPPjqFrMoDzUuLqnJ2cvj2YxIA2gf7e6M8d/u/cG2pWGzL/J2XvFcPL2mGTP8a56PVutJWUzp
-        DQs9wJVa/FzOZAc7mkn5pFjtfuSjKTJjno8IV+IBQvv/TWO5LOp2nZX6Z3N3cX1JSN4lXOgH/pTf
-        No2L5neR1dc0hrZe573vdO6FVj9JWNDwqO1HZy8v9z2wv8T8qr98XwF9NFs2r/O2Ja4M+EA+ry8J
-        IH38PdOcvshWq7LIZ0+Hvi8ggcusfFotsmL5ghTG6/X5efGOmn00v9/OyuVqp27fre+dN9Xubr57
-        OW2WP52NZ+/G5s3xtKzWM+pn7EhjiPIRUX1S0oifVfVVVs8IbwJ8npWNIc1H9BKI/TqfruuivebJ
-        ozZuaD+XDBFDDnywbC7MSPFDhvtRe71iPTEIx6k7evuX/D/DXtFJYgcAAA==
+        7Syf3tueTh7uPdg733l4/+HO3TpvqnU9zT+vq/WquUuwf3/A/v0J9u/fTPNlVhfV3VVdXRazvG7u
+        flFM66qpztvxi7y9quq3d5fy82zZ5vV5Ns0ZRhe/vM0ugOF37/6+Hz3YnT54sHs+2d6bTKfb+3u7
+        59vZ9ODB9uTezgP63/mn2cNPf9+P9MWymmYYDV6+IpjrRr8ggA19+It/ifxJGK7yui1y/hAfyYeX
+        RUNvF8uL123WMvVer6fTPJ/lMwFEzSwJ1kLG8+zBw1m2e297Mnn4kOiW39s+mB7cJ7rdzw8me5O9
+        nYe5fblYnVTL8+JiXTOe6P578lVq8MBjJ69YTbn9roGA5/+983e3Oz76IDaArzvB8mCmetMnD766
+        xSTKQ42LS2py9vJ4NiPKANpHuztj/Ld7f7Btabjsi7ydVzwVT69pwgz7muej1XpSFlN6w0IPcKUW
+        P4cT2UGOJlI+KVa7H/lYisSY5yNClViAsP5/0VAui7pdZ6X+2dxdXF8SjncJFfqBP+W3TcOi2V1k
+        9TUNoa3Xee87nXkh1U8SFjQ6avvR2cvLfQ/sLzG/6i/fV0AfzZbN67xtiScDLpDP60sCSB9/zzSn
+        L7LVqizy2dOh7wvI3zIrn1aLrFi+IG3xen1+XryjZh+tf/reveVOuW7eVfn5Yuf+7mVTZLOd6v5s
+        PHs3Nm+Op2W1nlE/Y0caQ5SPiOiTkkb8rKqvsnpGeBPg86xsDGk+opdA7Nf5dF0X7TXPHbVxQ/s5
+        5IcYbmCDZXNhBoofMtqP2usVK4lBOE7X0du/5P8B7OiU6V0HAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:04:55 GMT']
-      etag: [W/"a567bb03-f0ef-4b8c-a44b-86f057fa37d1"]
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:17:54 GMT']
+      ETag: [W/"71c771fb-2bcc-421f-ac87-b307307f6a96"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkInterfaces/cli-test-nic",
-      "etag": "W/\"a567bb03-f0ef-4b8c-a44b-86f057fa37d1\"", "location": "westus",
-      "properties": {"dnsSettings": {"internalDomainNameSuffix": "h5tdlnp0rtxu3fso11e1vcsnja.dx.internal.cloudapp.net",
-      "appliedDnsServers": [], "internalDnsNameLabel": "noodle", "dnsServers": []},
-      "networkSecurityGroup": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkSecurityGroups/myothernsg"},
-      "provisioningState": "Succeeded", "enableIPForwarding": true, "ipConfigurations":
-      [{"etag": "W/\"a567bb03-f0ef-4b8c-a44b-86f057fa37d1\"", "properties": {"subnet":
-      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},
-      "privateIPAddressVersion": "IPv4", "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/publicIPAddresses/publicip1"},
-      "privateIPAllocationMethod": "Dynamic", "primary": true, "privateIPAddress":
-      "10.0.0.15", "provisioningState": "Succeeded"}, "name": "ipconfig1", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkInterfaces/cli-test-nic/ipConfigurations/ipconfig1"}],
-      "resourceGuid": "38e7c5fc-7f82-492d-8023-66a622e5094c"}, "tags": {}}'
+    body: '{"etag": "W/\"71c771fb-2bcc-421f-ac87-b307307f6a96\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/networkInterfaces/cli-test-nic",
+      "location": "westus", "properties": {"resourceGuid": "fa79da13-bb99-4de3-8c85-cb5e8b2b209e",
+      "dnsSettings": {"internalDnsNameLabel": "noodle", "dnsServers": [], "appliedDnsServers":
+      [], "internalDomainNameSuffix": "uj33n0lusxoefm051vsiad0o5d.dx.internal.cloudapp.net"},
+      "enableIPForwarding": true, "provisioningState": "Succeeded", "networkSecurityGroup":
+      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/networkSecurityGroups/myothernsg"},
+      "ipConfigurations": [{"etag": "W/\"71c771fb-2bcc-421f-ac87-b307307f6a96\"",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/networkInterfaces/cli-test-nic/ipConfigurations/ipconfig1",
+      "name": "ipconfig1", "properties": {"publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/publicIPAddresses/publicip1"},
+      "subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},
+      "primary": true, "privateIPAddress": "10.0.0.15", "provisioningState": "Succeeded",
+      "privateIPAllocationMethod": "Dynamic", "privateIPAddressVersion": "IPv4"}}]},
+      "tags": {}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
       Connection: [keep-alive]
-      Content-Length: ['1557']
+      Content-Length: ['1552']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [dc92b59e-a7aa-11e6-ac07-a0b3ccf7272a]
+      x-ms-client-request-id: [4ff1ac36-a854-11e6-a244-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkInterfaces/cli-test-nic?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/networkInterfaces/cli-test-nic?api-version=2016-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9aFoW223etNvLYvrRiL8qZvjibrOeNNO6WLVFtWzu7kx2zz/df7C7vTs539nen82y
-        7Syf3tueTh7uPdg733l4/+HO3TpvqnU9zT+vq/WquUuwf3/A/v0J9u/fTPNlVhfV7t1VXV0Ws7xu
-        7n5RTOuqqc7b8Yu8varqt3eX8vNs2eb1eTbNGUgXwbzNLoDid+/+vh99+vDhg2w6e7g9Ob93vr0/
-        nd3ffvhwb287y+7vzHbPZ5OHB/u/70f6YllNMwwHL18RzHWjXxDAhj78xb9E/iQMV3ndFjl/iI/k
-        w8uiobeL5cXrNmuZfK/X02mez/KZAKJmlgZroeO9g/zB9P75dPvB+cHe9v7Dvdn2wc7eve1PP80+
-        3dvL7+883Ndx0cvF6qRanhcX65rxRPffk69SgwceO3vFasrtdw0EPP8vnsC73QHSB7ERfN0ZlgdT
-        1Zs/efDVLWZRHmpcXFKTs5fHsxmRBtA+2t0Z47/d+4NtS8NmX+TtvOK5eHpNM2b41zwfrdaTspjS
-        GxZ6gCu1+LmcyQ52NJPySbHa/chHU2TGPB8RrsQDhPb/m8ZyWdTtOiv1z+bu4vqSkLxLuNAP/Cm/
-        bRoXze8iq69pDG29znvf6dwLrX6SsKDhUduPzl5e7ntgf4n5VX/5vgL6aLZsXudtS1wZ8IF8Xl8S
-        QPr4e6Y5fZGtVmWRz54OfV9AApdZSQ1ekLZ4nk3ykpp8tKyqWZk7TrQNn/2iGWMsDcbz++2sXK52
-        6vbd+t55U+3u5ruX02b509l49m5sXhpPy2o9I1zGIF8f6NNqkRVLIPB6fX5evEMHXweyADZT8hHN
-        +aQkej+r6qusnhHVCLA3Lx/RO5jp1/l0XRftNXMONXF0/bnkxhhyYMKqndPQmwszWvyQIX/UXq9Y
-        Uw0CcwqX3v4l/w+BaBai5AcAAA==
+        7Syf3tueTh7uPdg733l4/+HO3TpvqnU9zT+vq/WquUuwf3/A/v0J9u/fTPNlVhfV3VVdXRazvG7u
+        flFM66qpztvxi7y9quq3d5fy82zZ5vV5Ns0ZRhe/vM0ugOF37/6+Hz3Mpw8Pdu7f2945z/Pt/YcP
+        720f3Cfc9qZ7+5Pd+wd7D7Ps9/1IXyyraYbR4OUrgrlu9AsC2NCHv/iXyJ+E4Sqv2yLnD/GRfHhZ
+        NPR2sbx43WYtU+/1ejrN81k+E0DUzJJgLWQ8zx48nGW797Ynk4cPiW45ITg9uE90u58fTPYmezsP
+        c/tysTqplufFxbpmPNH99+Sr1OCBx05esZpy+10DAc//e+fvbnd89EFsAF93guXBTPWmTx58dYtJ
+        lIcaF5fU5Ozl8WxGlAG0j3Z3xvhv9/5g29Jw2Rd5O694Kp5e04QZ9jXPR6v1pCym9IaFHuBKLX4O
+        J7KDHE2kfFKsdj/ysRSJMc9HhCqxAGH9/6KhXBZ1u85K/bO5u7i+JBzvEir0A3/Kb5uGRbO7yOpr
+        GkJbr/PedzrzQqqfJCxodNT2o7OXl/se2F9iftVfvq+APpotm9d52xJPBlwgn9eXBJA+/p5pTl9k
+        q1VZ5LOnQ98XkL9lVlKDF6QqnmeTvKQmHy2ralZadeM1fPaLZoyxNBivf/reveVOuW7eVfn5Yuf+
+        7mVTZLOd6v5sPHs3Ni+Np2W1nhEuY5CvD/RptciKJRB4vT4/L96hg68DWQCbKfmIpnxSEr2fVfVV
+        Vs+IagTYm5eP6B3M9Ot8uq6L9poZh5o4uv4cMmMMN/Bg1c5p5M2FGSx+yIg/aq9XrKYGgTltS2//
+        kv8Hh7tRwt8HAAA=
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/a0305bf3-1604-496d-a3df-c2bb5dbeeaf7?api-version=2016-06-01']
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:04:56 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/5ee945dd-cf52-4c69-9778-54cad4119c92?api-version=2016-06-01']
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:17:55 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [dd288d00-a7aa-11e6-8f57-a0b3ccf7272a]
+      x-ms-client-request-id: [50783282-a854-11e6-bbcd-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkInterfaces/cli-test-nic?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/networkInterfaces/cli-test-nic?api-version=2016-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9aFoW223etNvLYvrRiL8qZvjibrOeNNO6WLVFtWzu7kx2zz/df7C7vTs539nen82y
-        7Syf3tueTh7uPdg733l4/+HO3TpvqnU9zT+vq/WquUuwf3/A/v0J9u/fTPNlVhfV7t1VXV0Ws7xu
-        7n5RTOuqqc7b8Yu8varqt3eX8vNs2eb1eTbNGUgXwbzNLoDid+/+vh99+vDhg2w6e7g9Ob93vr0/
-        nd3ffvhwb287y+7vzHbPZ5OHB/u/70f6YllNMwwHL18RzHWjXxDAhj78xb9E/iQMV3ndFjl/iI/k
-        w8uiobeL5cXrNmuZfK/X02mez/KZAKJmlgZroeO9g/zB9P75dPvB+cHe9v7Dvdn2wc7eve1PP80+
-        3dvL7+883Ndx0cvF6qRanhcX65rxRPffk69SgwceO3vFasrtdw0EPP8vnsC73QHSB7ERfN0ZlgdT
-        1Zs/efDVLWZRHmpcXFKTs5fHsxmRBtA+2t0Z47/d+4NtS8NmX+TtvOK5eHpNM2b41zwfrdaTspjS
-        GxZ6gCu1+LmcyQ52NJPySbHa/chHU2TGPB8RrsQDhPb/m8ZyWdTtOiv1z+bu4vqSkLxLuNAP/Cm/
-        bRoXze8iq69pDG29znvf6dwLrX6SsKDhUduPzl5e7ntgf4n5VX/5vgL6aLZsXudtS1wZ8IF8Xl8S
-        QPr4e6Y5fZGtVmWRz54OfV9AApdZSQ1ekLZ4nk3ykpp8tKyqWZk7TrQNn/2iGWMsDcbz++2sXK52
-        6vbd+t55U+3u5ruX02b509l49m5sXhpPy2o9I1zGIF8f6NNqkRVLIPB6fX5evEMHXweyADZT8hHN
-        +aQkej+r6qusnhHVCLA3Lx/RO5jp1/l0XRftNXMONXF0/bnkxhhyYMKqndPQmwszWvyQIX/UXq9Y
-        Uw0CcwqX3v4l/w+BaBai5AcAAA==
+        7Syf3tueTh7uPdg733l4/+HO3TpvqnU9zT+vq/WquUuwf3/A/v0J9u/fTPNlVhfV3VVdXRazvG7u
+        flFM66qpztvxi7y9quq3d5fy82zZ5vV5Ns0ZRhe/vM0ugOF37/6+Hz3Mpw8Pdu7f2945z/Pt/YcP
+        720f3Cfc9qZ7+5Pd+wd7D7Ps9/1IXyyraYbR4OUrgrlu9AsC2NCHv/iXyJ+E4Sqv2yLnD/GRfHhZ
+        NPR2sbx43WYtU+/1ejrN81k+E0DUzJJgLWQ8zx48nGW797Ynk4cPiW45ITg9uE90u58fTPYmezsP
+        c/tysTqplufFxbpmPNH99+Sr1OCBx05esZpy+10DAc//e+fvbnd89EFsAF93guXBTPWmTx58dYtJ
+        lIcaF5fU5Ozl8WxGlAG0j3Z3xvhv9/5g29Jw2Rd5O694Kp5e04QZ9jXPR6v1pCym9IaFHuBKLX4O
+        J7KDHE2kfFKsdj/ysRSJMc9HhCqxAGH9/6KhXBZ1u85K/bO5u7i+JBzvEir0A3/Kb5uGRbO7yOpr
+        GkJbr/PedzrzQqqfJCxodNT2o7OXl/se2F9iftVfvq+APpotm9d52xJPBlwgn9eXBJA+/p5pTl9k
+        q1VZ5LOnQ98XkL9lVlKDF6QqnmeTvKQmHy2ralZadeM1fPaLZoyxNBivf/reveVOuW7eVfn5Yuf+
+        7mVTZLOd6v5sPHs3Ni+Np2W1nhEuY5CvD/RptciKJRB4vT4/L96hg68DWQCbKfmIpnxSEr2fVfVV
+        Vs+IagTYm5eP6B3M9Ot8uq6L9poZh5o4uv4cMmMMN/Bg1c5p5M2FGSx+yIg/aq9XrKYGgTltS2//
+        kv8Hh7tRwt8HAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:04:58 GMT']
-      etag: [W/"6997acd9-bf3f-4cd5-9922-aa50d1fdb984"]
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:17:56 GMT']
+      ETag: [W/"9ec98053-0fee-4993-85da-2c24b15829aa"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkInterfaces/cli-test-nic",
-      "etag": "W/\"6997acd9-bf3f-4cd5-9922-aa50d1fdb984\"", "location": "westus",
-      "properties": {"dnsSettings": {"internalDomainNameSuffix": "h5tdlnp0rtxu3fso11e1vcsnja.dx.internal.cloudapp.net",
-      "internalFqdn": "noodle.h5tdlnp0rtxu3fso11e1vcsnja.dx.internal.cloudapp.net",
-      "appliedDnsServers": [], "internalDnsNameLabel": "doodle", "dnsServers": []},
-      "networkSecurityGroup": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkSecurityGroups/myothernsg"},
-      "provisioningState": "Succeeded", "enableIPForwarding": false, "ipConfigurations":
-      [{"etag": "W/\"6997acd9-bf3f-4cd5-9922-aa50d1fdb984\"", "properties": {"subnet":
-      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},
-      "privateIPAddressVersion": "IPv4", "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/publicIPAddresses/publicip1"},
-      "privateIPAllocationMethod": "Dynamic", "primary": true, "privateIPAddress":
-      "10.0.0.15", "provisioningState": "Succeeded"}, "name": "ipconfig1", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkInterfaces/cli-test-nic/ipConfigurations/ipconfig1"}],
-      "resourceGuid": "38e7c5fc-7f82-492d-8023-66a622e5094c"}, "tags": {}}'
+    body: '{"etag": "W/\"9ec98053-0fee-4993-85da-2c24b15829aa\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/networkInterfaces/cli-test-nic",
+      "location": "westus", "properties": {"resourceGuid": "fa79da13-bb99-4de3-8c85-cb5e8b2b209e",
+      "dnsSettings": {"internalDnsNameLabel": "doodle", "dnsServers": [], "internalFqdn":
+      "noodle.uj33n0lusxoefm051vsiad0o5d.dx.internal.cloudapp.net", "appliedDnsServers":
+      [], "internalDomainNameSuffix": "uj33n0lusxoefm051vsiad0o5d.dx.internal.cloudapp.net"},
+      "enableIPForwarding": false, "provisioningState": "Succeeded", "networkSecurityGroup":
+      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/networkSecurityGroups/myothernsg"},
+      "ipConfigurations": [{"etag": "W/\"9ec98053-0fee-4993-85da-2c24b15829aa\"",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/networkInterfaces/cli-test-nic/ipConfigurations/ipconfig1",
+      "name": "ipconfig1", "properties": {"publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/publicIPAddresses/publicip1"},
+      "subnet": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},
+      "primary": true, "privateIPAddress": "10.0.0.15", "provisioningState": "Succeeded",
+      "privateIPAllocationMethod": "Dynamic", "privateIPAddressVersion": "IPv4"}}]},
+      "tags": {}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
       Connection: [keep-alive]
-      Content-Length: ['1636']
+      Content-Length: ['1631']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [dd6dd361-a7aa-11e6-9799-a0b3ccf7272a]
+      x-ms-client-request-id: [51255a9e-a854-11e6-b4c1-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkInterfaces/cli-test-nic?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/networkInterfaces/cli-test-nic?api-version=2016-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9aFoW223etNvLYvrRiL8qZvjibrOeNNO6WLVFtWzu7kx2zz/df7C7vTs539nen82y
-        7Syf3tueTh7uPdg733l4/+HO3TpvqnU9zT+vq/WquUuwf3/A/v0J9u/fTPNlVhfV7t1VXV0Ws7xu
-        7n5RTOuqqc7b8Yu8varqt3eX8vNs2eb1eTbNGUgXwbzNLoDid+/+vh9N7k2ns+ns4fa96e797f1J
-        Ntme3M8fbu8c7N6b7h/s5p/uZb/vR/piWU0zDAcvXxHMdaNfEMCGPvzFv0T+JAxXed0WOX+Ij+TD
-        y6Kht4vlxes2a5l8r9fTaZ7P8pkAomaWBmuh472D/MH0/vl0+8H5wd72/sO92fbBzt697U8/zT7d
-        28vv7zzc13HRy8XqpFqeFxfrmvFE99+Tr1KDBx47e8Vqyu13DQQ8/y+ewLvdAdIHsRF83RmWB1PV
-        mz958NUtZlEealxcUpOzl8ezGZEG0D7a3Rnjv937g21Lw2Zf5O284rl4ek0zZvjXPB+t1pOymNIb
-        FnqAK7X4uZzJDnY0k/JJsdr9yEdTZMY8HxGuxAOE9v+bxnJZ1O06K/XP5u7i+pKQvEu40A/8Kb9t
-        GhfN7yKrr2kMbb3Oe9/p3AutfpKwoOFR24/OXl7ue2B/iflVf/m+Avpotmxe521LXBnwgXxeXxJA
-        +vh7pjl9ka1WZZHPng59X0ACl1lJDV6QtnieTfKSmnw0q6pZmTtOtA2f/aIZYywNxvP77axcrnbq
-        9t363nlT7e7mu5fTZvnT2Xj2bmxeGk/Laj0jXMYgXx/o02qRFUsg8Hp9fl68QwdfB7IANlPyEc35
-        pCR6P6vqq6yeEdUI8HlWNmZiPqKXMNWv8+m6LtprZh1q4wj7c8mOMeTAhVU7p7E3F2a4+CFj/qi9
-        XrGqGgTmNC69/Uv+H95xUn/lBwAA
+        7Syf3tueTh7uPdg733l4/+HO3TpvqnU9zT+vq/WquUuwf3/A/v0J9u/fTPNlVhfV3VVdXRazvG7u
+        flFM66qpztvxi7y9quq3d5fy82zZ5vV5Ns0ZRhe/vM0ugOF37/6+Hz2Y3ft0/97BzvZkL/90e//h
+        +b3th/n+g+3d2f50lu3sTO6f57/vR/piWU0zjAYvXxHMdaNfEMCGPvzFv0T+JAxXed0WOX+Ij+TD
+        y6Kht4vlxes2a5l6r9fTaZ7P8pkAomaWBGsh43n24OEs2723PZk8fEh0y+9tH0wP7hPd7ucHk73J
+        3s7D3L5crE6q5Xlxsa4ZT3T/PfkqNXjgsZNXrKbcftdAwPP/3vm72x0ffRAbwNedYHkwU73pkwdf
+        3WIS5aHGxSU1OXt5PJsRZQDto92dMf7bvT/YtjRc9kXeziueiqfXNGGGfc3z0Wo9KYspvWGhB7hS
+        i5/DiewgRxMpnxSr3Y98LEVizPMRoUosQFj/v2gol0XdrrNS/2zuLq4vCce7hAr9wJ/y26Zh0ewu
+        svqahtDW67z3nc68kOonCQsaHbX96Ozl5b4H9peYX/WX7yugj2bL5nXetsSTARfI5/UlAaSPv2ea
+        0xfZalUW+ezp0PcF5G+ZldTgBamK59kkL6nJR7OqmpVW3XgNn/2iGWMsDcbrn753b7lTrpt3VX6+
+        2Lm/e9kU2Wynuj8bz96NzUvjaVmtZ4TLGOTrA31aLbJiCQRer8/Pi3fo4OtAFsBmSj6iKZ+URO9n
+        VX2V1TOiGgE+z8rGTMxH9BKm+nU+XddFe82cQ20cYX8OuTGGG5iwauc09ObCjBY/ZMgftdcr1lOD
+        wJy6pbd/yf8DzJHdN+AHAAA=
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/1150cb45-8469-4b83-b8c4-465b27849a9d?api-version=2016-06-01']
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:04:57 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/cf2d31ae-7ed4-4e02-afef-c429df2bd536?api-version=2016-06-01']
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:17:58 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
       x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 200, message: OK}
 - request:
@@ -2455,47 +2480,47 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [dddbb061-a7aa-11e6-956d-a0b3ccf7272a]
+      x-ms-client-request-id: [51ffb686-a854-11e6-84df-a0b3ccf7272a]
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkInterfaces/cli-test-nic?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/networkInterfaces/cli-test-nic?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/cd02b5e3-7dcb-4b16-b07f-e4614316be2d?api-version=2016-06-01']
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Fri, 11 Nov 2016 01:04:58 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/cd02b5e3-7dcb-4b16-b07f-e4614316be2d?api-version=2016-06-01']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/b68b2ab4-9a5f-41d9-9292-5aa0087ffa6f?api-version=2016-06-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Fri, 11 Nov 2016 21:17:58 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/b68b2ab4-9a5f-41d9-9292-5aa0087ffa6f?api-version=2016-06-01']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 202, message: Accepted}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [dddbb061-a7aa-11e6-956d-a0b3ccf7272a]
+      x-ms-client-request-id: [51ffb686-a854-11e6-84df-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/cd02b5e3-7dcb-4b16-b07f-e4614316be2d?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/b68b2ab4-9a5f-41d9-9292-5aa0087ffa6f?api-version=2016-06-01
   response:
     body:
       string: !!binary |
@@ -2503,31 +2528,31 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UdNm7Xr5qNH6Uev19Npns/y2Ue/cfJL/h9PlJBHHQAAAA==
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:05:08 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:18:09 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODk2ODExLCJuYmYiOjE0Nzg4OTY4MTEsImV4cCI6MTQ3ODkwMDcxMSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.DTvb2nPz9KRycU7WP-lwG_ASqFQVLo_uB1DPzHXX3sdwiLqawLnftMltDIZfdAVsjCMWNntLIWVxshx1sP4sZIfzcw0ThFLSRMCjAJcTRFZTNzcaGwKUQ7BOQL35kJ-6adlUMm5EFg3Kjxcji4hiLRTgMA9tls_IKGa2GIDNj6edhKw3deiwEbDg05rv5RcORWz_OyHrCx_ASlucMhEFwuRvgOEsg2nLiVHRaS-qYoISV0HKfxY7aebYFmWw7PccYPBn6pRvBE7xsRsd8M8yOmnmxia0QTUreoTJ1WSBwaphOAe4nv4kKhfcd_MyxCEM7W53ALElpgnHj5kbtkNfeQ]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [e4a709cf-a7aa-11e6-8b20-a0b3ccf7272a]
+      x-ms-client-request-id: [59688662-a854-11e6-9252-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkInterfaces?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario/providers/Microsoft.Network/networkInterfaces?api-version=2016-06-01
   response:
     body:
       string: !!binary |
@@ -2535,14 +2560,14 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
         uc4/evS97/+S/wdC6kBEDAAAAA==
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['133']
-      content-type: [application/json; charset=utf-8]
-      date: ['Fri, 11 Nov 2016 01:05:10 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['133']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 11 Nov 2016 21:18:11 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_nic.yaml
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_nic.yaml
@@ -1,51 +1,49 @@
 interactions:
 - request:
-    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateVnet_2016-07-18/azuredeploy.json"},
+    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateVnet_2016-09-07/azuredeploy.json"},
       "mode": "Incremental", "parameters": {"subnetName": {"value": "mysubnet"}, "virtualNetworkPrefix":
       {"value": "10.0.0.0/16"}, "virtualNetworkName": {"value": "myvnet"}, "subnetPrefix":
       {"value": "10.0.0.0/24"}}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Length: ['348']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 vnetcreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 vnetcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [08e5eb68-7612-11e6-a3c4-a0999b14fe87]
+      x-ms-client-request-id: [20c4dbf0-a7aa-11e6-8b83-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Resources/deployments/azurecli1473373051.2165013","name":"azurecli1473373051.2165013","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVnet_2016-07-18/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"location":{"type":"String","value":"westus"},"subnetName":{"type":"String","value":"mysubnet"},"subnetPrefix":{"type":"String","value":"10.0.0.0/24"},"tags":{"type":"Object","value":{}},"virtualNetworkName":{"type":"String","value":"myvnet"},"virtualNetworkPrefix":{"type":"String","value":"10.0.0.0/16"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-09-08T22:17:31.9701784Z","duration":"PT0.298465S","correlationId":"9316c048-ee42-45b1-9704-82b0c10a8c75","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]}]}],"dependencies":[]}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478825981.7443243","name":"azurecli1478825981.7443243","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVnet_2016-09-07/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"dnsServers":{"type":"Array","value":[]},"location":{"type":"String","value":"westus"},"subnetName":{"type":"String","value":"mysubnet"},"subnetPrefix":{"type":"String","value":"10.0.0.0/24"},"tags":{"type":"Object","value":{}},"virtualNetworkName":{"type":"String","value":"myvnet"},"virtualNetworkPrefix":{"type":"String","value":"10.0.0.0/16"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-11-11T00:59:43.0921644Z","duration":"PT0.5826551S","correlationId":"de90eccd-93c2-4a4d-b600-8d4a21b3ee61","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]}]}],"dependencies":[]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/azurecli1473373051.2165013/operationStatuses/08587282338338059160?api-version=2015-11-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478825981.7443243/operationStatuses/08587227809029681539?api-version=2015-11-01']
       cache-control: [no-cache]
-      content-length: ['988']
+      content-length: ['1043']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:17:31 GMT']
+      date: ['Fri, 11 Nov 2016 00:59:42 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 vnetcreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 vnetcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [08e5eb68-7612-11e6-a3c4-a0999b14fe87]
+      x-ms-client-request-id: [20c4dbf0-a7aa-11e6-8b83-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587282338338059160?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587227809029681539?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -57,7 +55,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['141']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:18:01 GMT']
+      date: ['Fri, 11 Nov 2016 01:00:13 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -68,42 +66,41 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 vnetcreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 vnetcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [08e5eb68-7612-11e6-a3c4-a0999b14fe87]
+      x-ms-client-request-id: [20c4dbf0-a7aa-11e6-8b83-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
         o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXenZfH7t3nT7t5d1dVlMcvr5u4XxbSumuq8Hb/Sxs3dWb4qq+tFvmybu9kP1nVOL+7u
-        P7h378G9nfu7473dT+/v7N77aPTRMlvkhNrGNtTVKq/bIm8+evSLP2rzxarM2vx5sXyLv9d1QQDm
-        bbtqHt2VzprZ22kxnpTVZDyt6nx8VSxn1VUzXubtXfP6vGrauyd1Tr/+JH3+++/t7H66vfNge/dA
-        YMgIxj/dVEtCYVotWxrMT9J4iXbU3+54B/999EsIvaymQbT0FdApq2kG+uL39nqFwb1u62J5QVAu
-        s3KND66IgusG79KMUOcvMhBhuP3iWtq5N17W+XnxbtM7u4Qd/ru7t4/X2uyC0dPmX05+Op+2rvkv
-        /iXU5rKo23VWvsjbq6p+ezNSl4QIYIfvvQdqu59+hH4X1Qwfny2ndQ6WyUpqTJN+WYDY9O7rlmaJ
-        WrxeT6c5zcyMvm+LBVExW6zoc5m7h9s7B2/29h7tPni0f3987+HDh/v3dn+Kms7WtU7JRy/f7N4b
-        P9g72Nt7+OA1fUXsUefEDvTtGUTk4b3dT6c7+wfbeb6/t71/f7K7/fDBzv72wd5kZ7q7kx1MH9yn
-        1xg5MP9Hj773i5mHm1U2BYpOGJQc1JoYksXiDdFD3vA/oZdCAjb0iuEiNDfs8v1fQv/RaPJVvpzl
-        yynLw/fok2rdrtYt/UGo5Fc/SWDwq1K/N9OC/AbKGuQ+X7PWuHd/79P9yc7O9qc7n97b3t89v7ed
-        PXh4b3tvkh3sPZxl93YPpvRWNpvRi81rocMvNn8LNzCmwbx/n+ZdWBlfEeIZuI2YSj4kgNz5Xfrz
-        Z1VlEbFA87udKbgr3H2Xuqcf+FN+I7xyEiXC7Lt3f9+P7h3skrqa7W3v3N8jbtknImX383vb92af
-        frrzYHY+fTi99/t+RO9Qz54Go782TkBAOvrO0g2iTEwAmZE5twqXacgUu+3QPgKg/wcad1NJGQYA
-        AA==
+        p/nndbVeNXenZfH7t3nT/v7LYvr7N9N8mdVFtXt3VVeXxSyvm7tfFNO6aqrzdvxK32zuzvJVWV0v
+        8mXb3M1+sK5zgrK7/+DgYO/+w4Pd8YP9/Xt7+/c+Gn20zBY54bmxDXW1yuu2yJuPHv3ij9p8sSqz
+        Nn9eLN/i73VdEIB5266aR3els2b2dlqMJ2U1GU+rOh9fFctZddWMl3l717w+r5r27kmd068/SZ//
+        /ns7u59u7zzc3nkgMGQE459uqiWhMK2WLQ3mJ2m8REjqb3e8g/8++iWEXlbTIFr6CujMls3rvL7U
+        v9rrFYZ3XNfZNYG5zMo1/f2979NrZTXNMCtes9dtXSwvXLuProju6wad0DwSli8yUGu4/eJa2rk3
+        Xtb5efFu0zu7NAz8d3dvH6+12YWP+ZeTn86nrWv+i38Jtbks6nadlS/y9qqq396M1CUhAtjhe++B
+        2u6nH6HfRTXDx2fLaZ2Dt7KSGhN3XBaYFXr3dUvTSS1er6fTnKZwRt+3xYKomC1W9DlP8i6x/+6b
+        nd1HOzuPdvbHuw8/Pfj0/v2foqazda1T8tHLN3u7408PHty7/+nea/qK+KjOiW/o2zMI1ix/uJNP
+        p7Pth/eme9v72f5se/Lpzs72wWw/29ud3MvzT3fpNUYOUkKT/ouZ2ZtVNgWKTmqUHNSaOJfl5w3R
+        Q97wP6GXQgI29IrhIjQ37PL9X0L/0WjyVb6c5cspC8736JNq3a7WLf1BqORXP0lg8KtSvzfTgvwG
+        yhrkPl+zrpncv3c///Te+fbB9Dzb3s/z8+2Hn+7n27N8+nCSHRCJ9g/orWw2oxeb10KHX2z+Fm5g
+        TIN5h6jM5tPVl6LC8IYvYixKwur4iwaWgRuJ6eRD6pCRu0t//vAUIVEWE3S3M193RRTuEi70A3/K
+        b4RkTnJHaH737u/70c69B3u7D+9n23sH00+39/f3d7az2S4R897+5MHeg918Z2//9/2I3qGePb1I
+        f22crYDO9J0lMuSeOAYCJgxi1TgTlMl326F9BED/DwI4IWd8BgAA
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
-      content-length: ['913']
+      content-length: ['951']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:18:02 GMT']
+      date: ['Fri, 11 Nov 2016 01:00:13 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -115,45 +112,43 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Length: ['203']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 nsgcreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 nsgcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [1c1e765c-7612-11e6-9c56-a0999b14fe87]
+      x-ms-client-request-id: [34ac12f0-a7aa-11e6-9425-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Resources/deployments/azurecli1473373083.4656484","name":"azurecli1473373083.4656484","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateNsg_2016-07-18/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"mynsg"},"tags":{"type":"Object","value":{}}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-09-08T22:18:04.1475704Z","duration":"PT0.3739198S","correlationId":"48ca33a0-b7bb-4cd7-90cd-b956057c1c49","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[]}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478826015.1370549","name":"azurecli1478826015.1370549","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateNsg_2016-07-18/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"mynsg"},"tags":{"type":"Object","value":{}}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-11-11T01:00:16.389236Z","duration":"PT0.4313961S","correlationId":"8b0727f5-289d-47d8-b9b2-320a99980290","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/azurecli1473373083.4656484/operationStatuses/08587282338017039749?api-version=2015-11-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478826015.1370549/operationStatuses/08587227808695198121?api-version=2015-11-01']
       cache-control: [no-cache]
-      content-length: ['811']
+      content-length: ['823']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:18:03 GMT']
+      date: ['Fri, 11 Nov 2016 01:00:16 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 nsgcreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 nsgcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [1c1e765c-7612-11e6-9c56-a0999b14fe87]
+      x-ms-client-request-id: [34ac12f0-a7aa-11e6-9425-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587282338017039749?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587227808695198121?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -165,7 +160,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['141']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:18:33 GMT']
+      date: ['Fri, 11 Nov 2016 01:00:45 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -176,47 +171,47 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 nsgcreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 nsgcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [1c1e765c-7612-11e6-9c56-a0999b14fe87]
+      x-ms-client-request-id: [34ac12f0-a7aa-11e6-9425-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
         o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXenZfH7t3nT7t5d1dVlMcvr5u4XxbSumuq8Hb/Sxs3dWb4qq+tFvmybu9kP1nVOL+7u
-        P7h378G9nYN74/1P73+6f7D/0eijZbbICbWNbairVV63Rd589OgXf9Tmi1WZtfnzYvkWf6/rggDM
-        23bVPLornTWzt9NiPCmryXha1fn4qljOqqtmvMzbu+b1edW0d0/qnH590Vz8/ns7u59u7zzY3j0Q
-        EDKA8U831ZIwmFbLlsbykzRcIh11tzvewX8f/RLCLqtpDC19BWzKapqBvPi9vV5hbK/bulheEJTL
-        rFzjgysi4LrBuzL64ZaL62VzgYZtdsHgteGXk5/Op61r+It/yS+hRotqRr9/dLac1jlIn5XUgoh3
-        WQBrgvy6pdFSi9fr6TSnIc7o+7ZYEDrZYkWfCxEebu8cvNnbe7R78GhvZ7y/v7t7b//hT1HT2brW
-        sX308s3up+NPP31AE3TvNX1FZK5zIit9ewZW2z+YZvfuZTvbkweTyfb+dPZg++HOdLY9eXj/0537
-        D6a70/2H9BojByb66NH3fjFTo1llU6DomOpF3l5V9VtqTRPL7PWGiCBv+J/QSzS/aPo6nxJTtNfC
-        s/SimRS8ZKj//V9C/9GY8lW+nOXLKXPX9+iTat2u1i39QQjlVy9ef47fhuguI9hAXoPh52sWwfP7
-        B9l0P59t73x6n2Ru/yHJ3P6DbPvBQZ7d27u3v7e3c05vNTqCV+vSoDXLz7N12ZqxmW8IyQw89NFx
-        WVZXP0kUOFs+qdZL9M093v3ZFnqdn7vUNX4aBPVd5mBSB33k70YwzonPCefv3v19P9rZyybZ7N79
-        7Yf7+/vb+3vZve2Dyeze9sPppw/29rIH96fZg9/3I3qHcPK0A/21cT5muSUGfcMopMVygv7Tts7O
-        z4tpel5XizQry/Qnv2joy/QnX5y+oVcJdFtNq5Le+xb9KSR6WdXtq2x5gX7wKcFviyVzW/creeF4
-        NiPyNi/r/Lx4R9/8ZFG366xUKlIzD8KNbTMaWEPjloHQB6u6qEDhjx4Rf+3sELSC9CpgUaMzGedH
-        pCtCtjmGxnteZbMnWZktp3ntZuT/Czy0Af3/NzEUsExLQjOdKJ70OoH/WWCqHkWopQek2xyAbmCl
-        XQJwAys9zZfX9LIj/v/LeaeH7w+bWYAA65lCqGn4hRoSoJ8FtsA33kuxry0bADn62+cCYgN6/wYu
-        IIqKVv9y3RrC/r+cEWIo/7B5gXFIyfdgihpOUM1BLAJT1Fb21/8fWSUiOo+5z0Vn5HTX4bT8f4GT
-        Imj/v5SbDKb0PsH/WWAjfOO91P3a6/8GnumYHyItjyzgGWgsepu+M2T/fzm39BH+YfMJMGCG6LIK
-        tSRIP3yOwNeWFYAd/e1zArECvR/nhO9zEEwjofDNZiI4RGI+eK8J+wjQ/h/I6W3tNxEAAA==
+        p/nndbVeNXenZfH7t3nT/v7LYvr7N9N8mdVFtXt3VVeXxSyvm7tfFNO6aqrzdvxK32zuzvJVWV0v
+        8mXb3M1+sK5zgrK7/+DgYO/Tnd374917D3bu7z/8aPTRMlvkhOfGNtTVKq/bIm8+evSLP2rzxarM
+        2vx5sXyLv9d1QQDmbbtqHt2VzprZ22kxnpTVZDyt6nx8VSxn1VUzXubtXfP6vGrauyd1Tr++aC5+
+        /72d3U+3dx5s7x4ICBnA+KebakkYTKtlS2P5SRou0ZG62x3v4L+Pfglhl9U0hpa+AjZlNc1Aa/ze
+        Xq8wttdtXSwvCMplVq7xwRVRc93gXRn9cMvF9bK5QMM2u2Dw2vDLyU/n09Y1/MW/5JdQo0U1o98/
+        OltO6xykz0pqQcS7LIA1QX7d0mipxev1dJrTEGf0fVssCJ1ssaLPmQi7xB27b3Z2H+3sPLr3YPzp
+        w0/v7396/6eo6Wxd69g+evlmb3f84N7Bg51PP31NXxGZ65zISt+ege8OJjsP9h6c39/eO3g4295/
+        MDvYnjyc7G3f29vJHj58eLCz93CHXmPkwEQfPfreL2ZqNKtsChQdU73I26uqfkutaWKZvd4QEeQN
+        /xN6ieYXTV/nU2KK9loYmF40k4KXDPW//0voPxpTvsqXs3w5Ze76Hn1SrdvVuqU/CKH86sXrz/Hb
+        EN1lBBvIazD8fM3yuLe3M7v36W6+nT14eL69f57vbT/cod/yT/N7D2YPHmQ79/bprUZH8GpdGrRm
+        +Xm2LlszNvMNIZmBhz46Lsvq6ieJAmfLJ9V6ib65x7s/VA2gk3WX8MBPg60CYnYm3dAfyd0I+jkx
+        PQ3gu3d/34+mn2a7+b3zbHsvAzvtZ/e3H57f39n+dO/eg/v3Hx6c55/Oft+P6B3CyVMV9NfGyZnl
+        ljL0DaOQFssJ+k/bOjs/L6bpeV0t0qws05/8oqEv0598cfqGXiXQbTWtSnrvW/Sn0OtlVbevsuUF
+        +sGnBL8tlsx63a/khePZjGjdvKzz8+IdffOTRd2us1KpSM08CDe2zWhgDY1bBkIfrGiaQOGPHn16
+        f2dnh6AVpGQBixqdyTg/IsUR8tAx1N/zKps9ycpsOc1rNyP/n2OoDWP5fxN3Acu0JDTTieJJrxP4
+        nwUO61GEWnpAus0B6Aa+2iUAN/DV03x5TS874v9/iZF6yP+wOQcIsAYqhLSGeaghAfpZ4BF8470U
+        +9ryBJCjv32WIJ6g929gCaKo6Psv160h7P+XuCKG/w+bMRiHlPwVJq9hC9UpxC+wWG1lf/3/kfEi
+        ovOY+yx1Ro56HU7L/+fYKjKG/5eylsGU3if4Pws8hW+8l7pfe/3fwEAdK0Wk5ZEFDARdRm/Td4bs
+        /19inT72P2ymAQbMHV2+oZYE6YfPHvja8gWwo799tiC+oPfjbPF9DqlpJBQM2rwGB1zMFO81YR8B
+        2v8DT+JUaJIRAAA=
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
-      content-length: ['1249']
+      content-length: ['1265']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:18:34 GMT']
+      date: ['Fri, 11 Nov 2016 01:00:47 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -227,41 +222,42 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [2f538c1c-7612-11e6-ac14-a0999b14fe87]
+      x-ms-client-request-id: [488da4a1-a7aa-11e6-95ac-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test1/providers/Microsoft.Network/networkSecurityGroups/mynsg?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkSecurityGroups/mynsg?api-version=2016-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9aHG9bC4+GvFnxQyf3G3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb
-        08nDvQd75zsP7z/cuVvnTbWup/nndbVeNXenZfH7t3nT7t5d1dVlMcvr5u4XxbSumuq8Hb/I26uq
-        fnt3KT9f59N1XbTX+q6PUN5mF0Dpu3d/34929rJJNrt3f/vh/v7+9v5edm/7YDK7t/1w+umDvb3s
-        wf1p9uD3/UhfbK9XPLpbdqpvldU0w6Dx5hWhvzZfEBoNffiLf4n8SYNa5XVb5PwhPpIPL4uG3i6W
-        F6/brOX+X6+n0zyf5TMBRM0spdZC7fP7B9l0P59t73x6n8i7/5DIu/8g235wkGf39u7t7+3tnNuX
-        G8X61brkvr/3ffPNLD/P1mVrhmUbyNepwRKPnfrjsqyufpIIcrZ8Uq2XFkc8/y/ihbuxsd3diPzX
-        5Rt5MJW9+ZUHX91iluWhSbG0QzNGOS2WE+CbtnV2fl5M0/O6WqRZWaY/+UVDX6Y/+eL0TQcOddpW
-        06oEkG91vhNav6zq9lW2vGB0uk0IjbZYMmdvbCegjmczmsHmZZ2fF+/Q7CeLul1npc5U5x0P9vu9
-        mBHJGtBXyNL5dlUXFeaaviex2NkJv50VdT5Fl/T1R2dCz49ci19ifhVxxeNNYsj+xz9Y1/nzKps9
-        ycpsOc3rGDv9f0IWbjWS/+8JBkaVljSsdKLj6sCijn8OhaNH9c5rHvjeu90u3kskdsNvvxmReJov
-        r6nvGOf8v10GNqD+/06mB8Ks9wuZLcP3nbeoi59D9u4288Dd2NaxM4ba+TLgZmLn8NtvhpuJHcRF
-        +HLd9rni/+0MvRn7/3fyNOOcVuuWZ8xwtGpyYnW4OG1lf/2Rt8MPjdgThs3eDjED0/ZrSsPZss3r
-        IZ76/4REbBzB/6elwoysA4x6/jkUh24zD1yv7cAA3ov3N7k1NOVMwffnfRgg6pwA9Hnm/+1cvwn3
-        /3fyOzBmxu6yfOc16uP/I5zdbetYGmPtfBlwNLF0+O3tOVp++T5+0O+/5P8BrV30/bcTAAA=
+        08nDvQd75zsP7z/cuVvnTbWup/nndbVeNXenZfH7t3nT/v7LYvr7N9N8mdVFtXt3VVeXxSyvm7tf
+        FNO6aqrzdvwib6+q+u3dpfx8nU/XddFeKyAfu7zNLoDfd+/+vh9NP81283vn2fZe9nC2vb+f3d9+
+        eH5/Z/vTvXsP7t9/eHCefzr7fT/SF9vrFQ/1lp3qW2U1zUABvHlFY1mbLwiNhj78xb9E/qRBrfK6
+        LXL+EB/Jh5dFQ28Xy4vXbdZy/6/X02mez/KZAKJmlmxrIf3e3s7s3qe7+Xb24OH59v55vrf9cId+
+        yz/N7z2YPXiQ7dzbty83ivWrdcl9f+/75ptZfp6ty9YMyzaQr1ODJR7LB8dlWV39JBHkbPmkWi8t
+        jnj+38oYd2MDvbtxJF+XieTBvPYmWx58dYspl4dmyBISzRjltFhOgG/a1tn5eTFNz+tqkWZlmf7k
+        Fw19mf7ki9M3HTjUaVtNqxJAvtX5Tgj/sqrbV9nygtHpNiE02mLJbL6xnYA6ns1oOpuXdX5evEOz
+        nyzqdp2VOlOddzzY7/diRiRrQF8hS+fbFTEM5pq+//T+zs5O+O2sqPMpuqSvPzoTen7kWvwS86vI
+        Lh5vEkNZOP7Bus6fV9nsSVZmy2lex9jp/3uCcath/X9PSjCqtKRhpRMdVwcWdfxzKCk9qnde88D3
+        3u128V7ysRt++83Ix9N8eU19xzjn/1MCsWEc/++UACDMFqGQqTNC0HmLuvg55PVuMw/cjW0db2Oo
+        nS8D1ibeDr/9Zlib2EGchy/XbZ8r/j/F3ZuH8v9OBmec02rd8vQZ9lYdT3wPT6it7K8/cor4oRF7
+        krHZKSJmYNp+TdE4W7Z5PcRT/98Tj43D+f+0iJiRdYBRzz+HstFt5oHrtR0YwHsJwibvh6acKfj+
+        ggDTRJ0TgD7P/H9KBDYN5P+dzA+Mmcu7/N95jfr4/wibd9s6/sZYO18G7E38HX57e/aWX76PH/T7
+        L/l/ADGeOUASFAAA
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:18:35 GMT']
-      etag: [W/"02abad35-9444-42a3-8bd3-9c6722a75ca7"]
+      date: ['Fri, 11 Nov 2016 01:00:47 GMT']
+      etag: [W/"c6a1e3fa-2a9d-44a5-9f50-62375598fe6d"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -274,45 +270,43 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Length: ['208']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 nsgcreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 nsgcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [2f941d7a-7612-11e6-9fcf-a0999b14fe87]
+      x-ms-client-request-id: [49096451-a7aa-11e6-b4db-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Resources/deployments/azurecli1473373116.15258","name":"azurecli1473373116.15258","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateNsg_2016-07-18/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"myothernsg"},"tags":{"type":"Object","value":{}}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-09-08T22:18:36.7890597Z","duration":"PT0.3283724S","correlationId":"bc67b651-9c59-477d-9a63-387072b5611c","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[]}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478826049.2911366","name":"azurecli1478826049.2911366","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateNsg_2016-07-18/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"myothernsg"},"tags":{"type":"Object","value":{}}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-11-11T01:00:50.5768411Z","duration":"PT0.5252519S","correlationId":"a9826e4d-8116-4f3e-ad88-e57114cad5f8","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/azurecli1473373116.15258/operationStatuses/08587282337690169361?api-version=2015-11-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478826049.2911366/operationStatuses/08587227808354260746?api-version=2015-11-01']
       cache-control: [no-cache]
-      content-length: ['812']
+      content-length: ['829']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:18:36 GMT']
+      date: ['Fri, 11 Nov 2016 01:00:49 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1194']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 nsgcreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 nsgcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [2f941d7a-7612-11e6-9fcf-a0999b14fe87]
+      x-ms-client-request-id: [49096451-a7aa-11e6-b4db-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587282337690169361?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587227808354260746?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -324,7 +318,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['141']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:19:06 GMT']
+      date: ['Fri, 11 Nov 2016 01:01:19 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -335,99 +329,100 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 nsgcreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 nsgcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [2f941d7a-7612-11e6-9fcf-a0999b14fe87]
+      x-ms-client-request-id: [49096451-a7aa-11e6-b4db-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
         o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXenZfH7t3nT7t5d1dVlMcvr5u4XxbSumuq8Hb/Sxs3dWb4qq+tFvmybu9kP1nVOL+7u
-        P7h378G93d1Px7v39+4ffDT6aJktckJsQwvqZpXXbZE3Hz36xR+1+WJVZm3+vFi+xd/ruqDX5227
-        ah7dlY6a2dtpMZ6U1WQ8rep8fFUsZ9VVM17m7V3z+rxq2rsndU6/vmgufv+9nd1Pt3cebO8eCAhB
-        fvzTTbUkDKbVsqVx/CQNlchG3e2Od/DfR7+EsMtqGkFLXwGbsppmIC1+b69XGNnrti6WFwTlMivX
-        +OCKiLdu8K6Mfbjl4rpq53m9bC7Qus0uuA9t/eXkp/Np61r/4l/yS6jRoprR7x+dLad1DtpnJbUg
-        Cl4WQJ3Av25pyNTi9Xo6zWmcM/q+LRaEU7ZY0edCiYfbOwdv9vYe7R48un9vvPPppw8ODnZ/iprO
-        1rUO8KOXb2iSPt35dHdn5+A1fUW0rnOiLX17Bl6bTD99MPn0/u72w+n9h9v7Dx7Mth9mn97bvnfw
-        YOfB3uT+p7u7U3qNkQMXffToe7+YSdKssilQdFz1Im+vqvottabZZf56Q0SQN/xP6CWaZDR9nU+J
-        M9prYVp60cwMXjJT8P1fQv/RmPJVvpzlyymz2Pfok2rdrtYt/UEI5VcvXn+O34boLiPYQF6D4edr
-        lsHz/N6Dnex+vp1nDw6293fPHxBd8vv05/75p+fZeTZ7kNNbjY7g1bo0aM3y82xdtmZs5htCMgMj
-        fXRcltXVTxIFzpZPqvUSfXOPd3+2pV7n5y51jZ8GQX3XsTEphf4I7kbQzonZCfHv3v19P9p9cPBp
-        Pt3Z2d7Jpve393fy3e3s00+nhHL+KVFs796ne/nv+xG9Q4h5eoL+2jgps9xShL5hFNJiOUH/aVtn
-        5+fFND2vq0WalWX6k1809GX6ky9O39CrBLqtplVJ732L/hQ6vazq9lW2vEA/+JTgt8WSWa77lbxw
-        PJsRjZuXdX5evKNvfrKo23VWKimpmQfhxrYZDayhcctA6INVXVSg8EePPr2/s7ND0ArSr4BFjc5k
-        nB+Rwgh55xi673mVzZ5kZbac5rWbkf/PMNKGMfy/iauAZVoSmulE8aTXCfzPAmf1KEItPSDd5gB0
-        Az/tEoAb+Olpvrymlx3x/7/AQD2kf9gcAwRY4xRCUsM01JAA/SzwBr7xXop9bXkByNHfPisQL9D7
-        N7ACUVT0+5fr1hD2/wvcEMP7h80QjENK/giT1bCD6hDiE1imtrK//v/ISBHRecx9Vjojb7wOp+X/
-        M+wUwf3/pSxlMKX3Cf7PAi/hG++l7tde/zcwTscaEWl5ZAHjQHfR2/SdIfv/F1imj/UPm1mAAXNF
-        l1+oJUH64bMFvrb8AOzob58diB/o/Tg7fJ9DZBoJBXc2UcEBFDPD+8/aRwD5/wCcPGlOWxEAAA==
+        p/nndbVeNXenZfH7t3nT/v7LYvr7N9N8mdVFtXt3VVeXxSyvm7tfFNO6aqrzdvxK32zuzvJVWV0v
+        8mXb3M1+sK5zgrK7/+DgYO/Tnf2H472Hu7v3Pv30o9FHy2yRE54b21BXq7xui7z56NEv/qjNF6sy
+        a/PnxfIt/l7XBQGYt+2qeXRXOmtmb6fFeFJWk/G0qvPxVbGcVVfNeJm3d83r86pp757UOf36orn4
+        /fd2dj/d3nmwvXsgIGQA459uqiVhMK2WLY3lJ2m4REfqbne8g/8++iWEXVbTGFr6CtiU1TQDrfF7
+        e73C2F63dbG8ICiXWbnGB1dEzXWDd2X0wy0X11U7z+tlc4HWbXbBfWjrLyc/nU9b1/oX/5JfQo0W
+        1Yx+/+hsOa1z0D8rqQVR8LIA6gT+dUtDphav19NpTuOc0fdtsSCcssWKPmdK7BKL7L7Z2X2E/z0Y
+        7+3e/3Tn4YOfoqazda0D/Ojlm90H491P93f2du6/pq+I1nVOtKVvz8B82UOaynx/tn2wSyD3z+/l
+        29ns4GA7v/9gd3d/ms3unx/Qa4wcOOmjR9/7xUySZpVNgaLjrBd5e1XVb6k1zS7z2Bsigrzhf0Iv
+        0SSj6et8SpzRXgsX04tmZvCSmYLv/xL6j8aUr/LlLF9OmcW+R59U63a1bukPQii/evH6c/w2RHcZ
+        wQbyGgw/X7NQHkwf5tPz2cPt7NPd8+39+3ufEl12ZtuTT6eTLH+wM92b7NNbjY7g1bo0aM3y82xd
+        tmZs5htCMgMjfXRcltXVTxIFzpZPqvUSfXOPd3+oakAn6y7hgZ8GWwXkeJq0RH84dyNjyInzaRTf
+        vfv7fpTdn872H967t30/28u293fy+9sH9/aJYXc+zXZ2Z/fOD6a7v+9H9A4h5ikN+mvjDM1ySx76
+        hlFIi+UE/adtnZ2fF9P0vK4WaVaW6U9+0dCX6U++OH1DrxLotppWJb33LfpTiPayqttX2fIC/eBT
+        gt8WS+a/7lfywvFsRgRvXtb5efGOvvnJom7XWamkpGYehBvbZjSwhsYtA6EPVjRXoPBHjz69v7Oz
+        Q9AKUreARY3OZJwfkfYIGekYivB5lc2eZGW2nOa1m5H/b3LVhgH9v4nFgGVaEprpRPGk1wn8zwKb
+        9ShCLT0g3eYAdANz7RKAG5jrab68ppcd8f8/x029Efyw2QcIsC4qhL6Gg6ghAfpZYBR8470U+9oy
+        BpCjv32+IMag92/gC6KoaP4v160h7P/nWCM2iB82dzAOKfkwTGPDG6pdiGlgwNrK/vr/I1tGROcx
+        9/nqjDz4OpyW/2/yVmQg/y/lL4MpvU/wfxYYC994L3W/9vq/gYs6RotIyyMLuAhajd6m7wzZ/z/H
+        P/0h/LA5Bxgwi3SZh1oSpB8+j+BryxzAjv72eYOYg96P88b3OeCmkVCoaFMfHI4xZ7z/rH0EkP8P
+        CIPI97oRAAA=
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
-      content-length: ['1252']
+      content-length: ['1262']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:19:06 GMT']
+      date: ['Fri, 11 Nov 2016 01:01:21 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreatePublicIp_2016-07-19/azuredeploy.json"},
+    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreatePublicIp_2016-09-14/azuredeploy.json"},
       "mode": "Incremental", "parameters": {"allocationMethod": {"value": "dynamic"},
-      "dnsNameType": {"value": "none"}, "name": {"value": "publicip1"}, "_artifactsLocation":
-      {"value": "https://azuresdkci.blob.core.windows.net/templatehost/CreatePublicIp_2016-07-19"}}}}'
+      "version": {"value": "ipv4"}, "name": {"value": "publicip1"}, "_artifactsLocation":
+      {"value": "https://azuresdkci.blob.core.windows.net/templatehost/CreatePublicIp_2016-09-14"},
+      "dnsNameType": {"value": "none"}, "idleTimeout": {"value": 4}}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
-      Content-Length: ['404']
+      Content-Length: ['463']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 publicipcreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 publicipcreationclient/2015-11-01 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [42ca9c17-7612-11e6-8b9b-a0999b14fe87]
+      x-ms-client-request-id: [5d831751-a7aa-11e6-8b5b-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Resources/deployments/azurecli1473373148.341907","name":"azurecli1473373148.341907","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreatePublicIp_2016-07-19/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreatePublicIp_2016-07-19"},"allocationMethod":{"type":"String","value":"dynamic"},"dnsName":{"type":"String","value":""},"dnsNameType":{"type":"String","value":"none"},"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"publicip1"},"tags":{"type":"Object","value":{}}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-09-08T22:19:09.4486382Z","duration":"PT0.3188545S","correlationId":"5625c782-4542-434b-b64f-c65b6d333f58","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]}]}],"dependencies":[]}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478826083.659178","name":"azurecli1478826083.659178","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreatePublicIp_2016-09-14/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreatePublicIp_2016-09-14"},"allocationMethod":{"type":"String","value":"dynamic"},"dnsName":{"type":"String","value":""},"dnsNameType":{"type":"String","value":"none"},"idleTimeout":{"type":"Int","value":4},"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"publicip1"},"reverseFqdn":{"type":"String","value":""},"tags":{"type":"Object","value":{}},"version":{"type":"String","value":"ipv4"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-11-11T01:01:24.6663342Z","duration":"PT0.3646618S","correlationId":"16abc600-e7c7-448b-a73c-399b134db286","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["westus"]}]}],"dependencies":[]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/azurecli1473373148.341907/operationStatuses/08587282337363478453?api-version=2015-11-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478826083.659178/operationStatuses/08587227808011760038?api-version=2015-11-01']
       cache-control: [no-cache]
-      content-length: ['1084']
+      content-length: ['1222']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:19:08 GMT']
+      date: ['Fri, 11 Nov 2016 01:01:24 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 publicipcreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 publicipcreationclient/2015-11-01 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [42ca9c17-7612-11e6-8b9b-a0999b14fe87]
+      x-ms-client-request-id: [5d831751-a7aa-11e6-8b5b-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587282337363478453?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587227808011760038?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -439,7 +434,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['141']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:19:39 GMT']
+      date: ['Fri, 11 Nov 2016 01:01:54 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -450,40 +445,41 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 publicipcreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 publicipcreationclient/2015-11-01 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [42ca9c17-7612-11e6-8b9b-a0999b14fe87]
+      x-ms-client-request-id: [5d831751-a7aa-11e6-8b5b-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
         o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXenZfH7t3nT7t5d1dVlMcvr5u4XxbSumuq8Hb/Sxs3dWb4qq+tFvmybu9kP1nVOL+7u
-        P7h378G93f2D8b393Yc7Dz4afbTMFjlhtqkJdbTK67bIm48e/eKP2nyxKrM2f14s3+LvdV3Q+/O2
-        XTWP7kpXzezttBhPymoynlZ1Pr4qlrPqqhkv8/aueX1eNe3dkzqnX1+uJ2UxPVv9/ns7u59u7zzY
-        3n0ocGQM459uqiWhMa2WLQ3nJ2nERD3qc3e8g/8++iWEYlbTOFr6Cij9/hlhe55N2+Z5Nc1Aa3za
-        Xq8w0tdtXSwvCN5lVq7xwTeMOtDJylI7/iJv5xVN/XD3s2uagmKK12bL5kWG6Rhu7TV7w02Gmy6r
-        ZY7mBpVNba+Io9YNWhMy9MFwyxWPuFjtonGbXTDBtfGXk5/Op61r/It/yS+hRotqRr9/dLac1jn4
-        MSupBfHUZYF5JOivW6IktXi9nk5zmvQZfd8WC0IpW6zoc6Htw+2dgzd7e492Hz7aezDeffBg/+H+
-        g5+iprN1reP76OWb3YPxzv6DB7u7r+kbmsE6pxmjL89oDj66/+ne/emDg73t/fv79M+9/cn25NP9
-        8+3pp/cnn87u3bt3fv+AXmPcIFgfPfreL2aCNKtsCgydoL3I26uqfkutiWdY5DAd8ob/Cb0kFDt7
-        eTyb0TcNNXJzghcM8b//S+g/Gk6+ypezfDllefsefVKt29W6pT9+sYFFVBkmuuC/gbaEBeP3+ZqV
-        0sHBJH9wvv9ge+c+/bO/c2+2PTnYIy10nu/mB+f3sizbpbe065fHPd7+6Kmy8OijYlbmb2jqCOWz
-        5RfFck2q6qNH+8wH9BkNw2ooGptqxR5V79q+DMn0E2a77/+SX/L/AOKDZn1PBQAA
+        p/nndbVeNXenZfH7t3nT/v7LYvr7N9N8mdVFtXt3VVeXxSyvm7tfFNO6aqrzdvxK32zuzvJVWV0v
+        8mXb3M1+sK5zgrK7/+DgYO/TnYN740/vP9x9cPDR6KNltsgJzU1NqKNVXrdF3nz06Bd/1OaLVZm1
+        +fNi+RZ/r+uC3p+37ap5dFe6amZvp8V4UlaT8bSq8/FVsZxVV814mbd3zevzqmnvntQ5/fpyPSmL
+        6dnq99/b2f10e+fh9u6+wJExjH+6qZaExrRatjScn6QREympz93xDv776JcQillN42jpK6D0+2eE
+        7Xk2bZvn1TQD4fFpe73CSF+3dbG8IHiXWbnGB98w6kAnK0vt+Iu8nVfEB8Pdz65pCoopXpstmxcZ
+        pmO4tdfsDTcZbrqsljmaF7Myf1Ms8mrdes3Plq1ru0/NDMZemx7IK+LCdQOghDN9MNxyxYQpVrto
+        XOeXNDP5s1802wgdTdvsgqdQ23w5+el86iH6i38JtQGwGxAtVpc0EdR2Uc3w99lyWucQhqykVsTQ
+        lwVA0EuvW5pGavF6PZ3mxHEz+r4lajVttljR5zyxuySvu292dh/R//Z3xvsPd3ce/hQ1nK1rpdlH
+        L9/sfjrePXi4v/vg09f0FXFPnRO30LdnNP8f7X6aTaaf7uxs5w+mD7b39w8m29mDe9Ptew8fTnbv
+        7c8mewef0muMGoT6o0ff+8VM5WaVTYGgE/IXeXtV1W+pNfEriztYQd7wP6GXZBrOXh7PZvRNQ43c
+        ROMFM6Pf/yX0H40nX+XLWb6csqx/jz4hplmtW/rjFxtYRBRL9970CP4bSEtYMH6fr1k73n84uzf7
+        9GG+/XD68GB7/97uw+3s/v2d7Yf38tnu3s7+zr38Ib2lXb887snVR09VfAI+P1t+USzXpDPB2mAD
+        +oyGYbUjjU3Vc4+qd21fhmT6CfPy93/JL/l/AFHmFzbYBQAA
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
-      content-length: ['846']
+      content-length: ['891']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:19:39 GMT']
+      date: ['Fri, 11 Nov 2016 01:01:55 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -494,34 +490,34 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [5600d838-7612-11e6-b625-a0999b14fe87]
+      x-ms-client-request-id: [716aea8f-a7aa-11e6-be20-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test1/providers/Microsoft.Network/publicIPAddresses/publicip1?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/publicIPAddresses/publicip1?api-version=2016-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9aLWelMW0WO1+NOLPixk+vdusJ820LlZtUS2buzuT3fNP9x/sbu9Ozne292ezbDvL
-        p/e2p5OHew/2znce3n+4c7fOm2pdT/PP62q9au5Oy+L3b/Om3b27qqvLYpbXzd0vimldNdV5O36R
-        t1dV/faudH/28ng2o/ebvNFPHEJ5m10Ape/e/X0/ynYnO+fTnXz73s7ug+39++fn29nkwWT7wf37
-        e7v3p58+eHj/09/3I32xvV7xCG/Rqb5RVtMMA8ZbV4T62nxBKDT04S/+JfInDWiV121BL9KH+Eg+
-        vCwaertYXrxus5b7fr2eTvN8ls8EEDWjDoVKa6H0wcEkf3C+/2B75z79s79zb7Y9Odgj0p7nu/nB
-        +b0sy5QS9HIH8Z8kmlKHAHP28nK/36w0I/oib+cV9/f0mma+mNq2xazM3xSLvFq3Z8sviuWa5oza
-        7ePrX/IbJ7/k/wG4bVVWLgIAAA==
+        p/e2p5OHew/2znce3n+4c7fOm2pdT/PP62q9au5Oy+L3b/Om/f2XxfT3b6b5MquLavfuqq4ui1le
+        N3e/KKZ11VTn7fhF3l5V9du7gsvZy+PZjIA1eaOfOOzyNrsAft+9+/t+tDfb/fR8/+HO9t7Bzn1C
+        an+6PXlwkG/f/3QyeTA9yO/fP5/8vh/pi+31iod7i071jbKaZhg93rqicazNF4RCQx/+4l8if9KA
+        VnndFvQifYiP5MPLoqG3i+XF6zZrue/X6+k0z2f5TABRM+pQSLYWst9/OLs3+/Rhvv1w+vBge//e
+        7sPt7P79ne2H9/LZ7t7O/s69/KF9uYP4TxJNqUOAOXt5ud9vVpoRfZG384r7e3pNbFBMbdtiVuZv
+        ikVerduz5RfFck0TSO328fUv+Y2TX/L/AN8iVXs7AgAA
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:19:40 GMT']
-      etag: [W/"a1b0fc0e-3017-45ff-ab7b-755215c67956"]
+      date: ['Fri, 11 Nov 2016 01:01:56 GMT']
+      etag: [W/"2d16f490-2805-4d4c-b78e-56bb7c8e55fb"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -539,77 +535,43 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Length: ['609']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 lbcreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 lbcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [5636590c-7612-11e6-b2ee-a0999b14fe87]
+      x-ms-client-request-id: [71db86b0-a7aa-11e6-805c-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Resources/deployments/azurecli1473373180.9275236","name":"azurecli1473373180.9275236","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-07-19/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-07-19"},"backendPoolName":{"type":"String","value":"mylbbepool"},"dnsNameType":{"type":"String","value":"none"},"frontendIpName":{"type":"String","value":"LoadBalancerFrontEnd"},"loadBalancerName":{"type":"String","value":"mylb"},"location":{"type":"String","value":"westus"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddress":{"type":"String","value":"PublicIPmylb"},"publicIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddressType":{"type":"String","value":"new"},"publicIpDnsName":{"type":"String","value":""},"subnet":{"type":"String","value":""},"subnetAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetType":{"type":"String","value":"none"},"tags":{"type":"Object","value":{}},"virtualNetworkName":{"type":"String","value":""},"vnetAddressPrefix":{"type":"String","value":"10.0.0.0/16"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-09-08T22:19:41.7800636Z","duration":"PT0.4507418S","correlationId":"1f34380f-1946-4dd4-8e33-11bf622fc994","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Resources/deployments/IPmylb","resourceType":"Microsoft.Resources/deployments","resourceName":"IPmylb"},{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Resources/deployments/Subnetmylb","resourceType":"Microsoft.Resources/deployments","resourceName":"Subnetmylb"}],"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"mylb"}]}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478826117.7823163","name":"azurecli1478826117.7823163","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-07-19/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateLb_2016-07-19"},"backendPoolName":{"type":"String","value":"mylbbepool"},"dnsNameType":{"type":"String","value":"none"},"frontendIpName":{"type":"String","value":"LoadBalancerFrontEnd"},"loadBalancerName":{"type":"String","value":"mylb"},"location":{"type":"String","value":"westus"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddress":{"type":"String","value":"PublicIPmylb"},"publicIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddressType":{"type":"String","value":"new"},"publicIpDnsName":{"type":"String","value":""},"subnet":{"type":"String","value":""},"subnetAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetType":{"type":"String","value":"none"},"tags":{"type":"Object","value":{}},"virtualNetworkName":{"type":"String","value":""},"vnetAddressPrefix":{"type":"String","value":"10.0.0.0/16"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-11-11T01:01:59.331743Z","duration":"PT0.7842205S","correlationId":"bdaf6804-a337-4f67-b5b5-8b2d2436313b","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"loadBalancers","locations":["westus"]}]},{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/IPmylb","resourceType":"Microsoft.Resources/deployments","resourceName":"IPmylb"},{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/Subnetmylb","resourceType":"Microsoft.Resources/deployments","resourceName":"Subnetmylb"}],"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"mylb"}]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/azurecli1473373180.9275236/operationStatuses/08587282337041483337?api-version=2015-11-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478826117.7823163/operationStatuses/08587227807669301773?api-version=2015-11-01']
       cache-control: [no-cache]
-      content-length: ['2444']
+      content-length: ['2495']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:19:40 GMT']
+      date: ['Fri, 11 Nov 2016 01:01:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1194']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 lbcreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 lbcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [5636590c-7612-11e6-b2ee-a0999b14fe87]
+      x-ms-client-request-id: [71db86b0-a7aa-11e6-805c-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587282337041483337?api-version=2015-11-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['140']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:20:11 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 lbcreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [5636590c-7612-11e6-b2ee-a0999b14fe87]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587282337041483337?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587227807669301773?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -621,7 +583,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['141']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:20:41 GMT']
+      date: ['Fri, 11 Nov 2016 01:02:29 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -632,47 +594,46 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 lbcreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 lbcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [5636590c-7612-11e6-b2ee-a0999b14fe87]
+      x-ms-client-request-id: [71db86b0-a7aa-11e6-805c-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
         o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXenZfH7t3nT7t5d1dVlMcvr5u4XxbSumuq8Hb/Sxs3dWb4qq+tFvmybu9kP1nVOL+7u
-        P7h378G93YOdMXVwf+/epx+NPlpmi5xQ29iGulrldVvkzUePfvFHbb5YlVmbPy+Wb/H3ui4IwLxt
-        V82ju9JZM3s7LcaTspqMp1Wdj6+K5ay6asbLvL1rXp9XTXv3pM7p1+eT339vZ/fT7Z0H27sPBYLg
-        P/7pploSAtNq2dJQfpJGS5Sj3nbHO/jvo19CyGU1DaGlr4DM758RnufZtG2eV9MMdMan7fUKg3zd
-        1sXyguBdZuUaH3xjSAORSTZ9my9nL6uqfJGBqMP9Lq7LySRfUUu8OFs2eOENNx5+aVktczQ/r5ka
-        s7MV3tr0xvMqmz3Jymw5zetneOt0OQOE0vv8JhhAVd65mZxXxJjrBq1XdXFJNDpbHc9mRFmemqG3
-        Yu2Py9v0N7sm7i2mDGA9KYupfX/TWy+l6Uszss6rH9r1jdOYX/lvPZXJ3/QGmpPmID68XStF5GWd
-        nxfvNr2ySyKE/+7u7bu3b8Rf2bDNLnwyfzn56Xzauna/+JdQm8uibtdZ+SJvr6r67W3GeUkYvD/+
-        u59+hO4W1Qwfny2ndQ7Vl5XUmJTXZQG1Qe++bonJqMXr9XSak46Z0fdtsSC2zRYr+lwE+uH2zsGb
-        vb1Hezv0v/H9h/uf7nx68FPUdLaulTE+evnm3sPx3qf39w7uv6ZvSGHUOSkI+vIMmn73/N7+vYOd
-        c1IN+59Cte9vH+T37m3vkqr/dG/vfPrw4T69xrhBh3/06Hu/mFVxs8qmwNDpdCUetSaisHbHDMkb
-        /if0ki/XDb1gGBmNjXB+/5d8/5eMhvqy9oNe9mEDQK83UdGgM5r7fS3XZYl+vk8ky1ekqvLllI0H
-        AZEPmi+JiPTXz6VZVA0QjpTQueE97wVh6I8UEMj6czme1yy+jIpD8euOyQOGafzhjEtZ/W7Ax3cZ
-        CYdgb0TRt7wXdEQMBmOp1u1qTWMmxeK/gr9V0fR0mQjqBiVi+vp8zZSaZvmDyacPDrYfZntEmp17
-        e9vZ5OHBdr47ne09vLdH7lVOb1lL/vKkWp4XF6peCDUSDUgogYra8J/7Cbk7hPvdAYRzsheE8nfv
-        /r4f7e/u7mX3HtzffpA/nG7vT/cebk9288n2w51Pc4xgP58e/L4f0TuEkud30l8b58D4EC+dBf8i
-        b+cVKPVUzTW1Erv7Uo0MAP9wadlBgAQxdEh+CXhUfUltA5eSMHVMgZbqP/6/gBUiyPIXFsOf7bln
-        kjnEqM2rdYkXv0ef06sT83uxnFTr5exF1noNSB9EPnVNeUD4kKaGW5P2sFqUPlcGug2pnI3ot76J
-        L77/S37J/wNsnKRBRw4AAA==
+        p/nndbVeNXenZfH7t3nT/v7LYvr7N9N8mdVFtXt3VVeXxSyvm7tfFNO6aqrzdvxK32zuzvJVWV0v
+        8mXb3M1+sK5zgrK7/+DgYO/T3d0H4wcHe/d2P7330eijZbbICc+NbairVV63Rd589OgXf9Tmi1WZ
+        tfnzYvkWf6/rggDM23bVPLornTWzt9NiPCmryXha1fn4qljOqqtmvMzbu+b1edW0d0/qnH59Pvn9
+        93Z2P93eebC9+1AgCP7jn26qJSEwrZYtDeUnabRERuptd7yD/z76JYRcVtMQWvoKyPz+GeF5nk3b
+        5nk1zUB0fNperzDI121dLC8I3mVWrvHBN4Y0EJlk07f5cvayqsoXGYg63O/iupxM8hW1xIuzZYMX
+        3nDj4ZeW1TJH8/OaqTE7W+GtTW88r7LZk6zMltO8foa3TpczQCi9z2+CAVTlnZvJeUVcum7QelUX
+        l0Sjs9XxbEaU5akZeivW/ri8TX+za+LeYsoA1pOymNr3N731Upq+NCPrvPqhXd84jfmV/9ZTmfxN
+        b6A5qRHiw9u1UkRe1vl58W7TK7skQvjv7t6+e/tG/JUN2+zCJ/OXk5/Op61r94t/CbW5LOp2nZUv
+        8vaqqt/eZpyXhMH747/76UfoblHN8PHZclrnUH1ZSY1JeV0WUBv07uuWmIxavF5PpznpmBl93xYL
+        YttssaLPWaB3STvvvtnZfbSz92jv3vj+7v1PP909+ClqOlvXyhgfvXyztz9++OnB7r2H917TV6Qx
+        6pw0BH17Br0/mWXnnx7s7G9n9+492N4///TB9uT+5P72wWRvtrd/79N7u/cm9BojByX+0aPv/WLW
+        xc0qmwJFp9SVetSaqMLqHVMkb/if0Eu+YDf0guFkNDbS+f1f8v1fMhrqyxoQetmHDQC93kRHg9Bo
+        7ve1XJcl+vk+0Sxfka7Kl1O2HgREPmi+JCrSX/+vMZKqD8JhE243vOe9IOz9kQICjf9fM7jXLNmM
+        l8P36w7QA4YJ/jkYpErE3YDd7zJGDtve8KJveS/o8BgMBlat29WaCEAKyH8Ff6tC6uk8kecNysb0
+        9fmayba//3D3/Hy2v/3gwaczaImD7YP9yXT73kGe3zs/vz+7P8Vb1uK/PKmW58WFqiFCjSQIgkyg
+        orb+/2Wzc3doIHcHsM/JyBD+3737+3706ex+9mB2kG9nn+59ur2/c/98O7u/+3A7//Th/uz8Qf6A
+        /v19P6J3CCXPWaW/Nk6IcTxeOrP/Rd7OK5Dtqdp4aiXG+qVaJgD+OSRsBxuS19Cl+SXgXvVGtQ2c
+        UkLbsQtaqgf6/zYmiWDOX1h0f7a5gunnEKM2r9YlXvwefU6vTszvxXJSrZezF1nrNSC1EfnUNeUB
+        4UOaJ25NSsZqXvpcWes2pHJGpt/6Jib5/i/5Jf8P4oADKqMOAAA=
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
-      content-length: ['1213']
+      content-length: ['1235']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:20:42 GMT']
+      date: ['Fri, 11 Nov 2016 01:02:29 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -683,36 +644,37 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [7b5cc8ee-7612-11e6-800d-a0999b14fe87]
+      x-ms-client-request-id: [85c46b61-a7aa-11e6-900c-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9aHFdTj4a8UfFDB/cbdaTZloXq7aols3dncnu+af7D3a3dyfnO9v7s1m2neXTe9vT
-        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edPu3l3V1WUxy+vm7hfFtK6a6rwdv8jbq6p+
-        e7esstmTrMyWU3zv4ZG32QUw+e7d3/ej/d3dvezeg/vbD/KH0+396d7D7cluPtl+uPNpDsT28+nB
-        7/uRvther3hMN/SlrctqmmGMeOOKsF2bL6j7hj78xb9E/qQxrPK6LXL+EB/Jh5dFQ28Xy4vXbdZy
-        v6/X02mez/KZAKJmljBrIe40yx9MPn1wsP0w2yNq7tzb284mDw+2893pbO/hvb3dg53cvnxeV8s2
-        X87OXp5Uy/PiYl0zvkDje9IkNfjgsVP63BvsM8A4XVqM8PzcT/TdoaHdvRH3r8sc8mDeepMpD766
-        xZTKQ42LS2py9vK4NHz0Rd7OK6bs02uaimLafWU9KYspvTGbERl7/VOLH/K8dBDKm7sv9RPM0Uc+
-        cr/E/WF/1V++r6P8aJJN39KUKrSXVVVijBs5Ff1M8hU19Wn1w6ZDhD8jY+EvIsj+nDGka6szYX+x
-        U+JGRiBerUvu5Hv2a+pg0vmoWE6q9XL2Imv7zat1O/yle5Gpxd/hK0Lpl/w/WjJPBnIGAAA=
+        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edP+/sti+vs303yZ1UW1e3dVV5fFLK+bu18U
+        07pqqvN2/CJvr6r67d2yymZPsjJbTvG9h1TeZhdA67t3f9+PPp3dzx7MDvLt7NO9T7f3d+6fb2f3
+        dx9u558+3J+dP8gf0L+/70f6Ynu94gHe0Je2LqtphgHjjStCfW2+oO4b+vAX/xL5k8awyuu2yPlD
+        fCQfXhYNvV0sL163Wcv9vl5Pp3k+y2cCiJpZKq2F0vv7D3fPz2f72w8efDrb3j//9GD7YH8y3b53
+        kOf3zs/vz+5P3cvndbVs8+Xs7OVJtTwvLtY14ws0vidNUoMPHju/z73BPgOM06UFiuf/ZbN+d2ic
+        d28cyNflFHkwib2ZlQdf3WJ+5aHGxSU1OXt5XBqm+iJv5xWT+ek1zUsx7b6ynpTFlN6YzYimvf6p
+        xc/lJHWwy5u7L/UTTNhHPqa/xP1hf9Vfvq9D/miSTd/S/Cq0l1VVYsAbeRj9TPIVNfUJ93NKlAjn
+        RgbGX0Qw/zljVddWp8X+YufHjYxAvFqX3Mn37NfUwaTzUbGcVOvl7EXW9ptX63b4S/ciU4u/w1eE
+        0i/5fwA8Vtg9pgYAAA==
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:20:42 GMT']
-      etag: [W/"4112a375-7e9c-4c29-b1eb-906e1f644ec8"]
+      date: ['Fri, 11 Nov 2016 01:02:31 GMT']
+      etag: [W/"6d5a7d8e-a626-405f-a519-e694df7e74df"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -720,105 +682,107 @@ interactions:
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb",
-      "etag": "W/\"4112a375-7e9c-4c29-b1eb-906e1f644ec8\"", "location": "westus",
-      "properties": {"inboundNatRules": [{"properties": {"protocol": "tcp", "backendPort":
-      100, "frontendIPConfiguration": {"etag": "W/\"4112a375-7e9c-4c29-b1eb-906e1f644ec8\"",
+    body: '{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb",
+      "etag": "W/\"6d5a7d8e-a626-405f-a519-e694df7e74df\"", "location": "westus",
+      "properties": {"inboundNatRules": [{"properties": {"protocol": "Tcp", "backendPort":
+      100, "frontendIPConfiguration": {"etag": "W/\"6d5a7d8e-a626-405f-a519-e694df7e74df\"",
       "properties": {"privateIPAllocationMethod": "Dynamic", "provisioningState":
-      "Succeeded", "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/publicIPAddresses/PublicIPmylb"}},
-      "name": "LoadBalancerFrontEnd", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"},
+      "Succeeded", "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/publicIPAddresses/PublicIPmylb"}},
+      "name": "LoadBalancerFrontEnd", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"},
       "enableFloatingIP": false, "frontendPort": 100}, "name": "rule1"}], "resourceGuid":
-      "cae7b678-9a20-4032-ab98-e1cd2932180e", "frontendIPConfigurations": [{"etag":
-      "W/\"4112a375-7e9c-4c29-b1eb-906e1f644ec8\"", "properties": {"privateIPAllocationMethod":
-      "Dynamic", "provisioningState": "Succeeded", "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/publicIPAddresses/PublicIPmylb"}},
-      "name": "LoadBalancerFrontEnd", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"}],
+      "4491ffd4-776d-4f68-84bc-38ee3ff5d5cd", "frontendIPConfigurations": [{"etag":
+      "W/\"6d5a7d8e-a626-405f-a519-e694df7e74df\"", "properties": {"privateIPAllocationMethod":
+      "Dynamic", "provisioningState": "Succeeded", "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/publicIPAddresses/PublicIPmylb"}},
+      "name": "LoadBalancerFrontEnd", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"}],
       "outboundNatRules": [], "loadBalancingRules": [], "inboundNatPools": [], "backendAddressPools":
-      [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mylbbepool",
-      "etag": "W/\"4112a375-7e9c-4c29-b1eb-906e1f644ec8\"", "name": "mylbbepool",
+      [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mylbbepool",
+      "etag": "W/\"6d5a7d8e-a626-405f-a519-e694df7e74df\"", "name": "mylbbepool",
       "properties": {"provisioningState": "Succeeded"}}], "provisioningState": "Succeeded",
       "probes": []}, "tags": {}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
-      Content-Length: ['1977']
+      Content-Length: ['2055']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [7b6cd282-7612-11e6-8135-a0999b14fe87]
+      x-ms-client-request-id: [85f4ca30-a7aa-11e6-9783-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9aHFdTj4a8UfFDB/cbdaTZloXq7aols3dncnu+af7D3a3dyfnO9v7s1m2neXTe9vT
-        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edPu3l3V1WUxy+vm7hfFtK6a6rwdv8jbq6p+
-        e7esstmTrMyWU3zv4ZG32QUw+e7d3/ej/P7D/U93swfbBw8Odrf38/2H2wcHD+5vP9jbz/cmk4NP
-        CYnf9yN9sb1e8Zhu6Etbl9U0wxjxxhVhuzZfUPcNffiLf4n8SWNY5XVb5PwhPpIPL4uG3i6WF6/b
-        rOV+X6+n0zyf5TMBRM0sYdZC3GmWP5h8+uBg+2G2R9Tcube3nU0eHmznu9PZ3sN7e7sHO7l9+byu
-        lm2+nJ29PKmW58XFumZ8gcb3pElq8MFjp/S5N9hngHG6tBjh+bmf6LtDQ7t7I+5flznkwbz1JlMe
-        fHWLKZWHGheX1OTs5XFp+OiLvJ1XTNmn1zQVxbT7ynpSFlN6YzYjMvb6pxY/5HnpIJQ3d1/qJ5ij
-        j3zkRBTM81GxnFTr5exF1r5al0xKy5DydEaGV364Y4vwXAfpuzX9uxuMksbp//l994f9XH/5vtLj
-        o0k2fUt8rCR8WVVlQA2PDlY8gcwkX1FTn0H+X0CgyFj4iwiyP2dS6NrqTNhf7JS4kREInmoC8T37
-        NXUw6XzU4Qx8J9/EJ1AYR1/G8/+CuesMQZnbx/HnbMo8KNR4QPPTKwFQavlzT9QBXAeslI9+R18a
-        QC+ruqVB7e7shN+r5A19nS+zSZk/IwxbIvHZS2pznpVNHrYqZmX+pljk1bo9W35RLNc0Zmq5H7Yi
-        ErTVlMSZaPtmuvKwVjmyv1jxIIABc9GrMdlhhcHf4SsC8kv+H657yDpqCgAA
+        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edP+/sti+vs303yZ1UW1e3dVV5fFLK+bu18U
+        07pqqvN2/CJvr6r67d2yymZPsjJbTvG9h1TeZhdA67t3f9+P8r17exPqcPvT2c7D7f1sNt3OHkzv
+        b0+mD3cODvZ29mcH2e/7kb7YXq94gDf0pa3LapphwHjjilBfmy+o+4Y+/MW/RP6kMazyui1y/hAf
+        yYeXRUNvF8uL123Wcr+v19Npns/ymQCiZpZKa6H0/v7D3fPz2f72gwefzrb3zz892D7Yn0y37x3k
+        +b3z8/uz+1P38nldLdt8OTt7eVItz4uLdc34Ao3vSZPU4IPHzu9zb7DPAON0aYHi+X/ZrN8dGufd
+        GwfydTlFHkxib2blwVe3mF95qHFxSU3OXh6Xhqm+yNt5xWR+ek3zUky7r6wnZTGlN2Yzommvf2rx
+        czlJHezy5u5L/QQT9pGPqQiJeT4qlpNqvZy9yNpX65LpallVns4w8crP4UAj3NgZwd2a/t0NhkyD
+        9v/8vvvDfq6/fF+J89Ekm74lDld6vqyqMiCNRxQrxUBmkq+oqc86/2+jVmRg/EUE858zYXVtdVrs
+        L3Z+3MgIBM87gfie/Zo6mHQ+6rAJvpNv4rMpXKQv4/l/20R2xqNs7yP8czZ/HhRqPGAt6JUAKLX8
+        fxmFBxAfMHP+WDo61gB6WdUtjXB3Zyf8XmVy6GtCf1LmzwjDluh99pLanGdlk4etilmZvykWebVu
+        z5ZfFMs1EYBa7oetiARtNSVBJ0K/ma48rFXC7C9WcAhgwGn0akyqWJXwd/iKgPyS/wdAOKBSxQoA
+        AA==
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/d7587c41-d8a2-4ad3-b78e-4784b39b523b?api-version=2016-06-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/9248b76a-94db-4be5-bfbc-9bf60cf429e0?api-version=2016-06-01']
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:20:43 GMT']
+      date: ['Fri, 11 Nov 2016 01:02:30 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1189']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [7bb324e3-7612-11e6-8acd-a0999b14fe87]
+      x-ms-client-request-id: [8661bccf-a7aa-11e6-ae41-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9aHFdTj4a8UfFDB/cbdaTZloXq7aols3dncnu+af7D3a3dyfnO9v7s1m2neXTe9vT
-        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edPu3l3V1WUxy+vm7hfFtK6a6rwdv8jbq6p+
-        e7esstmTrMyWU3zv4ZG32QUw+e7d3/ej/P7D/U93swfbBw8Odrf38/2H2wcHD+5vP9jbz/cmk4NP
-        CYnf9yN9sb1e8Zhu6Etbl9U0wxjxxhVhuzZfUPcNffiLf4n8SWNY5XVb5PwhPpIPL4uG3i6WF6/b
-        rOV+X6+n0zyf5TMBRM0sYdZC3GmWP5h8+uBg+2G2R9Tcube3nU0eHmznu9PZ3sN7e7sHO7l9+byu
-        lm2+nJ29PKmW58XFumZ8gcb3pElq8MFjp/S5N9hngHG6tBjh+bmf6LtDQ7t7I+5flznkwbz1JlMe
-        fHWLKZWHGheX1OTs5XFp+OiLvJ1XTNmn1zQVxbT7ynpSFlN6YzYjMvb6pxY/5HnpIJQ3d1/qJ5ij
-        j3zkRBTM81GxnFTr5exF1r5al0xKy5DydEaGV364Y4vwXAfpuzX9uxuMksbp//l994f9XH/5vtLj
-        o0k2fUt8rCR8WVVlQA2PDlY8gcwkX1FTn0H+X0CgyFj4iwiyP2dS6NrqTNhf7JS4kREInmoC8T37
-        NXUw6XzU4Qx8J9/EJ1AYR1/G8/+CuesMQZnbx/HnbMo8KNR4QPPTKwFQavlzT9QBXAeslI9+R18a
-        QC+ruqVB7e7shN+r5A19nS+zSZk/IwxbIvHZS2pznpVNHrYqZmX+pljk1bo9W35RLNc0Zmq5H7Yi
-        ErTVlMSZaPtmuvKwVjmyv1jxIIABc9GrMdlhhcHf4SsC8kv+H657yDpqCgAA
+        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edP+/sti+vs303yZ1UW1e3dVV5fFLK+bu18U
+        07pqqvN2/CJvr6r67d2yymZPsjJbTvG9h1TeZhdA67t3f9+P8r17exPqcPvT2c7D7f1sNt3OHkzv
+        b0+mD3cODvZ29mcH2e/7kb7YXq94gDf0pa3LapphwHjjilBfmy+o+4Y+/MW/RP6kMazyui1y/hAf
+        yYeXRUNvF8uL123Wcr+v19Npns/ymQCiZpZKa6H0/v7D3fPz2f72gwefzrb3zz892D7Yn0y37x3k
+        +b3z8/uz+1P38nldLdt8OTt7eVItz4uLdc34Ao3vSZPU4IPHzu9zb7DPAON0aYHi+X/ZrN8dGufd
+        GwfydTlFHkxib2blwVe3mF95qHFxSU3OXh6Xhqm+yNt5xWR+ek3zUky7r6wnZTGlN2Yzommvf2rx
+        czlJHezy5u5L/QQT9pGPqQiJeT4qlpNqvZy9yNpX65LpallVns4w8crP4UAj3NgZwd2a/t0NhkyD
+        9v/8vvvDfq6/fF+J89Ekm74lDld6vqyqMiCNRxQrxUBmkq+oqc86/2+jVmRg/EUE858zYXVtdVrs
+        L3Z+3MgIBM87gfie/Zo6mHQ+6rAJvpNv4rMpXKQv4/l/20R2xqNs7yP8czZ/HhRqPGAt6JUAKLX8
+        fxmFBxAfMHP+WDo61gB6WdUtjXB3Zyf8XmVy6GtCf1LmzwjDluh99pLanGdlk4etilmZvykWebVu
+        z5ZfFMs1EYBa7oetiARtNSVBJ0K/ma48rFXC7C9WcAhgwGn0akyqWJXwd/iKgPyS/wdAOKBSxQoA
+        AA==
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:20:43 GMT']
-      etag: [W/"e59461a7-8781-4e49-8875-724e2bb86272"]
+      date: ['Fri, 11 Nov 2016 01:02:31 GMT']
+      etag: [W/"e232b959-6d09-4adc-a7c5-bc9088204d8a"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -826,111 +790,113 @@ interactions:
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb",
-      "etag": "W/\"e59461a7-8781-4e49-8875-724e2bb86272\"", "location": "westus",
-      "properties": {"inboundNatRules": [{"etag": "W/\"e59461a7-8781-4e49-8875-724e2bb86272\"",
-      "properties": {"frontendIPConfiguration": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"},
+    body: '{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb",
+      "etag": "W/\"e232b959-6d09-4adc-a7c5-bc9088204d8a\"", "location": "westus",
+      "properties": {"inboundNatRules": [{"etag": "W/\"e232b959-6d09-4adc-a7c5-bc9088204d8a\"",
+      "properties": {"frontendIPConfiguration": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"},
       "protocol": "Tcp", "frontendPort": 100, "backendPort": 100, "enableFloatingIP":
       false, "idleTimeoutInMinutes": 4, "provisioningState": "Succeeded"}, "name":
-      "rule1", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule1"},
-      {"properties": {"protocol": "tcp", "backendPort": 200, "frontendIPConfiguration":
-      {"etag": "W/\"e59461a7-8781-4e49-8875-724e2bb86272\"", "properties": {"privateIPAllocationMethod":
-      "Dynamic", "provisioningState": "Succeeded", "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/publicIPAddresses/PublicIPmylb"}},
-      "name": "LoadBalancerFrontEnd", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"},
+      "rule1", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule1"},
+      {"properties": {"protocol": "Tcp", "backendPort": 200, "frontendIPConfiguration":
+      {"etag": "W/\"e232b959-6d09-4adc-a7c5-bc9088204d8a\"", "properties": {"privateIPAllocationMethod":
+      "Dynamic", "provisioningState": "Succeeded", "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/publicIPAddresses/PublicIPmylb"}},
+      "name": "LoadBalancerFrontEnd", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"},
       "enableFloatingIP": false, "frontendPort": 200}, "name": "rule2"}], "resourceGuid":
-      "cae7b678-9a20-4032-ab98-e1cd2932180e", "frontendIPConfigurations": [{"etag":
-      "W/\"e59461a7-8781-4e49-8875-724e2bb86272\"", "properties": {"privateIPAllocationMethod":
-      "Dynamic", "provisioningState": "Succeeded", "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/publicIPAddresses/PublicIPmylb"}},
-      "name": "LoadBalancerFrontEnd", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"}],
+      "4491ffd4-776d-4f68-84bc-38ee3ff5d5cd", "frontendIPConfigurations": [{"etag":
+      "W/\"e232b959-6d09-4adc-a7c5-bc9088204d8a\"", "properties": {"privateIPAllocationMethod":
+      "Dynamic", "provisioningState": "Succeeded", "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/publicIPAddresses/PublicIPmylb"}},
+      "name": "LoadBalancerFrontEnd", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"}],
       "outboundNatRules": [], "loadBalancingRules": [], "inboundNatPools": [], "backendAddressPools":
-      [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mylbbepool",
-      "etag": "W/\"e59461a7-8781-4e49-8875-724e2bb86272\"", "name": "mylbbepool",
+      [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mylbbepool",
+      "etag": "W/\"e232b959-6d09-4adc-a7c5-bc9088204d8a\"", "name": "mylbbepool",
       "properties": {"provisioningState": "Succeeded"}}], "provisioningState": "Succeeded",
       "probes": []}, "tags": {}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
-      Content-Length: ['2577']
+      Content-Length: ['2681']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [7bc30e9c-7612-11e6-85d1-a0999b14fe87]
+      x-ms-client-request-id: [8693f05e-a7aa-11e6-b0c5-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9aHFdTj4a8UfFDB/cbdaTZloXq7aols3dncnu+af7D3a3dyfnO9v7s1m2neXTe9vT
-        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edPu3l3V1WUxy+vm7hfFtK6a6rwdv8jbq6p+
-        e7esstmTrMyWU3zv4ZG32QUw+e7d3/ej/Z2Hn+7dO7i3nU93D7b3p+cH25Ps093t8+nOzqd7u/cm
-        2b1Pf9+P9MX2esVjuqEvbV1W0wxjxBtXhO3afEHdN/ThL/4l8ieNYZXXbZHzh/hIPrwsGnq7WF68
-        brOW+329nk7zfJbPBBA1s4RZC3GnWf5g8umDg+2H2R5Rc+fe3nY2eXiwne9OZ3sP7+3tHuzk9uXz
-        ulq2+XJ29vKkWp4XF+ua8QUa35MmqcEHj53S595gnwHG6dJihOfnfqLvDg3t7o24f13mkAfz1ptM
-        efDVLaZUHmpcXFKTs5fHpeGjL/J2XjFln17TVBTT7ivrSVlM6Y3ZjMjY659a/JDnpYNQ3tx9qZ9g
-        jj7ykRNRMM9HxXJSrZezF1n7al0yKS1DytMZGV754Y4twnMdpO/W9O9uMMruOP+/M4697jj8P7/v
-        /rCf6y/f1/F+NMmmb0kelRVeVlUZzKpHB6tmgMwkX1FTn9H/X0CgyFj4iwiyP2faxLXVmbC/2Clx
-        IyMQPNUE4nv2a+pg0vmowxn4Tr6JTyAYZzcYz8/93HWGwMwd4vhzNmUeFGo8YMHolQAotfy5J+oA
-        rgPW1kc/1Id20C+ruqVB7e7shN+r5A19nS+zSZk/IwxbIvHZS2pznpVNHrYqZmX+pljk1bo9W35R
-        LNc0Zmq5H7YiErTVlMSZaPtmuvKwVjmiX+wb3pQE3L/nTyp1jM/v/hxOVIz7Qxx/xP3vTdQBXD+Y
-        +/e67B1yf+/rHzb3yy/WOBDAgLno1ZjlYHPJ3+ErAvJL/h8eqApUMA4AAA==
+        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edP+/sti+vs303yZ1UW1e3dVV5fFLK+bu18U
+        07pqqvN2/CJvr6r67d2yymZPsjJbTvG9h1TeZhdA67t3f9+PpvsPd3fu3Xuwvbezd769v793f/vg
+        YPf+9r3zg+nuw/sPHu5ln/6+H+mL7fWKB3hDX9q6rKYZBow3rgj1tfmCum/ow1/8S+RPGsMqr9si
+        5w/xkXx4WTT0drG8eN1mLff7ej2d5vksnwkgamaptBZK79Nwzs9n+9sPHnw6294///Rg+2B/Mt2+
+        d5Dn987P78/uT93L53W1bPPl7OzlSbU8Ly7WNeMLNL4nTVKDDx47v8+9wT4DjNOlBYrn/2Wzfndo
+        nHdvHMjX5RR5MIm9mZUHX91ifuWhxsUlNTl7eVwapvoib+cVk/npNc1LMe2+sp6UxZTemM2Ipr3+
+        qcXP5SR1sMubuy/1E0zYRz6mIiTm+ahYTqr1cvYia1+tS6arZVV5OsPEKz+HA41wY2cEd2v6dzcY
+        cnfQ/x8d1F53UP6f33d/2M/1l+/r4D+aZNO3JLbKJC+rqgzm2yOKVU1AZpKvqKkvD/9vo1ZkYPxF
+        BPOfMw3k2uq02F/s/LiREQiedwLxPfs1dTDpfNRhE3wn38RnE1y0G4zn/2UT2RkPs32I8M/Z/HlQ
+        qPGACaRXAqDU8v9lFB5AfMB2+2MJdailwMuqbmmEuzs74fcqk0NfE/qTMn9GGLZE77OX1OY8K5s8
+        bFXMyvxNscirdXu2/KJYrokA1HI/bEUkaKspCToR+s105WGtEka/2De8+QnkYs+fYeoYn9/9f8us
+        xeQiRPhHcvFhFB5A/IPlYq/L+KFc9L4m9H+ociG/WINCAANOo1dj1oZNLH+HrwjIL/l/ALwlywey
+        DgAA
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/a8776ebe-4825-4796-919e-327d06497691?api-version=2016-06-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/aa05ac15-5c73-4251-a1a1-334fb8f2dc28?api-version=2016-06-01']
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:20:43 GMT']
+      date: ['Fri, 11 Nov 2016 01:02:31 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1190']
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [7c05f978-7612-11e6-b924-a0999b14fe87]
+      x-ms-client-request-id: [87043e61-a7aa-11e6-8fe0-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9aHFdTj4a8UfFDB/cbdaTZloXq7aols3dncnu+af7D3a3dyfnO9v7s1m2neXTe9vT
-        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edPu3l3V1WUxy+vm7hfFtK6a6rwdv8jbq6p+
-        e7esstmTrMyWU3zv4ZG32QUw+e7d3/ej/Z2Hn+7dO7i3nU93D7b3p+cH25Ps093t8+nOzqd7u/cm
-        2b1Pf9+P9MX2esVjuqEvbV1W0wxjxBtXhO3afEHdN/ThL/4l8ieNYZXXbZHzh/hIPrwsGnq7WF68
-        brOW+329nk7zfJbPBBA1s4RZC3GnWf5g8umDg+2H2R5Rc+fe3nY2eXiwne9OZ3sP7+3tHuzk9uXz
-        ulq2+XJ29vKkWp4XF+ua8QUa35MmqcEHj53S595gnwHG6dJihOfnfqLvDg3t7o24f13mkAfz1ptM
-        efDVLaZUHmpcXFKTs5fHpeGjL/J2XjFln17TVBTT7ivrSVlM6Y3ZjMjY659a/JDnpYNQ3tx9qZ9g
-        jj7ykRNRMM9HxXJSrZezF1n7al0yKS1DytMZGV754Y4twnMdpO/W9O9uMMruOP+/M4697jj8P7/v
-        /rCf6y/f1/F+NMmmb0kelRVeVlUZzKpHB6tmgMwkX1FTn9H/X0CgyFj4iwiyP2faxLXVmbC/2Clx
-        IyMQPNUE4nv2a+pg0vmowxn4Tr6JTyAYZzcYz8/93HWGwMwd4vhzNmUeFGo8YMHolQAotfy5J+oA
-        rgPW1kc/1Id20C+ruqVB7e7shN+r5A19nS+zSZk/IwxbIvHZS2pznpVNHrYqZmX+pljk1bo9W35R
-        LNc0Zmq5H7YiErTVlMSZaPtmuvKwVjmiX+wb3pQE3L/nTyp1jM/v/hxOVIz7Qxx/xP3vTdQBXD+Y
-        +/e67B1yf+/rHzb3yy/WOBDAgLno1ZjlYHPJ3+ErAvJL/h8eqApUMA4AAA==
+        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edP+/sti+vs303yZ1UW1e3dVV5fFLK+bu18U
+        07pqqvN2/CJvr6r67d2yymZPsjJbTvG9h1TeZhdA67t3f9+PpvsPd3fu3Xuwvbezd769v793f/vg
+        YPf+9r3zg+nuw/sPHu5ln/6+H+mL7fWKB3hDX9q6rKYZBow3rgj1tfmCum/ow1/8S+RPGsMqr9si
+        5w/xkXx4WTT0drG8eN1mLff7ej2d5vksnwkgamaptBZK79Nwzs9n+9sPHnw6294///Rg+2B/Mt2+
+        d5Dn987P78/uT93L53W1bPPl7OzlSbU8Ly7WNeMLNL4nTVKDDx47v8+9wT4DjNOlBYrn/2Wzfndo
+        nHdvHMjX5RR5MIm9mZUHX91ifuWhxsUlNTl7eVwapvoib+cVk/npNc1LMe2+sp6UxZTemM2Ipr3+
+        qcXP5SR1sMubuy/1E0zYRz6mIiTm+ahYTqr1cvYia1+tS6arZVV5OsPEKz+HA41wY2cEd2v6dzcY
+        cnfQ/x8d1F53UP6f33d/2M/1l+/r4D+aZNO3JLbKJC+rqgzm2yOKVU1AZpKvqKkvD/9vo1ZkYPxF
+        BPOfMw3k2uq02F/s/LiREQiedwLxPfs1dTDpfNRhE3wn38RnE1y0G4zn/2UT2RkPs32I8M/Z/HlQ
+        qPGACaRXAqDU8v9lFB5AfMB2+2MJdailwMuqbmmEuzs74fcqk0NfE/qTMn9GGLZE77OX1OY8K5s8
+        bFXMyvxNscirdXu2/KJYrokA1HI/bEUkaKspCToR+s105WGtEka/2De8+QnkYs+fYeoYn9/9f8us
+        xeQiRPhHcvFhFB5A/IPlYq/L+KFc9L4m9H+ociG/WINCAANOo1dj1oZNLH+HrwjIL/l/ALwlywey
+        DgAA
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:20:44 GMT']
-      etag: [W/"40962383-ec18-4cf8-ba61-fc006213ba36"]
+      date: ['Fri, 11 Nov 2016 01:02:32 GMT']
+      etag: [W/"c4910337-202f-4425-8815-3f8c195792a6"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -942,40 +908,41 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [7c29c2c2-7612-11e6-bccc-a0999b14fe87]
+      x-ms-client-request-id: [87657130-a7aa-11e6-88f2-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9aHFdTj4a8UfFDB/cbdaTZloXq7aols3dncnu+af7D3a3dyfnO9v7s1m2neXTe9vT
-        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edPu3l3V1WUxy+vm7hfFtK6a6rwdv8jbq6p+
-        e7esstmTrMyWU3zv4ZG32QUw+e7d3/ej/Z2Hn+7dO7i3nU93D7b3p+cH25Ps093t8+nOzqd7u/cm
-        2b1Pf9+P9MX2esVjuqEvbV1W0wxjxBtXhO3afEHdN/ThL/4l8ieNYZXXbZHzh/hIPrwsGnq7WF68
-        brOW+329nk7zfJbPBBA1s4RZC3GnWf5g8umDg+2H2R5Rc+fe3nY2eXiwne9OZ3sP7+3tHuzk9uXz
-        ulq2+XJ29vKkWp4XF+ua8QUa35MmqcEHj53S595gnwHG6dJihOfnfqLvDg3t7o24f13mkAfz1ptM
-        efDVLaZUHmpcXFKTs5fHpeGjL/J2XjFln17TVBTT7ivrSVlM6Y3ZjMjY659a/JDnpYNQ3tx9qZ9g
-        jj7ykRNRMM9HxXJSrZezF1n7al0yKS1DytMZGV754Y4twnMdpO/W9O9uMMruOP+/M4697jj8P7/v
-        /rCf6y/f1/F+NMmmb0kelRVeVlUZzKpHB6tmgMwkX1FTn9H/X0CgyFj4iwiyP2faxLXVmbC/2Clx
-        IyMQPNUE4nv2a+pg0vmowxn4Tr6JTyAYZzcYz8/93HWGwMwd4vhzNmUeFGo8YMHolQAotfy5J+oA
-        rgPW1kc/1Id20C+ruqVB7e7shN+r5A19nS+zSZk/IwxbIvHZS2pznpVNHrYqZmX+pljk1bo9W35R
-        LNc0Zmq5H7YiErTVlMSZaPtmuvKwVjmiX+wb3pQE3L/nTyp1jM/v/hxOVIz7Qxx/xP3vTdQBXD+Y
-        +/e67B1yf+/rHzb3yy/WOBDAgLno1ZjlYHPJ3+ErAvJL/h8eqApUMA4AAA==
+        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edP+/sti+vs303yZ1UW1e3dVV5fFLK+bu18U
+        07pqqvN2/CJvr6r67d2yymZPsjJbTvG9h1TeZhdA67t3f9+PpvsPd3fu3Xuwvbezd769v793f/vg
+        YPf+9r3zg+nuw/sPHu5ln/6+H+mL7fWKB3hDX9q6rKYZBow3rgj1tfmCum/ow1/8S+RPGsMqr9si
+        5w/xkXx4WTT0drG8eN1mLff7ej2d5vksnwkgamaptBZK79Nwzs9n+9sPHnw6294///Rg+2B/Mt2+
+        d5Dn987P78/uT93L53W1bPPl7OzlSbU8Ly7WNeMLNL4nTVKDDx47v8+9wT4DjNOlBYrn/2Wzfndo
+        nHdvHMjX5RR5MIm9mZUHX91ifuWhxsUlNTl7eVwapvoib+cVk/npNc1LMe2+sp6UxZTemM2Ipr3+
+        qcXP5SR1sMubuy/1E0zYRz6mIiTm+ahYTqr1cvYia1+tS6arZVV5OsPEKz+HA41wY2cEd2v6dzcY
+        cnfQ/x8d1F53UP6f33d/2M/1l+/r4D+aZNO3JLbKJC+rqgzm2yOKVU1AZpKvqKkvD/9vo1ZkYPxF
+        BPOfMw3k2uq02F/s/LiREQiedwLxPfs1dTDpfNRhE3wn38RnE1y0G4zn/2UT2RkPs32I8M/Z/HlQ
+        qPGACaRXAqDU8v9lFB5AfMB2+2MJdailwMuqbmmEuzs74fcqk0NfE/qTMn9GGLZE77OX1OY8K5s8
+        bFXMyvxNscirdXu2/KJYrokA1HI/bEUkaKspCToR+s105WGtEka/2De8+QnkYs+fYeoYn9/9f8us
+        xeQiRPhHcvFhFB5A/IPlYq/L+KFc9L4m9H+ociG/WINCAANOo1dj1oZNLH+HrwjIL/l/ALwlywey
+        DgAA
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:20:44 GMT']
-      etag: [W/"40962383-ec18-4cf8-ba61-fc006213ba36"]
+      date: ['Fri, 11 Nov 2016 01:02:33 GMT']
+      etag: [W/"c4910337-202f-4425-8815-3f8c195792a6"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -983,113 +950,113 @@ interactions:
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb",
-      "etag": "W/\"40962383-ec18-4cf8-ba61-fc006213ba36\"", "location": "westus",
-      "properties": {"inboundNatRules": [{"etag": "W/\"40962383-ec18-4cf8-ba61-fc006213ba36\"",
-      "properties": {"frontendIPConfiguration": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"},
+    body: '{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb",
+      "etag": "W/\"c4910337-202f-4425-8815-3f8c195792a6\"", "location": "westus",
+      "properties": {"inboundNatRules": [{"etag": "W/\"c4910337-202f-4425-8815-3f8c195792a6\"",
+      "properties": {"frontendIPConfiguration": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"},
       "protocol": "Tcp", "frontendPort": 100, "backendPort": 100, "enableFloatingIP":
       false, "idleTimeoutInMinutes": 4, "provisioningState": "Succeeded"}, "name":
-      "rule1", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule1"},
-      {"etag": "W/\"40962383-ec18-4cf8-ba61-fc006213ba36\"", "properties": {"frontendIPConfiguration":
-      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"},
+      "rule1", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule1"},
+      {"etag": "W/\"c4910337-202f-4425-8815-3f8c195792a6\"", "properties": {"frontendIPConfiguration":
+      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"},
       "protocol": "Tcp", "frontendPort": 200, "backendPort": 200, "enableFloatingIP":
       false, "idleTimeoutInMinutes": 4, "provisioningState": "Succeeded"}, "name":
-      "rule2", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule2"}],
-      "resourceGuid": "cae7b678-9a20-4032-ab98-e1cd2932180e", "frontendIPConfigurations":
-      [{"etag": "W/\"40962383-ec18-4cf8-ba61-fc006213ba36\"", "properties": {"privateIPAllocationMethod":
-      "Dynamic", "provisioningState": "Succeeded", "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/publicIPAddresses/PublicIPmylb"}},
-      "name": "LoadBalancerFrontEnd", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"}],
+      "rule2", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule2"}],
+      "resourceGuid": "4491ffd4-776d-4f68-84bc-38ee3ff5d5cd", "frontendIPConfigurations":
+      [{"etag": "W/\"c4910337-202f-4425-8815-3f8c195792a6\"", "properties": {"privateIPAllocationMethod":
+      "Dynamic", "provisioningState": "Succeeded", "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/publicIPAddresses/PublicIPmylb"}},
+      "name": "LoadBalancerFrontEnd", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"}],
       "outboundNatRules": [], "loadBalancingRules": [], "inboundNatPools": [], "backendAddressPools":
-      [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mylbbepool",
-      "etag": "W/\"40962383-ec18-4cf8-ba61-fc006213ba36\"", "name": "mylbbepool",
+      [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mylbbepool",
+      "etag": "W/\"c4910337-202f-4425-8815-3f8c195792a6\"", "name": "mylbbepool",
       "properties": {"provisioningState": "Succeeded"}}, {"name": "bap1"}], "provisioningState":
       "Succeeded", "probes": []}, "tags": {}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
-      Content-Length: ['2523']
+      Content-Length: ['2627']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [7c39db8a-7612-11e6-a8a4-a0999b14fe87]
+      x-ms-client-request-id: [878f675e-a7aa-11e6-9c71-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9aHFdTj4a8UfFDB/cbdaTZloXq7aols3dncnu+af7D3a3dyfnO9v7s1m2neXTe9vT
-        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edPu3l3V1WUxy+vm7hfFtK6a6rwdv8jbq6p+
-        e7esstmTrMyWU3zv4ZG32QUw+e7d3/ejh+ef5vm9h5PtnXvZve397MF0ezI9z7fvz6jjbJY/2D2Y
-        /b4f6Yvt9YrHdENf2rqsphnGiDeuCNu1+YK6b+jDX/xL5E8awyqv2yLnD/GRfHhZNPR2sbx43WYt
-        9/t6PZ3m+SyfCSBqZgmzFuJOs/zB5NMHB9sPsz2i5s69ve1s8vBgO9+dzvYe3tvbPdjJ7cvndbVs
-        8+Xs7OVJtTwvLtY14ws0vidNUoMPHjulz73BPgOM06XFCM/P/UTfHRra3Rtx/7rMIQ/mrTeZ8uCr
-        W0ypPNS4uKQmZy+PS8NHX+TtvGLKPr2mqSim3VfWk7KY0huzGZGx1z+1+CHPSwehvLn7Uj/BHH3k
-        IyeiYJ6PiuWkWi9nL7L21bpkUlqGlKczMrzywx1bhOc6SN+t6d/dYJTdcf5/Zxx73XH4f37f/WE/
-        11++r+P9aJJN35I8Kiu8rKoymFWPDlbNAJlJvqKmPqP/v4BAkbHwFxFkf860iWurM0G/WMgeJEvt
-        SbbaDfr+fyede2j+v4rC8otlejcmAsHCRCC+Z7+mDiadjzqyh+/km/ikQTRDcvzcz1pnCKw+Qhx/
-        zqbMg0KNB3wEeiUASi1/7ok6gOuAP+Oj76Qejx30y6puaVC7Ozvh9ypzQ1/ny2xS5s8Iw5ZIfPaS
-        2pxnZZOHrYpZmb8pFnm1bs+WXxTLNY2ZWu6HrYgEbTUlhUm0fTNdeVirHNEv9g1vSgLu3/MnlTrG
-        53d/Dicqxv0hjj/i/vcm6gCuH8z9e132Drm/9/UPm/vlF2scCGDAXPRqzHKwoeTv8BUB+SX/D1IK
-        Xr+SDwAA
+        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edP+/sti+vs303yZ1UW1e3dVV5fFLK+bu18U
+        07pqqvN2/CJvr6r67d2yymZPsjJbTvG9h1TeZhdA67t3f9+P9j/99ME02/t0e3ae72/v708/3T7Y
+        27m//fDhg73Z+eQg353t/L4f6Yvt9YoHeENf2rqsphkGjDeuCPW1+YK6b+jDX/xL5E8awyqv2yLn
+        D/GRfHhZNPR2sbx43WYt9/t6PZ3m+SyfCSBqZqm0Fkrv7z/cPT+f7W8/ePDpbHv//NOD7YP9yXT7
+        3kGe3zs/vz+7P3Uvn9fVss2Xs7OXJ9XyvLhY14wv0PieNEkNPnjs/D73BvsMME6XFiie/5fN+t2h
+        cd69cSBfl1PkwST2ZlYefHWL+ZWHGheX1OTs5XFpmOqLvJ1XTOan1zQvxbT7ynpSFlN6YzYjmvb6
+        pxY/l5PUwS5v7r7UTzBhH/mYipCY56NiOanWy9mLrH21LpmullXl6QwTr/wcDjTCjZ0R3K3p391g
+        yN1B/390UHvdQfl/ft/9YT/XX76vg/9okk3fktgqk7ysqjKYb48oVjUBmUm+oqa+PPy/jVqRgfEX
+        Ecx/zjSQa6vTQr9YyB4kS/pJttoN+v7/ANF7OP+/itzyixUHNyYCwWJGIL5nv6YOJp2POlKJ7+Sb
+        +AxCaENy/L9sCjvjYS0TIvxzNn8eFGo84HHQKwFQavn/MgoPID7gKvljccoBj6XAy6puaYS7Ozvh
+        9yqNQ18T+pMyf0YYtkTvs5fU5jwrmzxsVczK/E2xyKt1e7b8oliuiQDUcj9sRSRoqynpVSL0m+nK
+        w1oljH6xb3jzE8jFnj/D1DE+v/v/llmLyUWI8I/k4sMoPID4B8vFXpfxQ7nofU3o/1DlQn6xBoUA
+        BpxGr8asDRtX/g5fEZBf8v8AZx+mOyEQAAA=
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/596d5765-c4f4-4aed-b50d-687b76a8f907?api-version=2016-06-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/ac6c134a-2660-4036-b3c8-435b4f039c5c?api-version=2016-06-01']
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:20:43 GMT']
+      date: ['Fri, 11 Nov 2016 01:02:34 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1190']
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [7ce82923-7612-11e6-861f-a0999b14fe87]
+      x-ms-client-request-id: [8820d1f0-a7aa-11e6-b9fe-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9aHFdTj4a8UfFDB/cbdaTZloXq7aols3dncnu+af7D3a3dyfnO9v7s1m2neXTe9vT
-        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edPu3l3V1WUxy+vm7hfFtK6a6rwdv8jbq6p+
-        e7esstmTrMyWU3zv4ZG32QUw+e7d3/ejh+ef5vm9h5PtnXvZve397MF0ezI9z7fvz6jjbJY/2D2Y
-        /b4f6Yvt9YrHdENf2rqsphnGiDeuCNu1+YK6b+jDX/xL5E8awyqv2yLnD/GRfHhZNPR2sbx43WYt
-        9/t6PZ3m+SyfCSBqZgmzFuJOs/zB5NMHB9sPsz2i5s69ve1s8vBgO9+dzvYe3tvbPdjJ7cvndbVs
-        8+Xs7OVJtTwvLtY14ws0vidNUoMPHjulz73BPgOM06XFCM/P/UTfHRra3Rtx/7rMIQ/mrTeZ8uCr
-        W0ypPNS4uKQmZy+PS8NHX+TtvGLKPr2mqSim3VfWk7KY0huzGZGx1z+1+CHPSwehvLn7Uj/BHH3k
-        IyeiYJ6PiuWkWi9nL7L21bpkUlqGlKczMrzywx1bhOc6SN+t6d/dYJTdcf5/Zxx73XH4f37f/WE/
-        11++r+P9aJJN35I8Kiu8rKoymFWPDlbNAJlJvqKmPqP/v4BAkbHwFxFkf860iWurM0G/WMgeJEvt
-        SbbaDfr+fyede2j+v4rC8otlejcmAsHCRCC+Z7+mDiadjzqyh+/km/ikQTRDcvzcz1pnCKw+Qhx/
-        zqbMg0KNB3wEeiUASi1/7ok6gOuAP+Oj76Qejx30y6puaVC7Ozvh9ypzQ1/ny2xS5s8Iw5ZIfPaS
-        2pxnZZOHrYpZmb8pFnm1bs+WXxTLNY2ZWu6HrYgEbTUlhUm0fTNdeVirHNEv9g1vSgLu3/MnlTrG
-        53d/Dicqxv0hjj/i/vcm6gCuH8z9e132Drm/9/UPm/vlF2scCGDAXPRqzHKwoeTv8BUB+SX/D1IK
-        Xr+SDwAA
+        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edP+/sti+vs303yZ1UW1e3dVV5fFLK+bu18U
+        07pqqvN2/CJvr6r67d2yymZPsjJbTvG9h1TeZhdA67t3f9+P9j/99ME02/t0e3ae72/v708/3T7Y
+        27m//fDhg73Z+eQg353t/L4f6Yvt9YoHeENf2rqsphkGjDeuCPW1+YK6b+jDX/xL5E8awyqv2yLn
+        D/GRfHhZNPR2sbx43WYt9/t6PZ3m+SyfCSBqZqm0Fkrv7z/cPT+f7W8/ePDpbHv//NOD7YP9yXT7
+        3kGe3zs/vz+7P3Uvn9fVss2Xs7OXJ9XyvLhY14wv0PieNEkNPnjs/D73BvsMME6XFiie/5fN+t2h
+        cd69cSBfl1PkwST2ZlYefHWL+ZWHGheX1OTs5XFpmOqLvJ1XTOan1zQvxbT7ynpSFlN6YzYjmvb6
+        pxY/l5PUwS5v7r7UTzBhH/mYipCY56NiOanWy9mLrH21LpmullXl6QwTr/wcDjTCjZ0R3K3p391g
+        yN1B/390UHvdQfl/ft/9YT/XX76vg/9okk3fktgqk7ysqjKYb48oVjUBmUm+oqa+PPy/jVqRgfEX
+        Ecx/zjSQa6vTQr9YyB4kS/pJttoN+v7/ANF7OP+/itzyixUHNyYCwWJGIL5nv6YOJp2POlKJ7+Sb
+        +AxCaENy/L9sCjvjYS0TIvxzNn8eFGo84HHQKwFQavn/MgoPID7gKvljccoBj6XAy6puaYS7Ozvh
+        9yqNQ18T+pMyf0YYtkTvs5fU5jwrmzxsVczK/E2xyKt1e7b8oliuiQDUcj9sRSRoqynpVSL0m+nK
+        w1oljH6xb3jzE8jFnj/D1DE+v/v/llmLyUWI8I/k4sMoPID4B8vFXpfxQ7nofU3o/1DlQn6xBoUA
+        BpxGr8asDRtX/g5fEZBf8v8AZx+mOyEQAAA=
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:20:44 GMT']
-      etag: [W/"9f6ee39b-03a3-4a7c-bcfe-5d959ade718d"]
+      date: ['Fri, 11 Nov 2016 01:02:34 GMT']
+      etag: [W/"4667ca26-dfe4-44c6-8205-9972dfb8e1d0"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1097,115 +1064,115 @@ interactions:
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb",
-      "etag": "W/\"9f6ee39b-03a3-4a7c-bcfe-5d959ade718d\"", "location": "westus",
-      "properties": {"inboundNatRules": [{"etag": "W/\"9f6ee39b-03a3-4a7c-bcfe-5d959ade718d\"",
-      "properties": {"frontendIPConfiguration": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"},
+    body: '{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb",
+      "etag": "W/\"4667ca26-dfe4-44c6-8205-9972dfb8e1d0\"", "location": "westus",
+      "properties": {"inboundNatRules": [{"etag": "W/\"4667ca26-dfe4-44c6-8205-9972dfb8e1d0\"",
+      "properties": {"frontendIPConfiguration": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"},
       "protocol": "Tcp", "frontendPort": 100, "backendPort": 100, "enableFloatingIP":
       false, "idleTimeoutInMinutes": 4, "provisioningState": "Succeeded"}, "name":
-      "rule1", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule1"},
-      {"etag": "W/\"9f6ee39b-03a3-4a7c-bcfe-5d959ade718d\"", "properties": {"frontendIPConfiguration":
-      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"},
+      "rule1", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule1"},
+      {"etag": "W/\"4667ca26-dfe4-44c6-8205-9972dfb8e1d0\"", "properties": {"frontendIPConfiguration":
+      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"},
       "protocol": "Tcp", "frontendPort": 200, "backendPort": 200, "enableFloatingIP":
       false, "idleTimeoutInMinutes": 4, "provisioningState": "Succeeded"}, "name":
-      "rule2", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule2"}],
-      "resourceGuid": "cae7b678-9a20-4032-ab98-e1cd2932180e", "frontendIPConfigurations":
-      [{"etag": "W/\"9f6ee39b-03a3-4a7c-bcfe-5d959ade718d\"", "properties": {"privateIPAllocationMethod":
-      "Dynamic", "provisioningState": "Succeeded", "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/publicIPAddresses/PublicIPmylb"}},
-      "name": "LoadBalancerFrontEnd", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"}],
+      "rule2", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule2"}],
+      "resourceGuid": "4491ffd4-776d-4f68-84bc-38ee3ff5d5cd", "frontendIPConfigurations":
+      [{"etag": "W/\"4667ca26-dfe4-44c6-8205-9972dfb8e1d0\"", "properties": {"privateIPAllocationMethod":
+      "Dynamic", "provisioningState": "Succeeded", "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/publicIPAddresses/PublicIPmylb"}},
+      "name": "LoadBalancerFrontEnd", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/frontendIPConfigurations/LoadBalancerFrontEnd"}],
       "outboundNatRules": [], "loadBalancingRules": [], "inboundNatPools": [], "backendAddressPools":
-      [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mylbbepool",
-      "etag": "W/\"9f6ee39b-03a3-4a7c-bcfe-5d959ade718d\"", "name": "mylbbepool",
-      "properties": {"provisioningState": "Succeeded"}}, {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/bap1",
-      "etag": "W/\"9f6ee39b-03a3-4a7c-bcfe-5d959ade718d\"", "name": "bap1", "properties":
+      [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mylbbepool",
+      "etag": "W/\"4667ca26-dfe4-44c6-8205-9972dfb8e1d0\"", "name": "mylbbepool",
+      "properties": {"provisioningState": "Succeeded"}}, {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/bap1",
+      "etag": "W/\"4667ca26-dfe4-44c6-8205-9972dfb8e1d0\"", "name": "bap1", "properties":
       {"provisioningState": "Succeeded"}}, {"name": "bap2"}], "provisioningState":
       "Succeeded", "probes": []}, "tags": {}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
-      Content-Length: ['2803']
+      Content-Length: ['2920']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [7cf8acd7-7612-11e6-8b4b-a0999b14fe87]
+      x-ms-client-request-id: [886d9261-a7aa-11e6-9529-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9aHFdTj4a8UfFDB/cbdaTZloXq7aols3dncnu+af7D3a3dyfnO9v7s1m2neXTe9vT
-        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edPu3l3V1WUxy+vm7hfFtK6a6rwdv8jbq6p+
-        e7esstmTrMyWU3zv4ZG32QUw+e7d3/ejg/187zyfPdyeZvne9v7Bzs72w0/zbPv+zvnD3Ul2//ze
-        zsHv+5G+2F6veEw39KWty2qaYYx444qwXZsvqPuGPvzFv0T+pDGs8rotcv4QH8mHl0VDbxfLi9dt
-        1nK/r9fTaZ7P8pkAomaWMGshLo3iweTTBwfbD7M9oubOvb3tbPLwYDvfnc72Ht7b2z3Yye3L53W1
-        bPPl7OzlSbU8Ly7WNeMLNL4nTVKDDx47pc+9wT4DjNOlxQjPz/1E3x0a2t0bcf+6zCEP5q03mfLg
-        q1tMqTzUuLikJmcvj0vDR1/k7bxiyj69pqkopt1X1pOymNIbsxmRsdc/tfghz0sHoby5+1I/wRx9
-        5CMnomCej4rlpFovZy+y9tW6ZFJahpSnMzK88sMdW4TnOkjfrenf3WCU3XH+f2cce91x+H9+3/1h
-        P9dfvq/j/WiSTd+SPCorvKyqMphVjw5WzQCZSb6ipj6j/7+AQJGx8BcRZH/OtIlrqzNBv1jIHiRL
-        7Um22g36/n8nnXto/n+KwntB3/+vpXCI5v+rKCy/WLXixkQgWF0RiO/Zr6mDSeejjnbDd/JNfNKg
-        /EKG+7mftc4QWEGHOP6cTZkHhRoPeGH0SgCUWv7cE3UA1wGP0UffST0eO+iXVd3SoHZ3dsLvVeaG
-        vs6X2aTMnxGGLZH47CW1Oc/KJg9bFbMyf1Ms8mrdni2/KJZrGjO13A9bEQnaakomiWj7ZrrysFY5
-        ol/sG96UBNwfKoOf+4mKcX+I44+4/72JOoDrB3P/Xpe9Q+7vff3D5n75xRoHAhgwF70asxxsKPk7
-        fEVAfsn/AyrY1tH0EAAA
+        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edP+/sti+vs303yZ1UW1e3dVV5fFLK+bu18U
+        07pqqvN2/CJvr6r67d2yymZPsjJbTvG9h1TeZhdA67t3f9+PHuzMptNPzx9sTz69/5BwuT/bznZm
+        B9vZ+WR39/79e1n+6cPf9yN9sb1e8QBv6Etbl9U0w4DxxhWhvjZfUPcNffiLf4n8SWNY5XVb5Pwh
+        PpIPL4uG3i6WF6/brOV+X6+n0zyf5TMBRM0sldZC6f39h7vn57P97QcPPp1t759/erB9sD+Zbt87
+        yPN75+f3Z/en7uXzulq2+XJ29vKkWp4XF+ua8QUa35MmqcEHj53f595gnwHG6dICxfP/slm/OzTO
+        uzcO5OtyijyYxN7MyoOvbjG/8lDj4pKanL08Lg1TfZG384rJ/PSa5qWYdl9ZT8piSm/MZkTTXv/U
+        4udykjrY5c3dl/oJJuwjH1MREvN8VCwn1Xo5e5G1r9Yl09WyqjydYeKVn8OBRrixM4K7Nf27Gwy5
+        O+j/jw5qrzso/8/vuz/s5/rL93XwH02y6VsSW2WSl1VVBvPtEcWqJiAzyVfU1JeH/7dRKzIw/iKC
+        +c+ZBnJtdVroFwvZg2RJP8lWu0Hf/x8geg/n/0+Rey/o+/8b5A5x/n8VueUXq33cmAgEazUC8T37
+        NXUw6XzUUYL4Tr6JzyB0ZMh9/y+bws54WKmHCP+czZ8HhRoPOHj0SgCUWv6/jMIDiA94pv5YnHLA
+        YynwsqpbGuHuzk74vUrj0NeE/qTMnxGGLdH77CW1Oc/KJg9bFbMyf1Ms8mrdni2/KJZrIgC13A9b
+        EQnaakpmjAj9ZrrysFYJo1/sG978BHIRqon/l81aTC5ChH8kFx9G4QHEP1gu9rqMH8pF72tC/4cq
+        F/KLNSgEMOA0ejVmbdi48nf4ioD8kv8H69hlcJARAAA=
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/0b6db38e-a1c8-4aa8-be8d-f198a2e80a5c?api-version=2016-06-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/31aef007-ec8c-4894-ace5-b1cdbc3b7922?api-version=2016-06-01']
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:20:45 GMT']
+      date: ['Fri, 11 Nov 2016 01:02:35 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1192']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [7da5a83a-7612-11e6-91a6-a0999b14fe87]
+      x-ms-client-request-id: [88f7a9f0-a7aa-11e6-adb8-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb?api-version=2016-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9aHFdTj4a8UfFDB/cbdaTZloXq7aols3dncnu+af7D3a3dyfnO9v7s1m2neXTe9vT
-        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edPu3l3V1WUxy+vm7hfFtK6a6rwdv8jbq6p+
-        e7esstmTrMyWU3zv4ZG32QUw+e7d3/ejg/187zyfPdyeZvne9v7Bzs72w0/zbPv+zvnD3Ul2//ze
-        zsHv+5G+2F6veEw39KWty2qaYYx444qwXZsvqPuGPvzFv0T+pDGs8rotcv4QH8mHl0VDbxfLi9dt
-        1nK/r9fTaZ7P8pkAomaWMGshLo3iweTTBwfbD7M9oubOvb3tbPLwYDvfnc72Ht7b2z3Yye3L53W1
-        bPPl7OzlSbU8Ly7WNeMLNL4nTVKDDx47pc+9wT4DjNOlxQjPz/1E3x0a2t0bcf+6zCEP5q03mfLg
-        q1tMqTzUuLikJmcvj0vDR1/k7bxiyj69pqkopt1X1pOymNIbsxmRsdc/tfghz0sHoby5+1I/wRx9
-        5CMnomCej4rlpFovZy+y9tW6ZFJahpSnMzK88sMdW4TnOkjfrenf3WCU3XH+f2cce91x+H9+3/1h
-        P9dfvq/j/WiSTd+SPCorvKyqMphVjw5WzQCZSb6ipj6j/7+AQJGx8BcRZH/OtIlrqzNBv1jIHiRL
-        7Um22g36/n8nnXto/n+KwntB3/+vpXCI5v+rKCy/WLXixkQgWF0RiO/Zr6mDSeejjnbDd/JNfNKg
-        /EKG+7mftc4QWEGHOP6cTZkHhRoPeGH0SgCUWv7cE3UA1wGP0UffST0eO+iXVd3SoHZ3dsLvVeaG
-        vs6X2aTMnxGGLZH47CW1Oc/KJg9bFbMyf1Ms8mrdni2/KJZrGjO13A9bEQnaakomiWj7ZrrysFY5
-        ol/sG96UBNwfKoOf+4mKcX+I44+4/72JOoDrB3P/Xpe9Q+7vff3D5n75xRoHAhgwF70asxxsKPk7
-        fEVAfsn/AyrY1tH0EAAA
+        ycO9B3vnOw/vP9y5W+dNta6n+ed1tV41d6dl8fu3edP+/sti+vs303yZ1UW1e3dVV5fFLK+bu18U
+        07pqqvN2/CJvr6r67d2yymZPsjJbTvG9h1TeZhdA67t3f9+PHuzMptNPzx9sTz69/5BwuT/bznZm
+        B9vZ+WR39/79e1n+6cPf9yN9sb1e8QBv6Etbl9U0w4DxxhWhvjZfUPcNffiLf4n8SWNY5XVb5Pwh
+        PpIPL4uG3i6WF6/brOV+X6+n0zyf5TMBRM0sldZC6f39h7vn57P97QcPPp1t759/erB9sD+Zbt87
+        yPN75+f3Z/en7uXzulq2+XJ29vKkWp4XF+ua8QUa35MmqcEHj53f595gnwHG6dICxfP/slm/OzTO
+        uzcO5OtyijyYxN7MyoOvbjG/8lDj4pKanL08Lg1TfZG384rJ/PSa5qWYdl9ZT8piSm/MZkTTXv/U
+        4udykjrY5c3dl/oJJuwjH1MREvN8VCwn1Xo5e5G1r9Yl09WyqjydYeKVn8OBRrixM4K7Nf27Gwy5
+        O+j/jw5qrzso/8/vuz/s5/rL93XwH02y6VsSW2WSl1VVBvPtEcWqJiAzyVfU1JeH/7dRKzIw/iKC
+        +c+ZBnJtdVroFwvZg2RJP8lWu0Hf/x8geg/n/0+Rey/o+/8b5A5x/n8VueUXq33cmAgEazUC8T37
+        NXUw6XzUUYL4Tr6JzyB0ZMh9/y+bws54WKmHCP+czZ8HhRoPOHj0SgCUWv6/jMIDiA94pv5YnHLA
+        YynwsqpbGuHuzk74vUrj0NeE/qTMnxGGLdH77CW1Oc/KJg9bFbMyf1Ms8mrdni2/KJZrIgC13A9b
+        EQnaakpmjAj9ZrrysFYJo1/sG978BHIRqon/l81aTC5ChH8kFx9G4QHEP1gu9rqMH8pF72tC/4cq
+        F/KLNSgEMOA0ejVmbdi48nf4ioD8kv8H69hlcJARAAA=
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:20:46 GMT']
-      etag: [W/"84e2fed9-cae2-4800-96ea-50f91ba5f308"]
+      date: ['Fri, 11 Nov 2016 01:02:36 GMT']
+      etag: [W/"70dcc6f7-b659-4d5d-a0d8-afb11553ae69"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -1217,31 +1184,31 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 resourcemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 resourcemanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [7dce708a-7612-11e6-ba7a-a0999b14fe87]
+      x-ms-client-request-id: [895cd45e-a7aa-11e6-9db0-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-09-01&$filter=resourceGroup%20eq%20%27cli_test1%27%20and%20name%20eq%20%27myvnet%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FvirtualNetworks%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27cli_test_nic_scenario1%27%20and%20name%20eq%20%27myvnet%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FvirtualNetworks%27
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
         uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
-        zsP7D3fu1nlTretp/nldrVfN3WlZ/P5t3rS7d1d1dVnM8rq5+0UxraumOm/HL/L2qqrf3r0s6nad
-        lfpnc3dxfbnM249GHy2zBeHzkf27vV7h7xshUNOymmbAm5pfEQJrfNZmF81Hj37xL/kl3/8l/w9W
-        ZuaC7QAAAA==
+        zsP7D3fu1nlTretp/nldrVfN3WlZ/P5t3rS//7KY/v7NNF9mdVHt3l3V1WUxy+vm7hfFtK6a6rwd
+        v8jbq6p+e/eyqNt1Vuqfzd3F9eUybz8afbTMFoTcR/bv9nqFv2+EQE3LapphENT8irBZ47M2u2g+
+        evSLf8kv+f4v+X8Agm88D/oAAAA=
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
-      content-length: ['292']
+      content-length: ['305']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:20:47 GMT']
+      date: ['Fri, 11 Nov 2016 01:02:37 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1249,54 +1216,52 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateNic_2016-08-01/azuredeploy.json"},
-      "mode": "Incremental", "parameters": {"subnet": {"value": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},
-      "publicIpAddressType": {"value": "none"}, "privateIpAddressVersion": {"value":
-      "ipv4"}, "subnetType": {"value": "existingId"}, "networkSecurityGroupType":
-      {"value": "none"}, "enableIpForwarding": {"value": false}, "virtualNetworkName":
-      {"value": "myvnet"}, "privateIpAddressAllocation": {"value": "dynamic"}, "networkInterfaceName":
-      {"value": "cli-test-nic"}, "useDnsSettings": {"value": "false"}}}}'
+      "mode": "Incremental", "parameters": {"subnet": {"value": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},
+      "publicIpAddressType": {"value": "none"}, "subnetType": {"value": "existingId"},
+      "networkSecurityGroupType": {"value": "none"}, "privateIpAddressAllocation":
+      {"value": "dynamic"}, "useDnsSettings": {"value": "false"}, "enableIpForwarding":
+      {"value": false}, "networkInterfaceName": {"value": "cli-test-nic"}, "privateIpAddressVersion":
+      {"value": "ipv4"}}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
-      Content-Length: ['742']
+      Content-Length: ['712']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 niccreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [7de71311-7612-11e6-ba63-a0999b14fe87]
+      x-ms-client-request-id: [89960ccf-a7aa-11e6-9752-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Resources/deployments/azurecli1473373247.3581085","name":"azurecli1473373247.3581085","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateNic_2016-08-01/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"enableIpForwarding":{"type":"Bool","value":false},"internalDnsNameLabel":{"type":"String","value":""},"loadBalancerBackendAddressPoolIds":{"type":"Array","value":[]},"loadBalancerInboundNatRuleIds":{"type":"Array","value":[]},"location":{"type":"String","value":"westus"},"networkInterfaceName":{"type":"String","value":"cli-test-nic"},"networkSecurityGroup":{"type":"String","value":""},"networkSecurityGroupType":{"type":"String","value":"none"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"privateIpAddressVersion":{"type":"String","value":"ipv4"},"publicIpAddress":{"type":"String","value":""},"publicIpAddressType":{"type":"String","value":"none"},"subnet":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},"subnetType":{"type":"String","value":"existingId"},"tags":{"type":"Object","value":{}},"useDnsSettings":{"type":"String","value":"false"},"virtualNetworkName":{"type":"String","value":"myvnet"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-09-08T22:20:48.7430715Z","duration":"PT0.6602834S","correlationId":"b121040f-d0ca-4d28-ad18-24cb72781daf","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["westus"]}]}],"dependencies":[]}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478826157.5960859","name":"azurecli1478826157.5960859","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateNic_2016-08-01/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"enableIpForwarding":{"type":"Bool","value":false},"internalDnsNameLabel":{"type":"String","value":""},"loadBalancerBackendAddressPoolIds":{"type":"Array","value":[]},"loadBalancerInboundNatRuleIds":{"type":"Array","value":[]},"location":{"type":"String","value":"westus"},"networkInterfaceName":{"type":"String","value":"cli-test-nic"},"networkSecurityGroup":{"type":"String","value":""},"networkSecurityGroupType":{"type":"String","value":"none"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"privateIpAddressVersion":{"type":"String","value":"ipv4"},"publicIpAddress":{"type":"String","value":""},"publicIpAddressType":{"type":"String","value":"none"},"subnet":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},"subnetType":{"type":"String","value":"existingId"},"tags":{"type":"Object","value":{}},"useDnsSettings":{"type":"String","value":"false"},"virtualNetworkName":{"type":"String","value":""}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-11-11T01:02:39.1089747Z","duration":"PT0.5269914S","correlationId":"85fddf64-1f2b-4b4e-9fe5-bb43ffe62710","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["westus"]}]}],"dependencies":[]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/azurecli1473373247.3581085/operationStatuses/08587282336373948611?api-version=2015-11-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478826157.5960859/operationStatuses/08587227807268956965?api-version=2015-11-01']
       cache-control: [no-cache]
-      content-length: ['1784']
+      content-length: ['1804']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:20:48 GMT']
+      date: ['Fri, 11 Nov 2016 01:02:38 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1194']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 niccreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [7de71311-7612-11e6-ba63-a0999b14fe87]
+      x-ms-client-request-id: [89960ccf-a7aa-11e6-9752-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587282336373948611?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587227807268956965?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -1308,7 +1273,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['141']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:21:18 GMT']
+      date: ['Fri, 11 Nov 2016 01:03:08 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1319,46 +1284,46 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 niccreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [7de71311-7612-11e6-ba63-a0999b14fe87]
+      x-ms-client-request-id: [89960ccf-a7aa-11e6-9752-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
         o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXenZfH7t3nT7t5d1dVlMcvr5u4XxbSumuq8Hb/Sxs3dWb4qq+tFvmybu9kP1nVOL+7u
-        P7h378G9vf0H43v3D3Z3Du5/NPpomS1yQm1jG+pqlddtkTcfPfrFH7X5YlVmbf68WL7F3+u6IADz
-        tl01j+5KZ83s7bQYT8pqMp5WdT6+Kpaz6qoZL/P2rnl9XjXt3ZM6p19fFNPff29n99PtnYPtnV0B
-        IQMY/3RTLQmDabVsaSw/ScMl0lF3u+Md/PfRLyHssprG0NJXwCZfZpMyP1s9q+qrrJ4Vywt82l6v
-        MMonVVUStMusXNOf51nZ5ASgINj1MiufLpsX2SJ/nk3y0nvpdVsDin3tI3RaVtnsSVZmy2leP8mm
-        b/Pl7Hg2o5E3L6mPsxnjogCO6zq7du9/7/ud98+Wk2q9nL3I2ldrQv0W704zcJDXrIfjFfHIugGm
-        RPOrqn57hkGeZ9McQ9z0JjHBNjhse1lMvfdf51Oa6Paa+XDT+0PvvOH2w+8tq2WOd1d1cUk8cbZS
-        em56J9b+uLwNfWbXxPgywC4Ay2TDbxery31+dT0pi6l9c9Mrkea3pQhpDSLoppZ3qcnPqmJ5IRN6
-        97Ko23VW6p/N3cX1JaF2l7qnH/hTfnNY3zTG/F3RtPTR2QzvtNmFT8QvJz+dT1vX+hf/EmqzbnIS
-        1Nd5i9f81j3YLN8AG2J9kwDImD5CX4tqhk/OltM6hy7NoD2YPuAQeu11S5xDLV6vp9OcdNaMvm+L
-        BdExW5CUfCRa7SEptjd7e4/2dh7d3x3f3995eO/Tg5+iprN1rZz60cs398b7pHH3Dx68pm9IbdY5
-        qUn6kkjz6KPJ7t7uzv7O+fZsZ5rRlO4dbGez3YPtvf3p5MHeg4PdWXZOrzFumDtSFb+YdXuzIpkn
-        AL25pNaGBTBJ8ob/Cb1EdEBTqzsaeslIF14waub7v4T+o+HkK9KD+XLKluJ79Em1blfrlv4gZPKr
-        F2cn+E0J35tdwX4DZQ12n6/ZnH56cG93Lz/Y3T7PH+5v72f7+9sH9/fPt+/vEtUfTvbu70/u0VvF
-        6qRanhcXSmtChgYK0hCIYkWWhb7bRTvABCv/UCSpR1q8ZxXv3S7S9IHDNCc5IVy/e/f3/Whnb5rd
-        f7g73T7Yy/Lt/YP9+9uTB4Rqls2mu+fn987zncnv+xG9Q7h4Npz+2khpoxNfqqqir3fJ3NJ/+8G3
-        Vtd+kbfzCgR8qorVKAD09sOlbCjtUEqQ57vUPf3An/IbFAMNZJHV1x89aut1/kuYhUPVwn/Wl9QR
-        cQ19na1WZZHPWAHZjwmQeh0vfa+D1c8vgRoRKbDOGb2jNOkjT4jh5wBbfERy9kv+H+bEJJhNCgAA
+        p/nndbVeNXenZfH7t3nT/v7LYvr7N9N8mdVFtXt3VVeXxSyvm7tfFNO6aqrzdvxK32zuzvJVWV0v
+        8mXb3M1+sK5zgrK7/+DgYO/T3fsPxvcffrpzcP/hR6OPltkiJzw3tqGuVnndFnnz0aNf/FGbL1Zl
+        1ubPi+Vb/L2uCwIwb9tV8+iudNbM3k6L8aSsJuNpVefjq2I5q66a8TJv75rX51XT3j2pc/r1BQ1s
+        b2f30+2dg+2dXQEhAxj/dFMtCYNptWxpLD9JwyU6Une74x3899EvIeyymsbQ0lfAhsgzKfOz1bOq
+        vsrqWbG8wKft9QqjfFJVJUG7zMo1/XmelU1OAAqCXS+z8umyeZEt8ufZJC+9l163NaDY1z5Cp2WV
+        zZ5kZbac5vWTbPo2X86OZzMaefOS+jibMS4K4Lius2v3/ve+33n/bDmp1svZi6x9tSbUb/HuNAM7
+        ec16OF4Rw6wbYEo0v6rqt2cY5Hk2zTHETW8SE2yD3baJ3bz3X+dTmuj2mply0/tD77zh9sPvLatl
+        jndXdXFJPHG2UnpueifW/ri8DX1m18T4MsAuAMtkw28Xq8t9fnU9KYupfXPTK5Hmt6UIqRAi6KaW
+        d6nJD0/LvJDZvXtZ1O06K/XP5u7i+pLwvEu40A/8Kb+5Idw04Pxd0bT00dkM77TZhU/RLyc/nU9b
+        1/oX/xJqs25yktrXeYvX/NY92CzsABtifZM0fIReFtUMv58tp3UOlZpBiTBlwCj0wuuWGIhavF5P
+        pzmprhl93xYLIme2IGH5iJXbLs3H7pud3Uc7e4/2d8af3vv03oPdhz9FTWfrWhn2o5dv9sY79/fv
+        HRx8+pq+Ie1Z56Qt6UsiyqOPDu6fz2Y0t9u753uT7f3Jfr798Dy/vz2Z7N87P88/3Xuwu0OvMW6Y
+        NdIYv5hVfLMi0ScAvVmk1oYTMD3yhv8JvURTh6ZWhTT0khEyvGC0zfd/Cf1Hw8lXpA7z5ZQNxvfo
+        k2rdrtYt/UHI5Fcvzk7wm5K8N6+C/QbKGuw+X7OJvXeQP5jeP59uPzg/2Nvef7g32z7Y2bu3/emn
+        2ad7e/n9nYf7U3qrWJ1Uy/PiQmlNyNBAQRoCUazIwNB3u2gHmGDiH75A9egMIFYZ3+2OgD5waOck
+        LoT4d+/+vh/tf/rpQZ5PHm5Ppw/3Cdt7e4Rtnm9Ppp/u3M+zB7PdvfPf9yN6h3Dx7Dr9tZHsRk++
+        VPVFX++SCab/9oNvrf79Im/nFaj5VJWt0QPo7eeQzKEGgKIa1Fs0qkVWX3/0qK3X+S9h5g7VDf9Z
+        X1JHxE/0dbZalUU+Y6VkPyZAhBfckpe+W8Iq6ZdAwYh8WO+N3lEC9ZEnxPBzgEc+Ign8Jf8PHXG+
+        HXsKAAA=
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
-      content-length: ['1197']
+      content-length: ['1202']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:21:18 GMT']
+      date: ['Fri, 11 Nov 2016 01:03:09 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1369,31 +1334,31 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 resourcemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 resourcemanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [911b293a-7612-11e6-8d76-a0999b14fe87]
+      x-ms-client-request-id: [9d777770-a7aa-11e6-b99f-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-09-01&$filter=resourceGroup%20eq%20%27cli_test1%27%20and%20name%20eq%20%27myvnet%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FvirtualNetworks%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27cli_test_nic_scenario1%27%20and%20name%20eq%20%27myvnet%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FvirtualNetworks%27
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
         uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
-        zsP7D3fu1nlTretp/nldrVfN3WlZ/P5t3rS7d1d1dVnM8rq5+0UxraumOm/HL/L2qqrf3r0s6nad
-        lfpnc3dxfbnM249GHy2zBeHzkf27vV7h7xshUNOymmbAm5pfEQJrfNZmF81Hj37xL/kl3/8l/w9W
-        ZuaC7QAAAA==
+        zsP7D3fu1nlTretp/nldrVfN3WlZ/P5t3rS//7KY/v7NNF9mdVHt3l3V1WUxy+vm7hfFtK6a6rwd
+        v8jbq6p+e/eyqNt1Vuqfzd3F9eUybz8afbTMFoTcR/bv9nqFv2+EQE3LapphENT8irBZ47M2u2g+
+        evSLf8kv+f4v+X8Agm88D/oAAAA=
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
-      content-length: ['292']
+      content-length: ['305']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:21:19 GMT']
+      date: ['Fri, 11 Nov 2016 01:03:10 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1404,31 +1369,31 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 resourcemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 resourcemanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [912e6a5e-7612-11e6-88ee-a0999b14fe87]
+      x-ms-client-request-id: [9d9a68c0-a7aa-11e6-aea1-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-09-01&$filter=resourceGroup%20eq%20%27cli_test1%27%20and%20name%20eq%20%27publicip1%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FpublicIPAddresses%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27cli_test_nic_scenario1%27%20and%20name%20eq%20%27publicip1%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FpublicIpAddresses%27
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
         uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
-        zsP7D3fu1nlTretp/nldrVfN3WlZ/P5t3rS7d1d1dVnM8rq5+0UxraumOm/HL/L2qqrf3l2tJ2Ux
-        PXt5PJvR+03e6CfFavej0UfLbEFIfeR/1F6v8NEtIFHjsppmGAG9cEWorPFZm100Hz36xb/kl3z/
-        l/w/O+BUR/cAAAA=
+        zsP7D3fu1nlTretp/nldrVfN3WlZ/P5t3rS//7KY/v7NNF9mdVHt3l3V1WUxy+vm7hfFtK6a6rwd
+        v8jbq6p+e3e1npTF9Ozl8WxGwJq80U+K1e5Ho4+W2YIw/Mj/qL1e4aNbQKLGZTXNMBx64YrwWuOz
+        NrtoPnr0i3/JL/n+L/l/ALWYEcMEAQAA
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
-      content-length: ['296']
+      content-length: ['309']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:21:19 GMT']
+      date: ['Fri, 11 Nov 2016 01:03:10 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1436,62 +1401,60 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateNic_2016-08-01/azuredeploy.json"},
-      "mode": "Incremental", "parameters": {"subnet": {"value": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},
+      "mode": "Incremental", "parameters": {"subnet": {"value": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},
       "useDnsSettings": {"value": "true"}, "loadBalancerInboundNatRuleIds": {"value":
-      [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule1"},
-      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule2"}]},
+      [{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule1"},
+      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule2"}]},
       "internalDnsNameLabel": {"value": "test"}, "privateIpAddress": {"value": "10.0.0.15"},
       "publicIpAddressType": {"value": "existingId"}, "privateIpAddressVersion": {"value":
-      "ipv4"}, "publicIpAddress": {"value": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/publicIPAddresses/publicip1"},
+      "ipv4"}, "publicIpAddress": {"value": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/publicIpAddresses/publicip1"},
       "networkSecurityGroupType": {"value": "none"}, "privateIpAddressAllocation":
       {"value": "static"}, "loadBalancerBackendAddressPoolIds": {"value": [{"id":
-      "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mylbbepool"},
-      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/bap1"},
-      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/bap2"}]},
+      "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mylbbepool"},
+      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/bap1"},
+      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/bap2"}]},
       "enableIpForwarding": {"value": true}, "networkInterfaceName": {"value": "cli-test-nic"},
       "subnetType": {"value": "existingId"}}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
-      Content-Length: ['1851']
+      Content-Length: ['1942']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 niccreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [9140c46b-7612-11e6-afc2-a0999b14fe87]
+      x-ms-client-request-id: [9db67c40-a7aa-11e6-8f45-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Resources/deployments/azurecli1473373279.7324876","name":"azurecli1473373279.7324876","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateNic_2016-08-01/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"enableIpForwarding":{"type":"Bool","value":true},"internalDnsNameLabel":{"type":"String","value":"test"},"loadBalancerBackendAddressPoolIds":{"type":"Array","value":[{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mylbbepool"},{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/bap1"},{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/bap2"}]},"loadBalancerInboundNatRuleIds":{"type":"Array","value":[{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule1"},{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule2"}]},"location":{"type":"String","value":"westus"},"networkInterfaceName":{"type":"String","value":"cli-test-nic"},"networkSecurityGroup":{"type":"String","value":""},"networkSecurityGroupType":{"type":"String","value":"none"},"privateIpAddress":{"type":"String","value":"10.0.0.15"},"privateIpAddressAllocation":{"type":"String","value":"static"},"privateIpAddressVersion":{"type":"String","value":"ipv4"},"publicIpAddress":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/publicIPAddresses/publicip1"},"publicIpAddressType":{"type":"String","value":"existingId"},"subnet":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},"subnetType":{"type":"String","value":"existingId"},"tags":{"type":"Object","value":{}},"useDnsSettings":{"type":"String","value":"true"},"virtualNetworkName":{"type":"String","value":""}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-09-08T22:21:20.8668894Z","duration":"PT0.3374185S","correlationId":"a6067c97-a60e-4fb5-9d0d-5cd8799ab225","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["westus"]}]}],"dependencies":[]}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478826191.3543586","name":"azurecli1478826191.3543586","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateNic_2016-08-01/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"enableIpForwarding":{"type":"Bool","value":true},"internalDnsNameLabel":{"type":"String","value":"test"},"loadBalancerBackendAddressPoolIds":{"type":"Array","value":[{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mylbbepool"},{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/bap1"},{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/bap2"}]},"loadBalancerInboundNatRuleIds":{"type":"Array","value":[{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule1"},{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/loadBalancers/mylb/inboundNatRules/rule2"}]},"location":{"type":"String","value":"westus"},"networkInterfaceName":{"type":"String","value":"cli-test-nic"},"networkSecurityGroup":{"type":"String","value":""},"networkSecurityGroupType":{"type":"String","value":"none"},"privateIpAddress":{"type":"String","value":"10.0.0.15"},"privateIpAddressAllocation":{"type":"String","value":"static"},"privateIpAddressVersion":{"type":"String","value":"ipv4"},"publicIpAddress":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/publicIpAddresses/publicip1"},"publicIpAddressType":{"type":"String","value":"existingId"},"subnet":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},"subnetType":{"type":"String","value":"existingId"},"tags":{"type":"Object","value":{}},"useDnsSettings":{"type":"String","value":"true"},"virtualNetworkName":{"type":"String","value":""}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-11-11T01:03:12.7404036Z","duration":"PT0.3505533S","correlationId":"74cb4312-aabf-400d-9a76-1b3ae8466865","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["westus"]}]}],"dependencies":[]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/azurecli1473373279.7324876/operationStatuses/08587282336049481770?api-version=2015-11-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478826191.3543586/operationStatuses/08587227806930878620?api-version=2015-11-01']
       cache-control: [no-cache]
-      content-length: ['2714']
+      content-length: ['2818']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:21:20 GMT']
+      date: ['Fri, 11 Nov 2016 01:03:12 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1188']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 niccreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [9140c46b-7612-11e6-afc2-a0999b14fe87]
+      x-ms-client-request-id: [9db67c40-a7aa-11e6-8f45-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587282336049481770?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587227806930878620?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -1503,7 +1466,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['141']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:21:51 GMT']
+      date: ['Fri, 11 Nov 2016 01:03:42 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1514,50 +1477,49 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 niccreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [9140c46b-7612-11e6-afc2-a0999b14fe87]
+      x-ms-client-request-id: [9db67c40-a7aa-11e6-8f45-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
         o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXenZfH7t3nT7t5d1dVlMcvr5u4XxbSumuq8Hb/Sxs3dWb4qq+tFvmybu9kP1nVOL+7u
-        P7h378G9vQcPx/Tv/sGDTz8afbTMFjmhtrENdbXK67bIm48e/eKP2nyxKrM2f14s3+LvdV0QgHnb
-        rppHd6WzZvZ2WownZTUZT6s6H18Vy1l11YyXeXvXvD6vmvbuSZ3Try+K6e+/t7P76fbOwfbOroCQ
-        AYx/uqmWhMG0WrY0lp+k4RLpqLvd8Q7+++iXEHZZTWNo6Stgky+zSZmfrZ5V9VVWz4rlBT5tr1cY
-        5ZOqKgnaZVau6c+2Xuf0fkGg62VWPl02L7JF/jyb5KX3zuu2BhD7Fo2/adFvWWWzJ1mZLad5/SSb
-        vs2Xs+PZjAbfvKRuzmaMjgI5ruvs2sH43g+LIV7k7VVVv73r49rcXVyXk7uTHsryxSRf0e80wP+X
-        4jjJVrv/r8Zu76Nf8v0Oe5wtJ9V6OXuRta/WxJz/b2eNIkC3uVvTv/8voXkMNUvwaQaMPNr2ZPeK
-        +lw3NJSPSBWhjzMI/3k2zSH6m94kjLeB8faymHrvv86npP/aax7XpveH3nnD7YffW1bLHO+u6uKS
-        VOXZStlt0zu7pBnpv937sRePy9sQqmmpCQ+0+77VwcMvF6vLfX51PSmLqX1z0yt3f1g8pTi9VJyI
-        heSTgrVKF+WbZid/VzQtfXQ2w8s0BpriTe3vUpMfyjAvi7pdZ6X+CeG5JNTuUvf0A3/Kbw7r9xtp
-        m1340/nl5Kfzaeta/+JfQm3WTU4m9XXe4jW/dQ82DDGghkjfJJEfoZNFNcPvZ8tpncPbyWDfmTBg
-        UnrhNTEyWrxeT6c5eRUz+r4tFkTAbEEC+5H4HQ/J9Xizt/dob/fR3qfjBw/u7z3cuf9T1HS2rkkQ
-        wO4fvXzz6Xhv//7B7sNPX9M35NjUOTky9CXRhDyoT3c+fTB9+GCbfsm3988n97cfznZm2/ens4MH
-        Dx9mk729+/Qa44ZJY1UP76tZkfohAL1JpNZm7jE78ob/Cb1EM4emVo019JKRb7xgNN73SUV+n4aT
-        r8hi5csp+3Lfo0+qdbtat/QHIZNfvTg7wW9K8t60CvYbKGuw+3zNluLTg3u7e/nB7vZ5/nB/ez/b
-        398+uL9/vn1/l6j+cLJ3f39yj94qVifV8ry4UFoTMjRQkIZAFCvy/ei7XbQDTPDwD0WEeqTFe9YG
-        3O0iTR84THMSEML1u3d/34/Os52HD2YPDraz7MHD7f1Jnm9n5/fy7en98/ze/b1sdm8//30/oncI
-        F8/Lpr82UtqoZaPI6Gun9v2vrbr/Im/nFSgIcKTbqZEoOwfih23gOwgQieUTVcaEBk3CDx+tUA9B
-        Ww4qT6LzIquvJZiA6DmPpR8TEIWJsX+4Y/ExAurkQ8X8VnzxI8+fev8Q7OCIhjwQOv7/L5n/mA/9
-        /xLCxlADVX8JCDsLvQn+s76kd4ms9HW2WpVFPmOfw/s4Ht5LFO++ffaLZrDx+HScTc6bxbKcLWY/
-        WM9+eq89r9bT9qomcz+evRubN8bTslrPqFNkNYh6JvPw0s88QCv8EvgpYmZtfoZQU2r3yULg8HPA
-        7jAx/h/Rhjt5UBIAAA==
+        p/nndbVeNXenZfH7t3nT/v7LYvr7N9N8mdVFtXt3VVeXxSyvm7tfFNO6aqrzdvxK32zuzvJVWV0v
+        8mXb3M1+sK5zgrK7/+DgYO/T3Ye743v39+/dP/j0o9FHy2yRE54b21BXq7xui7z56NEv/qjNF6sy
+        a/PnxfIt/l7XBQGYt+2qeXRXOmtmb6fFeFJWk/G0qvPxVbGcVVfNeJm3d83r86pp757UOf36gga2
+        t7P76fbOwfbOroCQAYx/uqmWhMG0WrY0lp+k4RIdqbvd8Q7+++iXEHZZTWNo6StgQ+SZlPnZ6llV
+        X2X1rFhe4NP2eoVRPqmqkqBdZuWa/mzrdU7vFwS6Xmbl02XzIlvkz7NJXnrvvG5rALFv0fibFv2W
+        VTZ7kpXZcprXT7Lp23w5O57NaPDNS+rmbMboKJDjus6uHYzv/Zxwx4u8varqt3d9xJu7i+tycnfS
+        w1++mOQr+p1G+/8FhCfZavf/O6juffRLvt/horPlpFovZy+y9tWaePj/UxxUBLg3d2v69/+NsxHD
+        007FNAN6HtV7wn9FCKwbGtdHpMvQxxm0x3k2zaE7Nr1J6G8D/W1C33v/dT4lBdpe8yA3vT/0zhtu
+        P/zeslrmeHdVF5eka89Wyoib3tkl1Ur/7d6PvXhc3oZQTUtNeKDd960SH365WF3u86vrSVlM7Zub
+        Xrn7c8JgHQSJn+STgjVRF/+bpip/VzQtfXQ2w8s0IJrvTe3vUpMf/pgvi7pdZ6X+CbG6JDzvEi70
+        A3/Kb24I7zfsNrvwJ/rLyU/n09a1/sW/hNqsm5ys9eu8xWt+6x5s2HhADZG+SVY/QieLaobfz5bT
+        OocjlcF1YMKAfemF18TiaPF6PZ3m5LDM6Pu2WBA1swWJ8kfs0uzSdOy+2dl9tHPv0e6D8acPH+wd
+        fHrwU9R0tq5JRCAIH718c398b+fB/r1P77+mb8hnqnPykehLosmjjx7sTyf793b3trNscr69v7Mz
+        236YPSDYk3tZfrD/6acHn96n1xg3TBqbBzh2zYoUEwHoTSK1NoyA2ZE3/E/oJZo5NLUKrqGXjOTj
+        BaMLv0/K8/s0nHxFVi5fTtlN/B59Uq3b1bqlPwiZ/OrF2Ql+U5L3plWw30BZg93nazYo9w7yB9P7
+        59PtB+cHe9v7D/dm2wc7e/e2P/00+3RvL7+/83B/Sm8Vq5NqeV5cKK0JGRooSEMgihW5lfTdLtoB
+        Jnj4hy9PPToDiDUVd7sjoA8c2jlJCyH+3bu/70cPDnaIUlm+/WDn4GB7/0Geb08+JWz3H54fTIlS
+        +7Pdye/7Eb1DuHjePP21kexGe79UHUZfO+vgf22twhd5O69AToAjE0CNRA06ED+nTkEHG6K3fKI6
+        m3CiGfk5xjFUV1CqgzqWZmCR1dcSzkBCncvTj0qI9sT/P4cD89HDOMgji/nH+OJHscfPGqpweENW
+        CUOP/zeyScxx/38jyWN4gt6/BCSfhV4L/1lf0rtEcPo6W63KIp+xb+N9HM9QSCLCffvsF83gS+DT
+        8fx+OyuXq526fbe+d95Uu7v57uW0Wf50Np69G5s3xtOyWs+oUyRmiJQmefLST55ArfwS+ENizm2K
+        iVBT0vfJQuDwc8CkMTH+HwMLCjUgEwAA
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
-      content-length: ['1381']
+      content-length: ['1392']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:21:50 GMT']
+      date: ['Fri, 11 Nov 2016 01:03:43 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1568,31 +1530,31 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 resourcemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 resourcemanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [a4795363-7612-11e6-b7ea-a0999b14fe87]
+      x-ms-client-request-id: [b1a15cc0-a7aa-11e6-99b2-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-09-01&$filter=resourceGroup%20eq%20%27cli_test1%27%20and%20name%20eq%20%27myvnet%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FvirtualNetworks%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27cli_test_nic_scenario1%27%20and%20name%20eq%20%27myvnet%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FvirtualNetworks%27
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
         uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
-        zsP7D3fu1nlTretp/nldrVfN3WlZ/P5t3rS7d1d1dVnM8rq5+0UxraumOm/HL/L2qqrf3r0s6nad
-        lfpnc3dxfbnM249GHy2zBeHzkf27vV7h7xshUNOymmbAm5pfEQJrfNZmF81Hj37xL/kl3/8l/w9W
-        ZuaC7QAAAA==
+        zsP7D3fu1nlTretp/nldrVfN3WlZ/P5t3rS//7KY/v7NNF9mdVHt3l3V1WUxy+vm7hfFtK6a6rwd
+        v8jbq6p+e/eyqNt1Vuqfzd3F9eUybz8afbTMFoTcR/bv9nqFv2+EQE3LapphENT8irBZ47M2u2g+
+        evSLf8kv+f4v+X8Agm88D/oAAAA=
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
-      content-length: ['292']
+      content-length: ['305']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:21:51 GMT']
+      date: ['Fri, 11 Nov 2016 01:03:44 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1603,31 +1565,31 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 resourcemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 resourcemanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [a48be587-7612-11e6-9420-a0999b14fe87]
+      x-ms-client-request-id: [b1baff40-a7aa-11e6-88fd-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-09-01&$filter=resourceGroup%20eq%20%27cli_test1%27%20and%20name%20eq%20%27mynsg%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FnetworkSecurityGroups%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27cli_test_nic_scenario1%27%20and%20name%20eq%20%27mynsg%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FnetworkSecurityGroups%27
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
         uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
-        zsP7D3fu1nlTretp/nldrVfN3WlZ/P5t3rS7d1d1dVnM8rq5+0UxraumOm/HL/L2qqrf3l3Kz9f5
-        dF0X7bW+u7heNhcfjT5aZgtC6iPzZ3u9wp+3hEIvlNU0wwjopStCZY3P2uyi+ejRL/4lv+T7v+T/
-        AWYMNwH3AAAA
+        zsP7D3fu1nlTretp/nldrVfN3WlZ/P5t3rS//7KY/v7NNF9mdVHt3l3V1WUxy+vm7hfFtK6a6rwd
+        v8jbq6p+e3cpP1/n03VdtNcKaHG9bC4+Gn20zBaE4Ufmz/Z6hT9vCYVeKKtphuHQS1eE1xqftdlF
+        89GjX/xLfsn3f8n/A+h0coUEAQAA
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
-      content-length: ['294']
+      content-length: ['306']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:21:51 GMT']
+      date: ['Fri, 11 Nov 2016 01:03:44 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1635,55 +1597,53 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateNic_2016-08-01/azuredeploy.json"},
-      "mode": "Incremental", "parameters": {"subnet": {"value": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},
-      "networkSecurityGroup": {"value": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/networkSecurityGroups/mynsg"},
-      "privateIpAddressAllocation": {"value": "dynamic"}, "publicIpAddressType": {"value":
-      "none"}, "privateIpAddressVersion": {"value": "ipv4"}, "networkSecurityGroupType":
-      {"value": "existingId"}, "virtualNetworkName": {"value": "myvnet"}, "useDnsSettings":
-      {"value": "false"}, "enableIpForwarding": {"value": false}, "networkInterfaceName":
-      {"value": "cli-test-nic"}, "subnetType": {"value": "existingId"}}}}'
+      "mode": "Incremental", "parameters": {"subnet": {"value": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},
+      "networkSecurityGroup": {"value": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkSecurityGroups/mynsg"},
+      "publicIpAddressType": {"value": "none"}, "subnetType": {"value": "existingId"},
+      "networkSecurityGroupType": {"value": "existingId"}, "privateIpAddressAllocation":
+      {"value": "dynamic"}, "useDnsSettings": {"value": "false"}, "enableIpForwarding":
+      {"value": false}, "networkInterfaceName": {"value": "cli-test-nic"}, "privateIpAddressVersion":
+      {"value": "ipv4"}}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
-      Content-Length: ['919']
+      Content-Length: ['902']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 niccreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [a49f74b5-7612-11e6-8746-a0999b14fe87]
+      x-ms-client-request-id: [b1f3e991-a7aa-11e6-9699-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Resources/deployments/azurecli1473373312.2214636","name":"azurecli1473373312.2214636","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateNic_2016-08-01/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"enableIpForwarding":{"type":"Bool","value":false},"internalDnsNameLabel":{"type":"String","value":""},"loadBalancerBackendAddressPoolIds":{"type":"Array","value":[]},"loadBalancerInboundNatRuleIds":{"type":"Array","value":[]},"location":{"type":"String","value":"westus"},"networkInterfaceName":{"type":"String","value":"cli-test-nic"},"networkSecurityGroup":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/networkSecurityGroups/mynsg"},"networkSecurityGroupType":{"type":"String","value":"existingId"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"privateIpAddressVersion":{"type":"String","value":"ipv4"},"publicIpAddress":{"type":"String","value":""},"publicIpAddressType":{"type":"String","value":"none"},"subnet":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},"subnetType":{"type":"String","value":"existingId"},"tags":{"type":"Object","value":{}},"useDnsSettings":{"type":"String","value":"false"},"virtualNetworkName":{"type":"String","value":"myvnet"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-09-08T22:21:53.5729686Z","duration":"PT0.3975845S","correlationId":"773b12f0-876e-46b7-8556-44ce4119ec6a","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["westus"]}]}],"dependencies":[]}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478826225.3191808","name":"azurecli1478826225.3191808","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateNic_2016-08-01/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"enableIpForwarding":{"type":"Bool","value":false},"internalDnsNameLabel":{"type":"String","value":""},"loadBalancerBackendAddressPoolIds":{"type":"Array","value":[]},"loadBalancerInboundNatRuleIds":{"type":"Array","value":[]},"location":{"type":"String","value":"westus"},"networkInterfaceName":{"type":"String","value":"cli-test-nic"},"networkSecurityGroup":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkSecurityGroups/mynsg"},"networkSecurityGroupType":{"type":"String","value":"existingId"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"privateIpAddressVersion":{"type":"String","value":"ipv4"},"publicIpAddress":{"type":"String","value":""},"publicIpAddressType":{"type":"String","value":"none"},"subnet":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},"subnetType":{"type":"String","value":"existingId"},"tags":{"type":"Object","value":{}},"useDnsSettings":{"type":"String","value":"false"},"virtualNetworkName":{"type":"String","value":""}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-11-11T01:03:47.0165899Z","duration":"PT0.3798726S","correlationId":"9b2a0b79-1637-45db-8058-c70829b2982c","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["westus"]}]}],"dependencies":[]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/azurecli1473373312.2214636/operationStatuses/08587282335723022845?api-version=2015-11-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478826225.3191808/operationStatuses/08587227806588409688?api-version=2015-11-01']
       cache-control: [no-cache]
-      content-length: ['1922']
+      content-length: ['1955']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:21:53 GMT']
+      date: ['Fri, 11 Nov 2016 01:03:46 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1191']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 niccreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [a49f74b5-7612-11e6-8746-a0999b14fe87]
+      x-ms-client-request-id: [b1f3e991-a7aa-11e6-9699-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587282335723022845?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587227806588409688?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -1695,7 +1655,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['141']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:22:23 GMT']
+      date: ['Fri, 11 Nov 2016 01:04:16 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1706,47 +1666,46 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 niccreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [a49f74b5-7612-11e6-8746-a0999b14fe87]
+      x-ms-client-request-id: [b1f3e991-a7aa-11e6-9699-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
         o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXenZfH7t3nT7t5d1dVlMcvr5u4XxbSumuq8Hb/Sxs3dWb4qq+tFvmybu9kP1nVOL+7u
-        P7h3j/63uzfe29vd//Tepx+NPlpmi5xQ29iGulrldVvkzUePfvFHbb5YlVmbPy+Wb/H3ui4IwLxt
-        V82ju9JZM3s7LcaTspqMp1Wdj6+K5ay6asbLvL1rXp9XTXv3pM7p1xfF9Pff29n9dHvnYHtnV0DI
-        AMY/3VRLwmBaLVsay0/ScIl01N3ueAf/ffRLCLuspjG09BWwyZfZpMzPVs+q+iqrZ8XyAp+21yuM
-        8klVlQTtMivX9Od5VjY5ASgIdr3MyqfL5kW2yJ9nk7z0Xnrd1oBiX/sInZZVNnuSldlymtdPsunb
-        fDk7ns1o5M1L6uNsxrgogOO6zq7d+9/7fuf9s+WkWi9nL7L21ZpQv8W70wwc5DXr4XhFPLJugCnR
-        /Kqq355hkOfZNMcQN71JTLANDtteFlPv/df5lCa6vWY+3PT+3Z9tJn8hCN2NIdbcXVwvm4shvN8w
-        zsO45++KpqWPzmaAsKqLS+LOs5XO7KY3Y+2Py9vM1OyaRFBI3QVg2X347WJ1uc+vridlMbVvbnol
-        0vwmuiyrZY7XaGqJrJta3qUmP5TZvyzqdp2V+ifm/ZJQu0vd0w/8Kb85rG8aYzj3bXbhE/HLyU/n
-        09a1/sW/hNqsm5xUxuu8xWt+6x5s1jQAG2J9kyjKmD5CX4tqhk/OltM6h1bPoMeYPuAQeu11S5xD
-        LV6vp9OctOeMvm+LBdExW5C8fiT69SGp2Dd7e4/2dh/dPxh/urP3YPfhvZ+iprN1rZz60cs398f7
-        e2QD7u+9pm9Igdc5KWz6kkjz6KMHD+5Ndmnqtg8efJpv7386ebB9cP/+p9v7+9N8f3f3YT79NKPX
-        GDfMHSmtX8xWplmR9iEAvbmk1oYFMEnyhv8JvUR0QFOrxRp6yUgXXjAK7/u/hP6j4eQr0sj5cso2
-        63v0SbVuV+uW/iBk8qsXZyf4TQnfm13BfgNlDXafr9mwf3pABjM/2N0+zx/ub+9n+/tEk/3z7fu7
-        RPWHk737+5N79FaxOqmW58WF0pqQoYGCNASiWJGNo+920Q4wwco/FEnqkRbvWRNwt4s0feAwzUlO
-        CNfv3v19P7q/M3mwM82m29PZPaLB+ex8e7J/cL69v3dwfu/8/v37s4Pz3/cjeodw8bwJ+msjpY1O
-        fKmqir7eJcNP/+3eD762yvaLvJ1XoOBT1axGA6C7Hy5pQ3GHVoJA36Xu6Qf+lN+gGWggi6y+/uhR
-        W6/zX8I8HOoW/rO+pI6IbejrbLUqi3zGGsh+TIDUAXrpO0Csf+ImEaB/uESJYQFasN2mx8iqdWZp
-        YIrjILAB5v2ItMEv+X8A6b5v530LAAA=
+        p/nndbVeNXenZfH7t3nT/v7LYvr7N9N8mdVFtXt3VVeXxSyvm7tfFNO6aqrzdvxK32zuzvJVWV0v
+        8mXb3M1+sK5zgrK7/+DgYO/Tvb3743u7D3cPdg4+Gn20zBY54bmxDXW1yuu2yJuPHv3ij9p8sSqz
+        Nn9eLN/i73VdEIB5266aR3els2b2dlqMJ2U1GU+rOh9fFctZddWMl3l717w+r5r27kmd068vaGB7
+        O7ufbu8cbO/sCggZwPinm2pJGEyrZUtj+UkaLtGRutsd7+C/j34JYZfVNIaWvgI2RJ5JmZ+tnlX1
+        VVbPiuUFPm2vVxjlk6oqCdplVq7pz/OsbHICUBDsepmVT5fNi2yRP88meem99LqtAcW+9hE6Lats
+        9iQrs+U0r59k07f5cnY8m9HIm5fUx9mMcVEAx3WdXbv3v/f9zvtny0m1Xs5eZO2rNaF+i3enGdjJ
+        a9bD8YoYZt0AU6L5VVW/PcMgz7NpjiFuepOYYBvstk3s5r3/Op/SRLfXzJSb3r/7Q+X4F4Ld3RiW
+        zd3F9bK5GBrEGx7A8EDyd0XT0kdnM0BY1cUlserZSqd505ux9sflbaZtdk3yKHTvArC8P/x2sbrc
+        51fXk7KY2jc3vRJpfhNdltUyx2s0z0TWTS3vUpMfPitcFnW7zkr9E0xwSXjeJVzoB/6U39wQbhpw
+        yAhtduFT9MvJT+fT1rX+xb+E2qybnJTJ67zFa37rHmzWQQAbYn2TkH6EXhbVDL+fLad1Dk2fQbcx
+        ZcAo9MLrlhiIWrxeT6c5adQZfd8WCyJntiAZ/oh17i7Nx+6bnd1HO/ce7T8c36fn4f7BT1HT2bpW
+        hv3o5Zu9MVmDgwcP7r+mb0ip1zkpcfqSiPLoo4eTvWxn8uDh9u6n9x5s79+fTbYPdu4fbE8f7Bzs
+        0ZcPD/am9BrjhlkjRfaL2fI0K9JIBKA3i9TacAKmR97wP6GXaOrQ1Gq2hl4yQoYXjBL8/i+h/2g4
+        +Yq0dL6csh37Hn1SrdvVuqU/CJn86sXZCX5TkvfmVbDfQFmD3edrtvz3DvIH0/vn0+0H5wd72/sP
+        92ZEk717259+mpF5ze/vPNwHTYrVSbU8Ly6U1oQMDRSkIRDFiuwefbeLdoAJJv7hC1SPzgBibcTd
+        7gjoA4d2TuJCiH/37u/70XT24N7O3oNse5bvErb39x9uZw+nD7bzh/kkp8/z8/2D3/cjeodw8dwN
+        +msj2Y2efKnqi77eJc+A/tu9H3xtFfAXeTuvQM6nqm2NIkB3P4d0DlUANNWg4qJRLbL6+qNHbb3O
+        fwlzd6hv+M/6kjoihqKvs9WqLPIZayX7MQEivOAuvfTdJdZJcZsJ0D+HFIqhBMKwlafHiLT1g2mU
+        ivAgsAG2/oiUxi/5fwBnMcV6xQsAAA==
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
-      content-length: ['1220']
+      content-length: ['1219']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:22:23 GMT']
+      date: ['Fri, 11 Nov 2016 01:04:16 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1757,31 +1716,31 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 resourcemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 resourcemanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [b7e23f54-7612-11e6-a9ec-a0999b14fe87]
+      x-ms-client-request-id: [c5d469cf-a7aa-11e6-bf81-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-09-01&$filter=resourceGroup%20eq%20%27cli_test1%27%20and%20name%20eq%20%27myvnet%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FvirtualNetworks%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27cli_test_nic_scenario1%27%20and%20name%20eq%20%27myvnet%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FvirtualNetworks%27
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
         uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
-        zsP7D3fu1nlTretp/nldrVfN3WlZ/P5t3rS7d1d1dVnM8rq5+0UxraumOm/HL/L2qqrf3r0s6nad
-        lfpnc3dxfbnM249GHy2zBeHzkf27vV7h7xshUNOymmbAm5pfEQJrfNZmF81Hj37xL/kl3/8l/w9W
-        ZuaC7QAAAA==
+        zsP7D3fu1nlTretp/nldrVfN3WlZ/P5t3rS//7KY/v7NNF9mdVHt3l3V1WUxy+vm7hfFtK6a6rwd
+        v8jbq6p+e/eyqNt1Vuqfzd3F9eUybz8afbTMFoTcR/bv9nqFv2+EQE3LapphENT8irBZ47M2u2g+
+        evSLf8kv+f4v+X8Agm88D/oAAAA=
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
-      content-length: ['292']
+      content-length: ['305']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:22:24 GMT']
+      date: ['Fri, 11 Nov 2016 01:04:18 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1792,31 +1751,31 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 resourcemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 resourcemanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [b7f56482-7612-11e6-a4cd-a0999b14fe87]
+      x-ms-client-request-id: [c5ef92ee-a7aa-11e6-94b4-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-09-01&$filter=resourceGroup%20eq%20%27cli_test1%27%20and%20name%20eq%20%27publicip1%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FpublicIPAddresses%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27cli_test_nic_scenario1%27%20and%20name%20eq%20%27publicip1%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FpublicIPAddresses%27
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
         uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
-        zsP7D3fu1nlTretp/nldrVfN3WlZ/P5t3rS7d1d1dVnM8rq5+0UxraumOm/HL/L2qqrf3l2tJ2Ux
-        PXt5PJvR+03e6CfFavej0UfLbEFIfeR/1F6v8NEtIFHjsppmGAG9cEWorPFZm100Hz36xb/kl3z/
-        l/w/O+BUR/cAAAA=
+        zsP7D3fu1nlTretp/nldrVfN3WlZ/P5t3rS//7KY/v7NNF9mdVHt3l3V1WUxy+vm7hfFtK6a6rwd
+        v8jbq6p+e3e1npTF9Ozl8WxGwJq80U+K1e5Ho4+W2YIw/Mj/qL1e4aNbQKLGZTXNMBx64YrwWuOz
+        NrtoPnr0i3/JL/n+L/l/ALWYEcMEAQAA
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
-      content-length: ['296']
+      content-length: ['309']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:22:24 GMT']
+      date: ['Fri, 11 Nov 2016 01:04:18 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1827,31 +1786,31 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 resourcemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 resourcemanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [b80776c2-7612-11e6-a525-a0999b14fe87]
+      x-ms-client-request-id: [c62262c0-a7aa-11e6-b2ca-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-09-01&$filter=resourceGroup%20eq%20%27cli_test1%27%20and%20name%20eq%20%27mynsg%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FnetworkSecurityGroups%27
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?api-version=2016-02-01&$filter=resourceGroup%20eq%20%27cli_test_nic_scenario1%27%20and%20name%20eq%20%27mynsg%27%20and%20resourceType%20eq%20%27Microsoft.Network%2FnetworkSecurityGroups%27
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
         uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
-        zsP7D3fu1nlTretp/nldrVfN3WlZ/P5t3rS7d1d1dVnM8rq5+0UxraumOm/HL/L2qqrf3l3Kz9f5
-        dF0X7bW+u7heNhcfjT5aZgtC6iPzZ3u9wp+3hEIvlNU0wwjopStCZY3P2uyi+ejRL/4lv+T7v+T/
-        AWYMNwH3AAAA
+        zsP7D3fu1nlTretp/nldrVfN3WlZ/P5t3rS//7KY/v7NNF9mdVHt3l3V1WUxy+vm7hfFtK6a6rwd
+        v8jbq6p+e3cpP1/n03VdtNcKaHG9bC4+Gn20zBaE4Ufmz/Z6hT9vCYVeKKtphuHQS1eE1xqftdlF
+        89GjX/xLfsn3f8n/A+h0coUEAQAA
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
-      content-length: ['294']
+      content-length: ['306']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:22:24 GMT']
+      date: ['Fri, 11 Nov 2016 01:04:18 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1859,57 +1818,54 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateNic_2016-08-01/azuredeploy.json"},
-      "mode": "Incremental", "parameters": {"subnet": {"value": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},
-      "networkSecurityGroup": {"value": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/networkSecurityGroups/mynsg"},
-      "privateIpAddressAllocation": {"value": "dynamic"}, "publicIpAddressType": {"value":
-      "existingId"}, "privateIpAddressVersion": {"value": "ipv4"}, "publicIpAddress":
-      {"value": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/publicIPAddresses/publicip1"},
-      "networkSecurityGroupType": {"value": "existingId"}, "virtualNetworkName": {"value":
-      "myvnet"}, "useDnsSettings": {"value": "false"}, "enableIpForwarding": {"value":
-      false}, "networkInterfaceName": {"value": "cli-test-nic"}, "subnetType": {"value":
-      "existingId"}}}}'
+      "mode": "Incremental", "parameters": {"subnet": {"value": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},
+      "networkSecurityGroup": {"value": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkSecurityGroups/mynsg"},
+      "privateIpAddressVersion": {"value": "ipv4"}, "publicIpAddressType": {"value":
+      "existingId"}, "subnetType": {"value": "existingId"}, "publicIpAddress": {"value":
+      "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/publicIPAddresses/publicip1"},
+      "networkSecurityGroupType": {"value": "existingId"}, "privateIpAddressAllocation":
+      {"value": "dynamic"}, "enableIpForwarding": {"value": false}, "networkInterfaceName":
+      {"value": "cli-test-nic"}, "useDnsSettings": {"value": "false"}}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
-      Content-Length: ['1091']
+      Content-Length: ['1087']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 niccreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [b81a8a82-7612-11e6-a2f6-a0999b14fe87]
+      x-ms-client-request-id: [c6592a30-a7aa-11e6-a223-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Resources/deployments/azurecli1473373344.7972629","name":"azurecli1473373344.7972629","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateNic_2016-08-01/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"enableIpForwarding":{"type":"Bool","value":false},"internalDnsNameLabel":{"type":"String","value":""},"loadBalancerBackendAddressPoolIds":{"type":"Array","value":[]},"loadBalancerInboundNatRuleIds":{"type":"Array","value":[]},"location":{"type":"String","value":"westus"},"networkInterfaceName":{"type":"String","value":"cli-test-nic"},"networkSecurityGroup":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/networkSecurityGroups/mynsg"},"networkSecurityGroupType":{"type":"String","value":"existingId"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"privateIpAddressVersion":{"type":"String","value":"ipv4"},"publicIpAddress":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/publicIPAddresses/publicip1"},"publicIpAddressType":{"type":"String","value":"existingId"},"subnet":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},"subnetType":{"type":"String","value":"existingId"},"tags":{"type":"Object","value":{}},"useDnsSettings":{"type":"String","value":"false"},"virtualNetworkName":{"type":"String","value":"myvnet"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-09-08T22:22:26.0786993Z","duration":"PT0.3367792S","correlationId":"f36afa9f-5a21-42c1-872e-f353bf9b4fdf","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["westus"]}]}],"dependencies":[]}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478826259.5333579","name":"azurecli1478826259.5333579","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateNic_2016-08-01/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"enableIpForwarding":{"type":"Bool","value":false},"internalDnsNameLabel":{"type":"String","value":""},"loadBalancerBackendAddressPoolIds":{"type":"Array","value":[]},"loadBalancerInboundNatRuleIds":{"type":"Array","value":[]},"location":{"type":"String","value":"westus"},"networkInterfaceName":{"type":"String","value":"cli-test-nic"},"networkSecurityGroup":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkSecurityGroups/mynsg"},"networkSecurityGroupType":{"type":"String","value":"existingId"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"privateIpAddressVersion":{"type":"String","value":"ipv4"},"publicIpAddress":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/publicIPAddresses/publicip1"},"publicIpAddressType":{"type":"String","value":"existingId"},"subnet":{"type":"String","value":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},"subnetType":{"type":"String","value":"existingId"},"tags":{"type":"Object","value":{}},"useDnsSettings":{"type":"String","value":"false"},"virtualNetworkName":{"type":"String","value":""}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-11-11T01:04:20.7553458Z","duration":"PT0.5349857S","correlationId":"21e5ebd4-248d-47cb-9110-187980ce1d27","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["westus"]}]}],"dependencies":[]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/azurecli1473373344.7972629/operationStatuses/08587282335397357320?api-version=2015-11-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/azurecli1478826259.5333579/operationStatuses/08587227806252573224?api-version=2015-11-01']
       cache-control: [no-cache]
-      content-length: ['2060']
+      content-length: ['2106']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:22:25 GMT']
+      date: ['Fri, 11 Nov 2016 01:04:20 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1190']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 niccreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [b81a8a82-7612-11e6-a2f6-a0999b14fe87]
+      x-ms-client-request-id: [c6592a30-a7aa-11e6-a223-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587282335397357320?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587227806252573224?api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -1921,7 +1877,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['141']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:22:55 GMT']
+      date: ['Fri, 11 Nov 2016 01:04:51 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1932,47 +1888,47 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 niccreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 niccreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [b81a8a82-7612-11e6-a2f6-a0999b14fe87]
+      x-ms-client-request-id: [c6592a30-a7aa-11e6-a223-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nic_scenario1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
         o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXenZfH7t3nT7t5d1dVlMcvr5u4XxbSumuq8Hb/Sxs3dWb4qq+tFvmybu9kP1nVOL+7u
-        P7h3j/63vz9+8PDB3qd7Dz8afbTMFjmhtrENdbXK67bIm48e/eKP2nyxKrM2f14s3+LvdV0QgHnb
-        rppHd6WzZvZ2WownZTUZT6s6H18Vy1l11YyXeXvXvD6vmvbuSZ3Try+K6e+/t7P76fbOwfbOroCQ
-        AYx/uqmWhMG0WrY0lp+k4RLpqLvd8Q7+++iXEHZZTWNo6Stgky+zSZmfrZ5V9VVWz4rlBT5tr1cY
-        5ZOqKgnaZVau6c/zrGxyAlAQ7HqZlU+XzYtskT/PJnnpvfS6rQHFvvYROi2rbPYkK7PlNK+fZNO3
-        +XJ2PJvRyJuX1MfZjHFRAMd1nV2797/3/c77Z8tJtV7OXmTtqzWhfot3pxk4yGvWw/GKeGTdAFOi
-        +VVVvz3DIM+zaY4hbnqTmGAbHLa9LKbe+6/zKU10e818uOn9uz/bTP5CELobQ6y5u7heNhdDeL9h
-        nIdxz98VTUsfnc0AYVUXl8SdZyud2U1vxtofl7eZqdk1iaCQugvAsvvw28Xqcp9fXU/KYmrf3PTK
-        3R/WBClOLxUn0krySbHajaD8fnNDY6AJ3tT+LjX5oQzzsqjbdVbqn+DAS0LtLnVPP/Cn/Oawfr+R
-        ttmFP51fTn46n7au9S/+JdRm3eSkvF7nLV7zW/dgs84D2BDrm5SCjOkj9LWoZvjkbDmtc9iXDBqV
-        6QNepddet8TD1OL1ejrNSY/P6Pu2WBAdswVpjo9E0z8kZf9mb+8R/ncw3v9059PdT3+KWs7WtYrM
-        Ry/f7I0f7B58SlPzmr4hS1LnZDnoS6IMDeXep9l59vB8+362t7u9vzfd3T54sJdvn9+7f29y/nCy
-        fz47p9cYNUwdac9fzOauWZEaJAC9qaTWhgMwR/KG/wm9RGRAU6tOG3rJiDleMJr3+7+E/qPh5Csy
-        Dflyysbze/RJtW5X65b+IGTyqxdnJ/hN6d6bXMF+A2ENdp+v2cP49ODe7l5+sLt9nj/c397P9ve3
-        D+7vE4l2iegPJ3v39yf36K1idVItz4sLpTUhQwMFaQhEsSJjS9/toh1ggpN/KILUIy3es7bobhdp
-        +sBhmpOYEK7fvfv7fnQwzbO96f1Pt+9l00+39++fz7Ynk3xveze/N9ndz3f3H97b/X0/oncIF8+t
-        ob82UtooZ6PO6Otd8kDov937wddW63+Rt/MKFHyqKp5aic5zMH5YnqGhcQcBorF8ojqZ0KBZ+OGj
-        FWojKE3om7vUPf3An/IbUCRCL7L6+qNHbb3OfwnLWKj6+M/6kjoitqavs9WqLPIZK0j7MQFST/Gl
-        7ymyeoz7DgD9wyVKDAvQgh0ceowusV4/DUxxHAQ2IFwfkbb6Jf8PqilnS6YMAAA=
+        p/nndbVeNXenZfH7t3nT/v7LYvr7N9N8mdVFtXt3VVeXxSyvm7tfFNO6aqrzdvxK32zuzvJVWV0v
+        8mXb3M1+sK5zgrK7/+DgYO/TvfsPx/fv3bt3/8HDj0YfLbNFTnhubENdrfK6LfLmo0e/+KM2X6zK
+        rM2fF8u3+HtdFwRg3rar5tFd6ayZvZ0W40lZTcbTqs7HV8VyVl0142Xe3jWvz6umvXtS5/TrCxrY
+        3s7up9s7B9s7uwJCBjD+6aZaEgbTatnSWH6Shkt0pO52xzv476NfQthlNY2hpa+ADZFnUuZnq2dV
+        fZXVs2J5gU/b6xVG+aSqSoJ2mZVr+vM8K5ucABQEu15m5dNl8yJb5M+zSV56L71ua0Cxr32ETssq
+        mz3Jymw5zesn2fRtvpwdz2Y08uYl9XE2Y1wUwHFdZ9fu/e99v/P+2XJSrZezF1n7ak2o3+LdaQZ2
+        8pr1cLwihlk3wJRoflXVb88wyPNsmmOIm94kJtgGu20Tu3nvv86nNNHtNTPlpvfv/lA5/oVgdzeG
+        ZXN3cb1sLoYG8YYHMDyQ/F3RtPTR2QwQVnVxSax6ttJp3vRmrP1xeZtpm12TPArduwAs7w+/Xawu
+        9/nV9aQspvbNTa/c/TmZLUXwpSJI+ko+KVa7Efzfb6JoQDTbm9rfpSY//DFfFnW7zkr9E7x5SXje
+        JVzoB/6U39wQ3m/YbXbhT/SXk5/Op61r/Yt/CbVZNznpuNd5i9f81j3YrBoBNsT6Jt3xEXpZVDP8
+        frac1jkMUAaVy5QB/9ILr1via2rxej2d5qToZ/R9WyyInNmCVMtHbAp2aT523+zsPtrZf7S3O374
+        YOfg4f39n6Kms3WtcvTRyze74wf3d+7fu3/vNX1DtqbOybbQl0QUArSb388ns/3tvf2D2fb+g+lk
+        ++Hu7s727sGDhwc703x3tveAXmPcMGukX38xG8RmRYqSAPRmkVobTsD0yBv+J/QSTR2aWoXb0EtG
+        9vGC0c3f/yX0Hw0nX5HxyJdTNq/fo0+qdbtat/QHIZNfvTg7wW9K8t68CvYbKGuw+3zNDsm9g/zB
+        9P75dPvB+cHe9v7Dvdn2wc7eve1PP80+3dvL7+883J/SW8XqpFqeFxdKa0KGBgrSEIhiReaYvttF
+        O8AEE//wBapHZwCxputudwT0gUM7J3EhxL979/f9KLv/6YPJZOfe9vlOfr69PzmYbmf7+5Ptg0/P
+        d+4/OM/uPZjt/r4f0TuEi+cF0V8byW7Ut9Fx9PUuOSz03+794GtrF77I23kFcj5VI0CtRBE6GD8n
+        XqUheAcbIrh8olqbcKIp+TnGMdRXUKuDWpamYJHV1x89aut1/ktYFEPlyH/Wl9QRcT99na1WZZHP
+        WIXajwkQ4QWX86XvcrICjfsdAP1zSKEYSiAMe0r0GP1jYwkapSI8CGxABj8iDfdL/h+pjMHHCQ0A
+        AA==
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
-      content-length: ['1244']
+      content-length: ['1255']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:22:56 GMT']
+      date: ['Fri, 11 Nov 2016 01:04:51 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -1983,14 +1939,14 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [cb520045-7612-11e6-8316-a0999b14fe87]
+      x-ms-client-request-id: [da42840f-a7aa-11e6-aa8c-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/networkInterfaces?api-version=2016-06-01
   response:
@@ -1999,221 +1955,245 @@ interactions:
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
         uc4/evS9X/zRMlvQLx9Ny2K7zZt2e1lMPxp9VMzos7vNetJM62LVFtWyubsz2T3/dP/B7vbu5Hxn
-        e382y7azfHpvezp5uPdg73zn4f2HO3frvKnW9TT/vK7Wq+Yugf39AXb37qquLotZXjd3vyimddVU
-        5+34Rd5eVfXbu0v5ebZs8/o8m+b8no9O3mYXhNB37/6+Hx1M82xvev/T7XvZ9NPt/fvns+3JJN/b
-        3s3vTXb38939h/d2f9+P6J2ymmZAnN67Ikjrhj4jMM1Hj37xLxl9ROis8rotcvyNvy6LhhoXy4vX
-        bdaCIq/X02mez/IZvWdHtWbCfHpwb3cvP9jdPs8f7m/vZ/v72wf398+37+/u7H76cLJ3f39yj94q
-        VifV8ry4WNeMCPXk6F2spvzdLtoB5t3/dxD7bhdp+sBh+nXmgXB5D0qv6uKSPj17eTyb0fDonY92
-        d8b4b/d+8HVp5veLvJ1XoODTa6Its8tqPSmLKTUyMH7xD5nGHQSIxvJJsdr9iJiP0KBZ+OGjdVnU
-        7Tor9c/m7uL6kvC4S93TD/wpvwFFIvQiq68/etTW65z/VLrLiH6SOiBkCfmzl5f7H/2SX/L90Uez
-        ZfM6b1uaWKY4/1lfUkPie/o6W63KIp897XxcgA+XWfm0WmTF8gVJx+v1+XnxjkBnk/NmsSxni9kP
-        1rOf3mvPq/W0varrOh/P3o3Ni+NpWa1nBH2sqOfLbFISqs+q+iqrZ4TPR4/Os7KhYVALjPx1Pl3X
-        RXvNxAOuP9xpiGEB6i+bC6IkaanrFcRi8EUnujRcq1Fml4vdn/ziBQvANzUeGkD+9laDcTjd9RHx
-        FMaDewcPd87vHWzv3D9/SEpzen87Oz/YJ/2R3b/3KWmSvdmUFYYRbHqvq7g/mhXNqsyuwSb0teJg
-        +yZyEKe+j7qx4xXFvvNwl6jzYI/U+aeE46e7k+3s4e759r0HhN3DfGd35x7UYFdHEifbaTDqElRA
-        U4C9+3M9E6TEQ4zpgwDNrzNPhMt7ULqrQehrVez7wbc/R3qdaHoTfTu9K31f6qfgPUKDJuGHjFZX
-        qQOpn3xx+uYu9U7YyAev+XfgSJT+YSh26mmRTRUoQdvZ2d55un3vePve7va9+9sHT2k68587RU20
-        zG+gawwFepGI+eL150QYUkpfV0/ny2l9vWrv3XtAVPjhD8nhheEEyHh64Pw8+/TT/clk+9MZqYD9
-        nU8fbE8O9h5s7073Dz49f7B7kD+csR4wAkvvWX1NWLyHbrAjES2czyb7O+e7n25Pzw+o54f7+fZk
-        N59uf7q792B35+Ag251l9FZXpxHbWSIb9QbdxjDv/r+BwKR1Q5TpA4fn16E9IfMedO4KO32tOvj/
-        Fb41EfUmAnd6DwhMQvYRIUFz8ENG6v+1Gjj//6aC9eZTSftFNp0XS2LnHwqCJ9VitW5zM6/aOb3i
-        oUa4fW3136yX7JWRNP0QRjOIFcbjoeKpn093Zg/vzbLp9vn+DuU3JtMZuYBkwfcpuzGb5JPp/YnE
-        9kZP0HtW9RMY4j9i0p9dV33/4ODB+eTTbPve3i7hePDw0+2H0/uUhHhAf09nD3Y+vYdRdTUuSYad
-        CqN8hQ5oDMB3f+5ng8xCiDV90EH168wW4fMe9O7qJfpajcX/px12It//G112QqtrMuijH7rRIBkA
-        R1JaJZKPeftu/dPXzd7e/G25vsx29i/fNjuLX7Tc/8H5xnzMYBzw8P72M3Z8lv+fNFM0PxwJ8Gz4
-        k6PTq3bjh4TuBqNFiBJHkGb+WgaL8lL5FWWGaaJ+CMMYRAn5MYOHp/zyc1Jz+/mn2/lB/mB7//6n
-        +Xb2aX5/O9/J9s8fTg8m9yf3WPkZLUXvdU0VkYZQeQ/VaIcjpmh2MN2dPZztbM/2HhAJHsxm25Q0
-        mgClvYMJBSz3+K2uUid5s0Q2+h3iwDDv/hxTmSxOiC194FD8OhNAeLwHiUmkAgVHX6v1+TT49v9L
-        1odpKx8XKxKxjwgPmoEfMl6qIPRPeoWCk67p+eFHK8T2YEKyHxHDUy129qfXbXO1t1hfTqv8Ymf5
-        rm1nk/bi6xiene3dve0nzMbLQcND4/SHrURTrYpR/RBmbEilXy62F9nyGst1pKlpoB+m2PeIEj+E
-        0QziJHKhiHia5dPs04Ps/P7Bdn7vgFYYpwcPtg/OJ/vb+YPJzvn0050Hu5MJaxajAui9b1q175zP
-        9g5ms93t+3vnhMP+/r3th3uE0s5DSoXf28mnDw5yequrLImjLZl9vckw7/5ck/luF90h3X7rGSCq
-        vgeNSbYCHUJfq25HCtJ9u0m3Ew2JkdDbD5GmKoj6J71CmvLnm+p8tv3gIdE/X96sOvVvpZqqLwzr
-        hzBlP+u6E8u8NNscrxM9fghDGkSMFGgHG0+G9ycHB5QBmGzf39+hVPIkPyDndJ88tVl+b7af5Uip
-        swwbYaP3vmktej8jHXp+f2f7IM9Ij5xDi07vn28/vJfd279/Ppvs7uKtrloi5rYENxrKDhXtAfvu
-        /ytoTho0xJ0+6CP8daaFsHoPwpPsBTqGvlbVehB8u0m1iodKjQyIH4rAGkp3evcp/f/GvM3PL/2/
-        t/30yfanJ8Qk+XJQ/xMIkCdImGAwP8SJiqHgMdL/B9I2FlfiC9LDH2Sk9lhF0aT9EMYziJgdkcXG
-        04b3Jp/uZrv3J9u7ZA/Izd7d2Z7kebb94P4kvzd98HCf1CFrQ6O26L1v2kg9OM+n+3s7D7YffLp3
-        Dhym21n26c72gwezvfPdB/sPJjlSD11FTxJoCd7V+QhoGPbd/1fQnGxSiDt90Ef460wLYfUehCe5
-        CxQhfa1GCp6l+/b/i0Zq70dGiszIz6mR2tm+93T7Pvtby//vGqm9/w8ZqT3iC9LDH2Sk7rGKokn7
-        IYxnEDE7IouNrw3vZw8OzmdkGx48IEf93u797ezBzvn27u7DT3cfTnfu0Sosa0Ojtui9b9pI7U4+
-        fXCwe36+/en9fULknJJSEzJP2+e700/z2cN873wfOrSr6EkCLcG7Ov8e2gP23f9X0JxsUog7fdBH
-        +OtMC2H1HoQnuQsUIX2tRmp3J/j6/4tW6t6PrBTZkZ9TK3Vv+2R3+3SfmCRf/n/XSt37/5CVukd8
-        QYr4a1qpq2I5q66aywVrKZq2H8KIBlGjMfXw8VTi/dlePtnZm21PdjPSi/c/Pd+enGf3ySl68GD3
-        YI8c9+l9VolGddF737Slevjw/vm9809npIfv7YMUtHaw+3B3e7p/MJnOds4fPsgm9FZX25MUWqI7
-        xW8HizcA/e7/S+hOxinEnz6IIf11Jocwew/ykwQGKpG+NvYKBtN9/f8te2WJ+COLRTbl59hine5v
-        fwpmypf/X7RYlpX+P2GzLLbEG6SUv5bVamh2sN7V0JfbBzun948fPPwUS1/bcGF/CMMbxPLuZtQ8
-        dTk52N09Pz/Ptqef3n9IEc8urR0RhO2HD3YeULZutk8r0qwujVqj96wtI5zeQ4XacYkFmzyc7d67
-        t7e3ne/uUc/Zp/e3H+7s72yfH2T39u7NZnsH03N6q2sBSCrtBJjvXlSzHE0B9u7PPsVvoniX4mS0
-        BE8zBvuBIv515oOo/R60J2EM9CN9vftgb7z7KRmw+8H3ffsFeGy+iLLEaejuh0hpFV3903D2JSFi
-        qXyXEKG/zXfC9V/XVIDTs9mTrMyW07x+kk3f5suZNn1ZVSWRjhjwh0gAH51wiNvlxNFg0sc0bLyi
-        j2zzj2AQfchny0m1Xs5eZO2rdQme+n/lIIsQy7uvX397O2hsWpKa+yXf/9mx+vsX72a719d791bz
-        9f3l/er+df3u+ge7v6g9/zpWf3f705Pthzcs+RHL+hysIqHWDKP6IczUkCkdJD+N+euZ1cX15aJp
-        dpuclCfR5edsbK+nWZkT78BdYIw63xMa/YGYtgZ7T7Xvzab5g4M9mLnz6fb+wf1729k0m23nswf3
-        dqcH2cP9PPsaqt0OU8zq+Wx/Nvl0SlNwL8+39/funW8/vLebbd87mN2jj/P8wadQcsYCGZNEbN+f
-        ABNsoT1g3/3/5CxYa2vG6r71BvizP1EkxYHhoa9NCInVFPd13wS7EJJmgEaL7n4IM2LEVSmuf9Ir
-        FIp9Y7FZaIf+X2dwlVfKSdTC6reTHNb1Z83kfLOB5s72k+PtTw+I8Pny/4Mm5xYKgYzP/yftye4N
-        moyw99XUwWQ/m9zPth/sTChUyO893D44yA+2792/vz89OLg3Oz/4OiszdphiT+4/nEzuUzy2ffCA
-        /tn/dH+y/fDTB/n2zoP7nz68P6FVoPOblsTsEDx1y7Dv/n9yFt7fnvzsTBSJaKBX6WtjT/aCr39k
-        TwKlzaz5Qxytj47llf9/2ZO97ZNjIny+/P+lPdkN7Ul2kS9bZG5ogYIG/f8CxCUGY7xcCIaxdN4g
-        xCK6jd9z4/EU1/69h7s79+5/up3vZxklo84fku4/yLc/3TnI7uc793emuw++huKyAxcLs3P/PnnU
-        uxTmT6b3t/enk8n25MGn+fb03v293dm9g0l+D1nxrtYlLrdTQlrZU70M9e7/T2akb23Cwf7sTxeJ
-        bqBv6Wu1M1C27tv/15sZmZRNqUP5C7qOhuXrK/pTRyk0+P+WzZHBMVcF6bSYBfLbwgjZ1j9r1mj/
-        m06o7W8/eUBTki//P22N/IkwczCgQv7/Y59ivje/58bjKbyDe9nug/P8Hvkgsz0axv7D7cm9yf72
-        wzyffPrgwb17O+d7X0Ph2YGrfTo/2M/ukUad0sLM9v7up5/Sksyne7RCQx/vzvb39w/gb3f1NPG9
-        nZJQZTPUu/8/mZH3sE8/S9NFwhzoZvpa7dNNK1s/sk/UlNU+M+sPceg+OmZwzFX/v7dP97Z3yT79
-        f3bB52upkNA+zbNqerm4zz79NzQMgKwvosMwHEezgp+eFsNLikegpKb3HuSzT7dJsT/YJpd6tj05
-        2Nknd3qa7e99mt/fneywkjLahN67ypt23dBnhMAqr2+ruOwgxM5ku7uT2e5sun3v/OEBLTt8urv9
-        cO+clh3u7XxKJmi292Afbk1X3xL/WtIavYv1BIZ59+eYtn3r4KP4dchOeHywbdh9L9uwWk/KYkqN
-        DIhvTvxAphto2+ldafuTX0DFEAJE+m8Soev1Rba8uNqIkYq3/mnfYcN1l1CgH+5D+RvIErF9nUZ/
-        Ku1lYB2L9bOjyturd/f3ZtVPZ7s/nf8gX+3OVvl00vx0tpN9HVW+u/10f/vBDQspBAJkep1P13XR
-        XjOdMZhvasbADTewUAwFeVHYiKbCnxmdX1XfPyRc49ZGXgGWhGZ7vSJsPnLvdMbn1A8NyqrE9WRN
-        Boo19PbuzsMH+/u79/f3t8lJpXn7pgZWFpf5PC9JMUUHN4jo3Y3Yeepxmp/vZPs7s+2Hu1NaQrif
-        UQyyv0Mhye75dLKXn08OHkxZPRo9Ru8x1A+2Svv3dw/u5/coJ/fwPlml/OH59sPpPuXpdmYH09n5
-        bnZvukNvdfU8iaKdAqvy9z892Lu3f29//+EOvwP4d/9fSX0yU+F46IP4IL7OJBGWhOxtJ4TEM9CU
-        9DXZMFgxOPbu258jG3ZL6ncwGKb+qliR/H5EiNGE/RwgqhpI/xxEM7B2A20a+hJjoTnyFSz9qVMm
-        tPimTB/1NGiI6Luvpz9pJe7BPmzcNzUNTTZgAgbRuWtx8ISNvMLd/Wxnuj19MKGuD3anlEf49P52
-        9un5NJ/s79+/d3DAwmakgt7jCfpgjXjv/N7B3s6D8+0HD3egEScPtifn+fl2Rkmi/b29+/ns3jm9
-        1dUgNEOWqFaZoB1g3v05pCupthBT+sCh93VITli8B3m74kBf7z7YG+8+IB33/woNdyNlO30LZbd/
-        tvTYjeh0NRheCPXVLD/P1uUPWTcNeNH7258+3X7ylKZwUHn97HvRINFGmsYQkGleNhdElq+rXk2c
-        tPuTX1AylYjwTY1IAd9mUA4z85ZDxxP/ew93Huzt359uUzpid3v/4b0HtLw429kmF/BTWqWd7We7
-        +yz+RkrpPatxCQxN+y8mOhFC76Ec7KhE9x7Mdvfu5YTDbOdTosTewXQ7O3+4v31/5zyfnmf7U6IG
-        vdXVaMSBluJGudmhoj1g3/1/B9FJ+4bI0wd9jL/OvBBW70H5riagr8ntROrk/xVKWYmxkdSd7n1S
-        v9SvSBY/ImRoUn7YyHW1tL4TKmrzofwNZInwPwx9TTIBBqVsyM96GuXe9v6T7Z2HxC4/hwZACb1x
-        xmI42De3d1+8/hyjpBnxJ0inWRMaPyyUh9Ip+g6pkA82WWWxXL9TnUVz9w2PiqFHhzaIY/CqQ8zT
-        lJP9BwfTLH9I+nGPMhjZ5N52Ntubbu8iy3xw/yGFbQ9YUxqVRu990xZsfzp5cH6+v7udPXiQbe8/
-        IP/n4e6ntBJ6vjc9v78zeZif462uESCZtBPQsQc6XryEDu7+v20OyH6FY6EPBgbwdeaK8HuP2SDp
-        DPQlfU1WDf/9v8mqMUU2Ur6DQ4/yPxT7xn1tRFP1j/4Zvkjs8eL0zV3ChrDrfvWaPwX2NCe+PqU/
-        dYpk5D8Ug3d1/yqbz8rzexdlXmY/uDe/v/NuMZlezi++jsHb3T4lmwc/9efe4DG5N05hDJHw9Z8z
-        08e9R5G/wf7xi6Rxvr4RpBzxtF61ZBxWzS4tWdJkflODC+BGRzeI4d0IWp5O3T3IHlDK/v72wcP7
-        tLQ6PSArlD98sL27N5nee3g+2zk4kAS1UX70Xp6p/SNE3kPP2jGJ1dvbm872Hj64v32PLBxp8/PJ
-        NunwB9t7BzsP8/v7B/Tdp/RW11KQYFqKG6MBO8Ew7/5skfrrkZqsmiKvyNMHDuOvMwtE4/egOAlf
-        oBjp6/83WbaQVjyYAa7uIEGkpk+Ilj4AEsWPCCealZ8bHFWv6J+UCCJMwrcJG/qMMkv8M/gOyNN8
-        +KqS/tTpkUH/UKza6m2+mP6iZXU9u1if//Ts7cX8+t4km61/MB1P3tuq7d7bfrK3fXpDHo/G6Q9b
-        yajqGaP64U3lkIm4XATvEu2/CRuxd/DgHpHmGx8e4EaHN4hhoLjwOqHlaaf7O9mDh9mDnJYzstn2
-        /vmnB9sHGf3zKaWUPt19ML03fbDH2smoEXrvm7ER2SS7N/k0z4mVMvL4ySpsPyQ3f/s8z/MH9x+e
-        7+8f/FysqwS0+kBSk0kIkacPHMZfZxYIn/egOIlfoGbo6/9X2gimFQ9mgNQdJIjU9AnR0gdAovgR
-        4USz8nODoyoW/ZMUC2ESvk3Y0Gc9G4HvgDzNh68s6U+dHhn0D8VGTHZXP2jO781mv+inicDF5fw6
-        uz+7X1WXX8tG7G0/fLq9f0pc9P8qGwGCR6fyFjYC7xLtvwkbcW9nj53gb3p4gBsd3iCGgeLC64SW
-        p51me/uznfvZw+3zBxTM7k/Irz84OH+wPfs023042cuns1wWgo0aofe+GRuxl9872P00n23nn+6Q
-        XnwwmW4fTIkY0zz7dPrp+fm9B3lOb3XVLLG5pThpCf4OGpdh3v1/F6nJJITI0wcO468zC4TPe1Cc
-        xC9QM/T1/yttBNOKBzNA6g4SRGr6hGjpAyBR/Ihwoln5ucFRFYv+SYqFMAnfJmzos56NwHdAnubD
-        V5b0p06PDPqHYiOu67ze+ekfTJr23voHk/PrH0yWq8n9ameWfx0bsb998mz7Pmculv8vshEgeHQq
-        b2Ej8C7R/huxEQ8f7BFpvvnhEdzo8AYxDBUXvU5oedrp4cPdnf09wob8hcn2fk7/PNw9z7Y/nT0g
-        pTU9n5Frz9rJqBF675uxETvZZO9Tgk9u832KI87JWmTn9w/otwefnu/tne89nGGxsatmic0txUlL
-        8HfQuAzz7v+7SE0mIUSePnAYf51ZIHzeg+IkfoGaoa//32kjQCsezACpO0gQqekToqUPgETxI8KJ
-        ZuXnBkdVLPonKRbCJHybsKHP+jaCvgPyNB++sqQ/dXpk0D8UGzFfr9blvXX1trjK27ftZbM/O794
-        d3/n3deyETvb93e399grXf6/yUYQwaNTeRsbQe8S7T/ARuxaWPs7B9AD3/j4ADc6vkEUobl6eHn6
-        abqzN3l4b//B9r37B6Sh9+i3yfk9QufB7sHDvcneOaHJ+skoEnrvm7ESB5Ry/xSO885uTlbiIKNc
-        C2U/tyfTyXl27/7Dew/vITPWVbTE6JbmpCf4O4yJYd79fxmtySqE2NMHDuWvMw2E0HuQnCQw0DT0
-        9XubCSIpjRS9/fBJrOKqf5K4Eibh24QNfdbTvPiOpBND9FUQ/akjFnr8UDRvsW5n9fkvKn9AIeG9
-        +eTyB+vy4gdF84v2vpbmvbe9t7f94IQm5jaaV/9WOqraw7B+eHN5C9WLd4n4H6B690JYNB8/tPEN
-        ogh10MPLk/l9Ckome1m2fbC392B7f3+fXMMH2YSm+OH9yaekAinhzjJvhJPe+2ZU78PZwTR/sLez
-        /Sl1sb1PyocS/Tv3tid7DyZ7k/PZ3mQH+qGrvIjTLc19PcYw7/6/jNakaUPs6QOH8teZBkLoPUhO
-        IhioGvpaVe/94Nsfqd5vXvX+LKleIvLO9gmzz/Jm1SvDVjKq1vvhTuUPRfM6UPcfgrO/+eER3Ojw
-        BjGEMgheJ7Q8gZ/t7u9OZjmlbfemU8JmQkt793Yfkh9Ka+/3s/z8wc4DFngjmfTeN6N3p/tZ9mn+
-        abb9YLpLyYBsZ7r9cDI5Jy9vn5TuvXu70wc/pwusoNUHkpq0bIg8feAw/jqzQPi8B8VJ/AI1Q1+r
-        2oVFc99uUruUgfBzEuj2h0/qDhJEavqEaOkDIFH8iHCiWfm5wVEVi/5JioUwCd8mbOizvo2g74A8
-        zYevLOlPnR4Z9A/FRtyfXbbtdX1RZPfWu9lP59l8Z5VnV8vF5OvYiP3tp3vb958QF/2/y0YQwaNT
-        eRsbQe8S7b8RG3GwC2X8zQ+P4EaHN4hhqLjodULL005759n+Di3ibZ/P9ik5Mcv3t7PZzu42Ref3
-        H1Aw/vD84T3WTkaN0HvfjI3Yfbg33T8g3/x8dkCLigeTyfbBTnaw/eD++Xm+95CWVx8i0d9Vs8Tm
-        luKkJfg7aFyGeff/XaQmkxAiTx84jL/OLBA+70FxEr9AzdDX/++0EaAVD2aA1B0kiNT0CdHSB0Ci
-        +BHhRLPyc4OjKhb9kxQLYRK+TdjQZ30bQd8BeZoPX1nSnzo9Mugfio14d767frd7XdXlPK+LZnpZ
-        XbxdnZ83V/OvaSNOtk/+X7fACoJHp/I2NoLeJdp/Ezbi/t6nWFf4xocHuNHhDWIYKC68Tmh52unT
-        /Z37ew9zWgqZTve29x8eTMmDzT/d3t3NPt3/9P6n9w4+vc/ayagReu+bsRG0uLq/d/DgfPvBJKOU
-        xcEeLbDu39vZzj6dTh7ce/Dw4f6DnN7qqllic0tx0hL8HTQuw7z7/y5Sk0kIkacPHMZfZxYIn/eg
-        OIlfoGbo6/9X2gimFQ9mgNQdJIjU9AnR0gdAovgR4USz8nODoyoW/ZMUC2ESvk3Y0Gc9G4HvgDzN
-        h68s6U+dHhn0D8VGXO79orc/KCqKa++vy2y984Pi7f3qbbt7/2vlmva3P93bPvh/XRwBgken8hY2
-        Au8S7b8JG0GZAl4b/KaHB7jR4Q1iGCguvE5oedppdrD34P6ne5PtnU/vzwgbUtcH+/vn2+fTTx88
-        3NnbuX//IGftZNQIvffN2AjK8dM3s3uU47//KdmIfEq+88H97U/vPTifPTzY//T84c9prgm0+kBS
-        k0kIkacPHMZfZxYIn/egOIlfoGbo6/9X2gimFQ9mgNQdJIjU9AnR0gdAovgR4USz8nODoyoW/ZMU
-        C2ESvk3Y0Gc9G4HvgDzNh68s6U+dHhn0D8VGzNvZ/atid14X2fpytXdv8tOr83b+i37RLzr/Ojbi
-        3vbDg+099kqX/y+yESB4dCpvYSPwLtH+G7ER+wcPiTTf/PAIbnR4gxiGioteJ7Q87TTZ+/SAct6f
-        bk/2H5J2ejA93354vr+3vXv/YOdgAnRmu6ydjBqh974ZG3Evn+3fO/90d3uSUcJp/9O9ve1sJ3u4
-        Pd0hJyZ7eH7vQYa8WFfNEptbipOW4O+gcRnm3f93kZpMQog8feAw/jqzQPi8B8VJ/AI1Q1//v9NG
-        gFY8mAFSd5AgUtMnREsfAIniR4QTzcrPDY6qWPRPUiyESfg2YUOf9W0EfQfkaT58ZUl/6vTIoH8o
-        NqJevbs4373307vV/no+uSour5f5VV1Vi9lGGzFoAui7b0CZPtyBvHxDU+pNKcHdOKU9DEMJp9cJ
-        LU+Md0hmd2bnZBez+/vbpMUofX6flljvzaazvZ3Z3v6eirGRN3rvm1GmswcH5/vTvfPtPL+fkzI9
-        J2W6d+8B/bN/b3bv3oP84H5Gb3X1EfGDpTiJE3+HMTFM8Ok3Jj1Eqw8kNenOEHn6wGH8dWaB8HkP
-        inflkb7+f6cyBa14MAOk7iBBpKZPiJY+ABLFjwgnmpWfGxw3K1O8TdjQZ31lSt8BeZqPn3Nlup+t
-        Fz+Y/CDfLa/Wuz+93qlr4oeq/enLzcp00OF+drx9wLw+pG15nP6wlYzq7GJUP7ypvI3DTe8S7b8J
-        G/Hw4D57i9/08AA3OrxBDAPFhdcJLU873ft0P9/79Dzb3tnZmWzvT+4dbB88pHTA/f296TklSfZ2
-        dyVlbNQIvffN2IhPd2gZ9/75/vZs9pCS1ecPJtsPyfemxd2D2f396b3pg+znNHEPWn0gqckkhMjT
-        Bw7jrzMLhM97UJzEL1Az9PX/K20E04oHM0DqDhJEavqEaOkDIFH8iHCiWfm5wVEVi/5JioUwCd8m
-        bOizno3Ad0Ce5sNXlvSnTo8M+odiIy53l9ne4t7OZbO3XhaL/b2r8mqRvytXX8tG7G/vPds+eEpc
-        9P8qGwGCR6fyFjYC7xLtv66NeLcqs5bUxKyavs3rewcHWPn+pgbIwN8Qmp//5BdPuYO9h/fj1nAQ
-        WQHSxdBTVbPJ3sPdnYfT7Z38gNZb9/fub08+JQV+kB3czx+StiLFxarK6BR675sxGAcHewc7M+Iu
-        QmGXVjf3aXXzfnawfW8n350+/PT+A+qa3urqXOJ5S35SGfwdpXTuH+zufkp5jgMYRIZ/9/+1M0Bm
-        IxwTfRAfyNeZKMLuPSaFxDVQS/T1e9sUIjQNG739HBJehVz/VBBCc6huWhVyKRLvO/no4YN7OyTX
-        GK+vvOhPHb4Q54eis/eW9++tz9+usnfX68vqqsp+0XxS/qLd5Tr7OjqbKH6wvX9Cs/T/Bp3NhL/d
-        vA4pbwZxuZjx27TY982p792dHSjHn72xfvpgJ26oBpEVIF0MPa3w4PzBQ8o5UDYi36PU7n6GhZNJ
-        vv3gwfk58fTDh9mOLP8Z8aX3vhn1neUPdu/lB7PtPLt3TnkQSgwd3LuXbX+6m+W7OWWaHz7EgnFX
-        1RH7W/J7Wu/TB/sH93cPPr0HrcPw7/6/dgZIW4djog/iA/k6E0XYvcekkOQGGoq+fm/1Tb63742j
-        25/DGehgY2ZAyF+s7u08eEAi/BHhRnP1c4yr6ib9U0EIprA5uwf7bunW+04++vQ+XE8if6h86U+d
-        MyHAD8fmFO/u7S135/cupjmt287Wv2inPX93f3+Wb7Q5gyaFvvsAjQzXnCTu04NP2QH8WZjfkzon
-        Gt+jZ+P89lAVICF+npDfm9zbu7f/INs+yHcpB7KXn28fnO9QGuBgf+c+MdNutidxv5FGeo9wbOdQ
-        yVlTIIlO+LyH/NsxqlLen2T7u0SNyYMHlKjPDwiVyfmD7d3zvd1Ppw/v3Zs8hFvZVWDEH3YGnC77
-        9MGnRMwHDx6SjaV3AP/u/0ungTRwOCL6ID6MrzNbhNt7TElXgOnr/7eq5FvSv4ONT/9i9enBzh5J
-        8EeEGc3TzzGmUYUMPKGO93cPXGLffiMf0CLW/2uU8X67vre/Lovs/k+vJxerxXx3flHNsvPmfFxs
-        UMbxAOB4Z/vew+09uGKD2prH6Q9byag+N0b1czCnNwQA93b3yMH8QN9/m5Br59u7+3sUlu+Shtgm
-        hUKk+saH+5NfvH4t4917EB3tIM4CYwhRT53dP3hwL9/JP91+MLtPCYJP82z74c75p9sPHzzMZ9MH
-        D3dm+aeszozeofcY6jdlfB4Scg/yhwfbD87v3d/ef3Bvtv1wunuwPc2z+5NPz8/v7d2/9QrA/gNK
-        Du0+uLf76Q5Yl+Hf/X/7fJDRCYdGH8TH83WmjbBc5fVt54YkOtBc9DVbod3/l1mhW09EB5nhiVgV
-        K5LzjwhHmrufW5xVdemfCqGPMYzTXcKPfgy2aehLDItmztfU9KdOpJDlh2KgqIP5ddUuq+VFfr+s
-        6+p6ubi6ysp7mw3UoP2h7z5ch99/cH+HxOz+ASSRmPfnbtZ7KAuMATw9VTC793D/4b1sdzunBALl
-        7fLJdjbZu0cLiOTT703u7dzLpqwKjMzSewz0G9Pg9wmx6d759nk+IfrkBwekhj7d2z6fkEN8b3ow
-        3XuIPrpqjhjGTklH4+3u7u/e38M7gH/3/+XTQfo6HBl9EB/O15k1QvI9pqYr2fT1/58VuJuH/4/o
-        b4fwoPp2TRr6DoOiafs5195EnXWxdz97+4PL9flPTy/O96t372ZZMfvhaO/v/5L/B+jxv3zD6AAA
+        e382y7azfHpvezp5uPdg73zn4f2HO3frvKnW9TT/vK7Wq+Yugf39Afb3J7C/fzPNl1ldVLt3V3V1
+        Wczyurn7RTGtq6Y6b8cv8vaqqt/eXcrPs2Wb1+fZNGcgPm55m10Qdt+9+/t+lN3/9MFksnNv+3wn
+        P9/enxxMt7P9/cn2wafnO/cfnGf3Hsx2f9+P6J2ymmYYBb13RZDWDX1GYJqPHv3iXzL6iNBZ5XVb
+        5Pgbf10WDTUulhev26wFeV6vp9M8n+Uzes8Occ1UuneQP5jeP59uPzg/2Nvef7g32z7Y2bu3/emn
+        2ad7e/n9nYf7wLpYnVTL8+JiXTMi1JMjfrGa8ne7aAeYd/9fSPm73RHQBw7trzMphMt7kH1VF5f0
+        6dnL49mMxkrvfLS7M8Z/u/eDr0sz2V/k7bwCOZ9eE6GZd1brSVlMqZGB8Yt/LgnewYYILp8Uq92P
+        iC0JJ5qSn2McL4u6XWel/tncXVxfElJ3CRf6gT/lN+BLU7DI6uuPHrX1Ouc/dUZkeD9JHRDmNJKz
+        l5f7H/2SX/L90UezZfM6b1uacp4L/rO+pIYkHvR1tlqVRT572vm4AIcus/JptciK5QsSotfr8/Pi
+        HYGe329n5XK1U7fv1vfOm2p3N9+9nDbLn87Gs3dj8+J4WlbrGUEfK+pEiUlJqD6r6qusnhE+Hz06
+        z8qGhkEtMPLX+XRdF+01UxK4/hzOSQwlTMWyuSCykma7XkF6Bl90Ek5jt1oo+8H2tFqsqmW+bFnq
+        f/KLFyw039RIZ/kkf1vltxqbQ/HuIF6eztm/v5vf398ndB5MZ9v7+e759sPzSb5NyuP+ZH/y8Hxv
+        P2edY3QDvfdNG4Lp7P7O7GGWEyH2723v79+/tz25Ryhl59mn+TTLHjzMH9BbXTVKLG2nwGjU3pDx
+        Hvq4+/+yWSAbEI6GPhgewteZMMLyPaakq3PoazUSB8G3P0c2YnYb2nf6j9H+pTYh8f2IsKLZ+qFj
+        2bULqzpfFOvF9uVie/cnX5y+uUt4EF7hF6/5M2BNU/Fzbyvy1W6dLyd7y+m6LK/2Fvfv7+xMZ5fl
+        ZluxyKaKJcHY2dneebp973j73u720yfbz9gX+rkzJrP8FlMXQyLCZC9ef47h0tT4M6Xz/kU2nRdL
+        Er8fEu4nhNq6zQ3bafcRrIlXSKN/XQO4uFztsmKjafyhjGsQMYzMx8bTndPzB/d3J5/Otu89+PTB
+        9v7ujHTnZPdge2/y6U5+kGc79w/us+40So7e+6aN3e7u/Z3dySTbJk+fcJjln25nnx483M6n092D
+        ndn5w/29Cb3VNQ8kk5bcnqXAQNEakO/+v4LiZMdCzOmDLrpfZ0oIo/cgOsleoBbpazVnu0DAff3/
+        OXsGEv7Iiv2/z4rtbx/sb+8fE9v8f9aKgbX+v2K7gCvxBanlr2uxrorlrLpqtvdYbdG8/VCGNIgd
+        BtVDyVOUD873H0weksm4f/Dp7vb+gwcTSg59em9778Fs58Gnu9nD2bn4/Uah0XvftO16eP/eQXZw
+        MNl+MH2Qbe9Pdx5uZ/cme8T8O/vZdO9g92D3Hr3VtQAkiZbwnjGwo8UrAH/3/z20J6MVjoE+iCL+
+        dWaIcHuPOSBRDHQjfa2mDEGx+/b/c5bMkvFH5uz/jebsybPt033inf/PmjPLX/9fsWkWYeIQ0tkf
+        aNhYj9H8/VBGNYibNy6DkK8y793LH+zn0+2DvR0yKA/O71Myi4KB6SS/9+m9h5/emz6csMo0uo3e
+        +6aN2vnDvXt7B/n+dvZwNyejdk602J19un2+l08eHswOsvs5sO4aBJJHS/S+bcALAH73/y10J/sV
+        4k8fRJD+OnNDeL0H9UkKA91IX6s5+zT49v+r5uxHxuz/fcbs3vYD+h/46wON2c/61NE48HPQmP1/
+        zJQRd5Ce/lqGbFVm1xeExHLG2UlJLtEM/lBGNojh3SG0PMVJK/j7s0/zB4TN7h5hszPbPng43due
+        fnr/wd7Op5PsXrbPitNoOHrvmzZq0+m9B/sPIQH7E6JIdm9nezKbPNi+d//+bDK5t/dgcv+2Wcbu
+        iPEaurj7/645IHsWjoU+GBzA15ktwvE95oMkNNCa9LWauYfBt//fMnNdUv7I2P2/z9jtbD98sP1g
+        h/jn/5vGrstj/58weV2kiVNIl38Thk/yUTSbP5TxDWLYHaFFy1Ol+b179x5MJufb+xRFbe/n2e72
+        QTa7v/3p+cN7pEuzT/fzXValRufRe9+04TuY7ny6P6HsJEVtpM7v7T6guO5evn0v3z2/t5fT0luO
+        tF3XWJCM2gkYsBv8Grq4+/+uOSA7F46FPhgcwNeZLcLxPeaD5DTQoPS1Gr5d6CT39f+nLd+PcpY0
+        Wv7TM3Fkm35OLR8l3U+2nyAr/v8Ly/f/jbxlF2niFFLmX8/yeXzKqo1m8ocytkHsqHUfJU+HZjsP
+        sxkte23fu3f+gMKsh9n2w4eUMrt3cE52aHfn/u7+OetQo+vovW/a4mV7u9nOg/MZ0QA47FEA8/B8
+        /x7RZW/ycPbg3iTPkcbvWgmSTUt4azC80eIVgL/7/x7ak2ELx0AfRBH/OjNEuL3HHJBMBtqSvlYr
+        B1q7b/8/ZuQ8Mv7IwP2/z8Dd2366t316QLzz/1ED583T/zeMm4cwcQjp7A81bOKz0wz+UMY1iB21
+        7qPkqc2D/exgMj24t33//gFhcm/v3vbBwe5se+8827n3YDab5dkDVptGv9F737hhe/BgJ8vvZduf
+        7og5o8zGfQpVZju7+d7u7u75fo6IomsUSCYt4SP2AVEQg7/7/x7akx0Lx0AfRBH/OjNEuL3HHJA8
+        BlqSvlbDdj/49v+zhu1HkRuNlv/0LBiZnp9Tw7a/ff8hLVUQ7/x/3rD9fyRq8xAmDiGd/bUM21Ve
+        X5zPGlZiNHk/lCENIna3g42nLPd3Z+d7u3uUF599ur+9f7A72X64v7tDyfKD2aeExv79Sc7K0mg1
+        eu8bN2ezjCIyWmjayWeUbzufkcLeP/90e2/nfP9gNvt090GO1EXXFJAkWnIbq6ADRWtAvvv/CoqT
+        zQoxpw+66H6dKSGM3oPoJHaBMqSv1X7twoC6r6MG7CYD9kMidN+AKQl/ZLv+32e7KG3+lFwvYq7/
+        b9ouZa3/T5gtxZX4gtTy17JY86yaXi7u36Pp+qZGApD1RXQcgyjxS4qHpxQP7k3vPchnn27P9vcp
+        W3Xv4Wx7crBD6vF8mu3vfZrf353ssFKM2SlC4D0UpR2EWqfd3clsd0aJsfOHB6SOP93dfrhHScX8
+        3s6n5wcUfD3Yv611QgaOYd79OaYtGaAQW/rAofh1yE54vAeJSZYC5UZfky3aJVv0/4pYCmS6gbad
+        3pW2P/kFSdRHhACR/ptE6Hp9kS0vrjZipBpB/7TvbF8SLncJBfrhPpS/gSwR21dr9KfSXgb2QzE7
+        7dW7+3uz6qez3Z/Of0AmaLbKp5Pmp7Odr2l2nu5vP/g5NjvghhtYKIaCvChsRFPhz4zOr2r8HxKu
+        Q+YGrwBLQvPrWZv1ZL1st1lDb+/uPHywv797f39/e8mi/U0NrCwu83lekmKKDm4Q0bsbsfPU4zQ/
+        38n2sa60O324vX8/+5Rc9Z1se7p7Pp3s5eeTgwdTVo9Gj9F7DPWDrdL+/d2D+/m9yfbk4X2ySvnD
+        8+2H0/3724TMwXR2vpvdm942Bbi7/+nB3r39e/v7D3f4HcC/+/9K6pOZCsdDH8QH8XUmibAkZG87
+        ISSegaakr8mGwYohW+O+/TmyYbekfgeDYeqvihXJ70eEGE3YzwGiqoH0z0E0A2s30KahLzEWmiNf
+        wdKfOmVCi2/K9FFPg4aIvvt6+jP7wfaqzK4viIbL2fbicsWZBmKpb2paCGSzXiyKdpsmJCdG2TA3
+        PUzvDqLnyWW2t7/7YPaQMpwH96fkWO/eIxV2MNvef7CfZbQGfX7v3kOWSyNA9B7PJZQngSHifnDq
+        6eFeNsl28sn2+YNzwuHTg93t7P69g+3p+X1aH89nuw934BF31Q5Nq50Jo4F6Q8Z76OPu/zsng1Rn
+        OCj6YHgkX2feCMv3mJmu+NHXrE93/t+hT4kMt56CDhqxKfjZzVdRB7dGtqtYe6gGuavet//vSmBl
+        k92LWfmL1vdml/mszPbWO8WiaWY/3Z5/nUhib/ves+2nJ8RYgwr8Zz+SIBrfei5juETm7Ied0aIu
+        bxzCUKTRQ544h9T/1zKa5EGyNv+GhkXgBsKmQWzwDlDw1OnD3ezh5P75LmVXzimxsruXbR9kB7QO
+        QqvYB2SQJnszUadG79F737QZ/DRDT8T4DzNabtwnTLcfPnhwvr3z6W6WPdibZvd3M3qrazFIHC1t
+        jfHA6Bjm3Z87ApMlCxGlDxx2X4f2hMN7UJcEK1B99PV7mzKiHg0Ovf3wqKmyp382d+FM796lnuln
+        oz93SaAwBF9z0J86IhnvD0XVt7NftCx+EamGZje/v/hF9+6t2yJbzGfnm5NGg5qcvvu6WmWZXS72
+        Pn34kKbtm5qsFwT0YnNE1EOKZtjDxGPzBzuTbPc+8fX9bEZsfv7wwfbBZOfe9qfk+j48v3f+4P59
+        iYANP9J7VsUQCu/B+nYYoljuUc/39/bz7fuUl9jefzij/PHug/3te5N7+wc7O5RYfwCR6MorTb4l
+        ry+6DPPuzzl1SZ2E+NIHDsmvQ3jC5D2I3JU3+nr3wd549wFpmP9XJNBvQd9O70RfvET03f7ZSjQA
+        /g1IXXYUoLwSJhVm+Xm2LlmXEJ1/ztXg+XU+v7d3Xs53ivzdTy/nF9Nlfr2aF79otlENDni8O9v3
+        P91+ygm0IT0Z93gxmB/iRNEo8LPj6OLFS+KgZXOBMdJ8+NNzKZOrnuUPCeEhtxavXC72iCk+zOwc
+        PIDA/xAGMoiT6kVBxNN9n96bPqTF0b3tT/P8U/Kopp9uT6b7B9sHBw/u7d6fTSgFe491n1FR9N43
+        Y3SmpAwnOw8/3d67f3APWney/fD8/vn2wfm9nb384OF0Zx96uqvESdQscX19zjDv/lwTl0xMiC59
+        4HD8OnQnRN6DxiRMgXKjr4nMYnNgwt33/9+zOT8yOT+HJmd3+8m97SefEnP8f9fk/H/H4hBLfF2D
+        s7h+cYZc2Dc1hvqibrL2/s7Op/d27z3MSEd9Gh3QIHJ3DUae9tv5lFRWlj3cfvDpbELaj2L7hzt7
+        k+1deuMBGYB72YP7rP2MkqL3vhmrc/5pvj+h7Pf25MGEciifTmiZ8Zy8qfN8d3KPej/YOQCTd9U4
+        SZulsK/RGebd/9dQmaxNiDd94JD9OhNASLwHsUmyAkVHX793SqWj/tHtzxWVO6gwlX92lwTeF0NV
+        H/on8AvWASTtv/3/mmzQ2+n0/qytz4v2Xb786bpq8531vevy7WrydWzSfTJI2zvHxDMbbBKN0x+2
+        Ekz1LUb1w566Ic1PU/cFkf3r6n3KG/JvRP9vaEAtKdz6YnfvIDqMQaTIGTaYeAqHMkmzfJKRj5/f
+        o8ztg918+2A6OdjO92fZwZQ83vuf7rHCMZqB3rMan8DQzP/ij97mNI8fXWblOqeh09S+j26yoxND
+        QM56PjmnJBfNGCV97u2RIdjL6Ld8mn863b1HQ0F+rqtQicUtyc13/Cc1Bdi7zfrnmO6k8gUtg7L9
+        AN8Snl9nVgiT9yA1yVygW+jr/zeZgdsRuIMAEVg+KVaEIvNfw9r1h4+Zag79UxYAgNPdhhEyawD4
+        CGgSvX0NSH8q+WVgPxTFn+/v7K7e7e7vlKt8tVy+a3bfNj/4Rfllm29U/IN6nb77emrykhaarz5t
+        8iuSFuKyb2riAHZg2Sau719PszInGsurnS8Jh/4ouKGHuifGu/v7O+c7uw+396bTbHt/52BvO3sw
+        fbBNKf17nx7c2z2fPPz0a4ixHaNozPv703uTB7N8eze7D59x9/725NNPp/Tbzv3Z3u6D/NMM6sVo
+        G6N+iDf61DduKdoD9t3/702BVatmoO5bb3Q/+7PUlWf6+r2VLVGfBovefgizYeRUCa5/yiuB94oP
+        xIMlCcZI3kONwZHIZk+yMltO8/pJNn2bL2fa9GVVlUQmYssf4mh9dOSFcnJ30seLv5rkK/r9I6hi
+        /72z5aRaL2cvsvbVugR3/L9gCEWIE3+8zFrgP96hEfzs2JNs+W6ev/vBTv7Txfresl7dW1/9dFHO
+        f/BuutGeDAQSu9snx9unnKMYMjjMcD7/KfequsCofggz8fUUGdn0/+9ZwN2b9C/h7inXvZxc+PuE
+        aH7+6Wx7f//ePfJpDyi/kZ+TIzu5n2UPZl9DudpBigk8mDx8OHuY72zvZhMyfPuf3t8+eEDhw252
+        Pvk025tkD2fAq2sZiJ375C+ckWDYd/8/OAfvbQN/lqaJZDMwBvS12kAk89y3P7KBga1hvvwhjtZH
+        R14gA/L/cxu4S+r3GzOCH2oEmYkGjOD+9pPT7b1nxDX/fzSCmIb/L1rB3Rs0MOHuqdfZvd2984cP
+        c4rJJqRe788ebmcH9x9u55/e25/u7s12J9Ovo17tIMUKzvY+/TQ7p7XrHVop2N4/oETswcOH90mn
+        T+/vnN97+PD84f+fAsEb5+C9reDP0jSRcAbmgL5WK/gg+PZHVjCwNsyXP8TR+ujIC2RC/v9uBWkJ
+        6v8rVvDZ9qenxDX/v7SCNA3/X7SCezdoYMLdU697D6cP7h3k2fb5gymtany6k1GUtpdt04pO/nA6
+        Od/L8vxrqFc7SLGCBwezvf3dT8+3D3aRzsseTrcPJvv59r3z+5P7+fnuZGd20wKSHULhzATDvvv/
+        wTl4byv4szRNJJyBOaCv1QoeBN/+yAoG1ob58oc4Wh8deYFMyP/freAeDeH/I1bwdPvB/29jQZqG
+        /y9awRsUMKHuadcJac/zh7sPtvPJOQUaO+ekXc93KFI7//ThvdmD/fzh18q02TGKEaRhZ58ePDzY
+        fvAw29/e3917uP1w+uk+KfJ8cvDwwfn+QbZDb3VNA7Fzn/qFsxIM++7/96bgvW3gz9IskWgGxoC+
+        Vht4P/j2RzYwsDXMlj/E0froyAtkQP7/bgNpBP8fMYEH2w/vEdP8/9IE/n/SAt4UghDqnm7d/XTn
+        frbzgOKLTx882N4/z2fb2acPzrd3d3N6c//e7uThztfQrXaMYgHv7e6fn9/bOd+eHexTFLM/u79N
+        Sv3h9vn+/U8n0/v5/u7OHr3VNQzEzX3qF85GMOy7/9+bgve2gD9Ls0SSGZgC+lot4O5u8PWPTGBg
+        apgvf4ij9dGRF8h+/P/cBFL48f8VE0grgsia/P/RBNIs/H/QBN67Qf8S6p5y3dm7v7PzYC/fnuzv
+        kXI92L+//XAvO9ie5NPdaX7+YJLtffo1lKsdo5jAnXzv4f7O/sH27MHeLqnw/XuUCb3/YDubHOze
+        e5g9eDDbg87tWgbi5j71C2ckGPbd/+9NwXubwJ+lWSLJDEzBR48+MiYQHon7+kcmMDA1zJc/xNH6
+        6MgLZD/+f24C79EI/j9iAp9snxwT0/z/0QTSLPx/0ATev0H/Euqecp3uzvb39+/nlKE8n23vT2eU
+        ocwPdrbv3T+fPHiwv3Mw+1oZNjtGMYEHB9Pp+YNsj7T3vYf0z2yfrB9ZxJ1sZ+/8/P6DyWwCndu1
+        DMTNfeoXzkgw7Lv/35uC9zaBP0uzRJIZmAL62phAGAL39Y9MYGBqmC9/iKP10ZEXyH78/9wE3qcR
+        /H/EBJ5sH/z/dS2QZuH/gybw0xv0L6HuKdf83r1P811aWtr9lEzS/t6MQrOdvU+3dx+c0wpddn6e
+        f/rwayhXO0Yxgef3JucPJw8m26TLP93ez6aUPp9MJtuf7t7PZ58+2CElPqG3upaBuLlP/cIZCYZ9
+        9/97U/DeJvBnaZZIMgNTQF8bE/ijtUCjsH9kAn/WhrDJBH5KI/j/iAl8sL13Qkzz/0cTSLPw/0ET
+        +OAG/Uuoe8r13u7DvXuz3fPtfO8+BWm7Dyfbk4fZ+fbe/vn9PJ/Q/x7e/xrK1Y5RTOD9nVm+t//g
+        3vaDyQ73cr79cJeIs/fw4b3Jzqe7Dx8+hObpWgbi5j71C2ckGPbd/+9NwXubwJ+lWSLJDEwBfW1M
+        4KfB1z8ygYGpYb78IY7WR0deIPvx/3MT+IBG8P8ZE3j8lJjm/48mkGbh/4Mm8OAG/Uuoe8r1PPv0
+        4S7p0e0H5/dIuebZDq0y3SOMH9w7n96/N33wcJp9DeVqxygmcHqe3Z892N3d3tndI7qckzHMPt2h
+        KCbbzw4OPr13f+feA3qraxmIm/vUL5yRYNh3/783Be9tAn+WZokkMzAF9LUxgZgO9/WPTGBgapgv
+        f4ij9dGRF8h+/P/cBB7QCP4/YgLvb7P2+lkzgd/MTAxrsk2a7P+TJvDhDfqXUPeU687eZH9vuvvp
+        dp49JIz383vbD+/tHWzn+aeT/fPJOQVsB19Dudoxigm8d757b7r/abb96f5utr2/u7NLa4EP8u18
+        Mv30/NPdnfO9GfDqWgbi5j71C2ckGPbd/+9NwXubwJ+lWeqaAvramMCD4OsfmcDA1DBf/hBH66Mj
+        L5D9+P+5CXxII/j/iAnc2366Q0zz/0cTSLPgm8Dr9UW2vLja3v3JL16w8H9TeCvgKOKGhWge8NPT
+        qfqWQ8dTmfnk4PxB/un59gOKsGjt7Xy6/XCWP9j+9P4O4Xawe3A/m7DKNKqN3rvKm3bd0GcEhmb5
+        F9OsE0LvoVDtqMTsHcx29+7l96fbs51PiRJ7B9Pt7Pzh/vb9nfOcosL9KVGD3upaA+JgS/FC7YEd
+        KtoD9t3/dxC9b8piGH+deSGs3oPyJGGBSqevyZTtkimDPnffbrJkq/WkLKbUyID45uRSibGR1J3u
+        fVK/1K+ghwgZmpQfNnKqGPRP+872JeFyl1CgH+5D+RvIEuF9xUd/6jzIGDuG92dH37dX7+7vzaqf
+        znZ/Ov9BvtqdrfLppPnpbCf7Ovr+3vb+k+2dh8QuG/Q9gQCZXufTdV2010xnDOaHOWMxHOyb27sv
+        Xn+OUdKM+BOk06z6/4eFctw02XdIhZAR+qi9XhFGH7nXOiN1OooGZhXobFo124usoe+2nz65f+/Z
+        k4cPt8kH32bN+80OLps20fENInp3I3ae1ty7TxjNzmcUNu3OKADY39nOHuwfbB/sTz89uH+QzWaT
+        fdaaRr3Re9aaEUrvoUnt0MSGPdzZJ5V8/un29P7kgHr+dLY92T/Y3X6Y7X66c/88e/BgD7qzawZI
+        Ku0UmO9eVLMcTQH27v8riU7GS1A1w7AfKO5fZ0oIufcgPwlkoCLp690He7QsR6bsfvB935QBHlsy
+        Ii4NG939kImtEqx/KqlhIyyh7xIu9Ld+JbPw/41A7ZYk8FEKRrldThwVYtGb3xYxkG1NoVA41J/N
+        YO4bHWY3wnv9+tvbflvTkPQddPb/V8bwsqrbvb3BkfwsBa677fqnq8v9H6zXdV5PFk22WhTn6/3L
+        txdfx5HZ3X62u/3gGQnRz70jc9NExdAIJ2zZXNgpwKBJc/iKRPWSehY/xBEMuTY+7gZvsA6h/g37
+        OYi/fkiDHUQ0PlyDnWdUpwf7+cH+zmR79975Q1orJXuanc8m25PZzmQn2723v7/7kI2qsX303jfj
+        59w7nz34dDaZbO/cyz7d3t+5T+SYAIcH9OGn+f69+1M4/cYfMA4CCa2dAvOd+goM9u7/K4lu3Roz
+        DPuB4v51poSQew/yk4AGpp2+tn7Op8H3P/JzwO7OUv3Iz/l/3zAjPkLcO6BQ9v8r3sHB9pMbVnYJ
+        BGgUmGUM5oc8RTE0wqn6/4V3QKxDqH/D3sEezfAPabCDiMaHa7DzTFH+6e75g4eUNt6593CyvX9A
+        rQ5mGVaVZ9mntLw8u3dvxqbIWAx67ybvgPgZ5gRE8s2THZp4B5SWfvBwmu1u793LqOcZdf/wAf15
+        sPPwYZ5ne5OHBxN6y1hRY1ZJaO0UmO/UwjLYu/+vJLp1Bsww7AeK+9eZEkLuG/IOoJTc9z/yDsDu
+        zkb9yDv4f98wb+0d7NEY/z/iHTzYvn9KrPcj7+BnbwTv5R0Q6xDqX887yC7yZftStAxUPK3r0tT+
+        nI7y9TQrcxIBHS1juE0TAxTdoC8XTbPTeZOQ7I/2LgPoDdEzZA8+3b3/4NMs357k9/e29ye0ap9l
+        tEyd7+xN9h/cn07PH97/GobM0kL8iGzn3v7ep7v7tI5473x7/975ve2D/ODe9vnDyaf7k70H051P
+        keQ39tYYYBJvO1lkos0SO1oC6t3//06SdT0MKe6G4//Zn0Edj7W+9PXuzvjeHnkisL3u674n8vSa
+        5owZjSaIhovufkgTZuReya5/6kRtcEX8Kfi6Dsn/FyzY3vbOs+0dTOAGC0bj9IettFQWxqh+SJP5
+        syB9NEn//zUAe7fTLTRET32cf/rg3nR3/8H2g9neLo1sQuu5Dye72+dTygCfP9w7n+7sfA31YWkh
+        BuDT/ft7s2z6YPvT+ztkAPY+3dvO9s+JnPf3Pj3Pdx/cz/dvSjOHCpCh3v3/7yS9hwH4WZpBHY/V
+        dvS1MQA3Jap/ZAD+32wA9rafYAJ/XhoAhAv//zUA926nW2iInvo4OM9nu5+eTymzt79PI3tAa1yk
+        SbazT+9NZg8/ne2f7xx8DfVhaSEGYP/+p/u7u/d2th/uHMy29x/unm8/pMziNi04kq462H2YP8jo
+        ra7WI+mwkxUqQIZ69/+/k/QeBuBnaQZ1PFbb0dfGANyUi/yRAfh/swHY2T74eWsA7tEkdQ2AShyR
+        5P+Fw1pPSlqcuGFUg1kFNzRPX0zOH9yfnB882N7fySljcJDtbz+8P/t0O59klI75dOfhwezB19AX
+        lgai8Xc+/XQy2TvY2b6HxM9+NpltTw6mtGLy4AFRdH+2N92BGumqORIHOzuhxmOod///Nznvoel/
+        lmZOZceqNfqaND3+Q6bAffv/I0XPM/d19Xy4HvP/3qUnHmqwJDO48iRNuwtP/x8xaCfbnz6jSfn/
+        kkETplUd8SHK5Wvas2+UBb9xlTmYJFGVicl2WvHT+/d2H+5PaQn+wU6+TdL1kDLgBwfbs/ufHuTZ
+        g/PznZ3J19CKlgZiz/bu3/v0/H5OEcz0gHTv9H62/ZAgb+89fPhp9mDvIHs4vUdvdZU5ScP/z+zZ
+        TZPzHvbsZ2nmuuqbvlZ7Br/Xffsje/YjeyZ/eoaLLM7PtT0jcj6hSfn5aM9iCTrVK0SR/6+OajDn
+        44bmacVplu9me5OD7Qfkz5Orj8WSg/NPKXDfPycddzDZuTf9GlrR0kDs2acH2WT66f0H27uz2YR6
+        mT3Yntx7SPZs+pCCien+/nQP2rKrzEka7OyEep2h3v3/3+S8hz37WZo5kvZAfdPXas8QQbtvf2TP
+        fmTP5E/PcJHF+bm2Z8fb93doUn4+2rNOvpE0x8He7oODezt797Nzosk3Na764uTLL34yv5ffo5Tb
+        /Yf3oqMzrEgThp+evuvh5Sm1nb0H00+p1fb5w31SavcnhM79CXnqn96b7WeU4pvl+6zUjPah9/Ks
+        adcNfUZgiB1+MbEHIfQeKs8OT4zVg3uT3f2D2XQ7n1L3+/fvf7qdPaDs1yybHCD82t3LbjJWhsWo
+        FSDe/X8ZzftWxiH8dSaDcHkPclNfgUKlr9XCQJu6b3+4Fua9CKySp382d2FiDvb29u7v7R/s5XcJ
+        G/qg0Z+7UFg0LCawKh36U0cpNOgYla+ta6mnuGrcvb/94P72pw+JdoOqkV5ur1eYrv6IaRz46ViK
+        BmXZnbhrd3/v4cGn9/cOpvnuvd371M03NzHLfNE8uDcD+AcUpk/3Ns5ND1Mw/24PPY/P9x+c7+3s
+        3n9Iawbnu5QZmN2jbMv92TalCChDMD0/3z3ImM8NQ9J737TSmX167+H5g5297V1aYCXKZPe3H376
+        gJy73U9J4exO7x8cQFV2BZfm3M4C8RSzGLUCxLv/7yT9LXXPreeE8HkPqlNfgdzR17sP9sa7n453
+        30P7iDmmRgbIN6mG3o/kHVSI5Kti9eDB/gFFVp+SjH5EKNG0/FyiGFOWD853+O2D+xQAnt8lpOjD
+        5u6zuiJvh5xSYE5zwXzxs6wySVzAr+RlRtzTrMnv3b+/2Lv86eX6cnKxt/OLZu29dvKL9rPxZIN7
+        GlOxMgpqACq8zqfrumivmaRA9edqcmL4NHfP82Vzce88YyAP9imUJPqSrvta1uHdqsxaUgSziuKN
+        +t7BAQLJb2q8DPxN3rSf/+QXT7mDvYf3d28zZIesAOli6Cmj2WTv4e7Ow+n2To710P29+9uTTx/u
+        bR9kB/fzh1Oi00NxhIzOoPesgSBU3kNB2eGJWTg4IG9kRlacUCA1SPnr7YP72cH2vZ18d/qQMirU
+        Nb3V1anE15b8JnuwS57swe7up3ufHhzAADL8u/+vnYG+nRgayNeZKMLuPSalq3ro6/8XeKxMs/cj
+        fFcVMwihObTywf6nLkHifScfPXxwj1YAebw/53p5b3n/3vr87Sp7d72+rK6q7BfNJ+Uv2l2uN+vl
+        Ad+YKH6wvX9CsxRT3Owb8zj9YSspNfjGqH4O5jWeQlAQl4sZv/3wYP8+TcM3o753d3agHH/2xvrp
+        g5370bEOIitAuhh6WuHB+YOHM4rMtvfyPfKt9zPyJQ8m+fYDso/E0w8fZjs5awUjvvTeN6O+s/zB
+        7r2c0rN5du+cIuj7+fbBvXvZ9qe7lLzNJ/sPHz68aR3X03qfklt3f/fg03vQOgz/7v9rZ4C0tR2T
+        IDc0kK8zUYTde0wKSW6goejr91bfHT8b3f4czkAHGzMDQv5idW/nwQMS4Y8IN5qrn2NcVTfpnwpC
+        MIXN2T3Yv3eXEKNfg+/ko0/v3yfdReQPlS/9qXMmBPjh2Jzi3b295e783sU0/+nV+Wz9i3ba83f3
+        92f5RpszaFLouw/QyC1NAkncpwec0/nZmN+TOica36Nn4/z2UBUgIX6ekN+b3Nu7t/8g2z7Id/e2
+        9/fy8+2D851se+dgf+c+MRMtat1nITfSSO8Rju0cKjlrioy+InzeQ/7tGFUp70+y/V2ixuTBg3x7
+        Pz8gVCbntDZ5vrf76fThvXuTh3AruwqM+MPOgNNlnz74lIj54MFDsrH0DuDf/X/pNJAGDkdEH8SH
+        8XVmi3B7jynpCjB9/f9WlXxL+new8elfrD492NkjCf6IMKN5+jnGNKqQgSfU8f7uwe5dQot+9b6R
+        D+7de/D/GmW8367v7a/LIrv/0+vJxWox351fVLPsvDkfFxuUcTwAON7Zvvdwew+u2KC25nH6w1Yy
+        qs+NUf0czOkNAcC93T1yMD/Q998m5Nr5NuVxKSzfJQ2xTQqFSPWND/cnv3j9Wsa79yA62kGcBcYQ
+        op46u3/w4F6+k3+6/WB2nxIEn+bZ9sOd80+3Hz54mM+mDx7uzPJPWZ0ZvUPvMdRvyvg8JOQe5A8p
+        sX9+7z7lte/Nth9Odw+2pzktrX16fn5v735Ob3VVNcmDnRSntR9Qcmj3wb3dTyk/R+8A/t3/t88H
+        GZ1waPRBfDxfZ9oIy/eYG5LoQHPR12yF/l+yFsBEfK+J6CAzPBG0SEBy/hHhSHP3c4uzqi79UyH0
+        MYZxukv40Y/BNg19iWHRzPmamv7UiRSy/FAMFHUwv67aZbW8yO+XdV1dLxdXV1l5b7OBGrQ/9N2H
+        6/D7D+7vkJjdP4AkEvP+3M16D2WBMYCnpwpm9x7uP7yX7W7nlECgvF0+2c4me/e29yfk0+9N7u3c
+        y6asCozM0nsM9BvT4PcJsene+fZ5PiH65AcHpIY+3ds+n5BDfG96MN17iD66ao4Yxk5JR+Pt7u7v
+        3t/DO4B/9//l00H6OhwZfRAfzteZNULyPaamK9n09f+fFbibh/+P6G+H8KD6dk0a+g6Domn7Odfe
+        RJ11sXc/e/uDy/X5T08vzverd+9mWTH7YWvvxfWLMyxMfFPz+9PZZTZtFvVFPJ4YxOmuQcQT6ns7
+        k+zgfD8nTbg7IVEmoX64uzcFJtN88nCyMzmYsVAb6aP3CJl2Ps2XbZ2VH55f//TB/d2H04eT7U8f
+        PKB+D6az7YOHk2z7PvHUwe7e+cHDc3iSXY1F028JbJUX2gHm3Z9rIpM+DdGlDxyOX4f+hMR70Lgr
+        cPQ1K9X/l+RmbkncDgZM3Jf6GQnYR4QI0f/nALGuvlxc/+SL0zd3qX/Cp7n7mn9u7wJHovXPuSZc
+        n8+uf1H1jlZWf1E+L6rpfHUxmS/mF9fZ+Kc3aMJ4ouXB3va9ne1PnxCHDKpKHqc/bCWY5jYwqh/S
+        jA0lV2jGviBqv59K//4v+X8AegYGVwc7AQA=
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
-      content-length: ['9576']
+      content-length: ['10856']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:22:57 GMT']
+      date: ['Fri, 11 Nov 2016 01:04:53 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
-      x-ms-original-request-ids: [e378e064-8c5d-4fe7-8e2c-d5a1945fc00e, 7be81eef-7ca5-4cd5-ae9d-04414a38f84e,
-        4442ea11-6452-4eea-af41-2f51ed5838cb]
+      x-ms-original-request-ids: [95b16910-477c-4ece-b28a-20f3e1f744e1, 5528f9b5-56c9-42dc-a303-cae296d637b9,
+        2a1d0f6c-672d-4509-96e1-296a52aaaaff, c9aff889-132e-45e4-a981-d43b14bcf4b1]
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [cbfd8e0a-7612-11e6-9656-a0999b14fe87]
+      x-ms-client-request-id: [db5553a1-a7aa-11e6-9e7e-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test1/providers/Microsoft.Network/networkInterfaces?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkInterfaces?api-version=2016-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UeXWbnOP3qUfg9/pSl/iOejZbbA5x9Ny2K7zZt2e1lMPxrZr4sZvrzbrCfNtC5WbVEtm7s7k93z
-        T/cf7G7vTs53tvdns2w7y6f3tqeTh3sP9s53Ht5/uHO3zptqXU/zz+tqvWruEvzfH/B3767q6rKY
-        5XVz94tiWldNdd6OX+TtVVW/vbuUn2fLNq/Ps2nO78XwytvsAph99+7v+9HBNM/2pvc/3b6XTT/d
-        3r9/PtueTPK97d383mR3P9/df3hv9/f9yHu5rKYZRgIAVwR73XhfEuCGvvjFv8R9RBiv8rotcv7C
-        fCxfXBYNQSqWF6/brGVKvl5Pp3k+y2cOKDW15FgLST89uLe7lx/sbp/nD/e397P9/e2D+/vn2/d3
-        d3Y/fTjZu78/uRcAKFYn1fK8uFjXjDtQ0cmUx8MLj53YYjXl93Z9aHj+3zW3d7vjow+GEP+QyZcH
-        MxedUnnw9S0nVh56obikZmcvj2czog6gfrS7M8Z/u/c3ti8NN36Rt/OKp+TpNU2ez+7m+Wi1npTF
-        lN6yvfRwp1Y/5IntIEUTK58Uq92Putg5qTLPR4QmsQZh/P+CoVwWdbvOSv2zubu4viTc7lL39AN/
-        ym+3GRbN8CKrrwn9tl7n0e+VA4RsP0kY0eio/UdnLy/3O138Ev9P74/ve4A/mi2b13nbEs/2OEO+
-        qy+pE/rqe/5r9GW2WpVFPnu6qU0BuV1m5dNqkRXLF6RdXq/Pz4t31PSjbHLeLJblbDH7wXr203vt
-        ebWetld1Xefj2buxeXM8Lav1jPoahyT0ifdRvswmJVHlWVVfZfWMxkIdnGdl45PwIwKACXqdT9d1
-        0V7zHFO7cMg/ZN6J4QSWWTYX/mDNr27UH7XXK1YwgzCdzlRIDOX7v3HyS/4fEaXMyt4HAAA=
+        T/cf7G7vTs53tvdns2w7y6f3tqeTh3sP9s53Ht5/uHO3zptqXU/zz+tqvWruEvzfH/B/f4L/+zfT
+        fJnVRbV7d1VXl8Usr5u7XxTTumqq83b8Im+vqvrt3aX8PFu2eX2eTXMGEkMyb7MLoPndu7/vR9n9
+        Tx9MJjv3ts938vPt/cnBdDvb359sH3x6vnP/wXl278Fs9/f9yHu5rKYZhgUAVwR73XhfEuCGvvjF
+        v8R9RBiv8rotcv7CfCxfXBYNQSqWF6/brGWyvl5Pp3k+y2cOKDW1tFkLfe8d5A+m98+n2w/OD/a2
+        9x/uzbYPdvbubX/6afbp3l5+f+fhvjdeAlCsTqrleXGxrhl3oKIzK4+HFx47y8Vqyu/t+tDw/L94
+        ou92B0sfDI3iQzhBHkxjdH7lwde3nGV56IXikpqdvTyezYhUgPrR7s4Y/+3e39i+NKz5Rd7OK56f
+        p9c0kz7vm+ej1XpSFlN6y/bSw51a/VzOcgdDmmX5pFjtftRF1cmbeT4inIlPCP3/t43rsqjbdVbq
+        n83dxfUlIXqXcKEf+FN+u80Yae4XWX1NY2nrdR79XnlDaPiThBENldp/dPbycr/TxS/x//T++L4H
+        +KPZsnmdty1xc49n5Lv6kjqhr77nv0ZfZqtVWeSzp5vaFJDoZVY+rRZZsXxBSuj1+vy8eEdNP5rf
+        b2flcrVTt+/W986banc3372cNsufzsazd2Pz5nhaVusZ9TUOSegT7yOapUlJVHlW1VdZPaOxUAfn
+        Wdn4JPyIAGCCXufTdV201zzh1C4c8s8lI8UQBP8smwt/5OZXR4KP2usV66FBmE61KiSG8v3fOPkl
+        /w9WI/v+HwgAAA==
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:22:57 GMT']
+      date: ['Fri, 11 Nov 2016 01:04:54 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2225,39 +2205,39 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [cc32d8c5-7612-11e6-99cc-a0999b14fe87]
+      x-ms-client-request-id: [dbd3844f-a7aa-11e6-92c2-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test1/providers/Microsoft.Network/networkInterfaces/cli-test-nic?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkInterfaces/cli-test-nic?api-version=2016-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9aFoW223etNvLYvrRiL8qZvjibrOeNNO6WLVFtWzu7kx2zz/df7C7vTs539nen82y
-        7Syf3tueTh7uPdg733l4/+HO3TpvqnU9zT+vq/WquUuwf3/A3r27qqvLYpbXzd0vimldNdV5O36R
-        t1dV/fbuUn6eLdu8Ps+mOb/XxSlvswtg9d27v+9HB9M825ve/3T7Xjb9dHv//vlsezLJ97Z383uT
-        3f18d//hvd3f9yN9saymGUaAl68I5rrRLwhgQx/+4l8ifxKGq7xui5w/xEfy4WXR0NvF8uJ1m7VM
-        sdfr6TTPZ/lMAFEzO+y1kO7Tg3u7e/nB7vZ5/nB/ez/b398+uL9/vn1/d2f304eTvfv7k3v25WJ1
-        Ui3Pi4t1zXii++/JV6nBA4+dsGI15fa7BgKe/3fN2d3umOiDGNJfd1Llwez0pkwefHWLiZOHGheX
-        1OTs5fFsRtQAtI92d8b4b/f+YNvScNYXeTuvmPxPr2mSDMua56PVelIWU3rDQg9wpRY/5MnrIEST
-        J58Uq92PfMxEMszzEaFH006Y/hyjf1nU7Tor9c/m7uL6kvC6S93TD/wpv20aCs3iIquvCe22Xue9
-        73SGhTw/SVjQiKjtR2cvL/c9sL/E/Kq/fF8BfTRbNq/ztiXeC2ZbPq8vCSB9/D3TnL7IVquyyGdP
-        h74vIGfLrHxaLbJi+YI0wev1+Xnxjpp9lE3Om8WynC1mP1jPfnqvPa/W0/aqrut8PHs3Nm+Op2W1
-        nlE/Y0caQ5SP8mU2KWnEz6r6KqtnhDcBPs/KxpDmI3oJxH6dT9d10V7zfFEbN7QfMg/E8MHUL5sL
-        Mzj8kBF+1F6vWAEMwnF6jN7+Jf8Pz4cOvCEHAAA=
+        7Syf3tueTh7uPdg733l4/+HO3TpvqnU9zT+vq/WquUuwf3/A/v0J9u/fTPNlVhfV7t1VXV0Ws7xu
+        7n5RTOuqqc7b8Yu8varqt3eX8vNs2eb1eTbNGUgXwbzNLoDid+/+vh9l9z99MJns3Ns+38nPt/cn
+        B9PtbH9/sn3w6fnO/Qfn2b0Hs93f9yN9saymGYaDl68I5rrRLwhgQx/+4l8ifxKGq7xui5w/xEfy
+        4WXR0NvF8uJ1m7VMvtfr6TTPZ/lMAFEzS4O10PHeQf5gev98uv3g/GBve//h3mz7YGfv3vann2af
+        7u3l93ce7uu46OVidVItz4uLdc14ovvvyVepwQOPnb1iNeX2uwYCnv8XT+Dd7gDpg9gIvu4My4Op
+        6s2fPPjqFrMoDzUuLqnJ2cvj2YxIA2gf7e6M8d/u/cG2pWGzL/J2XvFcPL2mGTP8a56PVutJWUzp
+        DQs9wJVa/FzOZAc7mkn5pFjtfuSjKTJjno8IV+IBQvv/TWO5LOp2nZX6Z3N3cX1JSN4lXOgH/pTf
+        No2L5neR1dc0hrZe573vdO6FVj9JWNDwqO1HZy8v9z2wv8T8qr98XwF9NFs2r/O2Ja4M+EA+ry8J
+        IH38PdOcvshWq7LIZ0+Hvi8ggcusfFotsmL5ghTG6/X5efGOmn00v9/OyuVqp27fre+dN9Xubr57
+        OW2WP52NZ+/G5s3xtKzWM+pn7EhjiPIRUX1S0oifVfVVVs8IbwJ8npWNIc1H9BKI/TqfruuivebJ
+        ozZuaD+XDBFDDnywbC7MSPFDhvtRe71iPTEIx6k7evuX/D/DXtFJYgcAAA==
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:22:58 GMT']
-      etag: [W/"8cea2c56-3ac6-45fd-bbe2-1e3b14e14931"]
+      date: ['Fri, 11 Nov 2016 01:04:55 GMT']
+      etag: [W/"a567bb03-f0ef-4b8c-a44b-86f057fa37d1"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2269,39 +2249,39 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [cc6a9bee-7612-11e6-b43a-a0999b14fe87]
+      x-ms-client-request-id: [dc4de470-a7aa-11e6-a504-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test1/providers/Microsoft.Network/networkInterfaces/cli-test-nic?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkInterfaces/cli-test-nic?api-version=2016-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9aFoW223etNvLYvrRiL8qZvjibrOeNNO6WLVFtWzu7kx2zz/df7C7vTs539nen82y
-        7Syf3tueTh7uPdg733l4/+HO3TpvqnU9zT+vq/WquUuwf3/A3r27qqvLYpbXzd0vimldNdV5O36R
-        t1dV/fbuUn6eLdu8Ps+mOb/XxSlvswtg9d27v+9HB9M825ve/3T7Xjb9dHv//vlsezLJ97Z383uT
-        3f18d//hvd3f9yN9saymGUaAl68I5rrRLwhgQx/+4l8ifxKGq7xui5w/xEfy4WXR0NvF8uJ1m7VM
-        sdfr6TTPZ/lMAFEzO+y1kO7Tg3u7e/nB7vZ5/nB/ez/b398+uL9/vn1/d2f304eTvfv7k3v25WJ1
-        Ui3Pi4t1zXii++/JV6nBA4+dsGI15fa7BgKe/3fN2d3umOiDGNJfd1Llwez0pkwefHWLiZOHGheX
-        1OTs5fFsRtQAtI92d8b4b/f+YNvScNYXeTuvmPxPr2mSDMua56PVelIWU3rDQg9wpRY/5MnrIEST
-        J58Uq92PfMxEMszzEaFH006Y/hyjf1nU7Tor9c/m7uL6kvC6S93TD/wpv20aCs3iIquvCe22Xue9
-        73SGhTw/SVjQiKjtR2cvL/c9sL/E/Kq/fF8BfTRbNq/ztiXeC2ZbPq8vCSB9/D3TnL7IVquyyGdP
-        h74vIGfLrHxaLbJi+YI0wev1+Xnxjpp9lE3Om8WynC1mP1jPfnqvPa/W0/aqrut8PHs3Nm+Op2W1
-        nlE/Y0caQ5SP8mU2KWnEz6r6KqtnhDcBPs/KxpDmI3oJxH6dT9d10V7zfFEbN7QfMg/E8MHUL5sL
-        Mzj8kBF+1F6vWAEMwnF6jN7+Jf8Pz4cOvCEHAAA=
+        7Syf3tueTh7uPdg733l4/+HO3TpvqnU9zT+vq/WquUuwf3/A/v0J9u/fTPNlVhfV7t1VXV0Ws7xu
+        7n5RTOuqqc7b8Yu8varqt3eX8vNs2eb1eTbNGUgXwbzNLoDid+/+vh9l9z99MJns3Ns+38nPt/cn
+        B9PtbH9/sn3w6fnO/Qfn2b0Hs93f9yN9saymGYaDl68I5rrRLwhgQx/+4l8ifxKGq7xui5w/xEfy
+        4WXR0NvF8uJ1m7VMvtfr6TTPZ/lMAFEzS4O10PHeQf5gev98uv3g/GBve//h3mz7YGfv3vann2af
+        7u3l93ce7uu46OVidVItz4uLdc14ovvvyVepwQOPnb1iNeX2uwYCnv8XT+Dd7gDpg9gIvu4My4Op
+        6s2fPPjqFrMoDzUuLqnJ2cvj2YxIA2gf7e6M8d/u/cG2pWGzL/J2XvFcPL2mGTP8a56PVutJWUzp
+        DQs9wJVa/FzOZAc7mkn5pFjtfuSjKTJjno8IV+IBQvv/TWO5LOp2nZX6Z3N3cX1JSN4lXOgH/pTf
+        No2L5neR1dc0hrZe573vdO6FVj9JWNDwqO1HZy8v9z2wv8T8qr98XwF9NFs2r/O2Ja4M+EA+ry8J
+        IH38PdOcvshWq7LIZ0+Hvi8ggcusfFotsmL5ghTG6/X5efGOmn00v9/OyuVqp27fre+dN9Xubr57
+        OW2WP52NZ+/G5s3xtKzWM+pn7EhjiPIRUX1S0oifVfVVVs8IbwJ8npWNIc1H9BKI/TqfruuivebJ
+        ozZuaD+XDBFDDnywbC7MSPFDhvtRe71iPTEIx6k7evuX/D/DXtFJYgcAAA==
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:22:59 GMT']
-      etag: [W/"8cea2c56-3ac6-45fd-bbe2-1e3b14e14931"]
+      date: ['Fri, 11 Nov 2016 01:04:55 GMT']
+      etag: [W/"a567bb03-f0ef-4b8c-a44b-86f057fa37d1"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2309,102 +2289,102 @@ interactions:
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/networkInterfaces/cli-test-nic",
-      "etag": "W/\"8cea2c56-3ac6-45fd-bbe2-1e3b14e14931\"", "location": "westus",
-      "properties": {"dnsSettings": {"internalDomainNameSuffix": "abfsmnldmdzudj2tfouctwrrre.dx.internal.cloudapp.net",
+    body: '{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkInterfaces/cli-test-nic",
+      "etag": "W/\"a567bb03-f0ef-4b8c-a44b-86f057fa37d1\"", "location": "westus",
+      "properties": {"dnsSettings": {"internalDomainNameSuffix": "h5tdlnp0rtxu3fso11e1vcsnja.dx.internal.cloudapp.net",
       "appliedDnsServers": [], "internalDnsNameLabel": "noodle", "dnsServers": []},
-      "networkSecurityGroup": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/networkSecurityGroups/myothernsg"},
+      "networkSecurityGroup": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkSecurityGroups/myothernsg"},
       "provisioningState": "Succeeded", "enableIPForwarding": true, "ipConfigurations":
-      [{"etag": "W/\"8cea2c56-3ac6-45fd-bbe2-1e3b14e14931\"", "properties": {"subnet":
-      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},
-      "privateIPAddressVersion": "IPv4", "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/publicIPAddresses/publicip1"},
+      [{"etag": "W/\"a567bb03-f0ef-4b8c-a44b-86f057fa37d1\"", "properties": {"subnet":
+      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},
+      "privateIPAddressVersion": "IPv4", "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/publicIPAddresses/publicip1"},
       "privateIPAllocationMethod": "Dynamic", "primary": true, "privateIPAddress":
-      "10.0.0.15", "provisioningState": "Succeeded"}, "name": "ipconfig1", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/networkInterfaces/cli-test-nic/ipConfigurations/ipconfig1"}],
-      "resourceGuid": "68312e81-fe94-4a44-854f-510169b254b3"}, "tags": {}}'
+      "10.0.0.15", "provisioningState": "Succeeded"}, "name": "ipconfig1", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkInterfaces/cli-test-nic/ipConfigurations/ipconfig1"}],
+      "resourceGuid": "38e7c5fc-7f82-492d-8023-66a622e5094c"}, "tags": {}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
-      Content-Length: ['1492']
+      Content-Length: ['1557']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [cc888eeb-7612-11e6-88aa-a0999b14fe87]
+      x-ms-client-request-id: [dc92b59e-a7aa-11e6-ac07-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test1/providers/Microsoft.Network/networkInterfaces/cli-test-nic?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkInterfaces/cli-test-nic?api-version=2016-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9aFoW223etNvLYvrRiL8qZvjibrOeNNO6WLVFtWzu7kx2zz/df7C7vTs539nen82y
-        7Syf3tueTh7uPdg733l4/+HO3TpvqnU9zT+vq/WquUuwf3/A3r27qqvLYpbXzd0vimldNdV5O36R
-        t1dV/fbuUn6eLdu8Ps+mOb/XxSlvswtg9d27v+9H+cP8wWw6+XT70937D7f39+7d2z6Y7O5tZ5Pz
-        3Wzn3t6n+3s7v+9H+mJZTTOMAC9fEcx1o18QwIY+/MW/RP4kDFd53RY5f4iP5MPLoqG3i+XF6zZr
-        mWKv19Npns/ymQCiZnbYayHdpwf3dvfyg93t8/zh/vZ+tr+/fXB//3z7/u7O7qcPJ3v39yf37MvF
-        6qRanhcX65rxRPffk69SgwceO2HFasrtdw0EPP/vmrO73THRBzGkv+6kyoPZ6U2ZPPjqFhMnDzUu
-        LqnJ2cvj2YyoAWgf7e6M8d/u/cG2peGsL/J2XjH5n17TJBmWNc9Hq/WkLKb0hoUe4EotfsiT10GI
-        Jk8+KVa7H/mYiWSY5yNCj6adMP05Rv+yqNt1Vuqfzd3F9SXhdZe6px/4U37bNBSaxUVWXxPabb3O
-        e9/pDAt5fpKwoBFR24/OXl7ue2B/iflVf/m+Avpotmxe521LvBfMtnxeXxJA+vh7pjl9ka1WZZHP
-        ng59X0DOlllJDV6QGnieTfKSmny0rKpZmTt+sw2f/aIZYywNxiREzWJZzhazH6xnP73XnlfraXtV
-        13U+nr0bm5fG07JazwiXMcjXB/q0WmTFEgi8Xp+fF+/QwdeBLIDNlHyUL7NJSfR+VtVXWT0jqhFg
-        b14+oncw06/z6bou2mtmFmri6PpDZsAYPuC7qp3TaJsLM0D8kFF+1F6vWAUNAnOalN7+Jf8Pym5h
-        9aMHAAA=
+        7Syf3tueTh7uPdg733l4/+HO3TpvqnU9zT+vq/WquUuwf3/A/v0J9u/fTPNlVhfV7t1VXV0Ws7xu
+        7n5RTOuqqc7b8Yu8varqt3eX8vNs2eb1eTbNGUgXwbzNLoDid+/+vh99+vDhg2w6e7g9Ob93vr0/
+        nd3ffvhwb287y+7vzHbPZ5OHB/u/70f6YllNMwwHL18RzHWjXxDAhj78xb9E/iQMV3ndFjl/iI/k
+        w8uiobeL5cXrNmuZfK/X02mez/KZAKJmlgZroeO9g/zB9P75dPvB+cHe9v7Dvdn2wc7eve1PP80+
+        3dvL7+883Ndx0cvF6qRanhcX65rxRPffk69SgwceO3vFasrtdw0EPP8vnsC73QHSB7ERfN0ZlgdT
+        1Zs/efDVLWZRHmpcXFKTs5fHsxmRBtA+2t0Z47/d+4NtS8NmX+TtvOK5eHpNM2b41zwfrdaTspjS
+        GxZ6gCu1+LmcyQ52NJPySbHa/chHU2TGPB8RrsQDhPb/m8ZyWdTtOiv1z+bu4vqSkLxLuNAP/Cm/
+        bRoXze8iq69pDG29znvf6dwLrX6SsKDhUduPzl5e7ntgf4n5VX/5vgL6aLZsXudtS1wZ8IF8Xl8S
+        QPr4e6Y5fZGtVmWRz54OfV9AApdZSQ1ekLZ4nk3ykpp8tKyqWZk7TrQNn/2iGWMsDcbz++2sXK52
+        6vbd+t55U+3u5ruX02b509l49m5sXhpPy2o9I1zGIF8f6NNqkRVLIPB6fX5evEMHXweyADZT8hHN
+        +aQkej+r6qusnhHVCLA3Lx/RO5jp1/l0XRftNXMONXF0/bnkxhhyYMKqndPQmwszWvyQIX/UXq9Y
+        Uw0CcwqX3v4l/w+BaBai5AcAAA==
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/6328ac6f-1179-4a09-a3ea-0ccc28b582fd?api-version=2016-06-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/a0305bf3-1604-496d-a3df-c2bb5dbeeaf7?api-version=2016-06-01']
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:22:59 GMT']
+      date: ['Fri, 11 Nov 2016 01:04:56 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1188']
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [cce0b694-7612-11e6-b5a1-a0999b14fe87]
+      x-ms-client-request-id: [dd288d00-a7aa-11e6-8f57-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test1/providers/Microsoft.Network/networkInterfaces/cli-test-nic?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkInterfaces/cli-test-nic?api-version=2016-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9aFoW223etNvLYvrRiL8qZvjibrOeNNO6WLVFtWzu7kx2zz/df7C7vTs539nen82y
-        7Syf3tueTh7uPdg733l4/+HO3TpvqnU9zT+vq/WquUuwf3/A3r27qqvLYpbXzd0vimldNdV5O36R
-        t1dV/fbuUn6eLdu8Ps+mOb/XxSlvswtg9d27v+9H+cP8wWw6+XT70937D7f39+7d2z6Y7O5tZ5Pz
-        3Wzn3t6n+3s7v+9H+mJZTTOMAC9fEcx1o18QwIY+/MW/RP4kDFd53RY5f4iP5MPLoqG3i+XF6zZr
-        mWKv19Npns/ymQCiZnbYayHdpwf3dvfyg93t8/zh/vZ+tr+/fXB//3z7/u7O7qcPJ3v39yf37MvF
-        6qRanhcX65rxRPffk69SgwceO2HFasrtdw0EPP/vmrO73THRBzGkv+6kyoPZ6U2ZPPjqFhMnDzUu
-        LqnJ2cvj2YyoAWgf7e6M8d/u/cG2peGsL/J2XjH5n17TJBmWNc9Hq/WkLKb0hoUe4EotfsiT10GI
-        Jk8+KVa7H/mYiWSY5yNCj6adMP05Rv+yqNt1Vuqfzd3F9SXhdZe6px/4U37bNBSaxUVWXxPabb3O
-        e9/pDAt5fpKwoBFR24/OXl7ue2B/iflVf/m+Avpotmxe521LvBfMtnxeXxJA+vh7pjl9ka1WZZHP
-        ng59X0DOlllJDV6QGnieTfKSmny0rKpZmTt+sw2f/aIZYywNxiREzWJZzhazH6xnP73XnlfraXtV
-        13U+nr0bm5fG07JazwiXMcjXB/q0WmTFEgi8Xp+fF+/QwdeBLIDNlHyUL7NJSfR+VtVXWT0jqhFg
-        b14+oncw06/z6bou2mtmFmri6PpDZsAYPuC7qp3TaJsLM0D8kFF+1F6vWAUNAnOalN7+Jf8Pym5h
-        9aMHAAA=
+        7Syf3tueTh7uPdg733l4/+HO3TpvqnU9zT+vq/WquUuwf3/A/v0J9u/fTPNlVhfV7t1VXV0Ws7xu
+        7n5RTOuqqc7b8Yu8varqt3eX8vNs2eb1eTbNGUgXwbzNLoDid+/+vh99+vDhg2w6e7g9Ob93vr0/
+        nd3ffvhwb287y+7vzHbPZ5OHB/u/70f6YllNMwwHL18RzHWjXxDAhj78xb9E/iQMV3ndFjl/iI/k
+        w8uiobeL5cXrNmuZfK/X02mez/KZAKJmlgZroeO9g/zB9P75dPvB+cHe9v7Dvdn2wc7eve1PP80+
+        3dvL7+883Ndx0cvF6qRanhcX65rxRPffk69SgwceO3vFasrtdw0EPP8vnsC73QHSB7ERfN0ZlgdT
+        1Zs/efDVLWZRHmpcXFKTs5fHsxmRBtA+2t0Z47/d+4NtS8NmX+TtvOK5eHpNM2b41zwfrdaTspjS
+        GxZ6gCu1+LmcyQ52NJPySbHa/chHU2TGPB8RrsQDhPb/m8ZyWdTtOiv1z+bu4vqSkLxLuNAP/Cm/
+        bRoXze8iq69pDG29znvf6dwLrX6SsKDhUduPzl5e7ntgf4n5VX/5vgL6aLZsXudtS1wZ8IF8Xl8S
+        QPr4e6Y5fZGtVmWRz54OfV9AApdZSQ1ekLZ4nk3ykpp8tKyqWZk7TrQNn/2iGWMsDcbz++2sXK52
+        6vbd+t55U+3u5ruX02b509l49m5sXhpPy2o9I1zGIF8f6NNqkRVLIPB6fX5evEMHXweyADZT8hHN
+        +aQkej+r6qusnhHVCLA3Lx/RO5jp1/l0XRftNXMONXF0/bnkxhhyYMKqndPQmwszWvyQIX/UXq9Y
+        Uw0CcwqX3v4l/w+BaBai5AcAAA==
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:22:59 GMT']
-      etag: [W/"e9e7dcb6-6159-4233-8b12-abf1a0326420"]
+      date: ['Fri, 11 Nov 2016 01:04:58 GMT']
+      etag: [W/"6997acd9-bf3f-4cd5-9922-aa50d1fdb984"]
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2412,110 +2392,110 @@ interactions:
       vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: '{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/networkInterfaces/cli-test-nic",
-      "etag": "W/\"e9e7dcb6-6159-4233-8b12-abf1a0326420\"", "location": "westus",
-      "properties": {"dnsSettings": {"internalDomainNameSuffix": "abfsmnldmdzudj2tfouctwrrre.dx.internal.cloudapp.net",
-      "internalFqdn": "noodle.abfsmnldmdzudj2tfouctwrrre.dx.internal.cloudapp.net",
+    body: '{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkInterfaces/cli-test-nic",
+      "etag": "W/\"6997acd9-bf3f-4cd5-9922-aa50d1fdb984\"", "location": "westus",
+      "properties": {"dnsSettings": {"internalDomainNameSuffix": "h5tdlnp0rtxu3fso11e1vcsnja.dx.internal.cloudapp.net",
+      "internalFqdn": "noodle.h5tdlnp0rtxu3fso11e1vcsnja.dx.internal.cloudapp.net",
       "appliedDnsServers": [], "internalDnsNameLabel": "doodle", "dnsServers": []},
-      "networkSecurityGroup": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/networkSecurityGroups/myothernsg"},
+      "networkSecurityGroup": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkSecurityGroups/myothernsg"},
       "provisioningState": "Succeeded", "enableIPForwarding": false, "ipConfigurations":
-      [{"etag": "W/\"e9e7dcb6-6159-4233-8b12-abf1a0326420\"", "properties": {"subnet":
-      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},
-      "privateIPAddressVersion": "IPv4", "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/publicIPAddresses/publicip1"},
+      [{"etag": "W/\"6997acd9-bf3f-4cd5-9922-aa50d1fdb984\"", "properties": {"subnet":
+      {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/mysubnet"},
+      "privateIPAddressVersion": "IPv4", "publicIPAddress": {"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/publicIPAddresses/publicip1"},
       "privateIPAllocationMethod": "Dynamic", "primary": true, "privateIPAddress":
-      "10.0.0.15", "provisioningState": "Succeeded"}, "name": "ipconfig1", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test1/providers/Microsoft.Network/networkInterfaces/cli-test-nic/ipConfigurations/ipconfig1"}],
-      "resourceGuid": "68312e81-fe94-4a44-854f-510169b254b3"}, "tags": {}}'
+      "10.0.0.15", "provisioningState": "Succeeded"}, "name": "ipconfig1", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkInterfaces/cli-test-nic/ipConfigurations/ipconfig1"}],
+      "resourceGuid": "38e7c5fc-7f82-492d-8023-66a622e5094c"}, "tags": {}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
-      Content-Length: ['1571']
+      Content-Length: ['1636']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [ccff6e40-7612-11e6-af4a-a0999b14fe87]
+      x-ms-client-request-id: [dd6dd361-a7aa-11e6-9799-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test1/providers/Microsoft.Network/networkInterfaces/cli-test-nic?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkInterfaces/cli-test-nic?api-version=2016-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
         6UfLbJF/9Cj9aFoW223etNvLYvrRiL8qZvjibrOeNNO6WLVFtWzu7kx2zz/df7C7vTs539nen82y
-        7Syf3tueTh7uPdg733l4/+HO3TpvqnU9zT+vq/WquUuwf3/A3r27qqvLYpbXzd0vimldNdV5O36R
-        t1dV/fbuUn6eLdu8Ps+mOb/XxSlvswtg9d27v+9Hu/n+zvTTyWR7kp/vbe/vzO5tZ/cf3N9+uJ/t
-        5p9OH+4c5Lu/70f6YllNM4wAL18RzHWjXxDAhj78xb9E/iQMV3ndFjl/iI/kw8uiobeL5cXrNmuZ
-        Yq/X02mez/KZAKJmdthrId2nB/d29/KD3e3z/OH+9n62v799cH//fPv+7s7upw8ne/f3J/fsy8Xq
-        pFqeFxfrmvFE99+Tr1KDBx47YcVqyu13DQQ8/++as7vdMdEHMaS/7qTKg9npTZk8+OoWEycPNS4u
-        qcnZy+PZjKgBaB/t7ozx3+79wbal4awv8nZeMfmfXtMkGZY1z0er9aQspvSGhR7gSi1+yJPXQYgm
-        Tz4pVrsf+ZiJZJjnI0KPpp0w/TlG/7Ko23VW6p/N3cX1JeF1l7qnH/hTfts0FJrFRVZfE9ptvc57
-        3+kMC3l+krCgEVHbj85eXu57YH+J+VV/+b4C+mi2bF7nbUu8F8y2fF5fEkD6+HumOX2RrVZlkc+e
-        Dn1fQM6WWUkNXpAaeJ5N8pKafDSrqlmZO36zDZ/9ohljLA3G2eS8WSzL2WL2g/Xsp/fa82o9ba/q
-        us7Hs3dj89J4WlbrGeEyBvn6QJ9Wi6xYAoHX6/Pz4h06+DqQBbCZko/yZTYpid7Pqvoqq2dENQJ8
-        npWNmZiP6CVM9et8uq6L9pq5hdo4wv6QOTCGDxivauc03ObCjBA/ZJgftdcr1kGDwJwqpbd/yf8D
-        nR95QqQHAAA=
+        7Syf3tueTh7uPdg733l4/+HO3TpvqnU9zT+vq/WquUuwf3/A/v0J9u/fTPNlVhfV7t1VXV0Ws7xu
+        7n5RTOuqqc7b8Yu8varqt3eX8vNs2eb1eTbNGUgXwbzNLoDid+/+vh9N7k2ns+ns4fa96e797f1J
+        Ntme3M8fbu8c7N6b7h/s5p/uZb/vR/piWU0zDAcvXxHMdaNfEMCGPvzFv0T+JAxXed0WOX+Ij+TD
+        y6Kht4vlxes2a5l8r9fTaZ7P8pkAomaWBmuh472D/MH0/vl0+8H5wd72/sO92fbBzt697U8/zT7d
+        28vv7zzc13HRy8XqpFqeFxfrmvFE99+Tr1KDBx47e8Vqyu13DQQ8/y+ewLvdAdIHsRF83RmWB1PV
+        mz958NUtZlEealxcUpOzl8ezGZEG0D7a3Rnjv937g21Lw2Zf5O284rl4ek0zZvjXPB+t1pOymNIb
+        FnqAK7X4uZzJDnY0k/JJsdr9yEdTZMY8HxGuxAOE9v+bxnJZ1O06K/XP5u7i+pKQvEu40A/8Kb9t
+        GhfN7yKrr2kMbb3Oe9/p3AutfpKwoOFR24/OXl7ue2B/iflVf/m+Avpotmxe521LXBnwgXxeXxJA
+        +vh7pjl9ka1WZZHPng59X0ACl1lJDV6QtnieTfKSmnw0q6pZmTtOtA2f/aIZYywNxvP77axcrnbq
+        9t363nlT7e7mu5fTZvnT2Xj2bmxeGk/Laj0jXMYgXx/o02qRFUsg8Hp9fl68QwdfB7IANlPyEc35
+        pCR6P6vqq6yeEdUI8HlWNmZiPqKXMNWv8+m6LtprZh1q4wj7c8mOMeTAhVU7p7E3F2a4+CFj/qi9
+        XrGqGgTmNC69/Uv+H95xUn/lBwAA
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/22150520-0e2e-4454-9fea-f5c4f238ac99?api-version=2016-06-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/1150cb45-8469-4b83-b8c4-465b27849a9d?api-version=2016-06-01']
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:22:59 GMT']
+      date: ['Fri, 11 Nov 2016 01:04:57 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1189']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [cd674d63-7612-11e6-820f-a0999b14fe87]
+      x-ms-client-request-id: [dddbb061-a7aa-11e6-956d-a0b3ccf7272a]
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test1/providers/Microsoft.Network/networkInterfaces/cli-test-nic?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkInterfaces/cli-test-nic?api-version=2016-06-01
   response:
     body: {string: !!python/unicode ''}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/64ca425a-9165-43ad-8c8d-6d2c3cbcb0e9?api-version=2016-06-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/cd02b5e3-7dcb-4b16-b07f-e4614316be2d?api-version=2016-06-01']
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Thu, 08 Sep 2016 22:23:00 GMT']
+      date: ['Fri, 11 Nov 2016 01:04:58 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/64ca425a-9165-43ad-8c8d-6d2c3cbcb0e9?api-version=2016-06-01']
+      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/cd02b5e3-7dcb-4b16-b07f-e4614316be2d?api-version=2016-06-01']
       pragma: [no-cache]
       retry-after: ['10']
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1187']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 202, message: Accepted}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [cd674d63-7612-11e6-820f-a0999b14fe87]
+      x-ms-client-request-id: [dddbb061-a7aa-11e6-956d-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/64ca425a-9165-43ad-8c8d-6d2c3cbcb0e9?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/cd02b5e3-7dcb-4b16-b07f-e4614316be2d?api-version=2016-06-01
   response:
     body:
       string: !!binary |
@@ -2526,7 +2506,7 @@ interactions:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:23:11 GMT']
+      date: ['Fri, 11 Nov 2016 01:05:08 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
@@ -2538,16 +2518,16 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyIsImtpZCI6IlliUkFRUlljRV9tb3RXVkpLSHJ3TEJiZF85cyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDczMzY5ODgzLCJuYmYiOjE0NzMzNjk4ODMsImV4cCI6MTQ3MzM3Mzc4MywiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xMDEuMjI1IiwibmFtZSI6IkFkbWluMiIsIm9pZCI6IjU5NjNmNTBjLTdjNDMtNDA1Yy1hZjdlLTUzMjk0ZGU3NmFiZCIsInB1aWQiOiIxMDAzQkZGRDk1OUY4NDIzIiwic2NwIjoidXNlcl9pbXBlcnNvbmF0aW9uIiwic3ViIjoic0RnZXhSd0NOSWZZLWh6UWpqQ0R2WlQ3SXpkZm80U3lycjR4MGRETnpSNCIsInRpZCI6IjU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YSIsInVuaXF1ZV9uYW1lIjoiYWRtaW4yQEF6dXJlU0RLVGVhbS5vbm1pY3Jvc29mdC5jb20iLCJ1cG4iOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInZlciI6IjEuMCIsIndpZHMiOlsiNjJlOTAzOTQtNjlmNS00MjM3LTkxOTAtMDEyMTc3MTQ1ZTEwIl19.tMgwoaEluMd6QMIp_vmK6P7VD7cLOy8BcZhqr25hPfANgRioUMdiWLrSYcEsOcRxTdW2xl4xx0B1sCbg6oJs-VE4OboJCpXNfcdsdVb0B5POr55AzMD0GyeCnU_fD_-iXALAX-spDRt2uQLEG5GJZrd7ZK9WgkEUxfaZ4NyQ2RtR_1SXY5Uq_R4gZlMDH5n3P54cgT9zCuUObzSyDfwwdCtI5Z6uwP9AUbno2PRdmbQnBfp2SlepuN0CojvHGYwKzCzEVDYNpnxvmCTLJ9Sjcq1gzOEaSdZqlIEOdR004fmjAWkK4Bj4ENdhEy9TESNSVu-I-SIxblbAk0w7YSCM3A]
+      Authorization: [Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyIsImtpZCI6Ikk2b0J3NFZ6QkhPcWxlR3JWMkFKZEE1RW1YYyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC81NDgyNmIyMi0zOGQ2LTRmYjItYmFkOS1iN2I5M2EzZTljNWEvIiwiaWF0IjoxNDc4ODI0Mzc1LCJuYmYiOjE0Nzg4MjQzNzUsImV4cCI6MTQ3ODgyODI3NSwiYWNyIjoiMSIsImFtciI6WyJwd2QiXSwiYXBwaWQiOiIwNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDYiLCJhcHBpZGFjciI6IjAiLCJlX2V4cCI6MTA4MDAsImZhbWlseV9uYW1lIjoiQWRtaW4yIiwiZ2l2ZW5fbmFtZSI6IkFkbWluMiIsImdyb3VwcyI6WyJlNGJiMGI1Ni0xMDE0LTQwZjgtODhhYi0zZDhhOGNiMGUwODYiLCI2Yjk3NzYxYS1kN2QwLTQ4ZjYtYWQ1Ni1mMzhkMzI3Yzg1NTMiXSwiaXBhZGRyIjoiMTY3LjIyMC4xLjE4NiIsIm5hbWUiOiJBZG1pbjIiLCJvaWQiOiI1OTYzZjUwYy03YzQzLTQwNWMtYWY3ZS01MzI5NGRlNzZhYmQiLCJwbGF0ZiI6IjE0IiwicHVpZCI6IjEwMDNCRkZEOTU5Rjg0MjMiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJzRGdleFJ3Q05JZlktaHpRampDRHZaVDdJemRmbzRTeXJyNHgwZEROelI0IiwidGlkIjoiNTQ4MjZiMjItMzhkNi00ZmIyLWJhZDktYjdiOTNhM2U5YzVhIiwidW5pcXVlX25hbWUiOiJhZG1pbjJAQXp1cmVTREtUZWFtLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImFkbWluMkBBenVyZVNES1RlYW0ub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIiwid2lkcyI6WyI2MmU5MDM5NC02OWY1LTQyMzctOTE5MC0wMTIxNzcxNDVlMTAiXX0.T9oICBmQ-dcuu8sAl89RwlXCRNoMpNw9dbYLtLx5QL3E3_PWW-YYhy2YAB1IQlJSJoiLEWTZCGJRxqIzc9IeNYMFyNJVRo_oU_LjAXAVCTrxkTyg1mDfRUpAJjdM89v4jqafXQK8Hf9M64zLgsNxNiMpe3mD-GR3bhLM9amwGA3oHT0MZdSIFz4cAZSLlqI39i2OmgR1YghsHK8M-VFDKtkyL3nQ9iOfB_Et_QmaKHe56hAD0tNgRoDlm7_Kx7wYjkTH3oEKCPOM_I1dPxyDeOkPhZ4NLtRQKyxFoTU7d8TIQrQJ1w4jxjg1RY9NcP9AvLM6mmuCGIKOkXM4_YaVwA]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b8]
       accept-language: [en-US]
-      x-ms-client-request-id: [d4a9c968-7612-11e6-84ce-a0999b14fe87]
+      x-ms-client-request-id: [e4a709cf-a7aa-11e6-8b20-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test1/providers/Microsoft.Network/networkInterfaces?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nic_scenario1/providers/Microsoft.Network/networkInterfaces?api-version=2016-06-01
   response:
     body:
       string: !!binary |
@@ -2559,7 +2539,7 @@ interactions:
       content-encoding: [gzip]
       content-length: ['133']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:23:12 GMT']
+      date: ['Fri, 11 Nov 2016 01:05:10 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/test_network_commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/test_network_commands.py
@@ -496,7 +496,7 @@ class NetworkNicScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
         super(NetworkNicScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'cli_test1'
+        self.resource_group = 'cli_test_nic_scenario1'
 
     def test_network_nic(self):
         self.execute()

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/test_network_commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/test_network_commands.py
@@ -392,7 +392,7 @@ class NetworkLoadBalancerSubresourceScenarioTest(ResourceGroupVCRTestBase):
         self.cmd('network lb frontend-ip create {} -n ipconfig1 --public-ip-address publicip1'.format(lb_rg))
         self.cmd('network lb frontend-ip create {} -n ipconfig2 --public-ip-address publicip2'.format(lb_rg))
         self.cmd('network lb frontend-ip create {} -n ipconfig3 --vnet-name {} --subnet {} --private-ip-address 10.0.0.99'.format(lb_rg, self.vnet_name, self.subnet_name),
-            allowed_exceptions="Run 'az resource feature register --namespace Microsoft.Network -n AllowMultiVipIlb' to enable the feature first")
+            allowed_exceptions=["Run 'az resource feature register --namespace Microsoft.Network -n AllowMultiVipIlb' to enable the feature first", 'is not registered for feature'])
         # Note that the ipconfig3 won't be added. The 3 that will be found are the default and two created ones
         self.cmd('network lb frontend-ip list {}'.format(lb_rg), checks=JMESPathCheck('length(@)', 3))
         self.cmd('network lb frontend-ip update {} -n ipconfig1 --public-ip-address publicip3'.format(lb_rg))
@@ -496,7 +496,7 @@ class NetworkNicScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
         super(NetworkNicScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'cli_test_nic_scenario1'
+        self.resource_group = 'cli_test_nic_scenario'
 
     def test_network_nic(self):
         self.execute()
@@ -608,9 +608,9 @@ class NetworkNicSubresourceScenarioTest(ResourceGroupVCRTestBase):
             JMESPathCheck('privateIpAllocationMethod', 'Dynamic')
         ])
         # TODO: Creating multiple ip-configurations per NIC currently not supported per rest-api-spec issue #305
-        expected_exception = "Run 'az resource feature register --namespace Microsoft.Network -n AllowMultipleIpConfigurationsPerNic' to enable the feature first"
+        expected_exception = ["Run 'az resource feature register --namespace Microsoft.Network -n AllowMultipleIpConfigurationsPerNic' to enable the feature first", 'is not registered for feature']
         self.cmd('network nic ip-config create -g {} --nic-name {} -n ipconfig2 --subnet {} --vnet-name {}'.format(rg, nic, subnet, vnet), allowed_exceptions=expected_exception)
-        expected_exception = 'Network interface {} must have one or more IP configurations.'.format(nic)
+        expected_exception = 'Network interface {} must have one or more IP configurations.'.format(nic) # pylint: disable=redefined-variable-type
         self.cmd('network nic ip-config delete -g {} --nic-name {} -n ipconfig1'.format(rg, nic), allowed_exceptions=expected_exception)
 
         # test various sets


### PR DESCRIPTION
Fixes #1237, fixes #920

This PR is currently for review only for the recommended changes to the way we handle "folded" CLI parameters for ARM-template based creates.

This PR shows the changes for NIC create, which affects subnet, public-ip and network-security-group. If acceptable, this same kind of change would be applied to other existing creates and the `register_folded_cli_argument` code will be removed.

The reason for this change is that the `register_folded_cli_argument` is too heavily parameterized, confusing, and does not work well with our existing parameter aliasing. 