### PR TITLE
[Component] Prevent the use of ‘component’ commands in dev mode

### DIFF
--- a/scripts/nightly/nightly-build.sh
+++ b/scripts/nightly/nightly-build.sh
@@ -5,10 +5,10 @@ cd azure-cli
 
 # modify versions of the packages (__init__.py and setup.py files)
 for initfile in src/azure-cli/azure/cli/__init__.py src/azure-cli-core/azure/cli/core/__init__.py; \
-    do sed -i 's/^__version__ = [\x22\x27]\(.*\)[\x22\x27]/__version__ = \x27\1+1.dev'$(date +%Y%m%d)'\x27/' $initfile; \
+    do sed -i 's/^__version__ = [\x22\x27]\(.*\)+dev[\x22\x27]/__version__ = \x27\1+1.dev'$(date +%Y%m%d)'\x27/' $initfile; \
     done;
 for d in src/azure-cli/ src/azure-cli-core/ src/azure-cli-nspkg/ src/command_modules/azure-cli-*/; \
-    do sed -i 's/^VERSION = [\x22\x27]\(.*\)[\x22\x27]/VERSION = \x27\1+1.dev'$(date +%Y%m%d)'\x27/' $d/setup.py; \
+    do sed -i 's/^VERSION = [\x22\x27]\(.*\)+dev[\x22\x27]/VERSION = \x27\1+1.dev'$(date +%Y%m%d)'\x27/' $d/setup.py; \
     done;
 
 pip install azure-storage==0.33.0

--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -5,4 +5,4 @@
 import pkg_resources
 pkg_resources.declare_namespace(__name__)
 
-__version__ = "0.1.0b10"
+__version__ = "0.1.0b10+dev"

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -9,7 +9,7 @@ from __future__ import print_function
 from codecs import open
 from setuptools import setup
 
-VERSION = "0.1.0b10"
+VERSION = "0.1.0b10+dev"
 
 # If we have source, validate that our version numbers match
 # This should prevent uploading releases with mismatched versions.

--- a/src/azure-cli/azure/cli/__init__.py
+++ b/src/azure-cli/azure/cli/__init__.py
@@ -11,4 +11,4 @@ import pkg_resources
 pkg_resources.declare_namespace(__name__)
 
 __author__ = "Microsoft Corporation <python@microsoft.com>"
-__version__ = "0.1.0b10"
+__version__ = "0.1.0b10+dev"

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -9,7 +9,7 @@ from __future__ import print_function
 from codecs import open
 from setuptools import setup
 
-VERSION = "0.1.0b10"
+VERSION = "0.1.0b10+dev"
 
 # If we have source, validate that our version numbers match
 # This should prevent uploading releases with mismatched versions.

--- a/src/command_modules/azure-cli-acr/setup.py
+++ b/src/command_modules/azure-cli-acr/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup
 
-VERSION = '0.1.0b10'
+VERSION = '0.1.0b10+dev'
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',

--- a/src/command_modules/azure-cli-acs/setup.py
+++ b/src/command_modules/azure-cli-acs/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup
 
-VERSION = '0.1.0b10'
+VERSION = '0.1.0b10+dev'
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',

--- a/src/command_modules/azure-cli-appservice/setup.py
+++ b/src/command_modules/azure-cli-appservice/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup
 
-VERSION = '0.1.0b10'
+VERSION = '0.1.0b10+dev'
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',

--- a/src/command_modules/azure-cli-cloud/setup.py
+++ b/src/command_modules/azure-cli-cloud/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup
 
-VERSION = '0.1.0b10'
+VERSION = '0.1.0b10+dev'
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',

--- a/src/command_modules/azure-cli-component/azure/cli/command_modules/component/custom.py
+++ b/src/command_modules/azure-cli-component/azure/cli/command_modules/component/custom.py
@@ -14,8 +14,15 @@ logger = _logging.get_az_logger(__name__)
 CLI_PACKAGE_NAME = 'azure-cli'
 COMPONENT_PREFIX = 'azure-cli-'
 
+def _verify_not_dev():
+    from azure.cli.core import __version__ as core_version
+    dev_version = core_version.endswith('+dev')
+    if dev_version:
+        raise CLIError('This operation is not available in the developer version of the CLI.')
+
 def list_components():
     """ List the installed components """
