### PR TITLE
[Test] Improve test recording

### DIFF
--- a/azure-cli.pyproj
+++ b/azure-cli.pyproj
@@ -725,7 +725,6 @@
     <Folder Include="command_modules\azure-cli-appservice\azure\cli\command_modules\" />
     <Folder Include="command_modules\azure-cli-appservice\azure\cli\command_modules\appservice\" />
     <Folder Include="command_modules\azure-cli-appservice\azure\cli\command_modules\appservice\tests\" />
-    <Folder Include="command_modules\azure-cli-appservice\azure\cli\command_modules\appservice\tests\recordings\" />
     <Folder Include="command_modules\azure-cli-appservice\azure\cli\command_modules\appservice\tests\sample_web\" />
     <Folder Include="command_modules\azure-cli-cloud\" />
     <Folder Include="command_modules\azure-cli-cloud\azure\" />
@@ -899,12 +898,6 @@
     <Content Include="command_modules\azure-cli-acr\azure\cli\command_modules\acr\tests\recordings\test_acr.yaml" />
     <Content Include="command_modules\azure-cli-acr\requirements.txt" />
     <Content Include="command_modules\azure-cli-acs\requirements.txt" />
-    <Content Include="command_modules\azure-cli-appservice\azure\cli\command_modules\appservice\tests\recordings\test_appservice_error_polish.yaml" />
-    <Content Include="command_modules\azure-cli-appservice\azure\cli\command_modules\appservice\tests\recordings\test_linux_webapp.yaml" />
-    <Content Include="command_modules\azure-cli-appservice\azure\cli\command_modules\appservice\tests\recordings\test_webapp_config.yaml" />
-    <Content Include="command_modules\azure-cli-appservice\azure\cli\command_modules\appservice\tests\recordings\test_webapp_e2e.yaml" />
-    <Content Include="command_modules\azure-cli-appservice\azure\cli\command_modules\appservice\tests\recordings\test_webapp_git.yaml" />
-    <Content Include="command_modules\azure-cli-appservice\azure\cli\command_modules\appservice\tests\recordings\test_webapp_scale.yaml" />
     <Content Include="command_modules\azure-cli-appservice\azure\cli\command_modules\appservice\tests\sample_web\.gitignore" />
     <Content Include="command_modules\azure-cli-appservice\azure\cli\command_modules\appservice\tests\sample_web\package.json" />
     <Content Include="command_modules\azure-cli-appservice\azure\cli\command_modules\appservice\tests\sample_web\server.js" />

--- a/src/azure-cli-core/azure/cli/core/test_utils/vcr_test_base.py
+++ b/src/azure-cli-core/azure/cli/core/test_utils/vcr_test_base.py
@@ -6,13 +6,12 @@
 from __future__ import print_function
 
 import json
-import logging
 import os
 import collections
 import shlex
 from random import choice
 import re
-from string import digits
+from string import digits, ascii_lowercase
 import sys
 from six.moves.urllib.parse import urlparse, parse_qs # pylint: disable=import-error
 import tempfile
@@ -62,8 +61,9 @@ def _mock_get_mgmt_service_client(client_type, subscription_bound=True, subscrip
 
     return (client, subscription_id)
 
-def _mock_generate_deployment_name(value):
-    return value if value != '_GENERATE_' else 'mock-deployment'
+def _mock_generate_deployment_name(namespace):
+    if not namespace.deployment_name:
+        namespace.deployment_name = 'mock-deployment'
 
 def _mock_handle_exceptions(ex):
     raise ex
@@ -233,6 +233,7 @@ class VCRTestBase(unittest.TestCase):#pylint: disable=too-many-instance-attribut
             self.exception = CLIError('No recorded result provided for {}.'.format(self.test_name))
 
         if debug_vcr:
+            import logging
             logging.basicConfig()
             vcr_log = logging.getLogger('vcr')
             vcr_log.setLevel(logging.INFO)
@@ -262,6 +263,13 @@ class VCRTestBase(unittest.TestCase):#pylint: disable=too-many-instance-attribut
                              '/graph.windows.net/{}/'.format(MOCKED_TENANT_ID), request.uri)
         request.uri = re.sub('/sig=([^/]+)&', '/sig=0000&', request.uri)
         request.uri = _scrub_deployment_name(request.uri)
+        # remove randomized portion from resource group name
+        resource_group_name = re.search('resource[Gg]roups/([^/]+_)/', request.uri)
+        if resource_group_name:
+            resource_group_name = resource_group_name.group(0)
+            resource_group_name = resource_group_name.rsplit('_', 2)[0]
+            request.uri = re.sub('resource[Gg]roups/([^/]+_)/',
+                                 '{}/'.format(resource_group_name), request.uri)
         # replace random storage account name with dummy name
         request.uri = re.sub('/vcrstorage([\\d]+).',
                              '/{}.'.format(MOCKED_STORAGE_ACCOUNT), request.uri)
@@ -323,7 +331,7 @@ class VCRTestBase(unittest.TestCase):#pylint: disable=too-many-instance-attribut
     @mock.patch('msrestazure.azure_operation.AzureOperationPoller._delay', _mock_operation_delay)
     @mock.patch('time.sleep', _mock_operation_delay)
     @mock.patch('azure.cli.core.commands.LongRunningOperation._delay', _mock_operation_delay)
