### PR TITLE
Prevent CI pylint from showing the full report

### DIFF
--- a/scripts/run_pylint.py
+++ b/scripts/run_pylint.py
@@ -19,12 +19,12 @@ modules_root = os.path.join(root, 'src', 'command_modules')
 pylintrc = os.path.join(root, 'pylintrc')
 
 all_modules = [os.path.join(modules_root, f, 'azure')
-        for f in fnmatch.filter(os.listdir(modules_root), 'azure-cli-*')]
+               for f in fnmatch.filter(os.listdir(modules_root), 'azure-cli-*')]
 
 all_modules += [os.path.join(root, 'src', 'azure-cli-core', 'azure'),
                 os.path.join(root, 'src', 'azure-cli', 'azure')]
 
-arguments = '{} --rcfile={} -j {} -d I0013'.format(
+arguments = '{} --rcfile={} -j {} -r n -d I0013'.format(
     ' '.join(all_modules),
     pylintrc,
     multiprocessing.cpu_count())


### PR DESCRIPTION
The full output pollutes CI output and makes it hard to find the pylint errors.

Reporting was disabled before the recent pylint perf change and I think it should still be disabled now.