### PR TITLE
web: initial slot end to end support

### DIFF
--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
@@ -82,6 +82,36 @@ helps['appservice web deployment'] = """
     short-summary: commands to manage deployments (slots, credentials, etc)
 """
 
+helps['appservice web deployment list-site-credentials'] = """
+    type: command
+    short-summary: show site level deployment credentials
+"""
+
+helps['appservice web deployment slot auto-swap'] = """
+    type: command
+    short-summary: configure slot auto swap
+"""
+
+helps['appservice web deployment slot create'] = """
+    type: command
+    short-summary: create a slot
+"""
+
+helps['appservice web deployment slot swap'] = """
+    type: command
+    short-summary: swap slots
+"""
+
+helps['appservice web deployment slot list'] = """
+    type: command
+    short-summary: list all slots
+"""
+
+helps['appservice web deployment slot delete'] = """
+    type: command
+    short-summary: delete a slot
+"""
+
 helps['appservice web deployment user'] = """
     type: group
     short-summary: commands to manage deployment user credentials

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
@@ -74,7 +74,7 @@ helps['appservice web config hostname'] = """
 
 helps['appservice web log'] = """
     type: group
-    short-summary: commands to manager logs 
+    short-summary: commands to manage logs 
 """
 
 helps['appservice web deployment'] = """

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
@@ -72,6 +72,26 @@ helps['appservice web config hostname'] = """
     short-summary: commands to configure hostnames
 """
 
+helps['appservice web log'] = """
+    type: group
+    short-summary: commands to manager logs 
+"""
+
+helps['appservice web deployment'] = """
+    type: group
+    short-summary: commands to manage deployments (slots, credentials, etc)
+"""
+
+helps['appservice web deployment user'] = """
+    type: group
+    short-summary: commands to manage deployment user credentials
+"""
+
+helps['appservice web deployment slot'] = """
+    type: group
+    short-summary: commands to manage deployment slots
+"""
+
 helps['appservice web source-control'] = """
     type: group
     short-summary: commands to manage source control systems

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
@@ -60,7 +60,8 @@ register_cli_argument('appservice web deployment user', 'user_name', help='user 
 register_cli_argument('appservice web deployment user', 'password', help='password, will prompt if not specified')
 
 register_cli_argument('appservice web deployment slot', 'slot', help='the name of the slot')
-register_cli_argument('appservice web deployment slot', 'webapp', help='Name of the webapp')
+register_cli_argument('appservice web deployment slot', 'webapp', arg_type=name_arg_type, completer=get_resource_name_completion_list('Microsoft.Web/sites'),
+                      help='Name of the webapp', id_part='name')
 register_cli_argument('appservice web deployment slot', 'auto_swap_slot', help='target slot to auto swap', default='production')
 register_cli_argument('appservice web deployment slot', 'disable', help='disable auto swap', action='store_true')
 register_cli_argument('appservice web deployment slot', 'target_slot', help="target slot to swap, default to 'production'")

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
@@ -61,8 +61,10 @@ register_cli_argument('appservice web deployment user', 'password', help='passwo
 
 register_cli_argument('appservice web deployment slot', 'slot', help='the name of the slot')
 register_cli_argument('appservice web deployment slot', 'webapp', help='Name of the webapp')
-register_cli_argument('appservice web deployment slot', 'auto_swap_slot', help='target slot to swap', default='production')
+register_cli_argument('appservice web deployment slot', 'auto_swap_slot', help='target slot to auto swap', default='production')
 register_cli_argument('appservice web deployment slot', 'disable', help='disable auto swap', action='store_true')
+register_cli_argument('appservice web deployment slot', 'target_slot', help="target slot to swap, default to 'production'")
+
 
 two_states_switch = ['true', 'false']
 

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/commands.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/commands.py
@@ -29,9 +29,6 @@ cli_command(__name__, 'appservice web config container delete', 'azure.cli.comma
 cli_command(__name__, 'appservice web config container show', 'azure.cli.command_modules.appservice.custom#show_container_settings')
 
 factory = lambda _: web_client_factory().sites
-cli_command(__name__, 'appservice web show-publish-profile',
-            'azure.mgmt.web.operations.sites_operations#SitesOperations.list_site_publishing_credentials', factory)
-
 cli_command(__name__, 'appservice web source-control config-local-git', 'azure.cli.command_modules.appservice.custom#enable_local_git')
 cli_command(__name__, 'appservice web source-control config', 'azure.cli.command_modules.appservice.custom#config_source_control')
 cli_command(__name__, 'appservice web source-control sync', 'azure.cli.command_modules.appservice.custom#sync_site_repo')
@@ -45,7 +42,7 @@ cli_command(__name__, 'appservice web browse', 'azure.cli.command_modules.appser
 
 cli_command(__name__, 'appservice web deployment slot list', 'azure.mgmt.web.operations.sites_operations#SitesOperations.get_site_slots', factory)
 cli_command(__name__, 'appservice web deployment slot auto-swap', 'azure.cli.command_modules.appservice.custom#config_slot_auto_swap')
-cli_command(__name__, 'appservice web deployment slot swap', 'azure.mgmt.web.operations.sites_operations#SitesOperations.swap_slots_slot', factory)
+cli_command(__name__, 'appservice web deployment slot swap', 'azure.cli.command_modules.appservice.custom#swap_slot')
 cli_command(__name__, 'appservice web deployment slot create', 'azure.cli.command_modules.appservice.custom#create_webapp_slot')
 cli_command(__name__, 'appservice web deployment user set', 'azure.cli.command_modules.appservice.custom#set_deployment_user')
 cli_command(__name__, 'appservice web deployment list-site-credentials',

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/commands.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/commands.py
@@ -41,6 +41,7 @@ cli_command(__name__, 'appservice web log config', 'azure.cli.command_modules.ap
 cli_command(__name__, 'appservice web browse', 'azure.cli.command_modules.appservice.custom#view_in_browser')
 
 cli_command(__name__, 'appservice web deployment slot list', 'azure.mgmt.web.operations.sites_operations#SitesOperations.get_site_slots', factory)
+cli_command(__name__, 'appservice web deployment slot delete', 'azure.cli.command_modules.appservice.custom#delete_slot')
 cli_command(__name__, 'appservice web deployment slot auto-swap', 'azure.cli.command_modules.appservice.custom#config_slot_auto_swap')
 cli_command(__name__, 'appservice web deployment slot swap', 'azure.cli.command_modules.appservice.custom#swap_slot')
 cli_command(__name__, 'appservice web deployment slot create', 'azure.cli.command_modules.appservice.custom#create_webapp_slot')

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -415,6 +415,11 @@ def swap_slot(resource_group_name, webapp, slot, target_slot=None):
 
     return AppServiceLongRunningOperation()(poller)
 
+def delete_slot(resource_group_name, webapp, slot):
+    client = web_client_factory()
+    #TODO: once swagger finalized, expose other parameters like: delete_all_slots, etc...
+    client.sites.delete_site_slot(resource_group_name, webapp, slot)
+
 def get_streaming_log(resource_group_name, name, provider=None, slot=None):
     client = web_client_factory()
     scm_url = _get_scm_url(client, resource_group_name, name, slot)

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -205,7 +205,9 @@ def create_webapp_slot(resource_group_name, webapp, slot, configuration_source=N
     else: # from other slot
         slot_def = client.sites.get_site_slot(resource_group_name, webapp, slot)
 
-    return client.sites.create_or_update_site_slot(resource_group_name, webapp, slot_def, slot)
+    poller = client.sites.create_or_update_site_slot(resource_group_name, webapp, slot_def, slot)
+    return AppServiceLongRunningOperation()(poller)
+
 
 def config_source_control(resource_group_name, name, repo_url, repository_type=None, branch=None,
                           manual_integration=None, slot=None):
@@ -403,6 +405,15 @@ def config_slot_auto_swap(resource_group_name, webapp, slot, auto_swap_slot=None
     site_config = client.sites.get_site_config_slot(resource_group_name, webapp, slot)
     site_config.auto_swap_slot_name = '' if disable else (auto_swap_slot or 'production')
     return client.sites.update_site_config_slot(resource_group_name, webapp, site_config, slot)
+
+def swap_slot(resource_group_name, webapp, slot, target_slot=None):
+    client = web_client_factory()
+    if target_slot is None:
+        poller = client.sites.swap_slot_with_production(resource_group_name, webapp, slot)
+    else:
+        poller = client.sites.swap_slots_slot(resource_group_name, webapp, slot, target_slot)
+
+    return AppServiceLongRunningOperation()(poller)
 
 def get_streaming_log(resource_group_name, name, provider=None, slot=None):
     client = web_client_factory()

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/recordings/test_webapp_slot.yaml
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/recordings/test_webapp_slot.yaml
@@ -1,0 +1,629 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [a6b87ebe-a966-11e6-9842-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test?api-version=2015-08-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
+        p/nndbVeNXenZbF9lU+y1Wq7Kat27+6qri6LWV43d78opnXVVOft+Lv55G5TtHlzl5pyu236o/1o
+        9NEyW+SESPfj9nqFjyMQ6MuymmZAmBp8l5qnX72mD9vsovno0XJdlqOPCIVVXrcFtX70i4e6aNqs
+        xeev1stlsbygT+ZV076gxvTW98Lm4+wH6zqnjxiF8TJvP/r+CE1er7IpgHSpsA3EvnpNHzXcgrrL
+        y/PnxfItNZ637ap5dPfuVXbVbBOus+1Jdr298+n9cbYqOl1dFctZdcVdPtq/v3/3a0wYYAGJ/lx1
+        sBQCoz1/zSMnzOt8VdE3VX39mr4HgWgM3UbV1TKvDf3XTXaRvxb67ow+ypfZpMyJ39p6nY8+ymaL
+        YnkafqZNvv0+M8AT4LVopotIK5on/PEyYIlF3mazrM0MwjQJ9tvv0RtEodd52xJb0Ado8kvos8us
+        KLNJURbttRtb05QnePO8IJ7E62g9+mja1PQ7QE1JEsynQOSLakZvyt+G4V43JUOkht+L82tkYARO
+        X2NEitWTrMlnBOpV3qzL1vRxWdTtOivPXpoP2vl6MVnVxdI2aauvVkQNghP+fWZBmm9cJ65jDOIN
+        i+vOLxkNYB+fmv/3jWD3l2DGqsVqHU5Uk9eXef0sqxf9T86IiX+4ipS7PqeuWVbNC9urMlsSTQks
+        GhBW51nZkGyVWdPSYIhF89mbYpF/1U4J472d3U+3dwnDe2927j+6//DR7v744S6935Ckk/i+yqcV
+        dXP9ND/PaDKUWp62nFbLNl+2x1GxqNfLlrqKfwkOOKmW58WFoeYsX5XV9YLAMTVpVDIk4hSwSVtn
+        5yRgX2RLQqz2lIS83bxd00sEfznL6hm1X9X5olgvjlerpwwYxNCm0wWU2HHZVK/barXCN0qmNqsv
+        8vb1VbZ6TV2bF8AbNN7TJXFhtQSGw9+QjjkvShqjNFhg1l7TXBRkAGCqJugaBuyCKHGVeepUXiAO
+        ICjHNNQl0aujIeVL6Br7hSIORACmeVo04TezapEVy5/Ma5p7Uk/EmmczAkJ/EVeZXt+ShTG/V+t2
+        Uq2Xs7PV8WxGjNQQuo8+2t8ZH9wb7z54OL63O9I/DnbHB/v2D/r/wx3/Lxok+IN6z+vXxQ9oiDTv
+        M2KG6y/yBVkS8OFPrCtoYPqiWTerfDkDe5ZWUsElZkSv8qyBvae25+vlFCM5fZdP1/jlKyJWc5JN
+        59SJvLnI3r0gDZHXX55/t6rfemOdV6Rs22yxolH1rC9wLitw99nyvHKvdKcZLCrf+T4HUctJM4Gn
+        +QrEmaDPRJQM/1IjasDfMqNHNOQv+SX/D5YKC3CpCQAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Sun, 13 Nov 2016 06:01:44 GMT']
+      ETag: ['"1D23D73102D3FE0"']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJwcm9wZXJ0aWVzIjogeyJzZXJ2ZXJGYXJtSWQiOiAiL3N1YnNjcmlwdGlvbnMvMGIxZjY0NzEt
+      MWJmMC00ZGRhLWFlYzMtY2I5MjcyZjA5NTkwL3Jlc291cmNlR3JvdXBzL2NsaS13ZWJhcHAtc2xv
+      dDIvcHJvdmlkZXJzL01pY3Jvc29mdC5XZWIvc2VydmVyZmFybXMvd2ViYXBwLXNsb3QtcGxhbiJ9
+      LCAibG9jYXRpb24iOiAiV2VzdCBVUyJ9
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['195']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [a808cd7e-a966-11e6-b57f-f4b7e2e85440]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test/slots/staging?api-version=2015-08-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
+        p/nndbVeNXenZbF9lU+y1Wq7Kat27+6qri6LWV43d78opnXVVOft+Lv55G5TtHlzl5pyu236o72L
+        35q7TZtdFMuLj0YfLbNFTmh1Gtmv2+sVvo7BRfOGmpTVNMNgqNl36eX0q9f0IQFoPnq0XJfl6CNC
+        b5XXbZHTJ7842uGWdniH3qRfWzR4tV4u6SP6ZF417Qt6i17/XvjeNjXGe+PsB+s6p68Ys/Eybz/6
+        /ghNX6+yKYB1SbYNTL96TR813IK6zcvz58XyLTWet+2qeXT37lV21WwT8rPtSXa9vfPp/XG2Kjpd
+        XRXLWXXFXT7av79/92vMLmABif7EdrBUutOf/DVTgDCv81VF31T19Wv6HoSiMXQbVVfLvDYTsm6y
+        i/y10Hln9FG+zCZlTszZ1ut89FE2WxTL0/AzbfLtrzMTPBGRls10EWlN84Y/XgY8s8jbbJa1mRkA
+        TYr99nv0BlHsdd62BJU+QJNfQp9dZkWZTYqyaK/dWJumPMGb5wUxLV5H69FH06am3wFqSmJkPgUi
+        X1QzelP+Noz4uikZIjX8Xpyh7SD7AySw+jojVKyeZE0+I5Cv8mZdtqavy6Ju11l59tJ80M7Xi8mq
+        Lpa2SVt9tSKqEJzw7zML0nzjOnEdYzBvWLp3fsnohlHEp+r/fSPZ/SWYwWqxWocT1+T1ZV4/y+pF
+        /5MzYvIfrlbmrs+pa5Zl88L2qsyWRFMCiwaE1XlWNiR7Zda0NBhi2Xz2pljkX7VTwnhvZ/fT7V3C
+        8N6bnU8f7ew+2n8wfnjwgAA0pApIvl/l04r6uX6an2c0G0ouT61Oq2WbL9vjqJzU62VLfcW/BAuc
+        VMvz4sKQc5avyup6QeCYnDQsGROxSvv7//7nB3u71GFbZ+ckd19kS0Kv9nSJwGjerulV6mU5y+oZ
+        tV/V+aJYL45Xq6cMHjTRptMFdN1x2VSv22q1wjdKrTarL/L29VW2ek0ImBfAIjTq0yUxY7UEnsPf
+        kOo5L0oaqTRYYPJe05QUZCdg4iboGobvguhxlXlaV14gRiAoxzTUJVGto0jlS6gg+4UiDkQApnla
+        NOE3s2qRFcufzGtiAdJaxKFnMwJCfxFzmV7fkiEyv1frdlKtl7Oz1fFsRvzUELqPPtrfGR/cG+8+
+        eDi+tzvSPw52xwf79g/6/8Md/y8aJLiEes/r18UPaIg0+zNiiesv8gUZHLDjT6wrKGb6olk3q3w5
+        A5eWVmDBK2ZEr/KsgZ9Abc/XyylGcvoun67xy1dErOYkm86pE3lzkb17QYoir788/25Vv/XGOq9I
+        B7fZYkWj6hlp4FxW4PGz5XnlXulOMxhVviMlZ0ETtZxQE3iar0CqCfpMBMrwLzWiBvwts7tVmn2F
+        +Ut+yf8DaQ6ZrwUKAAA=
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Sun, 13 Nov 2016 06:01:53 GMT']
+      ETag: ['"1D23D73102D3FE0"']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b3994e8c-a966-11e6-b657-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test?api-version=2015-08-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
+        p/nndbVeNXenZbF9lU+y1Wq7Kat27+6qri6LWV43d78opnXVVOft+Lv55G5TtHlzl5pyu236o/1o
+        9NEyW+SESPfj9nqFjyMQ6MuymmZAmBp8l5qnX72mD9vsovno0XJdlqOPCIVVXrcFtX70i4e6aNqs
+        xeev1stlsbygT+ZV076gxvTW98Lm4+wH6zqnjxiF8TJvP/r+CE1er7IpgHSpsA3EvnpNHzXcgrrL
+        y/PnxfItNZ637ap5dPfuVXbVbBOus+1Jdr298+n9cbYqOl1dFctZdcVdPtq/v3/3a0wYYAGJ/lx1
+        sBQCoz1/zSMnzOt8VdE3VX39mr4HgWgM3UbV1TKvDf3XTXaRvxb67ow+ypfZpMyJ39p6nY8+ymaL
+        YnkafqZNvv0+M8AT4LVopotIK5on/PEyYIlF3mazrM0MwjQJ9tvv0RtEodd52xJb0Ado8kvos8us
+        KLNJURbttRtb05QnePO8IJ7E62g9+mja1PQ7QE1JEsynQOSLakZvyt+G4V43JUOkht+L82tkYARO
+        X2NEitWTrMlnBOpV3qzL1vRxWdTtOivPXpoP2vl6MVnVxdI2aauvVkQNghP+fWZBmm9cJ65jDOIN
+        i+vOLxkNYB+fmv/3jWD3l2DGqsVqHU5Uk9eXef0sqxf9T86IiX+4ipS7PqeuWVbNC9urMlsSTQks
+        GhBW51nZkGyVWdPSYIhF89mbYpF/1U4J472d3U+3dwnDe2927j+6//DR7v744S6935Ckk/i+yqcV
+        dXP9ND/PaDKUWp62nFbLNl+2x1GxqNfLlrqKfwkOOKmW58WFoeYsX5XV9YLAMTVpVDIk4hSwSVtn
+        5yRgX2RLQqz2lIS83bxd00sEfznL6hm1X9X5olgvjlerpwwYxNCm0wWU2HHZVK/barXCN0qmNqsv
+        8vb1VbZ6TV2bF8AbNN7TJXFhtQSGw9+QjjkvShqjNFhg1l7TXBRkAGCqJugaBuyCKHGVeepUXiAO
+        ICjHNNQl0aujIeVL6Br7hSIORACmeVo04TezapEVy5/Ma5p7Uk/EmmczAkJ/EVeZXt+ShTG/V+t2
+        Uq2Xs7PV8WxGjNQQuo8+2t8ZH9wb7z54OL63O9I/DnbHB/v2D/r/wx3/Lxok+IN6z+vXxQ9oiDTv
+        M2KG6y/yBVkS8OFPrCtoYPqiWTerfDkDe5ZWUsElZkSv8qyBvae25+vlFCM5fZdP1/jlKyJWc5JN
+        59SJvLnI3r0gDZHXX55/t6rfemOdV6Rs22yxolH1rC9wLitw99nyvHKvdKcZLCrf+T4HUctJM4Gn
+        +QrEmaDPRJQM/1IjasDfMqNHNOQv+SX/D5YKC3CpCQAA
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Sun, 13 Nov 2016 06:02:05 GMT']
+      ETag: ['"1D23D73102D3FE0"']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJwcm9wZXJ0aWVzIjogeyJyZXBvVXJsIjogImh0dHBzOi8vZ2l0aHViLmNvbS95dWdhbmd3LW1z
+      ZnQvYXp1cmUtc2l0ZS10ZXN0IiwgImlzTWVyY3VyaWFsIjogZmFsc2UsICJicmFuY2giOiAic3Rh
+      Z2luZyJ9LCAibG9jYXRpb24iOiAiV2VzdCBVUyJ9
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['144']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b40ab2b6-a966-11e6-b8ec-f4b7e2e85440]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test/slots/staging/sourcecontrols/web?api-version=2015-08-01
+  response:
+    body: {string: '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test/slots/staging/sourcecontrols/web","name":"web-slot-test","type":"Microsoft.Web/sites/sourcecontrols","location":"West
+        US","tags":null,"properties":{"repoUrl":"https://github.com/yugangw-msft/azure-site-test","branch":"staging","isManualIntegration":false,"deploymentRollbackEnabled":false,"isMercurial":false,"provisioningState":"InProgress"}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['478']
+      Content-Type: [application/json]
+      Date: ['Sun, 13 Nov 2016 06:02:25 GMT']
+      ETag: ['"1D23D736BCF0B30"']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.9.1]
+    method: GET
+    uri: http://web-slot-test-staging.azurewebsites.net/
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/Il632UWx
+        vNh7lH47L8sqvarqcpae19UiLYvl+l26//8AcJBNhSIAAAA=
+    headers:
+      Content-Encoding: [gzip]
+      Content-Length: ['149']
+      Content-Type: [text/html; charset=utf-8]
+      Date: ['Sun, 13 Nov 2016 06:03:40 GMT']
+      ETag: [W/"22-08QfZ0Mt9RwnXj/cUIdxPw"]
+      Server: [Microsoft-IIS/8.0]
+      Set-Cookie: [ARRAffinity=1821d0abd676d88dc3a3af7e818ab958a3a41b7b4705a840db3baeeb49f82cda;Path=/;Domain=web-slot-test-staging.azurewebsites.net]
+      Vary: [Accept-Encoding]
+      X-Powered-By: [Express, ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!binary |
+      eyJ0YXJnZXRTbG90IjogInN0YWdpbmcifQ==
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['25']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [fa88a090-a966-11e6-8fe2-f4b7e2e85440]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test/slotsswap?api-version=2015-08-01
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Sun, 13 Nov 2016 06:04:05 GMT']
+      ETag: ['"1D23D73102D3FE0"']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test/operationresults/af976105-689b-4a3c-9c4e-040b07bbd3b1?api-version=2015-08-01']
+      Pragma: [no-cache]
+      Retry-After: ['15']
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [fa88a090-a966-11e6-8fe2-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test/operationresults/af976105-689b-4a3c-9c4e-040b07bbd3b1?api-version=2015-08-01
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Sun, 13 Nov 2016 06:04:24 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test/operationresults/af976105-689b-4a3c-9c4e-040b07bbd3b1?api-version=2015-08-01']
+      Pragma: [no-cache]
+      Retry-After: ['15']
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [fa88a090-a966-11e6-8fe2-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test/operationresults/af976105-689b-4a3c-9c4e-040b07bbd3b1?api-version=2015-08-01
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Sun, 13 Nov 2016 06:04:40 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test/operationresults/af976105-689b-4a3c-9c4e-040b07bbd3b1?api-version=2015-08-01']
+      Pragma: [no-cache]
+      Retry-After: ['15']
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [fa88a090-a966-11e6-8fe2-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test/operationresults/af976105-689b-4a3c-9c4e-040b07bbd3b1?api-version=2015-08-01
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Sun, 13 Nov 2016 06:04:55 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test/operationresults/af976105-689b-4a3c-9c4e-040b07bbd3b1?api-version=2015-08-01']
+      Pragma: [no-cache]
+      Retry-After: ['15']
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [fa88a090-a966-11e6-8fe2-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test/operationresults/af976105-689b-4a3c-9c4e-040b07bbd3b1?api-version=2015-08-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
+        p/nndbVeNXenZbF9lU+y1Wq7Kat27+6qri6LWV43d78opnXVVOft+Lv55G5TtHlzl5pyu236o/1o
+        9NEyW+SESPfj9nqFjyMQ6MuymmZAmBp8l5qnX72mD9vsovno0XJdlqOPCIVVXrcFtX70i4e6aNqs
+        xeev1stlsbygT+ZV076gxvTW98Lm4+wH6zqnjxiF8TJvP/r+CE1er7IpgHSpsA3EvnpNHzXcgrrL
+        y/PnxfItNZ637ap5dPfuVXbVbBOus+1Jdr298+n9cbYqOl1dFctZdcVdPtq/v3/3a0wYYAGJ/lx1
+        sBQCoz1/zSMnzOt8VdE3VX39mr4HgWgM3UbV1TKvDf3XTXaRvxb67ow+ypfZpMyJ39p6nY8+ymaL
+        YnkafqZNvv0+M8AT4LVopotIK5on/PEyYIlF3mazrM0MwjQJ9tvv0RtEodd52xJb0Ado8kvos8us
+        KLNJURbttRtb05QnePO8IJ7E62g9+mja1PQ7QE1JEsynQOSLakZvyt+G4V43JUOkht+L82tkYARO
+        X2NEitWTrMlnBOpV3qzL1vRxWdTtOivPXpoP2vl6MVnVxdI2aauvVkQNghP+fWZBmm9cJ65jDOIN
+        i+vOLxkNYB+fmv/3jWD3l2DGqsVqHU5Uk9eXef0sqxf9T86IiX+4ipS7PqeuWVbNC9urMlsSTQks
+        GhBW51nZkGyVWdPSYIhF89mbYpF/1U4J472d3U+3dwnDe292Pn20s0//G9/7lN5vSNJJfF/l04q6
+        uX6an2c0GUotT1tOq2WbL9vjqFjU62VLXcW/BAecVMvz4sJQc5avyup6QeCYmjQqGRJxSvv7//7n
+        B3u71GFbZ+ckZl9kS0Kv9lSFwGjerulV6mU5y+oZtV/V+aJYL45Xq6cMHiTRptMFVNlx2VSv22q1
+        wjdKrDarL/L29VW2ek0ImBfAITTq0yXxYrUEnsPfkKY5L0oaqTRYYO5e04wUZAZgsCboGmbsguhx
+        lXlKVV4gPiAoxzTUJVGtoyflS2gc+4UiDkQApnlaNOE3s2qRFcufzGviAFJSxKBnMwJCfxFvmV7f
+        kp0xv1frdlKtl7Oz1fFsRuzUELqPPtrfGR/cG+8+eDi+tzvSPw52xwf79g/6/8Md/y8aJLiEes/r
+        18UPaIg0+zNiiesv8gXZE3DjT6wr6GH6olk3q3w5A5OWVl7BK2ZEr/KsgdWntufr5RQjOX2XT9f4
+        5SsiVnOSTefUiby5yN69ID2R11+ef7eq33pjnVekcttssaJR9WwwcC4r8PjZ8rxyr3SnGYwq3/me
+        B1HLyTSBp/kKhJqgz0SgDP9SI2rA3zK7R/TkL/kl/w8/aC5ArwkAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Sun, 13 Nov 2016 06:05:11 GMT']
+      ETag: ['"1D23D73BCB3D080"']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.9.1]
+    method: GET
+    uri: http://web-slot-test.azurewebsites.net/
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/Il632UWx
+        vNh7lH47L8sqvarqcpae19UiLYvl+l26//8AcJBNhSIAAAA=
+    headers:
+      Content-Encoding: [gzip]
+      Content-Length: ['149']
+      Content-Type: [text/html; charset=utf-8]
+      Date: ['Sun, 13 Nov 2016 06:07:39 GMT']
+      ETag: [W/"22-08QfZ0Mt9RwnXj/cUIdxPw"]
+      Server: [Microsoft-IIS/8.0]
+      Set-Cookie: [ARRAffinity=1821d0abd676d88dc3a3af7e818ab958a3a41b7b4705a840db3baeeb49f82cda;Path=/;Domain=web-slot-test.azurewebsites.net]
+      Vary: [Accept-Encoding]
+      X-Powered-By: [Express, ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [964807ae-a967-11e6-9033-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test/slots?api-version=2015-08-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
+        zsP7D3fu1nlTretp/nldrVfN3WlZbF/lk2y12m7Kqt27u6qry2KW183dL4ppXTXVeTv+bj652xRt
+        3tylptxum/5o7+K35m7TZhfF8uKj0UfLbEHYfdRpZL9ur1f4OgYXzRtqUlbTDIOhZt+ll9OvXtOH
+        BKD56NFyXZajjwi9VV63RU6f/OJoh1va4R16k35t0eDVermkj+iTedW0L+gtev174Xvb1BjvjbMf
+        rOucvmLMxsu8/ej7IzR9vcqmANYl2TYw/eo1fdRwC+o2L8+fF8u31Hjetqvm0d27V9lVs03Iz7Yn
+        2fX2zqf3x9mq6HR1VSxn1RV3+Wj//v7drzG7gAUk+hPbwVLpTn/y10wBwrzOVxV9U9XXr+l7EIrG
+        0G1UXS3z2kzIusku8tdC553RR/kym5Q5MWdbr/PRR9lsUSxPw8+0ybe/zkzwRERaNtNFpDXNG/54
+        GfDMIm+zWdZmZgA0Kfbb79EbRLHXedsSVPoATX4JfXaZFWU2KcqivXZjbZryBG+eF8S0eB2tRx9N
+        m5p+B6gpiZH5FIh8Uc3oTfnbMOLrpmSI1JDEOsbQdpD9ARJYfZ0RKlZPsiafEchXebMuW9PXZVG3
+        66w8e2k+aOfrxWRVF0vbpK2+WhFVCE7495kFab5xnbiOMZg3LN07v2R0wyjiU/X/vpHs/hLMYLVY
+        rcOJa/L6Mq+fZfWi/8kZMfkPVytz1+fUNcuyeWF7VWZLoimBRQPC6jwrG5K9MmtaGgyxbD57Uyzy
+        r9opYby3s/vp9i5heO/NzqePdvYf3X8wvrf/gAA0pApIvl/l04r6uX6an2c0G0ouT61Oq2WbL9vj
+        qJzU62VLfcW/BAucVMvz4sKQc5avyup6QeCYnDQsGROxCvikrbNzkrgvsiUhVntaRN5u3q7pJYK/
+        nGX1jNqv6nxRrBfHq9VTBgxqaNPpAlruuGyq1221WuEbpVOb1Rd5+/oqW72mrs0LYA4a7+mS2LBa
+        AsPhb0jpnBcljVEaLDBtr2kyCrIQMG4TdA2Td0GUuMo8fSsvEAsQlGMa6pLo1VGh8iWUj/1CEQci
+        ANM8LZrwm1m1yIrlT+Y1TT7pK+LNsxkBob+IrUyvb8kEmd+rdTup1svZ2ep4NiNOagjdRx/t74wP
+        7o13Hzwc39sd6R8Hu+ODffsH/f/hjv8XDRL8Qb3n9eviBzREmvcZMcP1F/mCTA0Y8SfWFVQyfdGs
+        m1W+nIE/Syuq4BIzold51sBDoLbn6+UUIzl9l0/X+OUrIlZzkk3n1Im8ucjevSAVkddfnn+3qt96
+        Y51XpH3bbLGiUfXMM3AuK3D32fK8cq90pxksKt+RerOgiVpOnAk8zVcgzwR9JqJk+JcaUQP+lhnd
+        qsu+qvwlUEzL/F0rLob0CH8Qv/2S/wdLgCACJQoAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Sun, 13 Nov 2016 06:08:26 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9abfabf6-a967-11e6-aa45-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test/slots?api-version=2015-08-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
+        zsP7D3fu1nlTretp/nldrVfN3WlZbF/lk2y12m7Kqt27u6qry2KW183dL4ppXTXVeTv+bj652xRt
+        3tylptxum/5o7+K35m7TZhfF8uKj0UfLbEHYfdRpZL9ur1f4OgYXzRtqUlbTDIOhZt+ll9OvXtOH
+        BKD56NFyXZajjwi9VV63RU6f/OJoh1va4R16k35t0eDVermkj+iTedW0L+gtev174Xvb1BjvjbMf
+        rOucvmLMxsu8/ej7IzR9vcqmANYl2TYw/eo1fdRwC+o2L8+fF8u31Hjetqvm0d27V9lVs03Iz7Yn
+        2fX2zqf3x9mq6HR1VSxn1RV3+Wj//v7drzG7gAUk+hPbwVLpTn/y10wBwrzOVxV9U9XXr+l7EIrG
+        0G1UXS3z2kzIusku8tdC553RR/kym5Q5MWdbr/PRR9lsUSxPw8+0ybe/zkzwRERaNtNFpDXNG/54
+        GfDMIm+zWdZmZgA0Kfbb79EbRLHXedsSVPoATX4JfXaZFWU2KcqivXZjbZryBG+eF8S0eB2tRx9N
+        m5p+B6gpiZH5FIh8Uc3oTfnbMOLrpmSI1JDEOsbQdpD9ARJYfZ0RKlZPsiafEchXebMuW9PXZVG3
+        66w8e2k+aOfrxWRVF0vbpK2+WhFVCE7495kFab5xnbiOMZg3LN07v2R0wyjiU/X/vpHs/hLMYLVY
+        rcOJa/L6Mq+fZfWi/8kZMfkPVytz1+fUNcuyeWF7VWZLoimBRQPC6jwrG5K9MmtaGgyxbD57Uyzy
+        r9opYby3s/vp9i5heO/NzqePdvYf3X8wvrf/gAA0pApIvl/l04r6uX6an2c0G0ouT61Oq2WbL9vj
+        qJzU62VLfcW/BAucVMvz4sKQc5avyup6QeCYnDQsGROxCvikrbNzkrgvsiUhVntaRN5u3q7pJYK/
+        nGX1jNqv6nxRrBfHq9VTBgxqaNPpAlruuGyq1221WuEbpVOb1Rd5+/oqW72mrs0LYA4a7+mS2LBa
+        AsPhb0jpnBcljVEaLDBtr2kyCrIQMG4TdA2Td0GUuMo8fSsvEAsQlGMa6pLo1VGh8iWUj/1CEQci
+        ANM8LZrwm1m1yIrlT+Y1TT7pK+LNsxkBob+IrUyvb8kEmd+rdTup1svZ2ep4NiNOagjdRx/t74wP
+        7o13Hzwc39sd6R8Hu+ODffsH/f/hjv8XDRL8Qb3n9eviBzREmvcZMcP1F/mCTA0Y8SfWFVQyfdGs
+        m1W+nIE/Syuq4BIzold51sBDoLbn6+UUIzl9l0/X+OUrIlZzkk3n1Im8ucjevSAVkddfnn+3qt96
+        Y51XpH3bbLGiUfXMM3AuK3D32fK8cq90pxksKt+RerOgiVpOnAk8zVcgzwR9JqJk+JcaUQP+lhnd
+        qsu+qvwlUEzL/F0rLob0CH8Qv/2S/wdLgCACJQoAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Sun, 13 Nov 2016 06:08:33 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9b6bd406-a967-11e6-a64a-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test/slots?api-version=2015-08-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
+        zsP7D3fu1nlTretp/nldrVfN3WlZbF/lk2y12m7Kqt27u6qry2KW183dL4ppXTXVeTv+bj652xRt
+        3tylptxum/5o7+K35m7TZhfF8uKj0UfLbEHYfdRpZL9ur1f4OgYXzRtqUlbTDIOhZt+ll9OvXtOH
+        BKD56NFyXZajjwi9VV63RU6f/OJoh1va4R16k35t0eDVermkj+iTedW0L+gtev174Xvb1BjvjbMf
+        rOucvmLMxsu8/ej7IzR9vcqmANYl2TYw/eo1fdRwC+o2L8+fF8u31Hjetqvm0d27V9lVs03Iz7Yn
+        2fX2zqf3x9mq6HR1VSxn1RV3+Wj//v7drzG7gAUk+hPbwVLpTn/y10wBwrzOVxV9U9XXr+l7EIrG
+        0G1UXS3z2kzIusku8tdC553RR/kym5Q5MWdbr/PRR9lsUSxPw8+0ybe/zkzwRERaNtNFpDXNG/54
+        GfDMIm+zWdZmZgA0Kfbb79EbRLHXedsSVPoATX4JfXaZFWU2KcqivXZjbZryBG+eF8S0eB2tRx9N
+        m5p+B6gpiZH5FIh8Uc3oTfnbMOLrpmSI1JDEOsbQdpD9ARJYfZ0RKlZPsiafEchXebMuW9PXZVG3
+        66w8e2k+aOfrxWRVF0vbpK2+WhFVCE7495kFab5xnbiOMZg3LN07v2R0wyjiU/X/vpHs/hLMYLVY
+        rcOJa/L6Mq+fZfWi/8kZMfkPVytz1+fUNcuyeWF7VWZLoimBRQPC6jwrG5K9MmtaGgyxbD57Uyzy
+        r9opYby3s/vp9i5heO/NzqePdvYf3X8wvrf/gAA0pApIvl/l04r6uX6an2c0G0ouT61Oq2WbL9vj
+        qJzU62VLfcW/BAucVMvz4sKQc5avyup6QeCYnDQsGROxCvikrbNzkrgvsiUhVntaRN5u3q7pJYK/
+        nGX1jNqv6nxRrBfHq9VTBgxqaNPpAlruuGyq1221WuEbpVOb1Rd5+/oqW72mrs0LYA4a7+mS2LBa
+        AsPhb0jpnBcljVEaLDBtr2kyCrIQMG4TdA2Td0GUuMo8fSsvEAsQlGMa6pLo1VGh8iWUj/1CEQci
+        ANM8LZrwm1m1yIrlT+Y1TT7pK+LNsxkBob+IrUyvb8kEmd+rdTup1svZ2ep4NiNOagjdRx/t74wP
+        7o13Hzwc39sd6R8Hu+ODffsH/f/hjv8XDRL8Qb3n9eviBzREmvcZMcP1F/mCTA0Y8SfWFVQyfdGs
+        m1W+nIE/Syuq4BIzold51sBDoLbn6+UUIzl9l0/X+OUrIlZzkk3n1Im8ucjevSAVkddfnn+3qt96
+        Y51XpH3bbLGiUfXMM3AuK3D32fK8cq90pxksKt+RerOgiVpOnAk8zVcgzwR9JqJk+JcaUQP+lhnd
+        qsu+qvwlUEzL/F0rLob0CH8Qv/2S/wdLgCACJQoAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Sun, 13 Nov 2016 06:08:34 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [acbd6acc-a967-11e6-a358-f4b7e2e85440]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test/slots/staging?api-version=2015-08-01
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Sun, 13 Nov 2016 06:09:08 GMT']
+      ETag: ['"1D23D73DC48FD30"']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bbe69e18-a967-11e6-8c86-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/sites/web-slot-test/slots?api-version=2015-08-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9748+Wubv2ufF8u1Hj5brshx9VMzkt1/y/wA/IGq2JgAAAA==
+    headers:
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json]
+      Date: ['Sun, 13 Nov 2016 06:09:29 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/test_webapp_commands.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/test_webapp_commands.py
@@ -311,39 +311,45 @@ class WebappGitScenarioTest(ResourceGroupVCRTestBase):
 class WebappSlotScenarioTest(ResourceGroupVCRTestBase):
     def __init__(self, test_method):
         super(WebappSlotScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'cli-webapp-slot'
+        self.resource_group = 'cli-webapp-slot2'
         self.webapp = 'web-slot-test'
 
     def test_webapp_slot(self):
         self.execute()
-
-    def set_up(self):
-        super(WebappSlotScenarioTest, self).set_up()
-        plan = 'webapp-slot-plan'
-        self.cmd('appservice plan create -g {} -n {} --sku S1'.format(self.resource_group, plan))
-        self.cmd('appservice web create -g {} -n {} --plan {}'.format(self.resource_group, self.webapp, plan))
 
     def body(self):
         slot = 'staging'
         #You can create and use any repros with the 3 files under "./sample_web" and with a 'staging 'branch
         test_git_repo = 'https://github.com/yugangw-msft/azure-site-test'
 
-        self.cmd('appservice web deployment slot create -g {} --webapp {} --slot {}'.format(self.resource_group, self.webapp, slot))
+        self.cmd('appservice web deployment slot create -g {} -n {} --slot {}'.format(self.resource_group, self.webapp, slot), checks=[
+            JMESPathCheck('name', self.webapp + '/' + slot),
+            JMESPathCheck('siteName', '{}({})'.format(self.webapp, slot))
+            ])
 
-        self.cmd('appservice web source-control config -g {} -n {} --repo-url {} --branch {}'.format(self.resource_group, self.webapp, test_git_repo, slot), checks=[
+        self.cmd('appservice web source-control config -g {} -n {} --repo-url {} --branch {} --slot {}'.format(self.resource_group, self.webapp, test_git_repo, slot, slot), checks=[
             JMESPathCheck('repoUrl', test_git_repo),
             JMESPathCheck('branch', slot)
             ])
-
-        self.cmd('az appservice web deployment slot swap -g {} --webapp {} --slot {}'.format(self.resource_group, self.webapp, slot))
 
         import time
         time.sleep(30) # 30 seconds should be enough for the deployment finished(Skipped under playback mode)
 
         import requests
+        r = requests.get('http://{}-{}.azurewebsites.net'.format(self.webapp, slot))
+        #verify the web page contains content from the staging branch
+        self.assertTrue('Staging' in str(r.content))
+
+        self.cmd('appservice web deployment slot swap -g {} -n {} --slot {}'.format(self.resource_group, self.webapp, slot))
+
+        time.sleep(30) # 30 seconds should be enough for the slot swap finished(Skipped under playback mode)
+
         r = requests.get('http://{}.azurewebsites.net'.format(self.webapp))
         #verify the web page contains content from the staging branch
         self.assertTrue('Staging' in str(r.content))
 
-        self.cmd('az appservice deployment slot list -g {} --webapp {}'.format(self.resource_group, self.webapp))
-        self.cmd('az appservice deployment slot delete -g {} --webapp {} --slot {}'.format(self.resource_group, self.webapp, slot))
+        self.cmd('appservice web deployment slot list -g {} -n {}'.format(self.resource_group, self.webapp), checks=[
+            JMESPathCheck("length([])", 1),
+            JMESPathCheck('[0].name', self.webapp + '/' + slot),
+            ])
+        self.cmd('appservice web deployment slot delete -g {} -n {} --slot {}'.format(self.resource_group, self.webapp, slot), checks=NoneCheck())


### PR DESCRIPTION
Ensure supports from create, link to git, swap, to deploy. Those are still the minimum, but enough to get basic functions.  This will get #1255 resolved.
In the next period, we should consider to 
1. enable private git repo.
2. create slot from existing configuration sources
3. extend `slot delete` to support auto delete site, etc