### PR TITLE
account: dump extra information on account or newly created service principal

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -247,6 +247,33 @@ class Profile(object):
                 str(account[_SUBSCRIPTION_ID]),
                 str(account[_TENANT_ID]))
 
+    #per ask from java sdk
+    def get_expanded_subscription_info(self, subscription_id=None, name=None, password=None):
+        account = self.get_subscription(subscription_id)
+
+        # is the credential created through command like 'create-for-rbac'?
+        if bool(name) and bool(password):
+            result = {}
+            result[_SUBSCRIPTION_ID] = subscription_id or account[_SUBSCRIPTION_ID]
+            result[_USER_NAME] = name
+            result['password'] = password
+            result[_TENANT_ID] = account[_TENANT_ID]
+            result[_ENVIRONMENT_NAME] = CLOUD.name
+        else: #has logged in through cli
+            from copy import deepcopy
+            result = deepcopy(account)
+            result[_USER_NAME] = account[_USER_ENTITY][_USER_NAME]
+            user_type = account[_USER_ENTITY].get(_USER_TYPE)
+            if user_type == _SERVICE_PRINCIPAL:
+                result['password'] = self._creds_cache.retrieve_secret_of_service_principal(
+                    account[_USER_ENTITY][_USER_NAME])
+            result.pop(_STATE)
+            result.pop(_USER_ENTITY)
+            result.pop(_IS_DEFAULT_SUBSCRIPTION)
+
+        result['endpoints'] = CLOUD.endpoints
+        return result
+
     def get_installation_id(self):
         installation_id = self._storage.get(_INSTALLATION_ID)
         if not installation_id:
@@ -380,6 +407,13 @@ class CredsCache(object):
                                                                     sp_id,
                                                                     cred[_ACCESS_TOKEN])
         return (token_entry[_TOKEN_ENTRY_TOKEN_TYPE], token_entry[_ACCESS_TOKEN])
+
+    def retrieve_secret_of_service_principal(self, sp_id):
+        matched = [x for x in self._service_principal_creds if sp_id == x[_SERVICE_PRINCIPAL_ID]]
+        if not matched:
+            raise CLIError("No matched service principal found")
+        cred = matched[0]
+        return cred[_ACCESS_TOKEN]
 
     def _load_creds(self):
         if self.adal_token_cache is not None:

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -255,22 +255,28 @@ class Profile(object):
         if bool(name) and bool(password):
             result = {}
             result[_SUBSCRIPTION_ID] = subscription_id or account[_SUBSCRIPTION_ID]
-            result[_USER_NAME] = name
+            result['client'] = name
             result['password'] = password
             result[_TENANT_ID] = account[_TENANT_ID]
             result[_ENVIRONMENT_NAME] = CLOUD.name
+            result['subscriptionName'] = account[_SUBSCRIPTION_NAME]
         else: #has logged in through cli
             from copy import deepcopy
             result = deepcopy(account)
-            result[_USER_NAME] = account[_USER_ENTITY][_USER_NAME]
             user_type = account[_USER_ENTITY].get(_USER_TYPE)
             if user_type == _SERVICE_PRINCIPAL:
+                result['client'] = account[_USER_ENTITY][_USER_NAME]
                 result['password'] = self._creds_cache.retrieve_secret_of_service_principal(
                     account[_USER_ENTITY][_USER_NAME])
+            else:
+                result['userName'] = account[_USER_ENTITY][_USER_NAME]
+
             result.pop(_STATE)
             result.pop(_USER_ENTITY)
             result.pop(_IS_DEFAULT_SUBSCRIPTION)
+            result['subscriptionName'] = result.pop(_SUBSCRIPTION_NAME)
 
