### PR TITLE
[Network] Add BGP Peering to local-network create and update

### DIFF
--- a/azure-cli.pyproj
+++ b/azure-cli.pyproj
@@ -273,24 +273,6 @@
     <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_app_gateway\lib\operations\__init__.py" />
     <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_app_gateway\lib\version.py" />
     <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_app_gateway\lib\__init__.py" />
-    <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_dns_zone\lib\credentials.py" />
-    <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_dns_zone\lib\dns_zone_creation_client.py" />
-    <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_dns_zone\lib\exceptions.py" />
-    <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_dns_zone\lib\models\basic_dependency.py" />
-    <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_dns_zone\lib\models\dependency.py" />
-    <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_dns_zone\lib\models\deployment_dns_zone.py" />
-    <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_dns_zone\lib\models\deployment_extended.py" />
-    <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_dns_zone\lib\models\deployment_properties_extended.py" />
-    <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_dns_zone\lib\models\dns_zone_creation_client_enums.py" />
-    <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_dns_zone\lib\models\parameters_link.py" />
-    <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_dns_zone\lib\models\provider.py" />
-    <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_dns_zone\lib\models\provider_resource_type.py" />
-    <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_dns_zone\lib\models\template_link.py" />
-    <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_dns_zone\lib\models\__init__.py" />
-    <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_dns_zone\lib\operations\dns_zone_operations.py" />
-    <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_dns_zone\lib\operations\__init__.py" />
-    <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_dns_zone\lib\version.py" />
-    <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_dns_zone\lib\__init__.py" />
     <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_express_route_circuit\lib\credentials.py" />
     <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_express_route_circuit\lib\exceptions.py" />
     <Compile Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_express_route_circuit\lib\express_route_circuit_creation_client.py" />
@@ -799,9 +781,6 @@
     <Folder Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_app_gateway\lib\" />
     <Folder Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_app_gateway\lib\models\" />
     <Folder Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_app_gateway\lib\operations\" />
-    <Folder Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_dns_zone\lib\" />
-    <Folder Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_dns_zone\lib\models\" />
-    <Folder Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_dns_zone\lib\operations\" />
     <Folder Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_express_route_circuit\lib\" />
     <Folder Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_express_route_circuit\lib\models\" />
     <Folder Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_express_route_circuit\lib\operations\" />
@@ -837,7 +816,6 @@
     <Folder Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_vpn_connection\lib\operations\" />
     <Folder Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_express_route_circuit\" />
     <Folder Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_traffic_manager_profile\" />
-    <Folder Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_dns_zone\" />
     <Folder Include="command_modules\azure-cli-network\azure\cli\command_modules\network\zone_file\" />
     <Folder Include="command_modules\azure-cli-redis\" />
     <Folder Include="command_modules\azure-cli-redis\azure\" />
@@ -945,8 +923,6 @@
     </Content>
     <Content Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_app_gateway\swagger_create_app_gateway.json" />
     <Content Include="command_modules\azure-cli-feedback\requirements.txt" />
-    <Content Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_dns_zone\azuredeploy.json" />
-    <Content Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_dns_zone\swagger_create_dns_zone.json" />
     <Content Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_express_route_circuit\azuredeploy.json" />
     <Content Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_express_route_circuit\swagger_create_express_route_circuit.json" />
     <Content Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_lb\azuredeploy_empty.json" />

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_format.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_format.py
@@ -1,0 +1,26 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+# pylint:disable=line-too-long
+
+from collections import OrderedDict
+
+def transform_local_gateway_table_output(result):
+    final_result = []
+    for item in result:
+        new_item = OrderedDict([
+            ('Name', item['name']), ('Location', item['location']),
+            ('ResourceGroup', item['resourceGroup']),
+            ('ProvisioningState', item['provisioningState']),
+            ('GatewayIpAddress', item['gatewayIpAddress'])
+        ])
+        try:
+            local_prefixes = item['localNetworkAddressSpace']['addressPrefixes'] or [' ']
+        except TypeError:
+            local_prefixes = [' ']
+        prefix_val = '{}{}'.format(local_prefixes[0], ', ...' if len(local_prefixes) > 1 else '')
+        new_item['AddressPrefixes'] = prefix_val
+        final_result.append(new_item)
+    return final_result

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
@@ -1011,6 +1011,32 @@ helps['network local-gateway'] = """
     type: group
     short-summary: Manage local gateways
 """
