### PR TITLE
Introduce batch upload and download for blob

### DIFF
--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
@@ -33,6 +33,7 @@ from ._validators import \
      resource_type_type, services_type, ipv4_range_type, validate_entity,
      validate_select, validate_source_uri, validate_blob_type, validate_included_datasets,
      validate_custom_domain, validate_public_access, public_access_types,
+     process_upload_batch_parameters, process_download_batch_parameters,
      get_content_setting_validator, validate_encryption, validate_accept,
      validate_key, storage_account_key_options,
      process_file_download_namespace, process_logging_update_namespace,
@@ -233,7 +234,7 @@ for item in ['download', 'upload']:
     register_cli_argument('storage blob {}'.format(item), 'max_connections', type=int)
     register_cli_argument('storage blob {}'.format(item), 'validate_content', action='store_true')
 
-for item in ['update', 'upload']:
+for item in ['update', 'upload', 'upload-batch']:
     register_content_settings_argument('storage blob {}'.format(item), BlobContentSettings, item == 'update')
 
 register_cli_argument('storage blob upload', 'blob_type', help="Defaults to 'page' for *.vhd files, or 'block' otherwise.", options_list=('--type', '-t'), validator=validate_blob_type, **enum_choice_list(blob_types.keys()))
@@ -241,6 +242,41 @@ register_cli_argument('storage blob upload', 'maxsize_condition', help='The max 
 register_cli_argument('storage blob upload', 'validate_content', help='Specifies that an MD5 hash shall be calculated for each chunk of the blob and verified by the service when the chunk has arrived.')
 # TODO: Remove once #807 is complete. Smart Create Generation requires this parameter.
 register_extra_cli_argument('storage blob upload', '_subscription_id', options_list=('--subscription',), help=argparse.SUPPRESS)
+
+# BLOB DOWNLOAD PARAMETERS
+register_cli_argument('storage blob download-batch', 'destination', options_list=('--destination', '-d'))
+register_cli_argument('storage blob download-batch', 'source', options_list=('--source', '-s'),
+                      validator=process_download_batch_parameters)
+
+register_cli_argument('storage blob download-batch', 'source_container_name', ignore_type)
+
+# BLOB UPLOAD PARAMETERS
+register_cli_argument('storage blob upload-batch', 'destination', options_list=('--destination', '-d'))
+register_cli_argument('storage blob upload-batch', 'source', options_list=('--source', '-s'),
+                      validator=process_upload_batch_parameters)
+
+register_cli_argument('storage blob upload-batch', 'source_files', ignore_type)
+register_cli_argument('storage blob upload-batch', 'destination_container_name', ignore_type)
+
+register_cli_argument('storage blob upload-batch', 'blob_type',
+                      help="Defaults to 'page' for *.vhd files, or 'block' otherwise.",
+                      options_list=('--type', '-t'),
+                      **enum_choice_list(blob_types.keys()))
+register_cli_argument('storage blob upload-batch', 'maxsize_condition',
+                      help='The max length in bytes permitted for an append blob.',
+                      arg_group='Content Control')
+register_cli_argument('storage blob upload-batch', 'validate_content',
+                      help='Specifies that an MD5 hash shall be calculated for each chunk of the blob and verified by' +
+                      ' the service when the chunk has arrived.',
+                      arg_group='Content Control')
+register_cli_argument('storage blob upload-batch', 'lease_id', help='Required if the blob has an active lease')
+register_cli_argument('storage blob upload-batch', 'content_encoding', arg_group='Content Control')
+register_cli_argument('storage blob upload-batch', 'content_disposition', arg_group='Content Control')
+register_cli_argument('storage blob upload-batch', 'content_md5', arg_group='Content Control')
+register_cli_argument('storage blob upload-batch', 'content_type', arg_group='Content Control')
+register_cli_argument('storage blob upload-batch', 'content_cache_control', arg_group='Content Control')
+register_cli_argument('storage blob upload-batch', 'content_language', arg_group='Content Control')
+register_cli_argument('storage blob upload-batch', 'max_connections', type=int, arg_group='Content Control')
 
 for item in ['file', 'blob']:
     register_cli_argument('storage {} url'.format(item), 'protocol', help='Protocol to use.', default='https', **enum_choice_list(['http', 'https']))
@@ -254,7 +290,6 @@ register_cli_argument('storage container create', 'fail_on_exist', help='Throw a
 
 register_cli_argument('storage container delete', 'fail_not_exist', help='Throw an exception if the container does not exist.')
 
-register_cli_argument('storage container exists', 'blob_name', ignore_type)
 register_cli_argument('storage container exists', 'blob_name', ignore_type)
 register_cli_argument('storage container exists', 'snapshot', ignore_type)
 

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
@@ -259,7 +259,7 @@ register_cli_argument('storage blob upload-batch', 'source_files', ignore_type)
 register_cli_argument('storage blob upload-batch', 'destination_container_name', ignore_type)
 
 register_cli_argument('storage blob upload-batch', 'blob_type',
-                      help="Defaults to 'page' for *.vhd files, or 'block' otherwise.",
+                      help="Defaults to 'page' for *.vhd files, or 'block' otherwise. The setting will override blob types for every file.",
                       options_list=('--type', '-t'),
                       **enum_choice_list(blob_types.keys()))
 register_cli_argument('storage blob upload-batch', 'maxsize_condition',
@@ -276,7 +276,7 @@ register_cli_argument('storage blob upload-batch', 'content_md5', arg_group='Con
 register_cli_argument('storage blob upload-batch', 'content_type', arg_group='Content Control')
 register_cli_argument('storage blob upload-batch', 'content_cache_control', arg_group='Content Control')
 register_cli_argument('storage blob upload-batch', 'content_language', arg_group='Content Control')
-register_cli_argument('storage blob upload-batch', 'max_connections', type=int, arg_group='Content Control')
+register_cli_argument('storage blob upload-batch', 'max_connections', type=int)
 
 for item in ['file', 'blob']:
     register_cli_argument('storage {} url'.format(item), 'protocol', help='Protocol to use.', default='https', **enum_choice_list(['http', 'https']))

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
@@ -10,6 +10,7 @@ import os
 import re
 
 from azure.cli.core._config import az_config
+from azure.cli.core._util import CLIError
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.commands.validators import validate_key_value_pairs
 
@@ -324,20 +325,14 @@ def validate_select(namespace):
 
 def process_download_batch_parameters(namespace):
     """Process the parameters for storage blob download command"""
-    from azure.cli.command_modules.storage.storage_url_helpers import parse_url
+    from azure.cli.command_modules.storage.storage_url_helpers import parse_storage_url
 
     # 1. quick check
-    if namespace.destination is None:
-        raise ValueError('Destination parameter is missing.')
-
-    if namespace.source is None:
-        raise ValueError('Source parameter is missing.')
-
     if not os.path.exists(namespace.destination) or not os.path.isdir(namespace.destination):
         raise ValueError('Destination folder {} does not exist'.format(namespace.source))
 
     # 2. try to extract account name and container name from source string
-    storage_desc = parse_url(namespace.source)
+    storage_desc = parse_storage_url(namespace.source)
 
     if storage_desc.blob is not None:
         raise ValueError('incorrect usage: --source should be either container URL or name')
@@ -350,15 +345,9 @@ def process_download_batch_parameters(namespace):
 
 def process_upload_batch_parameters(namespace):
     """Process the source and destination of storage blob upload command"""
-    from azure.cli.command_modules.storage.storage_url_helpers import parse_url
+    from azure.cli.command_modules.storage.storage_url_helpers import parse_storage_url
 
     # 1. quick check
-    if namespace.destination is None:
-        raise ValueError('incorrect usage: --destination is missing.')
-
-    if namespace.source is None:
-        raise ValueError('incorrect usage: --source is missing.')
-
     if not os.path.exists(namespace.source):
         raise ValueError('incorrect usage: source {} does not exist'.format(namespace.source))
 
@@ -366,7 +355,7 @@ def process_upload_batch_parameters(namespace):
         raise ValueError('incorrect usage: source must be a directory')
 
     # 2. try to extract account name and container name from destination string
-    storage_desc = parse_url(namespace.destination)
+    storage_desc = parse_storage_url(namespace.destination)
 
     if storage_desc.blob is not None:
         raise ValueError('incorrect usage: destination cannot be a blob url')
@@ -386,6 +375,7 @@ def process_upload_batch_parameters(namespace):
         def _file_selector(file_path):
             return fnmatch(file_path, pattern)
     else:
+        #pylint: disable=unused-argument
         def _file_selector(_):
             return True
 
@@ -406,7 +396,7 @@ def process_upload_batch_parameters(namespace):
             namespace.blob_type = 'page'
         elif any(vhd_files):
             # source files contain vhd files but not all of them
-            raise ValueError('''Fail to guess the required blob type. Type of the files to be
+            raise CLIError('''Fail to guess the required blob type. Type of the files to be
             uploaded are not consistent. Default blob type for .vhd files is "page", while
             others are "block". You can solve this problem by either explicitly set the blob
             type or ensure the pattern matches a correct set of files.''')

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/blob.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/blob.py
@@ -127,7 +127,8 @@ def storage_blob_copy_batch(client, source_account, source_container, destinatio
 
 
 #pylint: disable=unused-argument
-def storage_blob_download_batch(client, source, destination, source_container_name, pattern=None, dryrun=False):
+def storage_blob_download_batch(client, source, destination, source_container_name, pattern=None,
+                                dryrun=False):
     """
     Download blobs in a container recursively
 
@@ -173,13 +174,13 @@ def storage_blob_download_batch(client, source, destination, source_container_na
     result = []
     if dryrun:
         logger = get_az_logger(__name__)
-        logger.warning('download action: from {} to {}'.format(source, destination))
-        logger.warning('    pattern {}'.format(pattern))
-        logger.warning('  container {}'.format(source_container_name))
-        logger.warning('      total {}'.format(len(source_blobs)))
+        logger.warning('download action: from %s to %s', source, destination)
+        logger.warning('    pattern %s', pattern)
+        logger.warning('  container %s', source_container_name)
+        logger.warning('      total %d', len(source_blobs))
         logger.warning(' operations')
         for b in source_blobs or []:
-            logger.warning('  - {}'.format(b))
+            logger.warning('  - %s', b)
     else:
         # TODO: try catch IO exception
         for blob in source_blobs:
@@ -196,7 +197,7 @@ def storage_blob_download_batch(client, source, destination, source_container_na
 def storage_blob_upload_batch(client, source, destination, pattern=None, source_files=None,
                               destination_container_name=None, blob_type=None,
                               content_settings=None, metadata=None, validate_content=False,
-                              maxsize_condition=None, max_connections=2, lease_id=None,
+                              maxsize_condition=None, max_connections=1, lease_id=None,
                               if_modified_since=None, if_unmodified_since=None, if_match=None,
                               if_none_match=None, timeout=None, dryrun=False):
     """
@@ -271,14 +272,14 @@ def storage_blob_upload_batch(client, source, destination, pattern=None, source_
 
     if dryrun:
         logger = get_az_logger(__name__)
-        logger.warning('upload action: from {} to {}'.format(source, destination))
-        logger.warning('    pattern {}'.format(pattern))
-        logger.warning('  container {}'.format(destination_container_name))
-        logger.warning('       type {}'.format(blob_type))
-        logger.warning('      total {}'.format(len(source_files)))
+        logger.warning('upload action: from %s to %s', source, destination)
+        logger.warning('    pattern %s', pattern)
+        logger.warning('  container %s', destination_container_name)
+        logger.warning('       type %s', blob_type)
+        logger.warning('      total %d', len(source_files))
         logger.warning(' operations')
         for f in source_files or []:
-            logger.warning('  - {} => {}'.format(*f))
+            logger.warning('  - %s => %s', *f)
     else:
         for f in source_files or []:
             print('uploading {}'.format(f[0]))

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/blob.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/blob.py
@@ -140,7 +140,7 @@ def storage_blob_download_batch(client, source, destination, source_container_na
         exist.
 
     :param str pattern:
-        The pattern is used for files globing. The supported patterns are '*', '?', '[seq]',
+        The pattern is used for files globbing. The supported patterns are '*', '?', '[seq]',
         and '[!seq]'.
     """
     import os.path
@@ -196,7 +196,7 @@ def storage_blob_upload_batch(client, source, destination, pattern=None, source_
         account name will parsed from the URL.
 
     :param str pattern:
-        The pattern is used for files globing. The supported patterns are '*', '?', '[seq]',
+        The pattern is used for files globbing. The supported patterns are '*', '?', '[seq]',
         and '[!seq]'.
 
     :param bool dryrun:

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
@@ -84,6 +84,14 @@ cli_storage_data_plane_command('storage blob copy start', 'azure.storage.blob.bl
 cli_storage_data_plane_command('storage blob copy start-batch', 'azure.cli.command_modules.storage.blob#storage_blob_copy_batch', factory)
 cli_storage_data_plane_command('storage blob copy cancel', 'azure.storage.blob.blockblobservice#BlockBlobService.abort_copy_blob', factory)
 
+cli_storage_data_plane_command('storage blob upload-batch',
+                               'azure.cli.command_modules.storage.blob#storage_blob_upload_batch',
+                               factory)
+
+cli_storage_data_plane_command('storage blob download-batch',
+                               'azure.cli.command_modules.storage.blob#storage_blob_download_batch',
+                               factory)
+
 # share commands
 factory = file_data_service_factory
 cli_storage_data_plane_command('storage share list', 'azure.storage.file.fileservice#FileService.list_shares', factory, transform=transform_storage_list_output, table_transformer=transform_share_list)

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/storage_url_helpers.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/storage_url_helpers.py
@@ -8,7 +8,6 @@ Help functions to extract storage account, container name, blob name and other i
 container and/or blob URL.
 """
 
-import sys
 from collections import namedtuple
 from azure.cli.core._profile import CLOUD
 
@@ -41,7 +40,7 @@ def parse_storage_url(url):
     blob = None
     snapshot = None
 
-    from six.moves.urllib.parse import urlparse
+    from six.moves.urllib.parse import urlparse #pylint: disable=import-error
 
     parsed_url = urlparse(url)
     if not parsed_url.scheme == 'http' and not parsed_url.scheme == 'https':

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/storage_url_helpers.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/storage_url_helpers.py
@@ -1,0 +1,74 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+"""
+Help functions to extract storage account, container name, blob name and other information from
+container and/or blob URL.
+"""
+
+import sys
+from collections import namedtuple
+from azure.cli.core._profile import CLOUD
+
+StorageUrlDescription = namedtuple('StorageUrlDescription',
+                                   ['account', 'container', 'blob', 'snapshot'])
+
+
+def parse_url(url):
+    """Extract information from a container/blob url path"""
+
+    def _parse_blob_path(path):
+        if path is None:
+            return None, None
+
+        path = path.lstrip('/')
+        if len(path) == 0:
+            return None, None
+
+        idx = path.find('/')
+        if idx == -1:
+            return path, None
+        else:
+            return path[:idx], path[idx + 1:]
+
+    if url is None:
+        raise ValueError('parameter url is None')
+
+    account_name = None
+    container = None
+    blob = None
+    snapshot = None
+
+    if sys.version_info >= (3,):
+        from urllib.parse import urlparse # pylint: disable=no-name-in-module, import-error
+    else:
+        from urlparse import urlparse # pylint: disable=no-name-in-module, import-error
+
+    parsed_url = urlparse(url)
+    if not parsed_url.scheme == 'http' and not parsed_url.scheme == 'https':
+        # the source string is not a url, regards it as a container name
+        container = url
+    else:
+        container, blob = _parse_blob_path(parsed_url.path)
+        if container is None:
+            raise ValueError('Failed to parse container name from the URL {}'.format(url))
+
+        blob_suffix = '.blob.%s' % CLOUD.suffixes.storage_endpoint
+        if parsed_url.netloc.endswith(blob_suffix):
+            # it is not a custom domain
+            account_name = parsed_url.netloc[:len(parsed_url.netloc) - len(blob_suffix)]
+
+    if parsed_url.query:
+        q = parsed_url.query
+        i = q.find('snapshot=')
+        if i != -1:
+            q = q[i:]
+            j = q.find('&')
+            if j == -1:
+                snapshot = q
+            else:
+                snapshot = q[:j]
+
+    return StorageUrlDescription(account_name, container, blob, snapshot)

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/storage_url_helpers.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/storage_url_helpers.py
@@ -16,7 +16,7 @@ StorageUrlDescription = namedtuple('StorageUrlDescription',
                                    ['account', 'container', 'blob', 'snapshot'])
 
 
-def parse_url(url):
+def parse_storage_url(url):
     """Extract information from a container/blob url path"""
 
     def _parse_blob_path(path):
@@ -41,10 +41,7 @@ def parse_url(url):
     blob = None
     snapshot = None
 
-    if sys.version_info >= (3,):
-        from urllib.parse import urlparse # pylint: disable=no-name-in-module, import-error
-    else:
-        from urlparse import urlparse # pylint: disable=no-name-in-module, import-error
+    from six.moves.urllib.parse import urlparse
 
     parsed_url = urlparse(url)
     if not parsed_url.scheme == 'http' and not parsed_url.scheme == 'https':

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/.gitignore
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/.gitignore
@@ -1,0 +1,2 @@
+resources/
+test_temp/

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/integration_test_base.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/integration_test_base.py
@@ -1,0 +1,49 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import os
+from unittest import TestCase, skipIf
+from datetime import datetime
+from azure.storage.blob.baseblobservice import BaseBlobService
+
+
+@skipIf(os.environ.get('Travis', 'false') == 'true', 'Integration tests are skipped in Travis CI')
+class StorageIntegrationTestBase(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.generate_resource_files()
+
+        cls._test_connection_string = os.environ['test_connection_string']
+        assert cls._test_connection_string
+
+        cls._blob_service = BaseBlobService(connection_string=cls._test_connection_string)
+        assert cls._blob_service
+
+        cls._test_account_key = cls._blob_service.account_key
+
+    @classmethod
+    def generate_resource_files(cls):
+        cls._resource_folder = os.path.join(os.getcwd(), 'resources')
+        if os.path.exists(cls._resource_folder):
+            from shutil import rmtree
+            rmtree(cls._resource_folder)
+
+        os.makedirs(cls._resource_folder)
+
+        with open(os.path.join(cls._resource_folder, 'sample_file.txt'), 'w') as f:
+            f.write('storage blob test sample file')
+
+        for folder_name in ['alpha', 'bravo', 'charlie']:
+            for file_index in range(10):
+                file_path = os.path.join(cls._resource_folder, folder_name, 'file_%s' % file_index)
+                if not os.path.exists(os.path.dirname(file_path)):
+                    os.makedirs(os.path.dirname(file_path))
+                with open(file_path, 'w') as f:
+                    f.write('storage blob test sample file. origin: %s' % file_path)
+
+    @classmethod
+    def generate_new_container_name(cls):
+        return 'blob-test-{}'.format(datetime.utcnow().strftime('%Y%m%d%H%M%S'))
+

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/integration_test_blob_download.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/integration_test_blob_download.py
@@ -1,0 +1,88 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+"""
+Integration test for blob upload
+
+The tests require environment variable 'test_connection_string' to set to the connection
+string of the storage account they will be run on.
+"""
+
+import os
+import os.path
+import shutil
+from unittest import TestCase
+from .integration_test_base import StorageIntegrationTestBase
+from azure.cli.main import main as cli_main
+
+
+class StorageBlobDownloadPlainTests(TestCase):
+    def test_blob_download_help(self):
+        with self.assertRaises(SystemExit):
+            cli_main('storage blob upload -h'.split())
+
+
+class StorageBlobDownloadIntegrationTests(StorageIntegrationTestBase):
+    @classmethod
+    def setUpClass(cls):
+        StorageIntegrationTestBase.setUpClass()
+        # set up sample container
+        cls._test_source_container = cls.generate_new_container_name()
+        assert cls._blob_service.create_container(cls._test_source_container)
+
+        cli_main('storage blob upload-batch -s {} -d {} --connection-string {}'
+                 .format(cls._resource_folder, cls._test_source_container,
+                         cls._test_connection_string)
+                 .split())
+
+        test_blobs = [b.name for b in cls._blob_service.list_blobs(cls._test_source_container)]
+        assert len(test_blobs) == 31
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._blob_service.delete_container(cls._test_source_container)
+
+    def setUp(self):
+        self._test_folder = os.path.join(os.getcwd(), 'test_temp')
+        if os.path.exists(self._test_folder):
+            shutil.rmtree(self._test_folder)
+
+        os.mkdir(self._test_folder)
+
+    def test_download_files_recursively_without_pattern(self):
+        command = 'storage blob download-batch -s {} -d {} --account-name {} --account-key {}'\
+            .format(self._test_source_container, self._test_folder,
+                    self._blob_service.account_name, self._blob_service.account_key)
+
+        cli_main(command.split())
+        assert sum(len(f) for r, d, f in os.walk(self._test_folder)) == 31
+
+    def test_download_files_recursively_with_pattern_1(self):
+        #pylint: disable=line-too-long
+        command = 'storage blob download-batch -s https://{}/{} -d {} --pattern {} --account-key {}'\
+            .format(self._blob_service.primary_endpoint, self._test_source_container,
+                    self._test_folder, '*', self._blob_service.account_key)
+
+        cli_main(command.split())
+        assert sum(len(f) for r, d, f in os.walk(self._test_folder)) == 31
+
+    def test_download_files_recursively_with_pattern_2(self):
+        #pylint: disable=line-too-long
+        command = 'storage blob download-batch -s https://{}/{} -d {} --pattern {} --account-key {}'\
+            .format(self._blob_service.primary_endpoint, self._test_source_container,
+                    self._test_folder, 'alpha/*', self._blob_service.account_key)
+
+        cli_main(command.split())
+        assert sum(len(f) for r, d, f in os.walk(self._test_folder)) == 10
+
+    def test_download_files_recursively_with_pattern_3(self):
+        #pylint: disable=line-too-long
+        command = 'storage blob download-batch -s https://{}/{} -d {} --pattern {} --account-key {}'\
+            .format(self._blob_service.primary_endpoint, self._test_source_container,
+                    self._test_folder, '*/file_0', self._blob_service.account_key)
+
+        cli_main(command.split())
+        assert sum(len(f) for r, d, f in os.walk(self._test_folder)) == 3
+

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/integration_test_blob_upload.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/integration_test_blob_upload.py
@@ -1,0 +1,85 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+"""
+Integration test for blob upload
+
+The tests require environment variable 'test_connection_string' to set to the connection string
+of the storage account they will be run on.
+"""
+
+import os
+import os.path
+from unittest import TestCase
+from azure.cli.main import main as cli_main
+from .integration_test_base import StorageIntegrationTestBase
+
+
+class StorageBlobUploadPlainTests(TestCase):
+    def test_blob_upload_help(self):
+        with self.assertRaises(SystemExit):
+            cli_main('storage blob upload-batch -h'.split())
+
+
+class StorageBlobUploadIntegrationTests(StorageIntegrationTestBase):
+    def setUp(self):
+        self._keep_test_context = False
+        self._test_container_name = self.generate_new_container_name()
+        assert self._blob_service.create_container(self._test_container_name)
+
+    def tearDown(self):
+        if self._keep_test_context:
+            return
+
+        self._blob_service.delete_container(self._test_container_name)
+
+    def _get_test_resource_file(self, file_name):
+        result = os.path.join(self._resource_folder, file_name)
+        assert os.path.exists(result)
+
+        return result
+
+    def test_blob_upload_multiple_files_no_pattern(self):
+        url = 'http://{}/{}'.format(self._blob_service.primary_endpoint, self._test_container_name)
+        command = 'storage blob upload-batch -s {} -d {} --account-key {}'\
+            .format(self._resource_folder, url, self._test_account_key)
+
+        cli_main(command.split())
+
+        blobs = [b.name for b in self._blob_service.list_blobs(self._test_container_name)]
+        assert len(blobs) == 31
+
+    def test_blob_upload_multiple_files_dry_run(self):
+        url = 'http://{}/{}'.format(self._blob_service.primary_endpoint, self._test_container_name)
+        command = 'storage blob upload-batch -s {} -d {} --account-key {} --dryrun' \
+            .format(self._resource_folder, url, self._test_account_key)
+
+        from six import StringIO
+        buf = StringIO()
+        cli_main(command.split(), file=buf)
+
+        blobs = [b.name for b in self._blob_service.list_blobs(self._test_container_name)]
+        assert len(blobs) == 0
+
+        self._keep_test_context = True
+
+    def test_blob_upload_multiple_files_patterns_1(self):
+        self._test_blob_upload_multiple_files_patterns('alpha/*', 10)
+
+    def test_blob_upload_multiple_files_patterns_2(self):
+        self._test_blob_upload_multiple_files_patterns('*/file_0', 3)
+
+    def test_blob_upload_multiple_files_patterns_3(self):
+        self._test_blob_upload_multiple_files_patterns('nonexists/*', 0)
+
+    def _test_blob_upload_multiple_files_patterns(self, pattern, expected_count):
+        url = 'http://{}/{}'.format(self._blob_service.primary_endpoint, self._test_container_name)
+        command = 'storage blob upload-batch -s {} -d {} --account-key {} --pattern {}' \
+            .format(self._resource_folder, url, self._test_account_key, pattern)
+
+        cli_main(command.split())
+
+        blobs = [b.name for b in self._blob_service.list_blobs(self._test_container_name)]
+        assert len(blobs) == expected_count


### PR DESCRIPTION
Resolve issue https://github.com/Azure/azure-cli/issues/1432

```
10:21 $ az storage blob upload-batch -h

Command
    az storage blob upload-batch: Upload files to storage container as blobs.

Arguments
    --destination -d [Required]: The string represents the destination of this upload operation. The
                                 source can be the container URL or the container name. When the
                                 source is the container URL, the storage account name will parsed
                                 from the URL.
    --source -s      [Required]: The directory where the files to be uploaded.
    --dryrun                   : Show the summary of the operations to be taken instead of actually
                                 upload the file(s).
    --lease-id                 : Required if the blob has an active lease.
    --metadata                 : Metadata in space-separated key=value pairs. This overwrites any
                                 existing metadata.
    --pattern                  : The pattern is used for files globing. The supported patterns are
                                 '*', '?', '[seq]', and '[!seq]'.
    --timeout                  : Request timeout in seconds. Applies to each call to the service.
    --type -t                  : Defaults to 'page' for *.vhd files, or 'block' otherwise.  Allowed
                                 values: append, block, page.

Content Control Arguments
    --content-cache-control    : The cache control string.
    --content-disposition      : Conveys additional information about how to process the response
                                 payload, and can also be used to attach additional metadata.
    --content-encoding         : The content encoding type.
    --content-language         : The content language.
    --content-md5              : The content's MD5 hash.
    --content-type             : The content MIME type.
    --max-connections          : Default: 2.
    --maxsize-condition        : The max length in bytes permitted for an append blob.
    --validate-content         : Specifies that an MD5 hash shall be calculated for each chunk of
                                 the blob and verified by the service when the chunk has arrived.

Pre-condition Arguments
    --if-match                 : An ETag value, or the wildcard character (*). Specify this header
                                 to perform the operation only if the resource's ETag matches the
                                 value specified.
    --if-modified-since        : Alter only if modified since supplied UTC datetime
                                 (Y-m-d'T'H:M'Z').
    --if-none-match            : An ETag value, or the wildcard character (*). Specify this header
                                 to perform the operation only if the resource's ETag does not match
                                 the value specified. Specify the wildcard character (*) to perform
                                 the operation only if the resource does not exist, and fail the
                                 operation if it does exist.
    --if-unmodified-since      : Alter only if unmodified since supplied UTC datetime
                                 (Y-m-d'T'H:M'Z').

Storage Account Arguments
    --account-key              : Storage account key. Must be used in conjunction with storage
                                 account name. Environment variable: AZURE_STORAGE_KEY.
    --account-name             : Storage account name. Must be used in conjunction with either
                                 storage account key or a SAS token. Environment variable:
                                 AZURE_STORAGE_ACCOUNT.
    --connection-string        : Storage account connection string. Environment variable:
                                 AZURE_STORAGE_CONNECTION_STRING.
    --sas-token                : A Shared Access Signature (SAS). Must be used in conjunction with
                                 storage account name. Environment variable:
                                 AZURE_STORAGE_SAS_TOKEN.

Global Arguments
    --debug                    : Increase logging verbosity to show all debug logs.
    --help -h                  : Show this help message and exit.
    --output -o                : Output format.  Allowed values: json, jsonc, list, table, tsv.
                                 Default: json.
    --query                    : JMESPath query string. See http://jmespath.org/ for more
                                 information and examples.
    --verbose                  : Increase logging verbosity. Use --debug for full debug logs.
```

```
10:15 $ az storage blob download-batch -h

Command
    az storage blob download-batch: Download blobs in a container recursively.

Arguments
    --destination -d [Required]: The string represents the destination folder of this download
                                 operation. The folder must exist.
    --source -s      [Required]: The string represents the source of this download operation. The
                                 source can be the container URL or the container name. When the
                                 source is the container URL, the storage account name will parsed
                                 from the URL.
    --pattern                  : The pattern is used for files globing. The supported patterns are
                                 '*', '?', '[seq]', and '[!seq]'.

Storage Account Arguments
    --account-key              : Storage account key. Must be used in conjunction with storage
                                 account name. Environment variable: AZURE_STORAGE_KEY.
    --account-name             : Storage account name. Must be used in conjunction with either
                                 storage account key or a SAS token. Environment variable:
                                 AZURE_STORAGE_ACCOUNT.
    --connection-string        : Storage account connection string. Environment variable:
                                 AZURE_STORAGE_CONNECTION_STRING.
    --sas-token                : A Shared Access Signature (SAS). Must be used in conjunction with
                                 storage account name. Environment variable:
                                 AZURE_STORAGE_SAS_TOKEN.

Global Arguments
    --debug                    : Increase logging verbosity to show all debug logs.
    --help -h                  : Show this help message and exit.
    --output -o                : Output format.  Allowed values: json, jsonc, list, table, tsv.
                                 Default: json.
    --query                    : JMESPath query string. See http://jmespath.org/ for more
                                 information and examples.
    --verbose                  : Increase logging verbosity. Use --debug for full debug logs.
```