### PR TITLE
Update for @file matching

### DIFF
--- a/src/azure-cli-core/azure/cli/core/application.py
+++ b/src/azure-cli-core/azure/cli/core/application.py
@@ -6,7 +6,6 @@
 from collections import defaultdict
 import sys
 import os
-import re
 import uuid
 import argparse
 from azure.cli.core.parser import AzCliCommandParser, enable_autocomplete
@@ -206,10 +205,10 @@ class Application(object):
         if ix == 0:
             return Application._load_file(arg[1:])
 
-        res = re.match('(\\-\\-?[a-zA-Z0-9]+[\\-a-zA-Z0-9]*\\=)\\"?@([^\\"]*)\\"?', arg)
-        if not res:
-            return arg
-        return res.group(1) + Application._load_file(res.group(2))
+        if arg[ix - 1] == '=':
+            return arg[:ix] + Application._load_file(arg[ix + 1:])
+
+        return arg
 
     @staticmethod
     def _expand_file_prefixed_files(argv):

--- a/src/azure-cli-core/azure/cli/core/tests/test_application.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_application.py
@@ -92,14 +92,13 @@ class TestApplication(unittest.TestCase):
             stream.write('foo')
 
         cases = [
-            [['--bar=baz'], ['--bar=baz']],
-            [['--bar', 'baz'], ['--bar', 'baz']],
-            [['--bar=@{}'.format(f.name)], ['--bar=foo']],
-            [['--bar', '@{}'.format(f.name)], ['--bar', 'foo']],
-            [['--bar', f.name], ['--bar', f.name]],
-            [['--bar="@{}"'.format(f.name)], ['--bar=foo']],
-            [['--bar=name@company.com'], ['--bar=name@company.com']],
-            [['--bar', 'name@company.com'], ['--bar', 'name@company.com']],
+            [['bar=baz'], ['bar=baz']],
+            [['bar', 'baz'], ['bar', 'baz']],
+            [['bar=@{}'.format(f.name)], ['bar=foo']],
+            [['bar', '@{}'.format(f.name)], ['bar', 'foo']],
+            [['bar', f.name], ['bar', f.name]],
+            [['bar=name@company.com'], ['bar=name@company.com']],
+            [['bar', 'name@company.com'], ['bar', 'name@company.com']],
         ]
 
         for test_case in cases:


### PR DESCRIPTION
Replace the regex from PR #1423.

- no longer requires the arg start with -- (for example `--set tags=@file.json` would not work with previous regex
- removes checks for quotes and associated test. By the time the check is reached, quotes have already been processed and thus we don't need to check for them (since they aren't there!)