+    _verify_not_dev()
     import pip
     return sorted([{'name': dist.key.replace(COMPONENT_PREFIX, ''), 'version': dist.version}
                    for dist in pip.get_installed_distributions(local_only=True)
@@ -23,6 +30,7 @@ def list_components():
 
 def list_available_components():
     """ List publicly available components that can be installed """
+    _verify_not_dev()
     import pip
     available_components = []
     installed_component_names = [dist.key.replace(COMPONENT_PREFIX, '') \
@@ -51,6 +59,7 @@ def list_available_components():
 
 def remove(component_name):
     """ Remove a component """
+    _verify_not_dev()
     if component_name in ['nspkg', 'core']:
         raise CLIError("This component cannot be removed, it is required for the CLI to function.")
     import pip
@@ -103,6 +112,7 @@ def _install_or_update(package_list, link, private, pre):
 
 def update(private=False, pre=False, link=None, additional_components=None):
     """ Update the CLI and all installed components """
+    _verify_not_dev()
     import pip
     # Update the CLI itself
     package_list = [CLI_PACKAGE_NAME]

--- a/src/command_modules/azure-cli-component/setup.py
+++ b/src/command_modules/azure-cli-component/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup
 
-VERSION = '0.1.0b10'
+VERSION = '0.1.0b10+dev'
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',

--- a/src/command_modules/azure-cli-configure/setup.py
+++ b/src/command_modules/azure-cli-configure/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup
 
-VERSION = '0.1.0b10'
+VERSION = '0.1.0b10+dev'
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',

--- a/src/command_modules/azure-cli-container/setup.py
+++ b/src/command_modules/azure-cli-container/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup
 
-VERSION = '0.1.0b10'
+VERSION = '0.1.0b10+dev'
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',

--- a/src/command_modules/azure-cli-context/setup.py
+++ b/src/command_modules/azure-cli-context/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup
 
-VERSION = '0.1.0b10'
+VERSION = '0.1.0b10+dev'
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',

--- a/src/command_modules/azure-cli-feedback/setup.py
+++ b/src/command_modules/azure-cli-feedback/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup
 
-VERSION = '0.1.0b10'
+VERSION = '0.1.0b10+dev'
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',

--- a/src/command_modules/azure-cli-iot/setup.py
+++ b/src/command_modules/azure-cli-iot/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup
 
-VERSION = '0.1.0b10'
+VERSION = '0.1.0b10+dev'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/src/command_modules/azure-cli-keyvault/setup.py
+++ b/src/command_modules/azure-cli-keyvault/setup.py
@@ -9,7 +9,7 @@
 from codecs import open
 from setuptools import setup
 
-VERSION = '0.1.0b10'
+VERSION = '0.1.0b10+dev'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/src/command_modules/azure-cli-network/setup.py
+++ b/src/command_modules/azure-cli-network/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup
 
-VERSION = '0.1.0b10'
+VERSION = '0.1.0b10+dev'
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',

--- a/src/command_modules/azure-cli-profile/setup.py
+++ b/src/command_modules/azure-cli-profile/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup
 
-VERSION = '0.1.0b10'
+VERSION = '0.1.0b10+dev'
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',

--- a/src/command_modules/azure-cli-redis/setup.py
+++ b/src/command_modules/azure-cli-redis/setup.py
@@ -9,7 +9,7 @@
 from codecs import open
 from setuptools import setup
 
-VERSION = '0.1.0b10'
+VERSION = '0.1.0b10+dev'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/src/command_modules/azure-cli-resource/setup.py
+++ b/src/command_modules/azure-cli-resource/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup
 
-VERSION = '0.1.0b10'
+VERSION = '0.1.0b10+dev'
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',

--- a/src/command_modules/azure-cli-role/setup.py
+++ b/src/command_modules/azure-cli-role/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup
 
-VERSION = '0.1.0b10'
+VERSION = '0.1.0b10+dev'
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',

--- a/src/command_modules/azure-cli-storage/setup.py
+++ b/src/command_modules/azure-cli-storage/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup
 
-VERSION = '0.1.0b10'
+VERSION = '0.1.0b10+dev'
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',

--- a/src/command_modules/azure-cli-taskhelp/setup.py
+++ b/src/command_modules/azure-cli-taskhelp/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup
 
-VERSION = '0.1.0b10'
+VERSION = '0.1.0b10+dev'
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',

--- a/src/command_modules/azure-cli-vm/setup.py
+++ b/src/command_modules/azure-cli-vm/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup
 
-VERSION = '0.1.0b10'
+VERSION = '0.1.0b10+dev'
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
- Also, the dev versions have all command modules installed by default
- If the user really wants to install another module, from some unknown location, they can use pip directly
- * pip doesn’t support mixing editable packages with regular packages *
pip install --editable and pip install clash for namespace packages #3
https://github.com/pypa/pip/issues/3

And, Fix nightly build version patching as well