### PR TITLE
Fix typo in mention-bot config

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -1,5 +1,5 @@
 {
-  "maxReviewers: 5,
+  "maxReviewers": 5,
   "userBlacklist": ["BurtBiel"],
   "assignToReviewer": true,
   "fallbackNotifyForPaths": [


### PR DESCRIPTION
The missing quote prevented mention-bot from using the configuration