-    @mock.patch('azure.cli.core.commands.parameters.generate_deployment_name',
+    @mock.patch('azure.cli.core.commands.validators.generate_deployment_name',
                 _mock_generate_deployment_name)
     def _execute_playback(self):
         # pylint: disable=no-member
@@ -412,39 +420,46 @@ class VCRTestBase(unittest.TestCase):#pylint: disable=too-many-instance-attribut
 
 class ResourceGroupVCRTestBase(VCRTestBase):
     # pylint: disable=too-many-arguments
-    def __init__(self, test_file, test_name, run_live=False, debug=False, debug_vcr=False,
-                 skip_setup=False, skip_teardown=False):
+    def __init__(self, test_file, test_name, resource_group='vcr_resource_group', run_live=False,
+                 debug=False, debug_vcr=False, skip_setup=False, skip_teardown=False):
         super(ResourceGroupVCRTestBase, self).__init__(test_file, test_name, run_live=run_live,
-                                                       debug=debug, skip_setup=skip_setup,
+                                                       debug=debug, debug_vcr=debug_vcr,
+                                                       skip_setup=skip_setup,
                                                        skip_teardown=skip_teardown)
-        self.resource_group = 'vcr_resource_group'
+        self.resource_group_original = resource_group
+        random_tag = '_{}_'.format(''.join((choice(ascii_lowercase + digits) for _ in range(4))))
+        self.resource_group = '{}{}'.format(resource_group, '' if self.playback else random_tag)
         self.location = 'westus'
 
     def set_up(self):
-        self.cmd('resource group create --location {} --name {}'.format(
+        self.cmd('resource group create --location {} --name {} --tags use=az-test'.format(
             self.location, self.resource_group))
 
     def tear_down(self):
-        self.cmd('resource group delete --name {}'.format(self.resource_group))
+        self.cmd('resource group delete --name {} --no-wait'.format(self.resource_group))
 
 class StorageAccountVCRTestBase(VCRTestBase):
     # pylint: disable=too-many-arguments
-    def __init__(self, test_file, test_name, run_live=False, debug=False, debug_vcr=False,
-                 skip_setup=False, skip_teardown=False):
+    def __init__(self, test_file, test_name, resource_group='vcr_resource_group', run_live=False,
+                 debug=False, debug_vcr=False, skip_setup=False, skip_teardown=False):
         super(StorageAccountVCRTestBase, self).__init__(test_file, test_name, run_live=run_live,
-                                                        debug=debug, skip_setup=skip_setup,
+                                                        debug=debug, debug_vcr=debug_vcr,
+                                                        skip_setup=skip_setup,
                                                         skip_teardown=skip_teardown)
-        self.resource_group = 'vcr_resource_group'
+        self.resource_group_original = resource_group
+        random_tag = '_{}_'.format(''.join((choice(ascii_lowercase + digits) for _ in range(4))))
+        self.resource_group = '{}{}'.format(resource_group, '' if self.playback else random_tag)
+
         self.account = MOCKED_STORAGE_ACCOUNT if self.playback else \
             'vcrstorage{}'.format(''.join(choice(digits) for i in range(12)))
         self.location = 'westus'
 
     def set_up(self):
-        self.cmd('resource group create --location {} --name {}'.format(
+        self.cmd('resource group create --location {} --name {} --tags use=az-test'.format(
             self.location, self.resource_group))
         self.cmd('storage account create --sku Standard_LRS -l westus -n {} -g {}'.format(
             self.account, self.resource_group))
 
     def tear_down(self):
         self.cmd('storage account delete -g {} -n {}'.format(self.resource_group, self.account))
-        self.cmd('resource group delete --name {}'.format(self.resource_group))
+        self.cmd('resource group delete --name {} --no-wait'.format(self.resource_group))

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/tests/test_acr_commands.py
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/tests/test_acr_commands.py
@@ -15,10 +15,9 @@ from azure.cli.core.test_utils.vcr_test_base import (
 class ACRTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(ACRTest, self).__init__(__file__, test_method)
+        super(ACRTest, self).__init__(__file__, test_method, resource_group='acr_resource_group')
         self.registry_name_1 = 'acrtestregistry1'
         self.registry_name_2 = 'acrtestregistry2'
-        self.resource_group = 'acr_resource_group'
         self.storage_account_1 = 'acrstorageaccount1'
         self.storage_account_2 = 'acrstorageaccount2'
         self.location = 'southcentralus'

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/test_webapp_commands.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/test_webapp_commands.py
@@ -10,8 +10,7 @@ from azure.cli.core.test_utils.vcr_test_base import (ResourceGroupVCRTestBase,
 class WebappBasicE2ETest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(WebappBasicE2ETest, self).__init__(__file__, test_method)
-        self.resource_group = 'azurecli-webapp-e2e'
+        super(WebappBasicE2ETest, self).__init__(__file__, test_method, resource_group='azurecli-webapp-e2e')
 
     def test_webapp_e2e(self):
         self.execute()
@@ -87,8 +86,7 @@ class WebappBasicE2ETest(ResourceGroupVCRTestBase):
 class WebappConfigureTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(WebappConfigureTest, self).__init__(__file__, test_method)
-        self.resource_group = 'azurecli-webapp-config'
+        super(WebappConfigureTest, self).__init__(__file__, test_method, resource_group='azurecli-webapp-config')
         self.webapp_name = 'webapp-config-test'
 
     def test_webapp_config(self):
@@ -154,12 +152,10 @@ class WebappConfigureTest(ResourceGroupVCRTestBase):
             JMESPathCheck('[0].name', '{0}/{0}.azurewebsites.net'.format(self.webapp_name))
             ])
 
-
 class WebappScaleTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(WebappScaleTest, self).__init__(__file__, test_method)
-        self.resource_group = 'azurecli-webapp-scale'
+        super(WebappScaleTest, self).__init__(__file__, test_method, resource_group='azurecli-webapp-scale')
 
     def test_webapp_scale(self):
         self.execute()
@@ -199,8 +195,7 @@ class WebappScaleTest(ResourceGroupVCRTestBase):
 
 class AppServiceBadErrorPolishTest(ResourceGroupVCRTestBase):
     def __init__(self, test_method):
-        super(AppServiceBadErrorPolishTest, self).__init__(__file__, test_method)
-        self.resource_group = 'clitest-error'
+        super(AppServiceBadErrorPolishTest, self).__init__(__file__, test_method, resource_group='clitest-error')
         self.resource_group2 = 'clitest-error2'
         self.webapp_name = 'webapp-error-test123'
         self.plan = 'webapp-error-plan'
@@ -227,8 +222,7 @@ class AppServiceBadErrorPolishTest(ResourceGroupVCRTestBase):
 #this test doesn't contain the ultimate verification which you need to manually load the frontpage in a browser
 class LinuxWebappSceanrioTest(ResourceGroupVCRTestBase):
     def __init__(self, test_method):
-        super(LinuxWebappSceanrioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'cli-webapp-linux2'
+        super(LinuxWebappSceanrioTest, self).__init__(__file__, test_method, resource_group='cli-webapp-linux2')
 
     def test_linux_webapp(self):
         self.execute()
@@ -264,8 +258,7 @@ class LinuxWebappSceanrioTest(ResourceGroupVCRTestBase):
 
 class WebappGitScenarioTest(ResourceGroupVCRTestBase):
     def __init__(self, test_method):
-        super(WebappGitScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'cli-webapp-git4'
+        super(WebappGitScenarioTest, self).__init__(__file__, test_method, resource_group='cli-webapp-git4')
 
     def test_webapp_git(self):
         self.execute()
@@ -310,8 +303,7 @@ class WebappGitScenarioTest(ResourceGroupVCRTestBase):
 
 class WebappSlotScenarioTest(ResourceGroupVCRTestBase):
     def __init__(self, test_method):
-        super(WebappSlotScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'cli-webapp-slot2'
+        super(WebappSlotScenarioTest, self).__init__(__file__, test_method, resource_group='cli-webapp-slot2')
         self.webapp = 'web-slot-test'
 
     def test_webapp_slot(self):

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/tests/test_iot_commands.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/tests/test_iot_commands.py
@@ -10,8 +10,7 @@ from azure.cli.core.test_utils.vcr_test_base import \
 
 class IoTHubTest(ResourceGroupVCRTestBase):
     def __init__(self, test_method):
-        super(IoTHubTest, self).__init__(__file__, test_method)
-        self.resource_group = 'iot-hub-test-rg'
+        super(IoTHubTest, self).__init__(__file__, test_method, resource_group='iot-hub-test-rg')
         self.hub_name = 'iot-hub-for-test'
         self.device_id_1 = 'test-device-1'
         self.device_id_2 = 'test-device-2'

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/test_keyvault_commands.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/tests/test_keyvault_commands.py
@@ -64,8 +64,7 @@ def _create_keyvault(test, vault_name, resource_group, location, retry_wait=30, 
 class KeyVaultMgmtScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(KeyVaultMgmtScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'cli-test-keyvault-mgmt'
+        super(KeyVaultMgmtScenarioTest, self).__init__(__file__, test_method, resource_group='cli-test-keyvault-mgmt')
         self.keyvault_names = ['cli-keyvault-12345-0',
                                'cli-keyvault-12345-1',
                                'cli-keyvault-12345-2',
@@ -138,11 +137,10 @@ class KeyVaultMgmtScenarioTest(ResourceGroupVCRTestBase):
 class KeyVaultKeyScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(KeyVaultKeyScenarioTest, self).__init__(__file__, test_method)
+        super(KeyVaultKeyScenarioTest, self).__init__(__file__, test_method, resource_group='cli-test-keyvault-key')
         self.my_vcr.before_record_response = _before_record_response
         if self.playback:
             KeyVaultAuthBase.__call__ = _mock_key_vault_auth_base
-        self.resource_group = 'cli-test-keyvault-key'
         self.keyvault_name = 'cli-keyvault-test-key'
         self.location = 'westus'
 
@@ -217,11 +215,10 @@ class KeyVaultKeyScenarioTest(ResourceGroupVCRTestBase):
 class KeyVaultSecretScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(KeyVaultSecretScenarioTest, self).__init__(__file__, test_method)
+        super(KeyVaultSecretScenarioTest, self).__init__(__file__, test_method, resource_group='cli-test-keyvault-secret')
         self.my_vcr.before_record_response = _before_record_response
         if self.playback:
             KeyVaultAuthBase.__call__ = _mock_key_vault_auth_base
-        self.resource_group = 'cli-test-keyvault-secret'
         self.keyvault_name = 'cli-test-keyvault-secret'
         self.location = 'westus'
 
@@ -298,11 +295,10 @@ class KeyVaultSecretScenarioTest(ResourceGroupVCRTestBase):
 class KeyVaultCertificateScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(KeyVaultCertificateScenarioTest, self).__init__(__file__, test_method)
+        super(KeyVaultCertificateScenarioTest, self).__init__(__file__, test_method, resource_group='cli-test-keyvault-cert')
         self.my_vcr.before_record_response = _before_record_response
         if self.playback:
             KeyVaultAuthBase.__call__ = _mock_key_vault_auth_base
-        self.resource_group = 'cli-test-keyvault-cert'
         self.keyvault_name = 'cli-test-keyvault-cert'
         self.location = 'westus'
 

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_traffic_manager.yaml
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_traffic_manager.yaml
@@ -1,33 +1,30 @@
 interactions:
 - request:
-    body: '{"type": "Microsoft.Network/trafficManagerProfiles", "name": "myfoobar1"}'
+    body: !!python/unicode '{"type": "Microsoft.Network/trafficManagerProfiles", "name":
+      "myfoobar1"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['73']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 trafficmanagermanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.5 trafficmanagermanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b10]
       accept-language: [en-US]
-      x-ms-client-request-id: [b46d6b80-6342-11e6-9fcc-001dd8b7c0ad]
+      x-ms-client-request-id: [fc301d8f-bcd0-11e6-a1f0-a0b3ccf7272a]
     method: POST
     uri: https://management.azure.com/providers/Microsoft.Network/checkTrafficManagerNameAvailability?api-version=2015-11-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8ts
-        kX/06KPF9XlVTbJ696PRR+31Ch99UUzrqqnO2/GLvL2q6re/7922zs7Pi+kX2TK7yOuXdXVelHlD
-        rwDK8WVWlNmkpHfbep2PPqrzrKmWHz1arsty9NEibxp6S/78Jf8P9cY4H3kAAAA=
+    body: {string: !!python/unicode '{"name":"myfoobar1","type":"Microsoft.Network\/trafficManagerProfiles","nameAvailable":true,"reason":null,"message":null}'}
     headers:
       cache-control: [private]
-      content-encoding: [gzip]
+      content-length: ['121']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 15 Aug 2016 23:48:02 GMT']
+      date: ['Wed, 07 Dec 2016 23:00:45 GMT']
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
@@ -35,7 +32,7 @@ interactions:
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateTrafficManagerProfile_2016-08-08/azuredeploy.json"},
+    body: !!python/unicode '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateTrafficManagerProfile_2016-08-08/azuredeploy.json"},
       "mode": "Incremental", "parameters": {"status": {"value": "enabled"}, "monitorPort":
       {"value": 80}, "trafficManagerProfileName": {"value": "mytmprofile"}, "monitorPath":
       {"value": "/"}, "monitorProtocol": {"value": "http"}, "ttl": {"value": 30},
@@ -47,25 +44,25 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['529']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 trafficmanagerprofilecreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.5 trafficmanagerprofilecreationclient/2015-11-01 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b10]
       accept-language: [en-US]
-      x-ms-client-request-id: [b4d30b21-6342-11e6-bdfc-001dd8b7c0ad]
+      x-ms-client-request-id: [fce3dd30-bcd0-11e6-af71-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_traffic_manager_test1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_traffic_manager_test/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourceGroups/cli_traffic_manager_test1/providers/Microsoft.Resources/deployments/azurecli1471304883.426765","name":"azurecli1471304883.426765","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateTrafficManagerProfile_2016-08-08/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"location":{"type":"String","value":"global"},"monitorPath":{"type":"String","value":"/"},"monitorPort":{"type":"Int","value":80},"monitorProtocol":{"type":"String","value":"http"},"routingMethod":{"type":"String","value":"weighted"},"status":{"type":"String","value":"enabled"},"trafficManagerProfileName":{"type":"String","value":"mytmprofile"},"ttl":{"type":"Int","value":30},"uniqueDnsName":{"type":"String","value":"mytrafficmanager001100a"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-08-15T23:48:04.3350504Z","duration":"PT0.3257968S","correlationId":"d9658395-1ccb-40af-aefc-05d3020b75b4","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"trafficManagerProfiles","locations":["global"]}]}],"dependencies":[]}}'}
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_traffic_manager_test_7stt_/providers/Microsoft.Resources/deployments/azurecli1481151646.3350271","name":"azurecli1481151646.3350271","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateTrafficManagerProfile_2016-08-08/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"location":{"type":"String","value":"global"},"monitorPath":{"type":"String","value":"/"},"monitorPort":{"type":"Int","value":80},"monitorProtocol":{"type":"String","value":"http"},"routingMethod":{"type":"String","value":"weighted"},"status":{"type":"String","value":"enabled"},"trafficManagerProfileName":{"type":"String","value":"mytmprofile"},"ttl":{"type":"Int","value":30},"uniqueDnsName":{"type":"String","value":"mytrafficmanager001100a"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-12-07T23:00:47.5402509Z","duration":"PT0.2984361S","correlationId":"158da6bd-353b-465f-9ddc-219775aea889","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"trafficManagerProfiles","locations":["global"]}]}],"dependencies":[]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/304e8996-77fb-46e8-bada-557601594be4/resourcegroups/cli_traffic_manager_test1/providers/Microsoft.Resources/deployments/azurecli1471304883.426765/operationStatuses/08587303020014683782?api-version=2015-11-01']
+      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_traffic_manager_test_7stt_/providers/Microsoft.Resources/deployments/azurecli1481151646.3350271/operationStatuses/08587204552382358478?api-version=2015-11-01']
       cache-control: [no-cache]
-      content-length: ['1168']
+      content-length: ['1175']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 15 Aug 2016 23:48:04 GMT']
+      date: ['Wed, 07 Dec 2016 23:00:47 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -74,25 +71,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 trafficmanagerprofilecreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.5 trafficmanagerprofilecreationclient/2015-11-01 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b10]
       accept-language: [en-US]
-      x-ms-client-request-id: [b4d30b21-6342-11e6-bdfc-001dd8b7c0ad]
+      x-ms-client-request-id: [fce3dd30-bcd0-11e6-af71-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_traffic_manager_test1/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587303020014683782?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_traffic_manager_test/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587204552382358478?api-version=2015-11-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
+    body: {string: !!python/unicode '{"status":"Succeeded"}'}
     headers:
       cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['141']
+      content-length: ['22']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 15 Aug 2016 23:48:33 GMT']
+      date: ['Wed, 07 Dec 2016 23:01:17 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -105,39 +97,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 trafficmanagerprofilecreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.5 trafficmanagerprofilecreationclient/2015-11-01 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b10]
       accept-language: [en-US]
-      x-ms-client-request-id: [b4d30b21-6342-11e6-bdfc-001dd8b7c0ad]
+      x-ms-client-request-id: [fce3dd30-bcd0-11e6-af71-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_traffic_manager_test1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_traffic_manager_test/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3W3Wk2ZaF6u2qJbN3Xs7+/nBw4efbj94cD7Z3v80P9ieZLNs+/79B5/u7N5/uD/J9+/WeVOt
-        62n+eV2tV83daVn8/m2dnZ8X099/kS2zi7z+/du8aXfvrurqspjldXP3i2JaV0113o5f6cvN3Vm+
-        KqvrRb5sm7vZD9Z1ToB29x/sEg4HB/fG+3ufPvj0/kejj5bZIidMNzWhjlZ53RZ589GjX/xRmy9W
-        Zdbmz4vlW/y9rgt6f962q+bRXemqmb2dFuNJWU3G06rOx1fFclZdNeNl3t41r8+rpr17Uuf06xsZ
-        3hcyupd1dV6U+e+/t7P76fbOAf1PgMqAxj/dVEvCaVotWxrbT9LwibSEwO54B/999EsI36ymQbX0
-        FfArq2kG8uP39nqFwb5u62J5QVAus3KNDy4I1azEu4tqWbRV/TJr55teuOu3rerWa3u2bF3Dgx2v
-        XV211bQqvbY9uCAjQNPct/TNF3k7r4iRhl+4youLeZvP8FLTZu2axzzUOl9mk1IaK0+FRH+RgRmG
-        319ctwviBjRlGK0/mGDg9zDw9bL4Rev86bK5BVxBRzl8Z2d3d2cn++iXEJBFNUOTs+W0zsHONE80
-        xeB9zDzBeU3DRovX6+k0JzaZ0fdtsSAZyRYr+tww0u79N3v3Hu0fPNp5MP70wc7+/r1Pf4qazta1
-        8sdHL9/cG3/66e7uw9f0OXFunROn0ldnNAUfzR5+ev/g3sP727vTKQnvTna+neXn0+2d+7N7O3s7
-        kwf3J/v0GmMGqfzo0fd+MUtXs8qmwM9J6Yu8varqt9SaZIXl9Q0RRt7wP6GXlC7hNDX0pmFrvGX4
-        9/u/hP6jEeWrfDnLl1OW2O/RJ8RNq3VLf9AUxADyF9Lhl5OfzqfeRP5ijAhtQGZw10enykREZYH1
-        isDTPBhm/ei7hicJlWVzUi3PiwsAEnJeKpcNTvroo/NfNMN0DDQYh59Cq9A7zIvMdSpurl8dwBfy
-        uR3H2TKbAh16mVqoaH707TdvXuITFuqDHfqNVYFIPJF1VRWkUkHWXwLupKETZa3apc9V9fdm+66i
-        HVK+uUujdDL1/V/yS/4fzBfE0jsGAAA=
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_traffic_manager_test_7stt_/providers/Microsoft.Resources/deployments/azurecli1481151646.3350271","name":"azurecli1481151646.3350271","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateTrafficManagerProfile_2016-08-08/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"location":{"type":"String","value":"global"},"monitorPath":{"type":"String","value":"/"},"monitorPort":{"type":"Int","value":80},"monitorProtocol":{"type":"String","value":"http"},"routingMethod":{"type":"String","value":"weighted"},"status":{"type":"String","value":"enabled"},"trafficManagerProfileName":{"type":"String","value":"mytmprofile"},"ttl":{"type":"Int","value":30},"uniqueDnsName":{"type":"String","value":"mytrafficmanager001100a"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-12-07T23:00:54.910193Z","duration":"PT7.6683782S","correlationId":"158da6bd-353b-465f-9ddc-219775aea889","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"trafficManagerProfiles","locations":["global"]}]}],"dependencies":[],"outputs":{"trafficManagerProfile":{"type":"Object","value":{"profileStatus":"Enabled","trafficRoutingMethod":"Weighted","dnsConfig":{"relativeName":"mytrafficmanager001100a","fqdn":"mytrafficmanager001100a.trafficmanager.net","ttl":30},"monitorConfig":{"profileMonitorStatus":"Inactive","protocol":"HTTP","port":80,"path":"/"},"endpoints":[]}}},"outputResources":[{"id":"Microsoft.Network/trafficManagerProfiles/mytmprofile"}]}}'}
     headers:
       cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['935']
+      content-length: ['1603']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 15 Aug 2016 23:48:34 GMT']
+      date: ['Wed, 07 Dec 2016 23:01:18 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
@@ -150,65 +123,57 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 trafficmanagermanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.5 trafficmanagermanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b10]
       accept-language: [en-US]
-      x-ms-client-request-id: [c7fb37de-6342-11e6-b1c1-001dd8b7c0ad]
+      x-ms-client-request-id: [10c8f14f-bcd1-11e6-89e2-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_traffic_manager_test1/providers/Microsoft.Network/trafficmanagerprofiles/mytmprofile?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_traffic_manager_test/providers/Microsoft.Network/trafficmanagerprofiles/mytmprofile?api-version=2015-11-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf/b53m/WkmdbFqi2qZfP73r23s58fPHz46faDB+eT7f1P84PtSTbLtu/ff/Dpzu79h/uTfP/3
-        vVvnTbWup/nndbVe0VvTsvj92zo7Py+mv/8iW2YXef37t3nT7v6+d1d1dVnM8ppafVFM66qpztvx
-        i7y9quq3v+9dfekLeedlXZ0XZU5NF9ftgt7EXx+NPlpmi5yQDT9sr1f48NZA6ZWymmYYJ712UVaT
-        rKTPCOAqr9uCGjz6xfgLjV+3WbumDz46XWaTMp9ROwX6qlq3xfLii7ydVyDgd/PiYt5yi9myOamW
-        58UFANV5SV1d5i8s6vK+UmdnZ3d3Zyejt85/0Qz4DDQYh5+Ol3lL77Rt+dGjezu/ZPTRoloWbVW7
-        fnUAX8jndhxny2wKdOhlatFW04ogfPTtN29e4pOqbj96dLBDv2XtnD7/fe9+RLDz5WxVFcuW3v/e
-        93/JL/l/AAxhfGwyAgAA
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_traffic_manager_test_7stt_\/providers\/Microsoft.Network\/trafficManagerProfiles\/mytmprofile","name":"mytmprofile","type":"Microsoft.Network\/trafficManagerProfiles","location":"global","properties":{"profileStatus":"Enabled","trafficRoutingMethod":"Weighted","dnsConfig":{"relativeName":"mytrafficmanager001100a","fqdn":"mytrafficmanager001100a.trafficmanager.net","ttl":30},"monitorConfig":{"profileMonitorStatus":"Inactive","protocol":"HTTP","port":80,"path":"\/"},"endpoints":[]}}'}
     headers:
       cache-control: [private]
-      content-encoding: [gzip]
+      content-length: ['567']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 15 Aug 2016 23:48:35 GMT']
+      date: ['Wed, 07 Dec 2016 23:01:19 GMT']
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['10799']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['10798']
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"target": "www.microsoft.com", "weight": 50}}'
+    body: !!python/unicode '{"properties": {"target": "www.microsoft.com", "weight":
+      50}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['61']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 trafficmanagermanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.5 trafficmanagermanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b10]
       accept-language: [en-US]