+
+helps['network local-gateway create'] = """
+    type: command
+    short-summary: Create a new local VPN gateway.
+"""
+
+helps['network local-gateway delete'] = """
+    type: command
+    short-summary: Delete a local VPN gateway.
+"""
+helps['network local-gateway list'] = """
+    type: command
+    short-summary: List local VPN gateways in a resource group.
+"""
+helps['network local-gateway show'] = """
+    type: command
+    short-summary: Show details of a local VPN gateway.
+"""
+
+helps['network local-gateway update'] = """
+    type: command
+    short-summary: Update an existing local VPN gateway.
+"""
+
+# Network Security Group (NSG)
+
 helps['network nsg'] = """
     type: group
     short-summary: Manage Network Security Groups (NSG)

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -30,7 +30,7 @@ from azure.cli.command_modules.network._validators import \
      process_nic_create_namespace, process_lb_create_namespace, process_ag_rule_create_namespace,
      process_ag_url_path_map_rule_create_namespace, process_auth_create_namespace,
      process_public_ip_create_namespace, validate_private_ip_address,
-     process_lb_frontend_ip_namespace,
+     process_lb_frontend_ip_namespace, process_local_gateway_create_namespace,
      validate_inbound_nat_rule_id_list, validate_address_pool_id_list,
      validate_inbound_nat_rule_name_or_id, validate_address_pool_name_or_id,
      validate_servers, load_cert_file,
@@ -239,6 +239,14 @@ register_cli_argument('network express-route peering', 'routing_registry_name', 
 
 # Local Gateway
 register_cli_argument('network local-gateway', 'local_network_gateway_name', name_arg_type, completer=get_resource_name_completion_list('Microsoft.Network/localNetworkGateways'), id_part='name')
+register_cli_argument('network local-gateway', 'asn', arg_group='BGP Peering', help='Autonomous System Number to use for the BGP settings.')
+register_cli_argument('network local-gateway', 'bgp_peering_address', arg_group='BGP Peering', help='IP address from the OnPremise VPN\'s subnet to use for BGP peering.')
+register_cli_argument('network local-gateway', 'peer_weight', arg_group='BGP Peering', help='Weight (0-100) added to routes learned through BGP peering.')
+register_cli_argument('network local-gateway', 'local_address_prefix', nargs='+', help='List of CIDR block prefixes representing the address space of the OnPremise VPN\'s subnet.')
+register_cli_argument('network local-gateway', 'gateway_ip_address', help='Gateway\'s public IP address. (e.g. 10.1.1.1).')
+
+register_cli_argument('network local-gateway create', 'use_bgp_settings', ignore_type)
+register_cli_argument('network local-gateway create', 'asn', validator=process_local_gateway_create_namespace)
 
 # NIC
 

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -242,7 +242,7 @@ register_cli_argument('network local-gateway', 'local_network_gateway_name', nam
 register_cli_argument('network local-gateway', 'asn', arg_group='BGP Peering', help='Autonomous System Number to use for the BGP settings.')
 register_cli_argument('network local-gateway', 'bgp_peering_address', arg_group='BGP Peering', help='IP address from the OnPremise VPN\'s subnet to use for BGP peering.')
 register_cli_argument('network local-gateway', 'peer_weight', arg_group='BGP Peering', help='Weight (0-100) added to routes learned through BGP peering.')
-register_cli_argument('network local-gateway', 'local_address_prefix', nargs='+', help='List of CIDR block prefixes representing the address space of the OnPremise VPN\'s subnet.')
+register_cli_argument('network local-gateway', 'local_address_prefix', nargs='+', options_list=('--local-address-prefixes',), help='List of CIDR block prefixes representing the address space of the OnPremise VPN\'s subnet.')
 register_cli_argument('network local-gateway', 'gateway_ip_address', help='Gateway\'s public IP address. (e.g. 10.1.1.1).')
 
 register_cli_argument('network local-gateway create', 'use_bgp_settings', ignore_type)

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
@@ -362,6 +362,13 @@ def process_lb_frontend_ip_namespace(namespace):
     else:
         get_public_ip_validator()(namespace)
 
+def process_local_gateway_create_namespace(namespace):
+    ns = namespace
+    ns.use_bgp_settings = any([ns.asn or ns.bgp_peering_address or ns.peer_weight])
+    if ns.use_bgp_settings and (not ns.asn or not ns.bgp_peering_address):
+        raise ValueError(
+            'incorrect usage: --bgp-peering-address IP --asn ASN [--peer-weight WEIGHT]')
+
 def process_nic_create_namespace(namespace):
 
     # process folded parameters

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
@@ -12,6 +12,8 @@ from ._client_factory import * #pylint: disable=wildcard-import
 from ._util import (list_network_resource_property,
                     get_network_resource_property_entry,
                     delete_network_resource_property_entry)
+from ._format import \
+    (transform_local_gateway_table_output)
 
 # Application gateways
 cli_command(__name__, 'network application-gateway delete', 'azure.mgmt.network.operations.application_gateways_operations#ApplicationGatewaysOperations.delete', cf_application_gateways)
@@ -157,7 +159,7 @@ cli_generic_update_command(__name__, 'network lb probe update',
 # LocalNetworkGatewaysOperations
 cli_command(__name__, 'network local-gateway delete', 'azure.mgmt.network.operations.local_network_gateways_operations#LocalNetworkGatewaysOperations.delete', cf_local_network_gateways)
 cli_command(__name__, 'network local-gateway show', 'azure.mgmt.network.operations.local_network_gateways_operations#LocalNetworkGatewaysOperations.get', cf_local_network_gateways)
-cli_command(__name__, 'network local-gateway list', 'azure.mgmt.network.operations.local_network_gateways_operations#LocalNetworkGatewaysOperations.list', cf_local_network_gateways)
+cli_command(__name__, 'network local-gateway list', 'azure.mgmt.network.operations.local_network_gateways_operations#LocalNetworkGatewaysOperations.list', cf_local_network_gateways, table_transformer=transform_local_gateway_table_output)
 cli_generic_update_command(__name__, 'network local-gateway update',
                            'azure.mgmt.network.operations.local_network_gateways_operations#LocalNetworkGatewaysOperations.get',
                            'azure.mgmt.network.operations.local_network_gateways_operations#LocalNetworkGatewaysOperations.create_or_update',

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
@@ -161,7 +161,8 @@ cli_command(__name__, 'network local-gateway list', 'azure.mgmt.network.operatio
 cli_generic_update_command(__name__, 'network local-gateway update',
                            'azure.mgmt.network.operations.local_network_gateways_operations#LocalNetworkGatewaysOperations.get',
                            'azure.mgmt.network.operations.local_network_gateways_operations#LocalNetworkGatewaysOperations.create_or_update',
-                           cf_local_network_gateways)
+                           cf_local_network_gateways,
+                           custom_function_op='azure.cli.command_modules.network.custom#update_local_gateway')
 
 cli_command(__name__, 'network local-gateway create',
             'azure.cli.command_modules.network.mgmt_local_gateway.lib.operations.local_gateway_operations#LocalGatewayOperations.create_or_update',

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -836,6 +836,37 @@ def create_vpn_gateway_root_cert(resource_group_name, gateway_name, public_cert_
     return ncf.create_or_update(resource_group_name, gateway_name, gateway)
 #endregion
 
+#region Local Gateway commands
+
+def update_local_gateway(instance, gateway_ip_address=None, local_address_prefix=None, asn=None,
+                         bgp_peering_address=None, peer_weight=None, tags=None):
+
+    if any([asn, bgp_peering_address, peer_weight]):
+        if instance.bgp_settings is not None:
+            # update existing parameters selectively
+            if asn is not None:
+                instance.bgp_settings.asn = asn
+            if peer_weight is not None:
+                instance.bgp_settings.peer_weight = peer_weight
+            if bgp_peering_address is not None:
+                instance.bgp_settings.bgp_peering_address = bgp_peering_address
+        elif asn and bgp_peering_address:
+            from azure.mgmt.network.models import BgpSettings
+            instance.bgp_settings = BgpSettings(asn, bgp_peering_address, peer_weight)
+        else:
+            raise CLIError(
+                'incorrect usage: --asn ASN --bgp-peering-address IP [--peer-weight WEIGHT]')
+
+    if gateway_ip_address is not None:
+        instance.gateway_ip_address = gateway_ip_address
+    if local_address_prefix is not None:
+        instance.local_address_prefix = local_address_prefix
+    if tags is not None:
+        instance.tags = tags
+    return instance
+
+#endregion
+
 #region Traffic Manager Commands
 def list_traffic_manager_profiles(resource_group_name=None):
     ncf = get_mgmt_service_client(TrafficManagerManagementClient).profiles

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_local_gateway/azuredeploy.json
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_local_gateway/azuredeploy.json
@@ -2,11 +2,18 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "localAddressPrefix": {
+    "asn": {
       "type": "string",
-      "defaultValue": "192.168.0.0/16",
+      "defaultValue": "",
       "metadata": {
-        "description": "CIDR block representing the address space of the OnPremise VPN network's Subnet."
+        "description": "Autonomous System Number to use for the BGP settings."
+      }
+    },
+    "bgpPeeringAddress": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "IP address from the OnPremise VPN's subnet to use for BGP peering."
       }
     },
     "gatewayIpAddress": {
@@ -15,10 +22,24 @@
         "description": "Gateway's Public IP address.  (e.g. 10.1.1.1)"
       }
     },
+    "localAddressPrefix": {
+      "type": "array",
+      "defaultValue": [ ],
+      "metadata": {
+        "description": "List of CIDR block prefixes representing the address space of the OnPremise VPN's subnet."
+      }
+    },
     "localNetworkGatewayName": {
       "type": "string",
       "metadata": {
         "description": "Gateway name."
+      }
+    },
+    "peerWeight": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Weight added to routes learned through BGP peering."
       }
     },
     "tags": {
@@ -27,9 +48,14 @@
       "metadata": {
         "description": "Tags object."
       }
+    },
+    "useBgpSettings": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description":  "Flag to enable BGP settings."
+      }
     }
-  },
-  "variables": {
   },
   "resources": [
     {
@@ -40,12 +66,21 @@
       "tags": "[parameters('tags')]",
       "properties": {
         "localNetworkAddressSpace": {
-          "addressPrefixes": [
-            "[parameters('localAddressPrefix')]"
-          ]
+          "addressPrefixes": "[parameters('localAddressPrefix')]"
         },
-        "gatewayIpAddress": "[parameters('gatewayIpAddress')]"
+        "gatewayIpAddress": "[parameters('gatewayIpAddress')]",
+        "bgpSettings": "[variables('bgpProperties')[concat(parameters('useBgpSettings'))]]"
       }
     }
-  ]
+  ],
+  "variables": {
+    "bgpProperties": {
+      "true": {
+        "asn": "[parameters('asn')]",
+        "bgpPeeringAddress": "[parameters('bgpPeeringAddress')]",
+        "peerWeight": "[parameters('peerWeight')]"
+      },
+      "false": null
+    }
+  }
 }

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_local_gateway/lib/local_gateway_creation_client.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_local_gateway/lib/local_gateway_creation_client.py
@@ -24,7 +24,7 @@ class LocalGatewayCreationClientConfiguration(AzureConfiguration):
     Note that all parameters used to create this instance are saved as instance
     attributes.
 
-    :param credentials: Gets Azure subscription credentials.
+    :param credentials: Credentials needed for the client to connect to Azure.
     :type credentials: :mod:`A msrestazure Credentials
      object<msrestazure.azure_active_directory>`
     :param subscription_id: Gets subscription credentials which uniquely
@@ -85,7 +85,7 @@ class LocalGatewayCreationClient(object):
     :ivar local_gateway: LocalGateway operations
     :vartype local_gateway: .operations.LocalGatewayOperations
 
-    :param credentials: Gets Azure subscription credentials.
+    :param credentials: Credentials needed for the client to connect to Azure.
     :type credentials: :mod:`A msrestazure Credentials
      object<msrestazure.azure_active_directory>`
     :param subscription_id: Gets subscription credentials which uniquely

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_local_gateway/lib/models/basic_dependency.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_local_gateway/lib/models/basic_dependency.py
@@ -15,8 +15,7 @@ from msrest.serialization import Model
 
 
 class BasicDependency(Model):
-    """
-    Deployment dependency information.
+    """Deployment dependency information.
 
     :param id: Gets or sets the ID of the dependency.
     :type id: str

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_local_gateway/lib/models/dependency.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_local_gateway/lib/models/dependency.py
@@ -15,12 +15,11 @@ from msrest.serialization import Model
 
 
 class Dependency(Model):
-    """
-    Deployment dependency information.
+    """Deployment dependency information.
 
     :param depends_on: Gets the list of dependencies.
     :type depends_on: list of :class:`BasicDependency
-     <default.models.BasicDependency>`
+     <Default.models.BasicDependency>`
     :param id: Gets or sets the ID of the dependency.
     :type id: str
     :param resource_type: Gets or sets the dependency resource type.

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_local_gateway/lib/models/deployment_extended.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_local_gateway/lib/models/deployment_extended.py
@@ -15,8 +15,7 @@ from msrest.serialization import Model
 
 
 class DeploymentExtended(Model):
-    """
-    Deployment information.
+    """Deployment information.
 
     :param id: Gets or sets the ID of the deployment.
     :type id: str
@@ -24,7 +23,7 @@ class DeploymentExtended(Model):
     :type name: str
     :param properties: Gets or sets deployment properties.
     :type properties: :class:`DeploymentPropertiesExtended
-     <default.models.DeploymentPropertiesExtended>`
+     <Default.models.DeploymentPropertiesExtended>`
     """ 
 
     _validation = {

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_local_gateway/lib/models/deployment_local_gateway.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_local_gateway/lib/models/deployment_local_gateway.py
@@ -15,28 +15,37 @@ from msrest.serialization import Model
 
 
 class DeploymentLocalGateway(Model):
-    """
-    Deployment operation parameters.
+    """Deployment operation parameters.
 
     Variables are only populated by the server, and will be ignored when
     sending a request.
 
     :ivar uri: URI referencing the template. Default value:
-     "https://azuresdkci.blob.core.windows.net/templatehost/CreateLocalGateway_2016-08-08/azuredeploy.json"
+     "https://azuresdkci.blob.core.windows.net/templatehost/CreateLocalGateway_2016-11-28/azuredeploy.json"
      .
     :vartype uri: str
     :param content_version: If included it must match the ContentVersion in
      the template.
     :type content_version: str
+    :param asn: Autonomous System Number to use for the BGP settings.
+    :type asn: str
+    :param bgp_peering_address: IP address from the OnPremise VPN's subnet to
+     use for BGP peering.
+    :type bgp_peering_address: str
     :param gateway_ip_address: Gateway's Public IP address.  (e.g. 10.1.1.1)
     :type gateway_ip_address: str
-    :param local_address_prefix: CIDR block representing the address space of
-     the OnPremise VPN network's Subnet. Default value: "192.168.0.0/16" .
-    :type local_address_prefix: str
+    :param local_address_prefix: List of CIDR block prefixes representing the
+     address space of the OnPremise VPN's subnet.
+    :type local_address_prefix: list of object
     :param local_network_gateway_name: Gateway name.
     :type local_network_gateway_name: str
+    :param peer_weight: Weight added to routes learned through BGP peering.
+    :type peer_weight: str
     :param tags: Tags object.
     :type tags: object
+    :param use_bgp_settings: Flag to enable BGP settings. Default value:
+     False .
+    :type use_bgp_settings: bool
     :ivar mode: Gets or sets the deployment mode. Default value:
      "Incremental" .
     :vartype mode: str
@@ -46,26 +55,35 @@ class DeploymentLocalGateway(Model):
         'uri': {'required': True, 'constant': True},
         'gateway_ip_address': {'required': True},
         'local_network_gateway_name': {'required': True},
+        'use_bgp_settings': {'required': True},
         'mode': {'required': True, 'constant': True},
     }
 
     _attribute_map = {
         'uri': {'key': 'properties.templateLink.uri', 'type': 'str'},
         'content_version': {'key': 'properties.templateLink.contentVersion', 'type': 'str'},
+        'asn': {'key': 'properties.parameters.asn.value', 'type': 'str'},
+        'bgp_peering_address': {'key': 'properties.parameters.bgpPeeringAddress.value', 'type': 'str'},
         'gateway_ip_address': {'key': 'properties.parameters.gatewayIpAddress.value', 'type': 'str'},
-        'local_address_prefix': {'key': 'properties.parameters.localAddressPrefix.value', 'type': 'str'},
+        'local_address_prefix': {'key': 'properties.parameters.localAddressPrefix.value', 'type': '[object]'},
         'local_network_gateway_name': {'key': 'properties.parameters.localNetworkGatewayName.value', 'type': 'str'},
+        'peer_weight': {'key': 'properties.parameters.peerWeight.value', 'type': 'str'},
         'tags': {'key': 'properties.parameters.tags.value', 'type': 'object'},
+        'use_bgp_settings': {'key': 'properties.parameters.useBgpSettings.value', 'type': 'bool'},
         'mode': {'key': 'properties.mode', 'type': 'str'},
     }
 
