### PR TITLE
[component update] Remove redundant show-logs flags

### DIFF
--- a/src/command_modules/azure-cli-component/azure/cli/command_modules/component/_params.py
+++ b/src/command_modules/azure-cli-component/azure/cli/command_modules/component/_params.py
@@ -10,5 +10,4 @@ register_cli_argument('component', 'component_name', options_list=('--name', '-n
 register_cli_argument('component', 'link', options_list=('--link', '-l'), help='If a url or path to an html file, parse for links to archives. If local path or file:// url that\'s a directory, then look for archives in the directory listing.')
 register_cli_argument('component', 'private', help='Include packages from a private server.', action='store_true')
 register_cli_argument('component', 'pre', help='Include pre-release versions', action='store_true')
-register_cli_argument('component', 'show_logs', help='Show logs from packaging installing/updating', action='store_true')
 register_cli_argument('component', 'additional_components', options_list=('--add',), nargs='+', help='The names of additional components to install (space separated)')

--- a/src/command_modules/azure-cli-component/azure/cli/command_modules/component/custom.py
+++ b/src/command_modules/azure-cli-component/azure/cli/command_modules/component/custom.py
@@ -21,7 +21,7 @@ def list_components():
                    for dist in pip.get_installed_distributions(local_only=True)
                    if dist.key.startswith(COMPONENT_PREFIX)], key=lambda x: x['name'])
 
-def remove(component_name, show_logs=False):
+def remove(component_name):
     """ Remove a component """
     import pip
     full_component_name = COMPONENT_PREFIX + component_name
@@ -29,7 +29,6 @@ def remove(component_name, show_logs=False):
                   if dist.key == full_component_name])
     if found:
         options = ['--isolated', '--yes']
-        options += [] if show_logs else ['--quiet']
         pip_args = ['uninstall'] + options + ['--disable-pip-version-check', full_component_name]
         _run_pip(pip, pip_args)
     else:
@@ -53,13 +52,11 @@ def _run_pip(pip, pip_exec_args):
         raise CLIError('An error occurred. Run command with --debug for more information.\n'
                        'If executing az with sudo, you may want sudo\'s -E and -H flags.')
 
-def _install_or_update(package_list, link, private, pre, show_logs=False):
+def _install_or_update(package_list, link, private, pre):
     import pip
     options = ['--isolated', '--disable-pip-version-check', '--upgrade']
     if pre:
         options.append('--pre')
-    if not show_logs:
-        options.append('--quiet')
     pkg_index_options = ['--find-links', link] if link else []
     if private:
         package_index_url = az_config.get('component', 'package_index_url', fallback=None)
@@ -74,7 +71,7 @@ def _install_or_update(package_list, link, private, pre, show_logs=False):
     pip_args = ['install'] + options + package_list + pkg_index_options
     _run_pip(pip, pip_args)
 
-def update(private=False, pre=False, link=None, additional_components=None, show_logs=False):
+def update(private=False, pre=False, link=None, additional_components=None):
     """ Update the CLI and all installed components """
     import pip
     # Update the CLI itself
@@ -86,4 +83,4 @@ def update(private=False, pre=False, link=None, additional_components=None, show
     if additional_components:
         for c in additional_components:
             package_list += [COMPONENT_PREFIX + c]
-    _install_or_update(package_list, link, private, pre, show_logs=show_logs)
+    _install_or_update(package_list, link, private, pre)


### PR DESCRIPTION
Logs are sent to logger.debug now so we should utilize that instead of having another flag named `--show-logs`.

If user wants logs, it’s expected that they should just use `—debug` instead of `—debug` and `—show-logs`