-      x-ms-client-request-id: [c8294cc0-6342-11e6-b1e4-001dd8b7c0ad]
+      x-ms-client-request-id: [114d3c80-bcd1-11e6-989b-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_traffic_manager_test1/providers/Microsoft.Network/trafficmanagerprofiles/mytmprofile/externalEndpoints/myendpoint?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_traffic_manager_test/providers/Microsoft.Network/trafficmanagerprofiles/mytmprofile/externalEndpoints/myendpoint?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/304e8996-77fb-46e8-bada-557601594be4\/resourceGroups\/cli_traffic_manager_test1\/providers\/Microsoft.Network\/trafficManagerProfiles\/mytmprofile\/externalEndpoints\/myendpoint","name":"myendpoint","type":"Microsoft.Network\/trafficManagerProfiles\/externalEndpoints","properties":{"endpointStatus":"Enabled","endpointMonitorStatus":"CheckingEndpoint","target":"www.microsoft.com","weight":50,"priority":1,"endpointLocation":null}}'}
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_traffic_manager_test_7stt_\/providers\/Microsoft.Network\/trafficManagerProfiles\/mytmprofile\/externalEndpoints\/myendpoint","name":"myendpoint","type":"Microsoft.Network\/trafficManagerProfiles\/externalEndpoints","properties":{"endpointStatus":"Enabled","endpointMonitorStatus":"CheckingEndpoint","target":"www.microsoft.com","weight":50,"priority":1,"endpointLocation":null}}'}
     headers:
       cache-control: [private]
-      content-length: ['456']
+      content-length: ['461']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 15 Aug 2016 23:48:36 GMT']
+      date: ['Wed, 07 Dec 2016 23:01:20 GMT']
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
       x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
@@ -218,31 +183,23 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Windows-8-6.2.9200) requests/2.9.1 msrest/0.4.0
-          msrest_azure/0.4.1 trafficmanagermanagementclient/0.30.0rc5 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.5 trafficmanagermanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b10]
       accept-language: [en-US]
