### PR TITLE
Mention bot config

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -1,0 +1,12 @@
+{
+  "maxReviewers: 5,
+  "userBlacklist": ["BurtBiel"],
+  "assignToReviewer": true,
+  "fallbackNotifyForPaths": [
+    {
+      "name": "JasonRShaver",
+      "files": ["doc/**"], // The array of file globs associated with the user
+      "skipTeamPrs": false
+    }
+  ]
+}

--- a/.mention-bot
+++ b/.mention-bot
@@ -5,7 +5,7 @@
   "fallbackNotifyForPaths": [
     {
       "name": "JasonRShaver",
-      "files": ["doc/**"], // The array of file globs associated with the user
+      "files": ["doc/**", "**/_help.py"],
       "skipTeamPrs": false
     }
   ]


### PR DESCRIPTION
- Don’t mention BurtBiel
- And allow mention bot to auto assign to what it thinks is the best reviewer.
- Always notify for JasonRShaver for docs/help