### PR TITLE
Use nosetests to run azure-cli core tests in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ script:
   - export PYTHONPATH=$PATHONPATH:./src
   - python -m azure.cli -h
   - python ./scripts/run_pylint.py
-  - python -m unittest discover -s src/azure-cli/azure/cli/tests --buffer
-  - python -m unittest discover -s src/azure-cli-core/azure/cli/core/tests --buffer
+  - nosetests -v --processes=-1 --process-timeout=600 -w src/azure-cli/azure/cli/tests
+  - nosetests -v --processes=-1 --process-timeout=600 -w src/azure-cli-core/azure/cli/core/tests
   - python scripts/command_modules/test.py
   - sh scripts/package_verify.sh
   - python scripts/license/verify.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ argcomplete==1.3.0
 colorama==0.3.7
 jmespath
 mock==1.3.0
+nose==1.3.7
 paramiko==2.0.2
 pip
 pygments==2.1.3
@@ -14,4 +15,3 @@ requests==2.9.1
 six==1.10.0
 tabulate==0.7.5
 vcrpy==1.10.3
-nose

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ requests==2.9.1
 six==1.10.0
 tabulate==0.7.5
 vcrpy==1.10.3
+nose


### PR DESCRIPTION
reduce test time for 20 seconds