### PR TITLE
Added exception handling for missing command "git remote get-url" in git versions less than 2.7.0

### DIFF
--- a/src/command_modules/azure-cli-container/azure/cli/command_modules/container/custom.py
+++ b/src/command_modules/azure-cli-container/azure/cli/command_modules/container/custom.py
@@ -288,8 +288,8 @@ def _get_remote_url():
             "A default remote was not found for the current folder. \
             Please run this command in a git repository folder with \
             an 'origin' remote or specify a remote using '--remote-url'")
-    except CalledProcessError:
-        raise CLIError('Command "git remote get-url" not supported in current version of git (git version 2.7.0 or greater required)')
+    except CalledProcessError as e:
+        raise CLIError(e)
     return remote_url.decode()
 
 def _check_registry_information(registry_name, registry_resource_id):

--- a/src/command_modules/azure-cli-container/azure/cli/command_modules/container/custom.py
+++ b/src/command_modules/azure-cli-container/azure/cli/command_modules/container/custom.py
@@ -288,6 +288,8 @@ def _get_remote_url():
             "A default remote was not found for the current folder. \
             Please run this command in a git repository folder with \
             an 'origin' remote or specify a remote using '--remote-url'")
+    except CalledProcessError:
+        raise CLIError('Command "git remote get-url" not supported in current version of git (git version 2.7.0 or greater required)')
     return remote_url.decode()
 
 def _check_registry_information(registry_name, registry_resource_id):


### PR DESCRIPTION
Added exception handling for missing command "git remote get-url" in git versions less than 2.7.0