### PR TITLE
Fix Ambiguity When Using Names and --IDS

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -123,7 +123,7 @@ def add_id_parameters(command_table):
                                     "Property '%s=%s' being overriden by value '%s' from IDs parameter.", # pylint: disable=line-too-long
                                     arg.name, existing_values, parts[arg.id_part]
                                 )
-                                existing_values = [existing_values] # pylint: disable=redefined-variable-type
+                                existing_values = [parts[arg.id_part]] # pylint: disable=redefined-variable-type
                             setattr(namespace, arg.name, existing_values)
                 except Exception as ex:
                     raise ValueError(ex)

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -117,7 +117,13 @@ def add_id_parameters(command_table):
                             existing_values = getattr(namespace, arg.name, None)
                             if existing_values is None:
                                 existing_values = IterateValue()
-                            existing_values.append(parts[arg.id_part])
+                                existing_values.append(parts[arg.id_part])
+                            elif isinstance(existing_values, str):
+                                logger.warning(
+                                    "Property '%s=%s' being overriden by value '%s' from IDs parameter.", # pylint: disable=line-too-long
+                                    arg.name, existing_values, parts[arg.id_part]
+                                )
+                                existing_values = [existing_values] # pylint: disable=redefined-variable-type
                             setattr(namespace, arg.name, existing_values)
                 except Exception as ex:
                     raise ValueError(ex)

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -123,7 +123,8 @@ def add_id_parameters(command_table):
                                     "Property '%s=%s' being overriden by value '%s' from IDs parameter.", # pylint: disable=line-too-long
                                     arg.name, existing_values, parts[arg.id_part]
                                 )
-                                existing_values = [parts[arg.id_part]] # pylint: disable=redefined-variable-type
+                                existing_values = IterateValue()
+                                existing_values.append(parts[arg.id_part])
                             setattr(namespace, arg.name, existing_values)
                 except Exception as ex:
                     raise ValueError(ex)


### PR DESCRIPTION
Fixes #793 and fixes issue seen in PR #1426. 

Previously, the logic of the IDs parameter would have unpredictable and ambiguous results if you supplied --ids along with --foo-name. In PR #1426, the team wishes to have a default value for one of the name parameters, which means that name component will always have a value even if --ids is used. In that case, it caused a crash.

This PR checks for an existing value and explicitly overwrites it if exists, logging a warning. Absent some mechanism to know whether a parameter was populated by the user or a default value (technically there is one but it's so ugly so as not to recommend anyone do it) this is reasonable compromise.