-    uri = "https://azuresdkci.blob.core.windows.net/templatehost/CreateLocalGateway_2016-08-08/azuredeploy.json"
+    uri = "https://azuresdkci.blob.core.windows.net/templatehost/CreateLocalGateway_2016-11-28/azuredeploy.json"
 
     mode = "Incremental"
 
-    def __init__(self, gateway_ip_address, local_network_gateway_name, content_version=None, local_address_prefix="192.168.0.0/16", tags=None):
+    def __init__(self, gateway_ip_address, local_network_gateway_name, content_version=None, asn=None, bgp_peering_address=None, local_address_prefix=None, peer_weight=None, tags=None, use_bgp_settings=False):
         self.content_version = content_version
+        self.asn = asn
+        self.bgp_peering_address = bgp_peering_address
         self.gateway_ip_address = gateway_ip_address
         self.local_address_prefix = local_address_prefix
         self.local_network_gateway_name = local_network_gateway_name
+        self.peer_weight = peer_weight
         self.tags = tags
+        self.use_bgp_settings = use_bgp_settings

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_local_gateway/lib/models/deployment_properties_extended.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_local_gateway/lib/models/deployment_properties_extended.py
@@ -15,8 +15,7 @@ from msrest.serialization import Model
 
 
 class DeploymentPropertiesExtended(Model):
