### PR TITLE
Incorrect URL for 'az acs kubernetes install-cli'

### DIFF
--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -107,7 +107,7 @@ def k8s_install_cli(client_version="1.4.5", install_location=None):
     elif system == 'Linux':
         file_url = 'https://storage.googleapis.com/kubernetes-release/release/v{}/bin/linux/amd64/kubectl'.format(client_version)
     elif system == 'Darwin':
-        file_url = 'https://storage.googleapis.com/kubernetes-release/release/v{}/darwin/amd64/kubectl'.format(client_version)
+        file_url = 'https://storage.googleapis.com/kubernetes-release/release/v{}/bin/darwin/amd64/kubectl'.format(client_version)
     else:
         raise CLIError('Proxy server ({}) does not exist on the cluster.'.format(system))
 


### PR DESCRIPTION
Looks like the URL should have `/bin` if system=='Darwin'
Otherwise, the blob is not found.

Closes https://github.com/Azure/azure-cli/issues/1323