### PR TITLE
Fix Document CI error due to command params not being loaded

### DIFF
--- a/doc/sphinx/azhelpgen/azhelpgen.py
+++ b/doc/sphinx/azhelpgen/azhelpgen.py
@@ -14,10 +14,11 @@ from azure.cli.core.application import APPLICATION, Configuration
 import azure.cli.core._help as _help
 
 app = APPLICATION
-try:
-    app.execute(['-h'])
-except:
-    pass
+for cmd in app.configuration.get_command_table():
+    try:
+        app.execute(cmd.split() + ['-h'])
+    except:
+        pass
 
 class AzHelpGenDirective(Directive):
     def make_rst(self):


### PR DESCRIPTION
- Fix error running azhelpgen.py
-- To load the full command table with all parameter values, we iterate over the command table running -h on each command.