-    """
-    Deployment properties with additional details.
+    """Deployment properties with additional details.
 
     :param provisioning_state: Gets or sets the state of the provisioning.
     :type provisioning_state: str
@@ -29,27 +28,26 @@ class DeploymentPropertiesExtended(Model):
     :type outputs: object
     :param providers: Gets the list of resource providers needed for the
      deployment.
-    :type providers: list of :class:`Provider <default.models.Provider>`
+    :type providers: list of :class:`Provider <Default.models.Provider>`
     :param dependencies: Gets the list of deployment dependencies.
     :type dependencies: list of :class:`Dependency
-     <default.models.Dependency>`
+     <Default.models.Dependency>`
     :param template: Gets or sets the template content. Use only one of
      Template or TemplateLink.
     :type template: object
     :param template_link: Gets or sets the URI referencing the template. Use
      only one of Template or TemplateLink.
-    :type template_link: :class:`TemplateLink <default.models.TemplateLink>`
+    :type template_link: :class:`TemplateLink <Default.models.TemplateLink>`
     :param parameters: Deployment parameters. Use only one of Parameters or
      ParametersLink.
     :type parameters: object
     :param parameters_link: Gets or sets the URI referencing the parameters.
      Use only one of Parameters or ParametersLink.
     :type parameters_link: :class:`ParametersLink