-      x-ms-client-request-id: [c8d19aae-6342-11e6-a99f-001dd8b7c0ad]
+      x-ms-client-request-id: [11f03340-bcd1-11e6-b4df-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_traffic_manager_test1/providers/Microsoft.Network/trafficmanagerprofiles/mytmprofile/externalEndpoints/myendpoint?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_traffic_manager_test/providers/Microsoft.Network/trafficmanagerprofiles/mytmprofile/externalEndpoints/myendpoint?api-version=2015-11-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf/b53m/WkmdbFqi2qZfP73r23s58fPHz46faDB+eT7f1P84PtSTbLtu/ff/Dpzu79h/uTfP/3
-        vVvnTbWup/nndbVe0VvTsvj92zo7Py+mv/8iW2YXef37t3nT7v6+d1d1dVnM8ppafVFM66qpztvx
-        i7y9quq3v+9dfekLeedlXZ0XZU5NF9ftgt7EX7/v3fxdm9fLrDxdzlZVsWz5+1z/+Gj00TJb5DSW
-        4LP2eoXP3qPLXi8EhVBY5XVb5M1Hj37xRwb86zZr1/TJR6fLbFLmM2povvqiWhZtVdsWJ/N8+rZY
-        Xhig1LTN6ou8pe+urq7GC4vftFrQl1d5cTGnL+/voPOiqov2+qNHu66D59U0w1R99Gi5Lstf8kv+
-        HxkbPfHIAQAA
+    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_traffic_manager_test_7stt_\/providers\/Microsoft.Network\/trafficManagerProfiles\/mytmprofile\/externalEndpoints\/myendpoint","name":"myendpoint","type":"Microsoft.Network\/trafficManagerProfiles\/externalEndpoints","properties":{"endpointStatus":"Enabled","endpointMonitorStatus":"CheckingEndpoint","target":"www.microsoft.com","weight":50,"priority":1,"endpointLocation":null}}'}
     headers:
       cache-control: [private]
-      content-encoding: [gzip]
+      content-length: ['461']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 15 Aug 2016 23:48:36 GMT']
+      date: ['Wed, 07 Dec 2016 23:01:21 GMT']
       server: [Microsoft-IIS/8.5]
       strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
       x-content-type-options: [nosniff]

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/test_network_commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/test_network_commands.py
@@ -32,8 +32,7 @@ class NetworkUsageListScenarioTest(VCRTestBase):
 class NetworkAppGatewayDefaultScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(NetworkAppGatewayDefaultScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'ag1rg'
+        super(NetworkAppGatewayDefaultScenarioTest, self).__init__(__file__, test_method, resource_group='ag1rg')
 
     def test_network_app_gateway_with_defaults(self):
         self.execute()
@@ -67,8 +66,7 @@ class NetworkAppGatewayDefaultScenarioTest(ResourceGroupVCRTestBase):
 class NetworkAppGatewayExistingSubnetScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(NetworkAppGatewayExistingSubnetScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'ag2rg'
+        super(NetworkAppGatewayExistingSubnetScenarioTest, self).__init__(__file__, test_method, resource_group='ag2rg')
 
     def test_network_app_gateway_with_existing_subnet(self):
         self.execute()
@@ -85,8 +83,7 @@ class NetworkAppGatewayExistingSubnetScenarioTest(ResourceGroupVCRTestBase):
 class NetworkAppGatewayNoWaitScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(NetworkAppGatewayNoWaitScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'cli_ag_no_wait'
+        super(NetworkAppGatewayNoWaitScenarioTest, self).__init__(__file__, test_method, resource_group='cli_ag_no_wait')
 
     def test_network_app_gateway_no_wait(self):
         self.execute()
@@ -106,12 +103,10 @@ class NetworkAppGatewayNoWaitScenarioTest(ResourceGroupVCRTestBase):
         self.cmd('network application-gateway delete -g {} -n ag2 --no-wait'.format(rg))
         self.cmd('network application-gateway wait -g {} -n ag2 --deleted'.format(rg))
 
-
 class NetworkAppGatewayPrivateIpScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(NetworkAppGatewayPrivateIpScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'ag3rg'
+        super(NetworkAppGatewayPrivateIpScenarioTest, self).__init__(__file__, test_method, resource_group='ag3rg')
 
     def test_network_app_gateway_with_private_ip(self):
         self.execute()
@@ -129,8 +124,7 @@ class NetworkAppGatewayPrivateIpScenarioTest(ResourceGroupVCRTestBase):
 class NetworkAppGatewayPublicIpScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(NetworkAppGatewayPublicIpScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'ag4rg'
+        super(NetworkAppGatewayPublicIpScenarioTest, self).__init__(__file__, test_method, resource_group='ag4rg')
 
     def test_network_app_gateway_with_public_ip(self):
         self.execute()
@@ -146,8 +140,7 @@ class NetworkAppGatewayPublicIpScenarioTest(ResourceGroupVCRTestBase):
 class NetworkPublicIpScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(NetworkPublicIpScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'cli_test_public_ip'
+        super(NetworkPublicIpScenarioTest, self).__init__(__file__, test_method, resource_group='cli_test_public_ip')
 
     def test_network_public_ip(self):
         self.execute()
@@ -192,8 +185,7 @@ class NetworkPublicIpScenarioTest(ResourceGroupVCRTestBase):
 class NetworkExpressRouteScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(NetworkExpressRouteScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'cli_test_express_route'
+        super(NetworkExpressRouteScenarioTest, self).__init__(__file__, test_method, resource_group='cli_test_express_route')
         self.circuit_name = 'circuit1'
         self.resource_type = 'Microsoft.Network/expressRouteCircuits'
 
@@ -295,8 +287,7 @@ class NetworkExpressRouteScenarioTest(ResourceGroupVCRTestBase):
 class NetworkLoadBalancerScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(NetworkLoadBalancerScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'cli_test_load_balancer'
+        super(NetworkLoadBalancerScenarioTest, self).__init__(__file__, test_method, resource_group='cli_test_load_balancer')
         self.lb_name = 'lb'
         self.resource_type = 'Microsoft.Network/loadBalancers'
 
@@ -360,8 +351,7 @@ class NetworkLoadBalancerScenarioTest(ResourceGroupVCRTestBase):
 class NetworkLoadBalancerIpConfigScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(NetworkLoadBalancerIpConfigScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'cli_test_load_balancer_ip_config'
+        super(NetworkLoadBalancerIpConfigScenarioTest, self).__init__(__file__, test_method, resource_group='cli_test_load_balancer_ip_config')
 
     def test_network_load_balancer_ip_config(self):
         self.execute()
@@ -404,14 +394,13 @@ class NetworkLoadBalancerIpConfigScenarioTest(ResourceGroupVCRTestBase):
         self.cmd('network lb frontend-ip create -g {} --lb-name lb2 -n ipconfig2 --vnet-name vnet1 --subnet subnet1 --private-ip-address 10.0.0.99'.format(rg))
         self.cmd('network lb frontend-ip list -g {} --lb-name lb2'.format(rg), checks=JMESPathCheck('length(@)', 2))
         self.cmd('network lb frontend-ip update -g {} --lb-name lb2 -n ipconfig2 --subnet subnet2 --vnet-name vnet1 --private-ip-address 10.0.1.100'.format(rg))
-        self.cmd('network lb frontend-ip show -g {} --lb-name lb2 -n ipconfig2'.format(rg))#,
-            #checks=JMESPathCheck("subnet.contains(id, 'subnet2')", True))
+        self.cmd('network lb frontend-ip show -g {} --lb-name lb2 -n ipconfig2'.format(rg),
+            checks=JMESPathCheck("subnet.contains(id, 'subnet2')", True))
 
 class NetworkLoadBalancerSubresourceScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(NetworkLoadBalancerSubresourceScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'cli_test_load_balancer_subresource'
+        super(NetworkLoadBalancerSubresourceScenarioTest, self).__init__(__file__, test_method, resource_group='cli_test_load_balancer_subresource')
         self.lb_name = 'lb1'
 
     def test_network_load_balancer_subresources(self):
@@ -526,8 +515,7 @@ class NetworkLoadBalancerSubresourceScenarioTest(ResourceGroupVCRTestBase):
 class NetworkLocalGatewayScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(NetworkLocalGatewayScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'local_gateway_scenario'
+        super(NetworkLocalGatewayScenarioTest, self).__init__(__file__, test_method, resource_group='local_gateway_scenario')
         self.name = 'cli-test-loc-gateway'
         self.resource_type = 'Microsoft.Network/localNetworkGateways'
 
@@ -554,8 +542,7 @@ class NetworkLocalGatewayScenarioTest(ResourceGroupVCRTestBase):
 class NetworkNicScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(NetworkNicScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'cli_test_nic_scenario'
+        super(NetworkNicScenarioTest, self).__init__(__file__, test_method, resource_group='cli_test_nic_scenario')
 
     def test_network_nic(self):
         self.execute()
@@ -646,8 +633,7 @@ class NetworkNicScenarioTest(ResourceGroupVCRTestBase):
 class NetworkNicSubresourceScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(NetworkNicSubresourceScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'cli_test_nic_subresource'
+        super(NetworkNicSubresourceScenarioTest, self).__init__(__file__, test_method, resource_group='cli_test_nic_subresource')
 
     def test_network_nic_subresources(self):
         self.execute()
@@ -723,8 +709,7 @@ class NetworkNicSubresourceScenarioTest(ResourceGroupVCRTestBase):
 class NetworkNicConvenienceCommandsScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(NetworkNicConvenienceCommandsScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'cli_nic_convenience_test'
+        super(NetworkNicConvenienceCommandsScenarioTest, self).__init__(__file__, test_method, resource_group='cli_nic_convenience_test')
         self.vm_name = 'conveniencevm1'
 
     def test_network_nic_convenience_commands(self):
@@ -748,8 +733,7 @@ class NetworkNicConvenienceCommandsScenarioTest(ResourceGroupVCRTestBase):
 class NetworkSecurityGroupScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(NetworkSecurityGroupScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'cli_nsg_test1'
+        super(NetworkSecurityGroupScenarioTest, self).__init__(__file__, test_method, resource_group='cli_nsg_test1')
         self.nsg_name = 'test-nsg1'
         self.nsg_rule_name = 'web'
         self.resource_type = 'Microsoft.Network/networkSecurityGroups'
@@ -827,8 +811,7 @@ class NetworkSecurityGroupScenarioTest(ResourceGroupVCRTestBase):
 class NetworkRouteTableOperationScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(NetworkRouteTableOperationScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'cli_route_table_test1'
+        super(NetworkRouteTableOperationScenarioTest, self).__init__(__file__, test_method, resource_group='cli_route_table_test1')
         self.route_table_name = 'cli-test-route-table'
         self.route_name = 'my-route'
         self.resource_type = 'Microsoft.Network/routeTables'
@@ -874,8 +857,7 @@ class NetworkRouteTableOperationScenarioTest(ResourceGroupVCRTestBase):
 class NetworkVNetScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(NetworkVNetScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'cli_vnet_test1'
+        super(NetworkVNetScenarioTest, self).__init__(__file__, test_method, resource_group='cli_vnet_test1')
         self.vnet_name = 'test-vnet'
         self.vnet_subnet_name = 'test-subnet1'
         self.resource_type = 'Microsoft.Network/virtualNetworks'
@@ -946,8 +928,7 @@ class NetworkVNetScenarioTest(ResourceGroupVCRTestBase):
 
 class NetworkVNetPeeringScenarioTest(ResourceGroupVCRTestBase):
     def __init__(self, test_method):
-        super(NetworkVNetPeeringScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'cli_vnet_peering_test'
+        super(NetworkVNetPeeringScenarioTest, self).__init__(__file__, test_method, resource_group='cli_vnet_peering_test')
 
     def test_network_vnet_peering(self):
         self.execute()
@@ -999,8 +980,7 @@ class NetworkVNetPeeringScenarioTest(ResourceGroupVCRTestBase):
 
 class NetworkSubnetSetScenarioTest(ResourceGroupVCRTestBase):
     def __init__(self, test_method):
-        super(NetworkSubnetSetScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'cli_subnet_set_test'
+        super(NetworkSubnetSetScenarioTest, self).__init__(__file__, test_method, resource_group='cli_subnet_set_test')
         self.vnet_name = 'test-vnet2'
 
     def test_network_subnet_set(self):
@@ -1037,8 +1017,7 @@ class NetworkSubnetSetScenarioTest(ResourceGroupVCRTestBase):
 class NetworkVpnGatewayScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(NetworkVpnGatewayScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'cli_test_vpn_gateway'
+        super(NetworkVpnGatewayScenarioTest, self).__init__(__file__, test_method, resource_group='cli_test_vpn_gateway')
         self.vnet1_name = 'myvnet1'
         self.vnet2_name = 'myvnet2'
         self.gateway1_name = 'gateway1'
@@ -1078,8 +1057,7 @@ class NetworkVpnGatewayScenarioTest(ResourceGroupVCRTestBase):
 class NetworkTrafficManagerScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(NetworkTrafficManagerScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'cli_traffic_manager_test1'
+        super(NetworkTrafficManagerScenarioTest, self).__init__(__file__, test_method, resource_group='cli_traffic_manager_test')
 
     def test_network_traffic_manager(self):
         self.execute()
@@ -1090,31 +1068,21 @@ class NetworkTrafficManagerScenarioTest(ResourceGroupVCRTestBase):
         unique_dns_name = 'mytrafficmanager001100a'
 
         self.cmd('network traffic-manager profile check-dns -n myfoobar1')
-        self.cmd('network traffic-manager profile create -n {tm_name} -g {resource_group}'
-                 ' --routing-method weighted --unique-dns-name {unique_dns_name}'
-                 .format(tm_name=tm_name, resource_group=self.resource_group, unique_dns_name=unique_dns_name), checks=[
-                     JMESPathCheck('trafficManagerProfile.trafficRoutingMethod', 'Weighted')
-                     ])
-        self.cmd('network traffic-manager profile show -g {resource_group} -n {tm_name}'
-                 .format(resource_group=self.resource_group, tm_name=tm_name), checks=[
-                     JMESPathCheck('dnsConfig.relativeName', unique_dns_name)
-                     ])
-        self.cmd('network traffic-manager endpoint create -n {endpoint_name} --profile-name {tm_name} -g {resource_group}'
-                 ' --type externalEndpoints --weight 50 --target www.microsoft.com'
-                 .format(endpoint_name=endpoint_name, tm_name=tm_name, resource_group=self.resource_group), checks=[
-                     JMESPathCheck('type', 'Microsoft.Network/trafficManagerProfiles/externalEndpoints')
-                     ])
-        self.cmd('network traffic-manager endpoint show --profile-name {tm_name} --type  externalEndpoints'
-                 ' -n {endpoint_name} -g {resource_group}'
-                 .format(tm_name=tm_name, endpoint_name=endpoint_name, resource_group=self.resource_group), checks=[
-                     JMESPathCheck('target', 'www.microsoft.com')
-                     ])
+        self.cmd('network traffic-manager profile create -n {} -g {} --routing-method weighted --unique-dns-name {}'.format(tm_name, self.resource_group, unique_dns_name),
+            checks=JMESPathCheck('trafficManagerProfile.trafficRoutingMethod', 'Weighted'))
+        self.cmd('network traffic-manager profile show -g {} -n {}'.format(self.resource_group, tm_name),
+            checks=JMESPathCheck('dnsConfig.relativeName', unique_dns_name))
+        # TODO: Test update
+        self.cmd('network traffic-manager endpoint create -n {} --profile-name {} -g {} --type externalEndpoints --weight 50 --target www.microsoft.com'.format(endpoint_name, tm_name, self.resource_group),
+            checks=JMESPathCheck('type', 'Microsoft.Network/trafficManagerProfiles/externalEndpoints'))
+        self.cmd('network traffic-manager endpoint show --profile-name {} --type  externalEndpoints -n {} -g {}'.format(tm_name, endpoint_name, self.resource_group),
+            checks=JMESPathCheck('target', 'www.microsoft.com'))
+        # TODO: Test update
 
 class NetworkDnsScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(NetworkDnsScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'cli_dns_test1'
+        super(NetworkDnsScenarioTest, self).__init__(__file__, test_method, resource_group='cli_dns_test1')
 
     def test_network_dns(self):
         self.execute()
@@ -1186,8 +1154,7 @@ class NetworkDnsScenarioTest(ResourceGroupVCRTestBase):
 class NetworkZoneImportExportTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(NetworkZoneImportExportTest, self).__init__(__file__, test_method)
-        self.resource_group = 'cli_dns_zone_import_export'
+        super(NetworkZoneImportExportTest, self).__init__(__file__, test_method, resource_group='cli_dns_zone_import_export')
 
     def test_network_dns_zone_import_export(self):
         self.execute()

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/test_resource.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/test_resource.py
@@ -79,8 +79,7 @@ class ResourceScenarioTest(ResourceGroupVCRTestBase):
         self.execute()
 
     def __init__(self, test_method):
-        super(ResourceScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'azure-cli-resource-test'
+        super(ResourceScenarioTest, self).__init__(__file__, test_method, resource_group='azure-cli-resource-test')
         self.vnet_name = 'cli-test-vnet1'
         self.subnet_name = 'cli-test-subnet1'
 
@@ -134,8 +133,7 @@ class ResourceIDScenarioTest(ResourceGroupVCRTestBase):
         self.execute()
 
     def __init__(self, test_method):
-        super(ResourceIDScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'azure-cli-resource-id-test3'
+        super(ResourceIDScenarioTest, self).__init__(__file__, test_method, resource_group='azure-cli-resource-id-test3')
         self.vnet_name = 'cli-test-vnet1'
         self.subnet_name = 'cli-test-subnet1'
 
@@ -238,8 +236,7 @@ class ProviderRegistrationTest(VCRTestBase): # Not RG test base because it opera
 
 class DeploymentTest(ResourceGroupVCRTestBase):
     def __init__(self, test_method):
-        super(DeploymentTest, self).__init__(__file__, test_method)
-        self.resource_group = 'azure-cli-deployment-test'
+        super(DeploymentTest, self).__init__(__file__, test_method, resource_group='azure-cli-deployment-test')
 
     def test_group_deployment(self):
         self.execute()
@@ -274,8 +271,7 @@ class DeploymentTest(ResourceGroupVCRTestBase):
 
 class DeploymentnoWaitTest(ResourceGroupVCRTestBase):
     def __init__(self, test_method):
-        super(DeploymentnoWaitTest, self).__init__(__file__, test_method)
-        self.resource_group = 'azure-cli-deployment-test'
+        super(DeploymentnoWaitTest, self).__init__(__file__, test_method, resource_group='azure-cli-deployment-test')
 
     def test_group_deployment_no_wait(self):
         self.execute()
@@ -297,8 +293,7 @@ class DeploymentnoWaitTest(ResourceGroupVCRTestBase):
 
 class DeploymentThruUriTest(ResourceGroupVCRTestBase):
     def __init__(self, test_method):
-        super(DeploymentThruUriTest, self).__init__(__file__, test_method)
-        self.resource_group = 'azure-cli-deployment-uri-test'
+        super(DeploymentThruUriTest, self).__init__(__file__, test_method, resource_group='azure-cli-deployment-uri-test')
 
     def test_group_deployment_thru_uri(self):
         self.execute()
@@ -383,8 +378,7 @@ class FeatureScenarioTest(VCRTestBase): # Not RG test base because it operates o
 class PolicyScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(PolicyScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'azure-cli-policy-test-group'
+        super(PolicyScenarioTest, self).__init__(__file__, test_method, resource_group='azure-cli-policy-test-group')
 
     def test_resource_policy(self):
         self.execute()

--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/test_role.py
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/test_role.py
@@ -56,8 +56,7 @@ class RoleCreateScenarioTest(VCRTestBase):
 class RoleAssignmentScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(RoleAssignmentScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'cli-role-assignment-test'
+        super(RoleAssignmentScenarioTest, self).__init__(__file__, test_method, resource_group='cli-role-assignment-test')
         self.user = 'testuser1@azuresdkteam.onmicrosoft.com'
 
     def set_up(self):

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/test_storage.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/test_storage.py
@@ -35,9 +35,8 @@ def _get_connection_string(test):
 class StorageAccountScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(StorageAccountScenarioTest, self).__init__(__file__, test_method)
+        super(StorageAccountScenarioTest, self).__init__(__file__, test_method, resource_group='test_storage_account_scenario')
         self.account = 'testcreatedelete'
-        self.resource_group = 'test_storage_account_scenario'
 
     def test_storage_account_scenario(self):
         self.execute()
@@ -97,8 +96,7 @@ class StorageAccountScenarioTest(ResourceGroupVCRTestBase):
 class StorageBlobScenarioTest(StorageAccountVCRTestBase):
 
     def __init__(self, test_method):
-        super(StorageBlobScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'test_blob_scenario_test'
+        super(StorageBlobScenarioTest, self).__init__(__file__, test_method, resource_group='test_blob_scenario_test')
         self.container = 'cont1'
         self.proposed_lease_id = 'abcdabcd-abcd-abcd-abcd-abcdabcdabcd'
         self.new_lease_id = 'dcbadcba-dcba-dcba-dcba-dcbadcbadcba'
@@ -261,8 +259,7 @@ class StorageBlobScenarioTest(StorageAccountVCRTestBase):
 class StorageBlobCopyScenarioTest(StorageAccountVCRTestBase):
 
     def __init__(self, test_method):
-        super(StorageBlobCopyScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'test_storage_blob_copy'
+        super(StorageBlobCopyScenarioTest, self).__init__(__file__, test_method, resource_group='test_storage_blob_copy')
         self.src_container = 'testcopyblob1'
         self.src_blob = 'src_blob'
         self.dest_container = 'testcopyblob2'
@@ -304,8 +301,7 @@ class StorageBlobCopyScenarioTest(StorageAccountVCRTestBase):
 class StorageFileScenarioTest(StorageAccountVCRTestBase):
 
     def __init__(self, test_method):
-        super(StorageFileScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'test_file_scenario'
+        super(StorageFileScenarioTest, self).__init__(__file__, test_method, resource_group='test_file_scenario')
         self.share1 = 'testshare01'
         self.share2 = 'testshare02'
         self.initialized = False
@@ -459,8 +455,7 @@ class StorageFileScenarioTest(StorageAccountVCRTestBase):
 class StorageFileCopyScenarioTest(StorageAccountVCRTestBase):
 
     def __init__(self, test_method):
-        super(StorageFileCopyScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'test_file_copy_scenario'
+        super(StorageFileCopyScenarioTest, self).__init__(__file__, test_method, resource_group='test_file_copy_scenario')
         self.src_share = 'testcopyfile1'
         self.src_dir = 'testdir'
         self.src_file = 'src_file.txt'
@@ -521,8 +516,7 @@ class StorageFileCopyScenarioTest(StorageAccountVCRTestBase):
 class StorageTableScenarioTest(StorageAccountVCRTestBase):
 
     def __init__(self, test_method):
-        super(StorageTableScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'test_table_scenario_test'
+        super(StorageTableScenarioTest, self).__init__(__file__, test_method, resource_group='test_table_scenario_test')
         self.table = 'table1'
 
     def test_storage_table_scenario(self):
@@ -609,8 +603,7 @@ class StorageTableScenarioTest(StorageAccountVCRTestBase):
 class StorageQueueScenarioTest(StorageAccountVCRTestBase):
 
     def __init__(self, test_method):
-        super(StorageQueueScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'test_queue_scenario_test'
+        super(StorageQueueScenarioTest, self).__init__(__file__, test_method, resource_group='test_queue_scenario_test')
         self.queue = 'queue1'
 
     def test_storage_queue_scenario(self):

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
@@ -80,8 +80,7 @@ class VMCombinedListTest(VCRTestBase):
 
 class VMOpenPortTest(ResourceGroupVCRTestBase):
     def __init__(self, test_method):
-        super(VMOpenPortTest, self).__init__(__file__, test_method)
-        self.resource_group = 'open_port_test_rg1'
+        super(VMOpenPortTest, self).__init__(__file__, test_method, resource_group='open_port_test_rg1')
         self.vm_name = 'vm1'
 
     def set_up(self):
@@ -132,9 +131,8 @@ class VMResizeTest(VCRTestBase):
 class VMShowListSizesListIPAddressesScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(VMShowListSizesListIPAddressesScenarioTest, self).__init__(__file__, test_method)
+        super(VMShowListSizesListIPAddressesScenarioTest, self).__init__(__file__, test_method, resource_group='cliTestRg_VmListIpAddresses')
         self.deployment_name = 'azurecli-test-deployment-vm-list-ips'
-        self.resource_group = 'cliTestRg_VmListIpAddresses'
         self.location = 'westus'
         self.vm_name = 'vm-with-public-ip'
         self.ip_allocation_method = 'dynamic'
@@ -263,9 +261,8 @@ class VMImageShowScenarioTest(VCRTestBase):
 class VMGeneralizeScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(VMGeneralizeScenarioTest, self).__init__(__file__, test_method)
+        super(VMGeneralizeScenarioTest, self).__init__(__file__, test_method, resource_group='cliTestRg_VmGeneralize')
         self.deployment_name = 'azurecli-test-deployment-vm-generalize'
-        self.resource_group = 'cliTestRg_VmGeneralize'
         self.location = 'westus'
         self.vm_name = 'vm-generalize'
 
@@ -288,9 +285,8 @@ class VMGeneralizeScenarioTest(ResourceGroupVCRTestBase):
 class VMCreateAndStateModificationsScenarioTest(ResourceGroupVCRTestBase): #pylint:disable=too-many-instance-attributes
 
     def __init__(self, test_method):
-        super(VMCreateAndStateModificationsScenarioTest, self).__init__(__file__, test_method)
+        super(VMCreateAndStateModificationsScenarioTest, self).__init__(__file__, test_method, resource_group='cliTestRg_VmStateMod2')
         self.deployment_name = 'azurecli-test-deployment-vm-state-mod2'
-        self.resource_group = 'cliTestRg_VmStateMod2'
         self.location = 'eastus'
         self.vm_name = 'vm-state-mod'
         self.nsg_name = 'mynsg'
@@ -384,8 +380,7 @@ class VMCreateAndStateModificationsScenarioTest(ResourceGroupVCRTestBase): #pyli
 
 class VMNoWaitScenarioTest(ResourceGroupVCRTestBase):
     def __init__(self, test_method):
-        super(VMNoWaitScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'cli_rg_vm_no_wait2'
+        super(VMNoWaitScenarioTest, self).__init__(__file__, test_method, resource_group='cli_rg_vm_no_wait2')
         self.location = 'westus'
         self.name = 'vmnowait2'
 
@@ -444,8 +439,7 @@ class VMAvailSetScenarioTest(VCRTestBase):
 class VMExtensionAutoUpgradeTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(VMExtensionAutoUpgradeTest, self).__init__(__file__, test_method)
-        self.resource_group = 'clitest_upgrade_vmext'
+        super(VMExtensionAutoUpgradeTest, self).__init__(__file__, test_method, resource_group='clitest_upgrade_vmext')
         self.vm_name = 'autoupgradevm1'
 
     def set_up(self):
@@ -712,8 +706,7 @@ class VMScaleSetVMsScenarioTest(VCRTestBase):
 
 class VMScaleSetCreateSimple(ResourceGroupVCRTestBase):
     def __init__(self, test_method):
-        super(VMScaleSetCreateSimple, self).__init__(__file__, test_method)
-        self.resource_group = 'scaleset_create_simple_rg'
+        super(VMScaleSetCreateSimple, self).__init__(__file__, test_method, resource_group='scaleset_create_simple_rg')
 
     def test_vm_scaleset_create_simple(self):
         self.execute()
@@ -730,8 +723,7 @@ class VMScaleSetCreateSimple(ResourceGroupVCRTestBase):
 class VMScaleSetCreateOptions(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(VMScaleSetCreateOptions, self).__init__(__file__, test_method)
-        self.resource_group = 'scaleset_create_options_rg'
+        super(VMScaleSetCreateOptions, self).__init__(__file__, test_method, resource_group='scaleset_create_options_rg')
 
     def test_vm_scaleset_create_options(self):
         self.execute()
@@ -762,8 +754,7 @@ class VMScaleSetCreateOptions(ResourceGroupVCRTestBase):
 
 class VMSSCreateNoneOptionsTest(ResourceGroupVCRTestBase): #pylint: disable=too-many-instance-attributes
     def __init__(self, test_method):
-        super(VMSSCreateNoneOptionsTest, self).__init__(__file__, test_method)
-        self.resource_group = 'cliTestRg_VMSSCreate_none_options'
+        super(VMSSCreateNoneOptionsTest, self).__init__(__file__, test_method, resource_group='cliTestRg_VMSSCreate_none_options')
 
     def test_vmss_create_none_options(self):
         self.execute()
@@ -789,8 +780,7 @@ class VMSSCreateNoneOptionsTest(ResourceGroupVCRTestBase): #pylint: disable=too-
 
 class VMScaleSetCreateExistingOptions(ResourceGroupVCRTestBase):
     def __init__(self, test_method):
-        super(VMScaleSetCreateExistingOptions, self).__init__(__file__, test_method)
-        self.resource_group = 'scaleset_create_existing_options_rg2'
+        super(VMScaleSetCreateExistingOptions, self).__init__(__file__, test_method, resource_group='scaleset_create_existing_options_rg2')
 
     def test_vm_scaleset_create_existing_options(self):
         self.execute()
@@ -834,8 +824,7 @@ class VMScaleSetCreateExistingOptions(ResourceGroupVCRTestBase):
 class VMScaleSetNicScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(VMScaleSetNicScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'test_vm_scaleset_nics'
+        super(VMScaleSetNicScenarioTest, self).__init__(__file__, test_method, resource_group='test_vm_scaleset_nics')
         self.vmss_name = 'vmss1'
         self.instance_id = 0
 
@@ -882,9 +871,8 @@ class VMAccessAddRemoveLinuxUser(VCRTestBase):
 class VMCreateUbuntuScenarioTest(ResourceGroupVCRTestBase): #pylint: disable=too-many-instance-attributes
 
     def __init__(self, test_method):
-        super(VMCreateUbuntuScenarioTest, self).__init__(__file__, test_method)
+        super(VMCreateUbuntuScenarioTest, self).__init__(__file__, test_method, resource_group='cliTestRg_VMCreate_Ubuntu2')
         self.deployment_name = 'azurecli-test-deployment-vm-create-ubuntu2'
-        self.resource_group = 'cliTestRg_VMCreate_Ubuntu2'
         self.admin_username = 'ubuntu'
         self.location = 'westus'
         self.vm_names = ['cli-test-vm2']
@@ -924,8 +912,7 @@ class VMCreateUbuntuScenarioTest(ResourceGroupVCRTestBase): #pylint: disable=too
 class VMMultiNicScenarioTest(ResourceGroupVCRTestBase): #pylint: disable=too-many-instance-attributes
 
     def __init__(self, test_method):
-        super(VMMultiNicScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'cli_test_multi_nic_vm'
+        super(VMMultiNicScenarioTest, self).__init__(__file__, test_method, resource_group='cli_test_multi_nic_vm')
         self.vm_name = 'multinicvm1'
 
     def test_vm_multi_nic_scenario(self):
@@ -979,8 +966,7 @@ class VMMultiNicScenarioTest(ResourceGroupVCRTestBase): #pylint: disable=too-man
 class VMCreateNoneOptionsTest(ResourceGroupVCRTestBase): #pylint: disable=too-many-instance-attributes
 
     def __init__(self, test_method):
-        super(VMCreateNoneOptionsTest, self).__init__(__file__, test_method)
-        self.resource_group = 'cliTestRg_VMCreate_none_options' # create resource group in westus...
+        super(VMCreateNoneOptionsTest, self).__init__(__file__, test_method, resource_group='cliTestRg_VMCreate_none_options') # create resource group in westus...
 
     def test_vm_create_none_options(self):
         self.execute()
@@ -1106,8 +1092,7 @@ def _write_config_file(user_name):
 class DiagnosticsExtensionInstallTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(DiagnosticsExtensionInstallTest, self).__init__(__file__, test_method)
-        self.resource_group = 'clitestdiagext'
+        super(DiagnosticsExtensionInstallTest, self).__init__(__file__, test_method, resource_group='clitestdiagext')
         self.storage_account = 'diagextstorage'
         self.vm = 'testdiagvm'
         self.vmss = 'testdiagvmss'
@@ -1166,8 +1151,7 @@ class DiagnosticsExtensionInstallTest(ResourceGroupVCRTestBase):
 
 class VMCreateExistingOptions(ResourceGroupVCRTestBase):
     def __init__(self, test_method):
-        super(VMCreateExistingOptions, self).__init__(__file__, test_method)
-        self.resource_group = 'vm_create_existing_options_rg'
+        super(VMCreateExistingOptions, self).__init__(__file__, test_method, resource_group='vm_create_existing_options_rg')
 
     def test_vm_create_existing_options(self):
         self.execute()
@@ -1214,8 +1198,7 @@ class VMCreateExistingOptions(ResourceGroupVCRTestBase):
 class VMCreateCustomIP(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(VMCreateCustomIP, self).__init__(__file__, test_method)
-        self.resource_group = 'vm_create_custom_ip_rg3'
+        super(VMCreateCustomIP, self).__init__(__file__, test_method, resource_group='vm_create_custom_ip_rg3')
 
     def test_vm_create_custom_ip(self):
         self.execute()
@@ -1239,9 +1222,8 @@ class VMCreateCustomIP(ResourceGroupVCRTestBase):
 class VMDataDiskVCRTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(VMDataDiskVCRTest, self).__init__(__file__, test_method)
+        super(VMDataDiskVCRTest, self).__init__(__file__, test_method, resource_group='cliTestRg_datadisk')
         self.deployment_name = 'azurecli-test-datadisk'
-        self.resource_group = 'cliTestRg_datadisk'
         self.location = 'westus'
         self.vm_name = 'vm-datadisk-test'
 
@@ -1312,8 +1294,7 @@ class VMDataDiskVCRTest(ResourceGroupVCRTestBase):
 class AzureContainerServiceScenarioTest(ResourceGroupVCRTestBase): #pylint: disable=too-many-instance-attributes
 
     def __init__(self, test_method):
-        super(AzureContainerServiceScenarioTest, self).__init__(__file__, test_method)
-        self.resource_group = 'cliTestRg_Acs'
+        super(AzureContainerServiceScenarioTest, self).__init__(__file__, test_method, resource_group='cliTestRg_Acs')
 
     def test_acs_create_update(self):
         self.execute()


### PR DESCRIPTION
This PR improves the performance of test recording by updating the framework to work with the newly released --no-wait feature.

- The `resource group delete` operation at the end of ResourceGroupVCRTestBase tests (and StorageAccountVCRTestBase tests) adds --no-wait so you don't have to wait for the RG to delete.
- A random four character tag is appended to the resource group name during recording (in the format `_{tag}_`) so that you can begin re-recording a test while a previous test's resource group is deleting.

There are limits: namely, for resources whose name must form a unique URL, trying to recreate that resource will fail if it already exists in a resource group being deleted (for example KeyVaults, Storage Accounts, etc.)