+        result['subscriptionId'] = result.pop('id')
         result['endpoints'] = CLOUD.endpoints
         return result
 

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
@@ -25,3 +25,4 @@ register_cli_argument('logout', 'username', help='account user, if missing, logo
 
 register_cli_argument('account', 'subscription', help='Name or ID of subscription.', completer=get_subscription_id_list)
 register_cli_argument('account list', 'list_all', options_list=('--all',), help='List all subscriptions across all cloud environments', action='store_true')
+register_cli_argument('account show', 'show_auth_details', action='store_true', help='show details ')

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/_params.py
@@ -25,4 +25,4 @@ register_cli_argument('logout', 'username', help='account user, if missing, logo
 
 register_cli_argument('account', 'subscription', help='Name or ID of subscription.', completer=get_subscription_id_list)
 register_cli_argument('account list', 'list_all', options_list=('--all',), help='List all subscriptions across all cloud environments', action='store_true')
-register_cli_argument('account show', 'show_auth_details', action='store_true', help='show details ')
+register_cli_argument('account show', 'expanded_view', action='store_true', help="display more information like service principal's password and cloud environments")

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
@@ -8,6 +8,9 @@ import requests
 from adal.adal_error import AdalError
 
 from azure.cli.core._profile import Profile, CLOUD
+from azure.cli.core.cloud import get_cloud
+from azure.cli.core.context import get_active_context
+
 from azure.cli.core._util import CLIError
 import azure.cli.core._logging as _logging
 
@@ -27,9 +30,13 @@ def list_subscriptions(list_all=False): # pylint: disable=redefined-builtin
         sub['cloudName'] = sub.pop('environmentName', None)
     return [sub for sub in subscriptions if list_all or sub['cloudName'] == CLOUD.name]
 
-def show_subscription(subscription=None):
+def show_subscription(subscription=None, show_auth_details=None):
     profile = Profile()
-    return profile.get_subscription(subscription)
+    result = profile.get_subscription(subscription)
+    if show_auth_details:
+        cloud = get_cloud(get_active_context()['cloud'])
+        result['endpoints'] = cloud.endpoints
+    return result
 
 def set_active_subscription(subscription):
     '''Set the current subscription'''

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
@@ -8,9 +8,6 @@ import requests
 from adal.adal_error import AdalError
 
 from azure.cli.core._profile import Profile, CLOUD
-from azure.cli.core.cloud import get_cloud
-from azure.cli.core.context import get_active_context
-
 from azure.cli.core._util import CLIError
 import azure.cli.core._logging as _logging
 
@@ -30,13 +27,12 @@ def list_subscriptions(list_all=False): # pylint: disable=redefined-builtin
         sub['cloudName'] = sub.pop('environmentName', None)
     return [sub for sub in subscriptions if list_all or sub['cloudName'] == CLOUD.name]
 
-def show_subscription(subscription=None, show_auth_details=None):
+def show_subscription(subscription=None, expanded_view=None):
     profile = Profile()
-    result = profile.get_subscription(subscription)
-    if show_auth_details:
-        cloud = get_cloud(get_active_context()['cloud'])
-        result['endpoints'] = cloud.endpoints
-    return result
+    if not expanded_view:
+        return profile.get_subscription(subscription)
+    else:
+        return profile.get_expanded_subscription_info(subscription)
 
 def set_active_subscription(subscription):
     '''Set the current subscription'''

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/_params.py
@@ -34,6 +34,7 @@ register_cli_argument('ad sp create', 'identifier', options_list=('--id',), help
 register_cli_argument('ad sp create-for-rbac', 'name', name_arg_type)
 register_cli_argument('ad sp create-for-rbac', 'years', type=int)
 register_cli_argument('ad sp create-for-rbac', 'scopes', nargs='+')
+register_cli_argument('ad sp create-for-rbac', 'expanded_view', action='store_true', help='Once created, display more information like subscription and cloud environments')
 register_cli_argument('ad sp reset-credentials', 'name', name_arg_type)
 register_cli_argument('ad sp reset-credentials', 'years', type=int)
 

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
@@ -11,7 +11,6 @@ from dateutil.relativedelta import relativedelta
 import dateutil.parser
 
 from azure.cli.core._util import CLIError, todict, get_file_json
-from azure.cli.core._profile import Profile
 import azure.cli.core._logging as _logging
 
 from azure.mgmt.authorization.models import (RoleAssignmentProperties, Permission, RoleDefinition,
@@ -474,6 +473,7 @@ def create_service_principal_for_rbac(name=None, password=None, years=1, #pylint
             _create_role_assignment(role, oid, None, scope, ocp_aad_session_key=session_key)
 
     if expanded_view:
+        from azure.cli.core._profile import Profile
         profile = Profile()
         result = profile.get_expanded_subscription_info(scopes[0].split('/')[2] if scopes else None,
                                                         aad_application.app_id, password)

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/custom.py
@@ -11,6 +11,7 @@ from dateutil.relativedelta import relativedelta
 import dateutil.parser
 
 from azure.cli.core._util import CLIError, todict, get_file_json
+from azure.cli.core._profile import Profile
 import azure.cli.core._logging as _logging
 
 from azure.mgmt.authorization.models import (RoleAssignmentProperties, Permission, RoleDefinition,
@@ -434,8 +435,8 @@ def _resolve_service_principal(client, identifier):
     except ValueError:
         raise CLIError("service principal '{}' doesn't exist".format(identifier))
 
-def create_service_principal_for_rbac(name=None, password=None, years=1,
-                                      scopes=None, role=None):
+def create_service_principal_for_rbac(name=None, password=None, years=1, #pylint:disable=too-many-arguments
+                                      scopes=None, role=None, expanded_view=None):
     '''create a service principal that can access or modify resources
     :param str name: an unique uri. If missing, the command will generate one.
     :param str password: the password used to login. If missing, command will generate one.
@@ -472,12 +473,18 @@ def create_service_principal_for_rbac(name=None, password=None, years=1,
         for scope in scopes:
             _create_role_assignment(role, oid, None, scope, ocp_aad_session_key=session_key)
 
-    return {
-        'appId': aad_application.app_id,
-        'password': password,
-        'name': name,
-        'tenant': client.config.tenant_id
-        }
+    if expanded_view:
+        profile = Profile()
+        result = profile.get_expanded_subscription_info(scopes[0].split('/')[2] if scopes else None,
+                                                        aad_application.app_id, password)
+    else:
+        result = {
+            'appId': aad_application.app_id,
+            'password': password,
+            'name': name,
+            'tenant': client.config.tenant_id
+            }
+    return result
 
 def reset_service_principal_credential(name, password=None, years=1):
     '''reset credential, on expiration or you forget it.


### PR DESCRIPTION
Per ask from java sdk team. Fix #1097. I updated some naming so this whole thing won't look odd.
Once we are fine with the change, i will add one test