-     <default.models.ParametersLink>`
+     <Default.models.ParametersLink>`
     :param mode: Gets or sets the deployment mode. Possible values include:
      'Incremental', 'Complete'
-    :type mode: str or :class:`DeploymentMode
-     <localgatewaycreationclient.models.DeploymentMode>`
+    :type mode: str or :class:`DeploymentMode <Default.models.DeploymentMode>`
     """ 
 
     _attribute_map = {

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_local_gateway/lib/models/parameters_link.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_local_gateway/lib/models/parameters_link.py
@@ -15,8 +15,7 @@ from msrest.serialization import Model
 
 
 class ParametersLink(Model):
-    """
-    Entity representing the reference to the deployment paramaters.
+    """Entity representing the reference to the deployment paramaters.
 
     :param uri: URI referencing the template.
     :type uri: str

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_local_gateway/lib/models/provider.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_local_gateway/lib/models/provider.py
@@ -15,8 +15,7 @@ from msrest.serialization import Model
 
 
 class Provider(Model):
-    """
-    Resource provider information.
+    """Resource provider information.
 
     :param id: Gets or sets the provider id.
     :type id: str
@@ -28,7 +27,7 @@ class Provider(Model):
     :param resource_types: Gets or sets the collection of provider resource
      types.
     :type resource_types: list of :class:`ProviderResourceType
-     <default.models.ProviderResourceType>`
+     <Default.models.ProviderResourceType>`
     """ 
 
     _attribute_map = {

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_local_gateway/lib/models/provider_resource_type.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_local_gateway/lib/models/provider_resource_type.py
@@ -15,8 +15,7 @@ from msrest.serialization import Model
 
 
 class ProviderResourceType(Model):
-    """
-    Resource type managed by the resource provider.
+    """Resource type managed by the resource provider.
 
     :param resource_type: Gets or sets the resource type.
     :type resource_type: str

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_local_gateway/lib/models/template_link.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_local_gateway/lib/models/template_link.py
@@ -15,14 +15,13 @@ from msrest.serialization import Model
 
 
 class TemplateLink(Model):
-    """
-    Entity representing the reference to the template.
+    """Entity representing the reference to the template.
 
     Variables are only populated by the server, and will be ignored when
     sending a request.
 
     :ivar uri: URI referencing the template. Default value:
-     "https://azuresdkci.blob.core.windows.net/templatehost/CreateLocalGateway_2016-08-08/azuredeploy.json"
+     "https://azuresdkci.blob.core.windows.net/templatehost/CreateLocalGateway_2016-11-28/azuredeploy.json"
      .
     :vartype uri: str
     :param content_version: If included it must match the ContentVersion in
@@ -39,7 +38,7 @@ class TemplateLink(Model):
         'content_version': {'key': 'contentVersion', 'type': 'str'},
     }
 
-    uri = "https://azuresdkci.blob.core.windows.net/templatehost/CreateLocalGateway_2016-08-08/azuredeploy.json"
+    uri = "https://azuresdkci.blob.core.windows.net/templatehost/CreateLocalGateway_2016-11-28/azuredeploy.json"
 
     def __init__(self, content_version=None):
         self.content_version = content_version

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_local_gateway/lib/operations/local_gateway_operations.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_local_gateway/lib/operations/local_gateway_operations.py
@@ -37,9 +37,8 @@ class LocalGatewayOperations(object):
         self.config = config
 
     def create_or_update(
-            self, resource_group_name, deployment_name, gateway_ip_address, local_network_gateway_name, content_version=None, local_address_prefix="192.168.0.0/16", tags=None, custom_headers=None, raw=False, **operation_config):
-        """
-        Create or update a virtual machine.
+            self, resource_group_name, deployment_name, gateway_ip_address, local_network_gateway_name, use_bgp_settings=False, content_version=None, asn=None, bgp_peering_address=None, local_address_prefix=None, peer_weight=None, tags=None, custom_headers=None, raw=False, **operation_config):
+        """Create a new LocalGateway.
 
         :param resource_group_name: The name of the resource group. The name
          is case insensitive.
@@ -51,12 +50,22 @@ class LocalGatewayOperations(object):
         :type gateway_ip_address: str
         :param local_network_gateway_name: Gateway name.
         :type local_network_gateway_name: str
+        :param use_bgp_settings: Flag to enable BGP settings.
+        :type use_bgp_settings: bool
         :param content_version: If included it must match the ContentVersion
          in the template.
         :type content_version: str
-        :param local_address_prefix: CIDR block representing the address
-         space of the OnPremise VPN network's Subnet.
-        :type local_address_prefix: str
+        :param asn: Autonomous System Number to use for the BGP settings.
+        :type asn: str
+        :param bgp_peering_address: IP address from the OnPremise VPN's
+         subnet to use for BGP peering.
+        :type bgp_peering_address: str
+        :param local_address_prefix: List of CIDR block prefixes representing
+         the address space of the OnPremise VPN's subnet.
+        :type local_address_prefix: list of object
+        :param peer_weight: Weight added to routes learned through BGP
+         peering.
+        :type peer_weight: str
         :param tags: Tags object.
         :type tags: object
         :param dict custom_headers: headers that will be added to the request
