### PR TITLE
Fix resource list table

### DIFF
--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/commands.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/commands.py
@@ -33,8 +33,16 @@ cli_command(__name__, 'resource group export', 'azure.cli.command_modules.resour
 # Resource commands
 
 def transform_resource_list(result):
-    return [OrderedDict([('Name', r['name']), ('ResourceGroup', r['resourceGroup']), \
-            ('Location', r['location']), ('Type', r['type']), ('Status', r['properties']['provisioningState'])]) for r in result]
+    transformed = []
+    for r in result:
+        res = OrderedDict([('Name', r['name']), ('ResourceGroup', r['resourceGroup']), \
+            ('Location', r['location']), ('Type', r['type'])])
+        try:
+            res['Status'] = r['properties']['provisioningStatus']
+        except TypeError:
+            res['Status'] = ' '
+        transformed.append(res)
+    return transformed
 
 cli_command(__name__, 'resource delete', 'azure.cli.command_modules.resource.custom#delete_resource')
 cli_command(__name__, 'resource show', 'azure.cli.command_modules.resource.custom#show_resource')


### PR DESCRIPTION
PR #1425 added status to the default table format for the `resource list` command, but if the value of properties is `null` then the table transformation will fail (due a TypeError) and you will get the "no table format" error.