@@ -65,11 +74,11 @@ class LocalGatewayOperations(object):
         :rtype:
          :class:`AzureOperationPoller<msrestazure.azure_operation.AzureOperationPoller>`
          instance that returns :class:`DeploymentExtended
-         <default.models.DeploymentExtended>`
+         <Default.models.DeploymentExtended>`
         :rtype: :class:`ClientRawResponse<msrest.pipeline.ClientRawResponse>`
          if raw=true
         """
-        parameters = models.DeploymentLocalGateway(content_version=content_version, gateway_ip_address=gateway_ip_address, local_address_prefix=local_address_prefix, local_network_gateway_name=local_network_gateway_name, tags=tags)
+        parameters = models.DeploymentLocalGateway(content_version=content_version, asn=asn, bgp_peering_address=bgp_peering_address, gateway_ip_address=gateway_ip_address, local_address_prefix=local_address_prefix, local_network_gateway_name=local_network_gateway_name, peer_weight=peer_weight, tags=tags, use_bgp_settings=use_bgp_settings)
 
         # Construct URL
         url = '/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Resources/deployments/{deploymentName}'

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_local_gateway/swagger_create_local_gateway.json
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_local_gateway/swagger_create_local_gateway.json
@@ -1,443 +1,506 @@
 {
-  "swagger": "2.0", 
+  "swagger": "2.0",
   "info": {
-    "title": "LocalGatewayCreationClient", 
+    "title": "LocalGatewayCreationClient",
     "version": "2015-11-01"
-  }, 
-  "host": "management.azure.com", 
+  },
+  "host": "management.azure.com",
   "schemes": [
     "https"
-  ], 
+  ],
   "consumes": [
     "application/json"
-  ], 
+  ],
   "produces": [
     "application/json"
-  ], 
+  ],
   "security": [
     {
       "azure_auth": [
         "user_impersonation"
       ]
     }
-  ], 
+  ],
   "securityDefinitions": {
     "azure_auth": {
-      "type": "oauth2", 
-      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize", 
-      "flow": "implicit", 
-      "description": "Azure Active Directory OAuth2 Flow", 
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
       "scopes": {
         "user_impersonation": "impersonate your user account"
       }
     }
-  }, 
+  },
   "paths": {
     "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Resources/deployments/{deploymentName}": {
       "put": {
         "tags": [
           "LocalGateway"
-        ], 
-        "operationId": "LocalGateway_CreateOrUpdate", 
-        "description": "Create or update a virtual machine.", 
+        ],
+        "operationId": "LocalGateway_CreateOrUpdate",
+        "description": "Create a new LocalGateway.",
         "parameters": [
           {
-            "name": "resourceGroupName", 
-            "in": "path", 
-            "required": true, 
-            "type": "string", 
-            "description": "The name of the resource group. The name is case insensitive.", 
-            "pattern": "^[-\\w\\._]+$", 
-            "minLength": 1, 
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group. The name is case insensitive.",
+            "pattern": "^[-\\w\\._]+$",
+            "minLength": 1,
             "maxLength": 64
-          }, 
+          },
           {
-            "name": "deploymentName", 
-            "in": "path", 
-            "required": true, 
-            "type": "string", 
-            "description": "The name of the deployment.", 
-            "pattern": "^[-\\w\\._]+$", 
-            "minLength": 1, 
+            "name": "deploymentName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the deployment.",
+            "pattern": "^[-\\w\\._]+$",
+            "minLength": 1,
             "maxLength": 64
-          }, 
+          },
           {
-            "name": "parameters", 
-            "x-ms-client-flatten": true, 
-            "in": "body", 
-            "required": true, 
+            "name": "parameters",
+            "x-ms-client-flatten": true,
+            "in": "body",
+            "required": true,
             "schema": {
               "$ref": "#/definitions/Deployment_LocalGateway"
-            }, 
+            },
             "description": "Additional parameters supplied to the operation."
-          }, 
+          },
           {
             "$ref": "#/parameters/ApiVersionParameter"
-          }, 
+          },
           {
             "$ref": "#/parameters/SubscriptionIdParameter"
           }
-        ], 
+        ],
         "responses": {
           "200": {
-            "description": "", 
+            "description": "",
             "schema": {
               "$ref": "#/definitions/DeploymentExtended"
             }
-          }, 
+          },
           "201": {
-            "description": "", 
+            "description": "",
             "schema": {
               "$ref": "#/definitions/DeploymentExtended"
             }
           }
-        }, 
+        },
         "x-ms-long-running-operation": true
       }
     }
-  }, 
+  },
   "definitions": {
     "Deployment_LocalGateway": {
       "properties": {
         "properties": {
-          "$ref": "#/definitions/DeploymentProperties_LocalGateway", 
-          "description": "Gets or sets the deployment properties.", 
+          "$ref": "#/definitions/DeploymentProperties_LocalGateway",
+          "description": "Gets or sets the deployment properties.",
           "x-ms-client-flatten": true
         }
-      }, 
+      },
       "description": "Deployment operation parameters."
-    }, 
+    },
     "DeploymentProperties_LocalGateway": {
       "properties": {
         "templateLink": {
-          "$ref": "#/definitions/TemplateLink", 
-          "description": "Gets or sets the URI referencing the template. Use only one of Template or TemplateLink.", 
+          "$ref": "#/definitions/TemplateLink",
+          "description": "Gets or sets the URI referencing the template. Use only one of Template or TemplateLink.",
           "x-ms-client-flatten": true
-        }, 
+        },
         "parameters": {
-          "$ref": "#/definitions/LocalGatewayParameters", 
-          "type": "object", 
-          "description": "Deployment parameters. Use only one of Parameters or ParametersLink.", 
+          "$ref": "#/definitions/LocalGatewayParameters",
+          "type": "object",
+          "description": "Deployment parameters. Use only one of Parameters or ParametersLink.",
           "x-ms-client-flatten": true
-        }, 
+        },
         "mode": {
-          "type": "string", 
-          "description": "Gets or sets the deployment mode.", 
+          "type": "string",
+          "description": "Gets or sets the deployment mode.",
           "enum": [
             "Incremental"
-          ], 
+          ],
           "x-ms-enum": {
-            "name": "DeploymentMode", 
+            "name": "DeploymentMode",
             "modelAsString": false
           }
         }
-      }, 
+      },
       "required": [
-        "templateLink", 
-        "parameters", 
+        "templateLink",
+        "parameters",
         "mode"
-      ], 
+      ],
       "description": "Deployment properties."
-    }, 
+    },
     "TemplateLink": {
       "properties": {
         "uri": {
-          "type": "string", 
-          "description": "URI referencing the template.", 
+          "type": "string",
+          "description": "URI referencing the template.",
           "enum": [
-            "https://azuresdkci.blob.core.windows.net/templatehost/CreateLocalGateway_2016-08-08/azuredeploy.json"
+            "https://azuresdkci.blob.core.windows.net/templatehost/CreateLocalGateway_2016-11-28/azuredeploy.json"
           ]
-        }, 
+        },
         "contentVersion": {
-          "type": "string", 
+          "type": "string",
           "description": "If included it must match the ContentVersion in the template."
         }
-      }, 
+      },
       "required": [
         "uri"
-      ], 
+      ],
       "description": "Entity representing the reference to the template."
-    }, 
+    },
     "LocalGatewayParameters": {
       "properties": {
+        "asn": {
+          "type": "object",
+          "$ref": "#/definitions/DeploymentParameter_asn",
+          "x-ms-client-flatten": true
+        },
+        "bgpPeeringAddress": {
+          "type": "object",
+          "$ref": "#/definitions/DeploymentParameter_bgpPeeringAddress",
+          "x-ms-client-flatten": true
+        },
         "gatewayIpAddress": {
-          "type": "object", 
-          "$ref": "#/definitions/DeploymentParameter_gatewayIpAddress", 
+          "type": "object",
+          "$ref": "#/definitions/DeploymentParameter_gatewayIpAddress",
           "x-ms-client-flatten": true
-        }, 
+        },
         "localAddressPrefix": {
-          "type": "object", 
-          "$ref": "#/definitions/DeploymentParameter_localAddressPrefix", 
+          "type": "object",
+          "$ref": "#/definitions/DeploymentParameter_localAddressPrefix",
           "x-ms-client-flatten": true
-        }, 
+        },
         "localNetworkGatewayName": {
-          "type": "object", 
-          "$ref": "#/definitions/DeploymentParameter_localNetworkGatewayName", 
+          "type": "object",
+          "$ref": "#/definitions/DeploymentParameter_localNetworkGatewayName",
           "x-ms-client-flatten": true
-        }, 
+        },
+        "peerWeight": {
+          "type": "object",
+          "$ref": "#/definitions/DeploymentParameter_peerWeight",
+          "x-ms-client-flatten": true
+        },
         "tags": {
-          "type": "object", 
-          "$ref": "#/definitions/DeploymentParameter_tags", 
+          "type": "object",
+          "$ref": "#/definitions/DeploymentParameter_tags",
+          "x-ms-client-flatten": true
+        },
+        "useBgpSettings": {
+          "type": "object",
+          "$ref": "#/definitions/DeploymentParameter_useBgpSettings",
           "x-ms-client-flatten": true
         }
-      }, 
+      },
       "required": [
-        "localNetworkGatewayName", 
+        "localNetworkGatewayName",
+        "useBgpSettings",
         "gatewayIpAddress"
       ]
-    }, 
+    },
+    "DeploymentParameter_asn": {
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "Autonomous System Number to use for the BGP settings.",
+          "x-ms-client-name": "asn"
+        }
+      }
+    },
+    "DeploymentParameter_bgpPeeringAddress": {
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "IP address from the OnPremise VPN's subnet to use for BGP peering.",
+          "x-ms-client-name": "bgpPeeringAddress"
+        }
+      }
+    },
     "DeploymentParameter_gatewayIpAddress": {
       "properties": {
         "value": {
-          "type": "string", 
-          "description": "Gateway's Public IP address.  (e.g. 10.1.1.1)", 
+          "type": "string",
+          "description": "Gateway's Public IP address.  (e.g. 10.1.1.1)",
           "x-ms-client-name": "gatewayIpAddress"
         }
-      }, 
+      },
       "required": [
         "value"
       ]
-    }, 
+    },
     "DeploymentParameter_localAddressPrefix": {
       "properties": {
         "value": {
-          "type": "string", 
-          "description": "CIDR block representing the address space of the OnPremise VPN network's Subnet.", 
-          "x-ms-client-name": "localAddressPrefix", 
-          "default": "192.168.0.0/16"
+          "type": "array",
+          "items": {
+            "type": "object"
+          },
+          "description": "List of CIDR block prefixes representing the address space of the OnPremise VPN's subnet.",
+          "x-ms-client-name": "localAddressPrefix"
         }
       }
-    }, 
+    },
     "DeploymentParameter_localNetworkGatewayName": {
       "properties": {
         "value": {
-          "type": "string", 
-          "description": "Gateway name.", 
+          "type": "string",
+          "description": "Gateway name.",
           "x-ms-client-name": "localNetworkGatewayName"
         }
-      }, 
+      },
       "required": [
         "value"
       ]
-    }, 
+    },
+    "DeploymentParameter_peerWeight": {
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "Weight added to routes learned through BGP peering.",
+          "x-ms-client-name": "peerWeight"
+        }
+      }
+    },
     "DeploymentParameter_tags": {
       "properties": {
         "value": {
-          "type": "object", 
-          "description": "Tags object.", 
+          "type": "object",
+          "description": "Tags object.",
           "x-ms-client-name": "tags"
         }
       }
-    }, 
+    },
+    "DeploymentParameter_useBgpSettings": {
+      "properties": {
+        "value": {
+          "type": "boolean",
+          "description": "Flag to enable BGP settings.",
+          "x-ms-client-name": "useBgpSettings",
+          "default": "False"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
     "ParametersLink": {
       "properties": {
         "uri": {
-          "type": "string", 
+          "type": "string",
           "description": "URI referencing the template."
-        }, 
+        },
         "contentVersion": {
-          "type": "string", 
+          "type": "string",
           "description": "If included it must match the ContentVersion in the template."
         }
-      }, 
+      },
       "required": [
         "uri"
-      ], 
+      ],
       "description": "Entity representing the reference to the deployment paramaters."
-    }, 
+    },
     "ProviderResourceType": {
       "properties": {
         "resourceType": {
-          "type": "string", 
+          "type": "string",
           "description": "Gets or sets the resource type."
-        }, 
+        },
         "locations": {
-          "type": "array", 
+          "type": "array",
           "items": {
             "type": "string"
-          }, 
+          },
           "description": "Gets or sets the collection of locations where this resource type can be created in."
-        }, 
+        },
         "apiVersions": {
-          "type": "array", 
+          "type": "array",
           "items": {
             "type": "string"
-          }, 
+          },
           "description": "Gets or sets the api version."
-        }, 
+        },
         "properties": {
-          "type": "object", 
+          "type": "object",
           "additionalProperties": {
             "type": "string"
-          }, 
+          },
           "description": "Gets or sets the properties."
         }
-      }, 
+      },
       "description": "Resource type managed by the resource provider."
-    }, 
+    },
     "Provider": {
       "properties": {
         "id": {
-          "type": "string", 
+          "type": "string",
           "description": "Gets or sets the provider id."
-        }, 
+        },
         "namespace": {
-          "type": "string", 
+          "type": "string",
           "description": "Gets or sets the namespace of the provider."
-        }, 
+        },
         "registrationState": {
-          "type": "string", 
+          "type": "string",
           "description": "Gets or sets the registration state of the provider."
-        }, 
+        },
         "resourceTypes": {
-          "type": "array", 
+          "type": "array",
           "items": {
             "$ref": "#/definitions/ProviderResourceType"
-          }, 
+          },
           "description": "Gets or sets the collection of provider resource types."
         }
-      }, 
+      },
       "description": "Resource provider information."
-    }, 
+    },
     "BasicDependency": {
       "properties": {
         "id": {
-          "type": "string", 
+          "type": "string",
           "description": "Gets or sets the ID of the dependency."
-        }, 
+        },
         "resourceType": {
-          "type": "string", 
+          "type": "string",
           "description": "Gets or sets the dependency resource type."
-        }, 
+        },
         "resourceName": {
-          "type": "string", 
+          "type": "string",
           "description": "Gets or sets the dependency resource name."
         }
-      }, 
+      },
       "description": "Deployment dependency information."
-    }, 
+    },
     "Dependency": {
       "properties": {
         "dependsOn": {
-          "type": "array", 
+          "type": "array",
           "items": {
             "$ref": "#/definitions/BasicDependency"
-          }, 
+          },
           "description": "Gets the list of dependencies."
-        }, 
+        },
         "id": {
-          "type": "string", 
+          "type": "string",
           "description": "Gets or sets the ID of the dependency."
-        }, 
+        },
         "resourceType": {
-          "type": "string", 
+          "type": "string",
           "description": "Gets or sets the dependency resource type."
-        }, 
+        },
         "resourceName": {
-          "type": "string", 
+          "type": "string",
           "description": "Gets or sets the dependency resource name."
         }
-      }, 
+      },
       "description": "Deployment dependency information."
-    }, 
+    },
     "DeploymentPropertiesExtended": {
       "properties": {
         "provisioningState": {
-          "type": "string", 
+          "type": "string",
           "description": "Gets or sets the state of the provisioning."
-        }, 
+        },
         "correlationId": {
-          "type": "string", 
+          "type": "string",
           "description": "Gets or sets the correlation ID of the deployment."
-        }, 
+        },
         "timestamp": {
-          "type": "string", 
-          "format": "date-time", 
+          "type": "string",
+          "format": "date-time",
           "description": "Gets or sets the timestamp of the template deployment."
-        }, 
+        },
         "outputs": {
-          "type": "object", 
+          "type": "object",
           "description": "Gets or sets key/value pairs that represent deploymentoutput."
-        }, 
+        },
         "providers": {
-          "type": "array", 
+          "type": "array",
           "items": {
             "$ref": "#/definitions/Provider"
-          }, 
+          },
           "description": "Gets the list of resource providers needed for the deployment."
-        }, 
+        },
         "dependencies": {
-          "type": "array", 
+          "type": "array",
           "items": {
             "$ref": "#/definitions/Dependency"
-          }, 
+          },
           "description": "Gets the list of deployment dependencies."
-        }, 
+        },
         "template": {
-          "type": "object", 
+          "type": "object",
           "description": "Gets or sets the template content. Use only one of Template or TemplateLink."
-        }, 
+        },
         "TemplateLink": {
-          "$ref": "#/definitions/TemplateLink", 
+          "$ref": "#/definitions/TemplateLink",
           "description": "Gets or sets the URI referencing the template. Use only one of Template or TemplateLink."
-        }, 
+        },
         "parameters": {
-          "type": "object", 
+          "type": "object",
           "description": "Deployment parameters. Use only one of Parameters or ParametersLink."
-        }, 
+        },
         "parametersLink": {
-          "$ref": "#/definitions/ParametersLink", 
+          "$ref": "#/definitions/ParametersLink",
           "description": "Gets or sets the URI referencing the parameters. Use only one of Parameters or ParametersLink."
-        }, 
+        },
         "mode": {
-          "type": "string", 
-          "description": "Gets or sets the deployment mode.", 
+          "type": "string",
+          "description": "Gets or sets the deployment mode.",
           "enum": [
-            "Incremental", 
+            "Incremental",
             "Complete"
-          ], 
+          ],
           "x-ms-enum": {
-            "name": "DeploymentMode", 
+            "name": "DeploymentMode",
             "modelAsString": false
           }
         }
-      }, 
+      },
       "description": "Deployment properties with additional details."
-    }, 
+    },
     "DeploymentExtended": {
       "properties": {
         "id": {
-          "type": "string", 
+          "type": "string",
           "description": "Gets or sets the ID of the deployment."
-        }, 
+        },
         "name": {
-          "type": "string", 
+          "type": "string",
           "description": "Gets or sets the name of the deployment."
-        }, 
+        },
         "properties": {
-          "$ref": "#/definitions/DeploymentPropertiesExtended", 
+          "$ref": "#/definitions/DeploymentPropertiesExtended",
           "description": "Gets or sets deployment properties."
         }
-      }, 
+      },
       "required": [
         "name"
-      ], 
+      ],
       "description": "Deployment information."
     }
-  }, 
+  },
   "parameters": {
     "SubscriptionIdParameter": {
-      "name": "subscriptionId", 
-      "in": "path", 
-      "required": true, 
-      "type": "string", 
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
       "description": "Gets subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
-    }, 
+    },
     "ApiVersionParameter": {
-      "name": "api-version", 
-      "in": "query", 
-      "required": true, 
-      "type": "string", 
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
       "description": "Client Api Version."
     }
   }


### PR DESCRIPTION
Fixes #1416. Fixes #1435. Adds parameters to `network local-gateway create` to support setting BGP settings at creation. Additionally, exposes the same parameters as convenience arguments on the update command. Adds a table transformer for the list command to match Xplat's list format.
