### PR TITLE
[Network] Traffic manager command improvements

### DIFF
--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
@@ -1088,18 +1088,81 @@ helps['network route-table route'] = """
     type: group
     short-summary: Manage route table routes
 """
+
+# Traffic Manager
+
 helps['network traffic-manager'] = """
     type: group
     short-summary: Route incoming traffic for high performance and availability
 """
+
 helps['network traffic-manager endpoint'] = """
     type: group
     short-summary: Manage traffic manager end points
 """
+
 helps['network traffic-manager profile'] = """
     type: group
     short-summary: Manage traffic manager profiles
 """
+
+helps['network traffic-manager profile check-dns'] = """
+    type: command
+    short-summary: Check the availability of a Traffic Manager relative DNS name.
+"""
+
+helps['network traffic-manager profile create'] = """
+    type: command
+    short-summary: Create a new Traffic Manager profile.
+"""
+
+helps['network traffic-manager profile delete'] = """
+    type: command
+    short-summary: Delete a Traffic Manager profile.
+"""
+
+helps['network traffic-manager profile list'] = """
+    type: command
+    short-summary: List Traffic Manager profiles in a resource group or subscription.
+"""
+
+helps['network traffic-manager profile show'] = """
+    type: command
+    short-summary: Show details of a Traffic Manager profile.
+"""
+
+helps['network traffic-manager profile update'] = """
+    type: command
+    short-summary: Update an existing Traffic Manager profile.
+"""
+
+helps['network traffic-manager endpoint create'] = """
+    type: command
+    short-summary: Create a new Traffic Manager endpoint.
+"""
+
+helps['network traffic-manager endpoint delete'] = """
+    type: command
+    short-summary: Delete a Traffic Manager endpoint.
+"""
+
+helps['network traffic-manager endpoint list'] = """
+    type: command
+    short-summary: List Traffic Manager endpoints in a resource group.
+"""
+
+helps['network traffic-manager endpoint show'] = """
+    type: command
+    short-summary: Show details of a Traffic Manager endpoint.
+"""
+
+helps['network traffic-manager endpoint update'] = """
+    type: command
+    short-summary: Update an existing Traffic Manager endpoint.
+"""
+
+# Virtual Network (VNET)
+
 helps['network vnet'] = """
     type: group
     short-summary: Provision private networks

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -458,7 +458,14 @@ register_cli_argument('network vpn-connection create', 'connection_type', help=a
 # Traffic manager profiles
 register_cli_argument('network traffic-manager profile', 'traffic_manager_profile_name', name_arg_type, id_part='name', completer=get_resource_name_completion_list('Microsoft.Network/trafficManagerProfiles'))
 register_cli_argument('network traffic-manager profile', 'profile_name', name_arg_type, id_part='name', completer=get_resource_name_completion_list('Microsoft.Network/trafficManagerProfiles'))
-register_cli_argument('network traffic-manager profile create', 'routing_method', **enum_choice_list(routingMethod))
+register_cli_argument('network traffic-manager profile', 'monitor_path', help='Path to monitor.')
+register_cli_argument('network traffic-manager profile', 'monitor_port', help='Port to monitor.')
+register_cli_argument('network traffic-manager profile', 'monitor_protocol', help='Monitor protocol.')
+register_cli_argument('network traffic-manager profile', 'monitor_status', help='The monitoring status of the profile.')
+register_cli_argument('network traffic-manager profile', 'profile_status', options_list=('--status',), help='Status of the Traffic Manager profile.')
+register_cli_argument('network traffic-manager profile', 'routing_method', help='Routing method.', **enum_choice_list(routingMethod))
+register_cli_argument('network traffic-manager profile', 'ttl', help='DNS config time-to-live in seconds.')
+
 register_cli_argument('network traffic-manager profile check-dns', 'name', name_arg_type, help='DNS prefix to verify availability for.', required=True)
 register_cli_argument('network traffic-manager profile check-dns', 'type', help=argparse.SUPPRESS, default='Microsoft.Network/trafficManagerProfiles')
 
@@ -467,6 +474,14 @@ endpoint_types = ['azureEndpoints', 'externalEndpoints', 'nestedEndpoints']
 register_cli_argument('network traffic-manager endpoint', 'endpoint_name', name_arg_type, id_part='child_name', help='Endpoint name.', completer=get_tm_endpoint_completion_list())
 register_cli_argument('network traffic-manager endpoint', 'endpoint_type', options_list=('--type',), help='Endpoint type.  Values include: {}.'.format(', '.join(endpoint_types)), completer=get_generic_completion_list(endpoint_types))
 register_cli_argument('network traffic-manager endpoint', 'profile_name', help='Name of parent profile.', completer=get_resource_name_completion_list('Microsoft.Network/trafficManagerProfiles'), id_part='name')
+register_cli_argument('network traffic-manager endpoint', 'endpoint_location', help="Location of the external or nested endpoints when using the 'Performance' routing method.")
+register_cli_argument('network traffic-manager endpoint', 'endpoint_monitor_status', help='The monitoring status of the endpoint.')
+register_cli_argument('network traffic-manager endpoint', 'endpoint_status', help="The status of the endpoint. If enabled the endpoint is probed for endpoint health and included in the traffic routing method.")
+register_cli_argument('network traffic-manager endpoint', 'min_child_endpoints', help="The minimum number of endpoints that must be available in the child profile for the parent profile to be considered available. Only applicable to an endpoint of type 'NestedEndpoints'.")
+register_cli_argument('network traffic-manager endpoint', 'priority', help="Priority of the endpoint when using the 'Priority' traffic routing method. Values range from 1 to 1000, with lower values representing higher priority.")
+register_cli_argument('network traffic-manager endpoint', 'target', help='Fully-qualified DNS name of the endpoint.')
+register_cli_argument('network traffic-manager endpoint', 'target_resource_id', help="The Azure Resource URI of the endpoint. Not applicable for endpoints of type 'ExternalEndpoints'.")
+register_cli_argument('network traffic-manager endpoint', 'weight', help="Weight of the endpoint when using the 'Weighted' traffic routing method. Values range from 1 to 1000.")
 
 # DNS
 register_cli_argument('network dns', 'location', help=argparse.SUPPRESS, default='global')

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -31,6 +31,7 @@ from azure.cli.command_modules.network._validators import \
      process_ag_url_path_map_rule_create_namespace, process_auth_create_namespace,
      process_public_ip_create_namespace, validate_private_ip_address,
      process_lb_frontend_ip_namespace, process_local_gateway_create_namespace,
+     process_tm_endpoint_create_namespace,
      validate_inbound_nat_rule_id_list, validate_address_pool_id_list,
      validate_inbound_nat_rule_name_or_id, validate_address_pool_name_or_id,
      validate_servers, load_cert_file,
@@ -483,6 +484,8 @@ register_cli_argument('network traffic-manager endpoint', 'priority', help="Prio
 register_cli_argument('network traffic-manager endpoint', 'target', help='Fully-qualified DNS name of the endpoint.')
 register_cli_argument('network traffic-manager endpoint', 'target_resource_id', help="The Azure Resource URI of the endpoint. Not applicable for endpoints of type 'ExternalEndpoints'.")
 register_cli_argument('network traffic-manager endpoint', 'weight', help="Weight of the endpoint when using the 'Weighted' traffic routing method. Values range from 1 to 1000.")
+
+register_cli_argument('network traffic-manager endpoint create', 'target', help='Fully-qualified DNS name of the endpoint.', validator=process_tm_endpoint_create_namespace)
 
 # DNS
 register_cli_argument('network dns', 'location', help=argparse.SUPPRESS, default='global')

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -41,7 +41,7 @@ from azure.cli.command_modules.network.mgmt_nic.lib.models.nic_creation_client_e
 from azure.cli.command_modules.network.mgmt_vnet_gateway.lib.models.vnet_gateway_creation_client_enums import \
     (gatewayType, sku, vpnType)
 from azure.cli.command_modules.network.mgmt_traffic_manager_profile.lib.models.traffic_manager_profile_creation_client_enums \
-    import routingMethod
+    import routingMethod, status
 from azure.cli.command_modules.network.custom import list_traffic_manager_endpoints
 
 # CHOICE LISTS
@@ -461,10 +461,11 @@ register_cli_argument('network traffic-manager profile', 'profile_name', name_ar
 register_cli_argument('network traffic-manager profile', 'monitor_path', help='Path to monitor.')
 register_cli_argument('network traffic-manager profile', 'monitor_port', help='Port to monitor.')
 register_cli_argument('network traffic-manager profile', 'monitor_protocol', help='Monitor protocol.')
-register_cli_argument('network traffic-manager profile', 'monitor_status', help='The monitoring status of the profile.')
-register_cli_argument('network traffic-manager profile', 'profile_status', options_list=('--status',), help='Status of the Traffic Manager profile.')
+register_cli_argument('network traffic-manager profile', 'profile_status', options_list=('--status',), help='Status of the Traffic Manager profile.', **enum_choice_list(['Enabled', 'Disabled']))
 register_cli_argument('network traffic-manager profile', 'routing_method', help='Routing method.', **enum_choice_list(routingMethod))
 register_cli_argument('network traffic-manager profile', 'ttl', help='DNS config time-to-live in seconds.')
+
+register_cli_argument('network traffic-manager profile create', 'status', **enum_choice_list(status))
 
 register_cli_argument('network traffic-manager profile check-dns', 'name', name_arg_type, help='DNS prefix to verify availability for.', required=True)
 register_cli_argument('network traffic-manager profile check-dns', 'type', help=argparse.SUPPRESS, default='Microsoft.Network/trafficManagerProfiles')

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -309,7 +309,7 @@ register_cli_argument('network nsg create', 'name', name_arg_type)
 # NSG Rule
 register_cli_argument('network nsg rule', 'security_rule_name', name_arg_type, id_part='child_name', help='Name of the network security group rule')
 register_cli_argument('network nsg rule', 'network_security_group_name', options_list=('--nsg-name',), metavar='NSGNAME', help='Name of the network security group', id_part='name')
-register_cli_argument('network nsg rule create', 'priority', default=1000)
+register_cli_argument('network nsg rule create', 'priority', default=1000, type=int)
 
 # Public IP
 register_cli_argument('network public-ip', 'public_ip_address_name', name_arg_type, completer=get_resource_name_completion_list('Microsoft.Network/publicIPAddresses'), id_part='name', help='The name of the public IP address.')
@@ -460,11 +460,11 @@ register_cli_argument('network vpn-connection create', 'connection_type', help=a
 register_cli_argument('network traffic-manager profile', 'traffic_manager_profile_name', name_arg_type, id_part='name', completer=get_resource_name_completion_list('Microsoft.Network/trafficManagerProfiles'))
 register_cli_argument('network traffic-manager profile', 'profile_name', name_arg_type, id_part='name', completer=get_resource_name_completion_list('Microsoft.Network/trafficManagerProfiles'))
 register_cli_argument('network traffic-manager profile', 'monitor_path', help='Path to monitor.')
-register_cli_argument('network traffic-manager profile', 'monitor_port', help='Port to monitor.')
+register_cli_argument('network traffic-manager profile', 'monitor_port', help='Port to monitor.', type=int)
 register_cli_argument('network traffic-manager profile', 'monitor_protocol', help='Monitor protocol.')
 register_cli_argument('network traffic-manager profile', 'profile_status', options_list=('--status',), help='Status of the Traffic Manager profile.', **enum_choice_list(['Enabled', 'Disabled']))
 register_cli_argument('network traffic-manager profile', 'routing_method', help='Routing method.', **enum_choice_list(routingMethod))
-register_cli_argument('network traffic-manager profile', 'ttl', help='DNS config time-to-live in seconds.')
+register_cli_argument('network traffic-manager profile', 'ttl', help='DNS config time-to-live in seconds.', type=int)
 
 register_cli_argument('network traffic-manager profile create', 'status', **enum_choice_list(status))
 
@@ -480,10 +480,10 @@ register_cli_argument('network traffic-manager endpoint', 'endpoint_location', h
 register_cli_argument('network traffic-manager endpoint', 'endpoint_monitor_status', help='The monitoring status of the endpoint.')
 register_cli_argument('network traffic-manager endpoint', 'endpoint_status', help="The status of the endpoint. If enabled the endpoint is probed for endpoint health and included in the traffic routing method.")
 register_cli_argument('network traffic-manager endpoint', 'min_child_endpoints', help="The minimum number of endpoints that must be available in the child profile for the parent profile to be considered available. Only applicable to an endpoint of type 'NestedEndpoints'.")
-register_cli_argument('network traffic-manager endpoint', 'priority', help="Priority of the endpoint when using the 'Priority' traffic routing method. Values range from 1 to 1000, with lower values representing higher priority.")
+register_cli_argument('network traffic-manager endpoint', 'priority', help="Priority of the endpoint when using the 'Priority' traffic routing method. Values range from 1 to 1000, with lower values representing higher priority.", type=int)
 register_cli_argument('network traffic-manager endpoint', 'target', help='Fully-qualified DNS name of the endpoint.')
 register_cli_argument('network traffic-manager endpoint', 'target_resource_id', help="The Azure Resource URI of the endpoint. Not applicable for endpoints of type 'ExternalEndpoints'.")
-register_cli_argument('network traffic-manager endpoint', 'weight', help="Weight of the endpoint when using the 'Weighted' traffic routing method. Values range from 1 to 1000.")
+register_cli_argument('network traffic-manager endpoint', 'weight', help="Weight of the endpoint when using the 'Weighted' traffic routing method. Values range from 1 to 1000.", type=int)
 
 register_cli_argument('network traffic-manager endpoint create', 'target', help='Fully-qualified DNS name of the endpoint.', validator=process_tm_endpoint_create_namespace)
 

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
@@ -364,7 +364,8 @@ cli_command(__name__, 'network traffic-manager profile list', 'azure.cli.command
 cli_generic_update_command(__name__, 'network traffic-manager profile update',
                            'azure.mgmt.trafficmanager.operations.profiles_operations#ProfilesOperations.get',
                            'azure.mgmt.trafficmanager.operations.profiles_operations#ProfilesOperations.create_or_update',
-                           cf_traffic_manager_mgmt_profiles)
+                           cf_traffic_manager_mgmt_profiles,
+                           custom_function_op='azure.cli.command_modules.network.custom#update_traffic_manager_profile')
 
 cli_command(__name__, 'network traffic-manager profile create',
             'azure.cli.command_modules.network.mgmt_traffic_manager_profile.lib.operations.traffic_manager_profile_operations#TrafficManagerProfileOperations.create_or_update',
@@ -379,7 +380,8 @@ cli_command(__name__, 'network traffic-manager endpoint list', 'azure.cli.comman
 cli_generic_update_command(__name__, 'network traffic-manager endpoint update',
                            'azure.mgmt.trafficmanager.operations.endpoints_operations#EndpointsOperations.get',
                            'azure.mgmt.trafficmanager.operations.endpoints_operations#EndpointsOperations.create_or_update',
-                           cf_traffic_manager_mgmt_endpoints)
+                           cf_traffic_manager_mgmt_endpoints,
+                           custom_function_op='azure.cli.command_modules.network.custom#update_traffic_manager_endpoint')
 
 # DNS ZonesOperations
 cli_command(__name__, 'network dns zone show', 'azure.mgmt.dns.operations.zones_operations#ZonesOperations.get', cf_dns_mgmt_zones)

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -932,26 +932,22 @@ def update_traffic_manager_profile(instance, profile_status=None, routing_method
     if tags is not None:
         instance.tags = tags
     if profile_status is not None:
-        instance.properties.profile_status = profile_status
+        instance.profile_status = profile_status # TODO: Needs choice list Enabled/Disabled
     if routing_method is not None:
-        instance.properties.traffic_routing_method = routing_method
+        instance.traffic_routing_method = routing_method
     if ttl is not None:
-        instance.properties.dns_config.ttl = ttl
+        instance.dns_config.ttl = ttl
 
-    if any([x for x in [monitor_protocol, monitor_port, monitor_path, monitor_status] is not None]):
-        if instance.monitor_config:
-            if monitor_status is not None:
-                instance.properties.monitor_config.profile_monitor_status = monitor_status
-            if monitor_protocol is not None:
-                instance.properties.monitor_config.protocol = monitor_protocol
-            if monitor_port is not None:
-                instance.properties.monitor_config.port = monitor_port
-            if monitor_path is not None:
-                instance.properties.monitor_config.path = monitor_path
-        else:
-            from azure.mgmt.trafficmanager.models import MonitorConfig
-            instance.properties.monitor_config = MonitorConfig(
-                monitor_status, monitor_protocol, monitor_port, monitor_path)
+    monitor_params = [monitor_protocol, monitor_port, monitor_path, monitor_status]
+    if any([x for x in monitor_params if x is not None]):
+        if monitor_status is not None:
+            instance.monitor_config.profile_monitor_status = monitor_status  # TODO: DOESN'T SEEM TO WORK?
+        if monitor_protocol is not None:
+            instance.monitor_config.protocol = monitor_protocol
+        if monitor_port is not None:
+            instance.monitor_config.port = monitor_port
+        if monitor_path is not None:
+            instance.monitor_config.path = monitor_path
 
     return instance
 
@@ -978,21 +974,21 @@ def update_traffic_manager_endpoint(instance, endpoint_type=None, endpoint_locat
     if endpoint_type is not None:
         instance.type = endpoint_type
     if endpoint_location is not None:
-        instance.properties.endpoint_location = endpoint_location
+        instance.endpoint_location = endpoint_location
     if endpoint_status is not None:
-        instance.properties.endpoint_status = endpoint_status
+        instance.endpoint_status = endpoint_status
     if endpoint_monitor_status is not None:
-        instance.properties.endpoint_monitor_status = endpoint_monitor_status
+        instance.endpoint_monitor_status = endpoint_monitor_status
     if priority is not None:
-        instance.properties.priority = priority
+        instance.priority = priority
     if target is not None:
-        instance.properties.target = target
+        instance.target = target
     if target_resource_id is not None:
-        instance.properties.target_resource_id = target_resource_id
+        instance.target_resource_id = target_resource_id
     if weight is not None:
-        instance.properties.weight = weight
+        instance.weight = weight
     if min_child_endpoints is not None:
-        instance.properties.min_child_endpoints = min_child_endpoints
+        instance.min_child_endpoints = min_child_endpoints
 
     return instance
 

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -919,6 +919,7 @@ def update_local_gateway(instance, gateway_ip_address=None, local_address_prefix
 #endregion
 
 #region Traffic Manager Commands
+
 def list_traffic_manager_profiles(resource_group_name=None):
     ncf = get_mgmt_service_client(TrafficManagerManagementClient).profiles
     if resource_group_name:
@@ -932,20 +933,18 @@ def update_traffic_manager_profile(instance, profile_status=None, routing_method
     if tags is not None:
         instance.tags = tags
     if profile_status is not None:
-        instance.profile_status = profile_status # TODO: Needs choice list Enabled/Disabled
+        instance.profile_status = profile_status
     if routing_method is not None:
         instance.traffic_routing_method = routing_method
     if ttl is not None:
         instance.dns_config.ttl = ttl
 
-    monitor_params = [monitor_protocol, monitor_port, monitor_path]
-    if any([x for x in monitor_params if x is not None]):
-        if monitor_protocol is not None:
-            instance.monitor_config.protocol = monitor_protocol
-        if monitor_port is not None:
-            instance.monitor_config.port = monitor_port
-        if monitor_path is not None:
-            instance.monitor_config.path = monitor_path
+    if monitor_protocol is not None:
+        instance.monitor_config.protocol = monitor_protocol
+    if monitor_port is not None:
+        instance.monitor_config.port = monitor_port
+    if monitor_path is not None:
+        instance.monitor_config.path = monitor_path
 
     return instance
 

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -928,7 +928,7 @@ def list_traffic_manager_profiles(resource_group_name=None):
 
 def update_traffic_manager_profile(instance, profile_status=None, routing_method=None, tags=None,
                                    monitor_protocol=None, monitor_port=None, monitor_path=None,
-                                   monitor_status=None, ttl=None):
+                                   ttl=None):
     if tags is not None:
         instance.tags = tags
     if profile_status is not None:
@@ -938,10 +938,8 @@ def update_traffic_manager_profile(instance, profile_status=None, routing_method
     if ttl is not None:
         instance.dns_config.ttl = ttl
 
-    monitor_params = [monitor_protocol, monitor_port, monitor_path, monitor_status]
+    monitor_params = [monitor_protocol, monitor_port, monitor_path]
     if any([x for x in monitor_params if x is not None]):
-        if monitor_status is not None:
-            instance.monitor_config.profile_monitor_status = monitor_status  # TODO: DOESN'T SEEM TO WORK?
         if monitor_protocol is not None:
             instance.monitor_config.protocol = monitor_protocol
         if monitor_port is not None:

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -926,6 +926,35 @@ def list_traffic_manager_profiles(resource_group_name=None):
     else:
         return ncf.list_all()
 
+def update_traffic_manager_profile(instance, profile_status=None, routing_method=None, tags=None,
+                                   monitor_protocol=None, monitor_port=None, monitor_path=None,
+                                   monitor_status=None, ttl=None):
+    if tags is not None:
+        instance.tags = tags
+    if profile_status is not None:
+        instance.properties.profile_status = profile_status
+    if routing_method is not None:
+        instance.properties.traffic_routing_method = routing_method
+    if ttl is not None:
+        instance.properties.dns_config.ttl = ttl
+
+    if any([x for x in [monitor_protocol, monitor_port, monitor_path, monitor_status] is not None]):
+        if instance.monitor_config:
+            if monitor_status is not None:
+                instance.properties.monitor_config.profile_monitor_status = monitor_status
+            if monitor_protocol is not None:
+                instance.properties.monitor_config.protocol = monitor_protocol
+            if monitor_port is not None:
+                instance.properties.monitor_config.port = monitor_port
+            if monitor_path is not None:
+                instance.properties.monitor_config.path = monitor_path
+        else:
+            from azure.mgmt.trafficmanager.models import MonitorConfig
+            instance.properties.monitor_config = MonitorConfig(
+                monitor_status, monitor_protocol, monitor_port, monitor_path)
+
+    return instance
+
 def create_traffic_manager_endpoint(resource_group_name, profile_name, endpoint_type, endpoint_name,
                                     target_resource_id=None, target=None,
                                     endpoint_status=None, weight=None, priority=None,
@@ -942,7 +971,30 @@ def create_traffic_manager_endpoint(resource_group_name, profile_name, endpoint_
     return ncf.create_or_update(resource_group_name, profile_name, endpoint_type, endpoint_name,
                                 endpoint)
 
-create_traffic_manager_endpoint.__doc__ = Endpoint.__doc__
+def update_traffic_manager_endpoint(instance, endpoint_type=None, endpoint_location=None,
+                                    endpoint_status=None, endpoint_monitor_status=None,
+                                    priority=None, target=None, target_resource_id=None,
+                                    weight=None, min_child_endpoints=None):
+    if endpoint_type is not None:
+        instance.type = endpoint_type
+    if endpoint_location is not None:
+        instance.properties.endpoint_location = endpoint_location
+    if endpoint_status is not None:
+        instance.properties.endpoint_status = endpoint_status
+    if endpoint_monitor_status is not None:
+        instance.properties.endpoint_monitor_status = endpoint_monitor_status
+    if priority is not None:
+        instance.properties.priority = priority
+    if target is not None:
+        instance.properties.target = target
+    if target_resource_id is not None:
+        instance.properties.target_resource_id = target_resource_id
+    if weight is not None:
+        instance.properties.weight = weight
+    if min_child_endpoints is not None:
+        instance.properties.min_child_endpoints = min_child_endpoints
+
+    return instance
 
 def list_traffic_manager_endpoints(resource_group_name, profile_name, endpoint_type=None):
     ncf = get_mgmt_service_client(TrafficManagerManagementClient).profiles

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_traffic_manager.yaml
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_traffic_manager.yaml
@@ -1,68 +1,67 @@
 interactions:
 - request:
-    body: !!python/unicode '{"type": "Microsoft.Network/trafficManagerProfiles", "name":
-      "myfoobar1"}'
+    body: '{"name": "myfoobar1", "type": "Microsoft.Network/trafficManagerProfiles"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['73']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.5 trafficmanagermanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b10]
+          AZURECLI/TEST/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [fc301d8f-bcd0-11e6-a1f0-a0b3ccf7272a]
+      x-ms-client-request-id: [6ce0ca54-bd6d-11e6-9836-a0b3ccf7272a]
     method: POST
     uri: https://management.azure.com/providers/Microsoft.Network/checkTrafficManagerNameAvailability?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"name":"myfoobar1","type":"Microsoft.Network\/trafficManagerProfiles","nameAvailable":true,"reason":null,"message":null}'}
+    body: {string: '{"name":"myfoobar1","type":"Microsoft.Network\/trafficManagerProfiles","nameAvailable":true,"reason":null,"message":null}'}
     headers:
-      cache-control: [private]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 08 Dec 2016 17:40:35 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       content-length: ['121']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 07 Dec 2016 23:00:45 GMT']
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
       x-ms-ratelimit-remaining-tenant-writes: ['1199']
-      x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateTrafficManagerProfile_2016-08-08/azuredeploy.json"},
-      "mode": "Incremental", "parameters": {"status": {"value": "enabled"}, "monitorPort":
-      {"value": 80}, "trafficManagerProfileName": {"value": "mytmprofile"}, "monitorPath":
-      {"value": "/"}, "monitorProtocol": {"value": "http"}, "ttl": {"value": 30},
-      "routingMethod": {"value": "weighted"}, "uniqueDnsName": {"value": "mytrafficmanager001100a"},
-      "location": {"value": "global"}}}}'
+    body: '{"properties": {"parameters": {"monitorPort": {"value": 80}, "routingMethod":
+      {"value": "weighted"}, "ttl": {"value": 30}, "location": {"value": "global"},
+      "uniqueDnsName": {"value": "mytrafficmanager001100a"}, "status": {"value": "enabled"},
+      "monitorProtocol": {"value": "http"}, "trafficManagerProfileName": {"value":
+      "mytmprofile"}, "monitorPath": {"value": "/"}}, "mode": "Incremental", "templateLink":
+      {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateTrafficManagerProfile_2016-08-08/azuredeploy.json"}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['529']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.5 trafficmanagerprofilecreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b10]
+          AZURECLI/TEST/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [fce3dd30-bcd0-11e6-af71-a0b3ccf7272a]
+      x-ms-client-request-id: [6d819d78-bd6d-11e6-889c-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_traffic_manager_test/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_traffic_manager_test_7stt_/providers/Microsoft.Resources/deployments/azurecli1481151646.3350271","name":"azurecli1481151646.3350271","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateTrafficManagerProfile_2016-08-08/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"location":{"type":"String","value":"global"},"monitorPath":{"type":"String","value":"/"},"monitorPort":{"type":"Int","value":80},"monitorProtocol":{"type":"String","value":"http"},"routingMethod":{"type":"String","value":"weighted"},"status":{"type":"String","value":"enabled"},"trafficManagerProfileName":{"type":"String","value":"mytmprofile"},"ttl":{"type":"Int","value":30},"uniqueDnsName":{"type":"String","value":"mytrafficmanager001100a"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-12-07T23:00:47.5402509Z","duration":"PT0.2984361S","correlationId":"158da6bd-353b-465f-9ddc-219775aea889","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"trafficManagerProfiles","locations":["global"]}]}],"dependencies":[]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_traffic_manager_test1/providers/Microsoft.Resources/deployments/azurecli1481218836.75846824014","name":"azurecli1481218836.75846824014","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateTrafficManagerProfile_2016-08-08/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"location":{"type":"String","value":"global"},"monitorPath":{"type":"String","value":"/"},"monitorPort":{"type":"Int","value":80},"monitorProtocol":{"type":"String","value":"http"},"routingMethod":{"type":"String","value":"weighted"},"status":{"type":"String","value":"enabled"},"trafficManagerProfileName":{"type":"String","value":"mytmprofile"},"ttl":{"type":"Int","value":30},"uniqueDnsName":{"type":"String","value":"mytrafficmanager001100a"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-12-08T17:40:38.4602671Z","duration":"PT0.438253S","correlationId":"b29af7c1-b4c2-4c4e-b7cd-1b9797893e11","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"trafficManagerProfiles","locations":["global"]}]}],"dependencies":[]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_traffic_manager_test_7stt_/providers/Microsoft.Resources/deployments/azurecli1481151646.3350271/operationStatuses/08587204552382358478?api-version=2015-11-01']
-      cache-control: [no-cache]
-      content-length: ['1175']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 07 Dec 2016 23:00:47 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_traffic_manager_test1/providers/Microsoft.Resources/deployments/azurecli1481218836.75846824014/operationStatuses/08587203880474556516?api-version=2015-11-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['1177']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 08 Dec 2016 17:40:37 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -71,24 +70,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.5 trafficmanagerprofilecreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b10]
+          AZURECLI/TEST/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [fce3dd30-bcd0-11e6-af71-a0b3ccf7272a]
+      x-ms-client-request-id: [6d819d78-bd6d-11e6-889c-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_traffic_manager_test/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587204552382358478?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_traffic_manager_test1/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587203880474556516?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"status":"Succeeded"}'}
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
+        tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 08 Dec 2016 17:41:08 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
       content-length: ['22']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 07 Dec 2016 23:01:17 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -97,24 +100,24 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.5 trafficmanagerprofilecreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b10]
+          AZURECLI/TEST/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [fce3dd30-bcd0-11e6-af71-a0b3ccf7272a]
+      x-ms-client-request-id: [6d819d78-bd6d-11e6-889c-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_traffic_manager_test/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_traffic_manager_test_7stt_/providers/Microsoft.Resources/deployments/azurecli1481151646.3350271","name":"azurecli1481151646.3350271","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateTrafficManagerProfile_2016-08-08/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"location":{"type":"String","value":"global"},"monitorPath":{"type":"String","value":"/"},"monitorPort":{"type":"Int","value":80},"monitorProtocol":{"type":"String","value":"http"},"routingMethod":{"type":"String","value":"weighted"},"status":{"type":"String","value":"enabled"},"trafficManagerProfileName":{"type":"String","value":"mytmprofile"},"ttl":{"type":"Int","value":30},"uniqueDnsName":{"type":"String","value":"mytrafficmanager001100a"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-12-07T23:00:54.910193Z","duration":"PT7.6683782S","correlationId":"158da6bd-353b-465f-9ddc-219775aea889","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"trafficManagerProfiles","locations":["global"]}]}],"dependencies":[],"outputs":{"trafficManagerProfile":{"type":"Object","value":{"profileStatus":"Enabled","trafficRoutingMethod":"Weighted","dnsConfig":{"relativeName":"mytrafficmanager001100a","fqdn":"mytrafficmanager001100a.trafficmanager.net","ttl":30},"monitorConfig":{"profileMonitorStatus":"Inactive","protocol":"HTTP","port":80,"path":"/"},"endpoints":[]}}},"outputResources":[{"id":"Microsoft.Network/trafficManagerProfiles/mytmprofile"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_traffic_manager_test1/providers/Microsoft.Resources/deployments/azurecli1481218836.75846824014","name":"azurecli1481218836.75846824014","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateTrafficManagerProfile_2016-08-08/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"location":{"type":"String","value":"global"},"monitorPath":{"type":"String","value":"/"},"monitorPort":{"type":"Int","value":80},"monitorProtocol":{"type":"String","value":"http"},"routingMethod":{"type":"String","value":"weighted"},"status":{"type":"String","value":"enabled"},"trafficManagerProfileName":{"type":"String","value":"mytmprofile"},"ttl":{"type":"Int","value":30},"uniqueDnsName":{"type":"String","value":"mytrafficmanager001100a"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-12-08T17:40:44.8946202Z","duration":"PT6.8726061S","correlationId":"b29af7c1-b4c2-4c4e-b7cd-1b9797893e11","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"trafficManagerProfiles","locations":["global"]}]}],"dependencies":[],"outputs":{"trafficManagerProfile":{"type":"Object","value":{"profileStatus":"Enabled","trafficRoutingMethod":"Weighted","dnsConfig":{"relativeName":"mytrafficmanager001100a","fqdn":"mytrafficmanager001100a.trafficmanager.net","ttl":30},"monitorConfig":{"profileMonitorStatus":"Inactive","protocol":"HTTP","port":80,"path":"/"},"endpoints":[]}}},"outputResources":[{"id":"Microsoft.Network/trafficManagerProfiles/mytmprofile"}]}}'}
     headers:
-      cache-control: [no-cache]
-      content-length: ['1603']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 07 Dec 2016 23:01:18 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 08 Dec 2016 17:41:09 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['1607']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -123,58 +126,87 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.5 trafficmanagermanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b10]
+          AZURECLI/TEST/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [10c8f14f-bcd1-11e6-89e2-a0b3ccf7272a]
+      x-ms-client-request-id: [81658b6e-bd6d-11e6-8c4d-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_traffic_manager_test/providers/Microsoft.Network/trafficmanagerprofiles/mytmprofile?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_traffic_manager_test_7stt_\/providers\/Microsoft.Network\/trafficManagerProfiles\/mytmprofile","name":"mytmprofile","type":"Microsoft.Network\/trafficManagerProfiles","location":"global","properties":{"profileStatus":"Enabled","trafficRoutingMethod":"Weighted","dnsConfig":{"relativeName":"mytrafficmanager001100a","fqdn":"mytrafficmanager001100a.trafficmanager.net","ttl":30},"monitorConfig":{"profileMonitorStatus":"Inactive","protocol":"HTTP","port":80,"path":"\/"},"endpoints":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_traffic_manager_test1\/providers\/Microsoft.Network\/trafficManagerProfiles\/mytmprofile","name":"mytmprofile","type":"Microsoft.Network\/trafficManagerProfiles","location":"global","properties":{"profileStatus":"Enabled","trafficRoutingMethod":"Weighted","dnsConfig":{"relativeName":"mytrafficmanager001100a","fqdn":"mytrafficmanager001100a.trafficmanager.net","ttl":30},"monitorConfig":{"profileMonitorStatus":"Inactive","protocol":"HTTP","port":80,"path":"\/"},"endpoints":[]}}'}
     headers:
-      cache-control: [private]
-      content-length: ['567']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 07 Dec 2016 23:01:19 GMT']
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['10798']
-      x-powered-by: [ASP.NET]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 08 Dec 2016 17:41:09 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['562']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['10799']
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"properties": {"target": "www.microsoft.com", "weight":
-      50}}'
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.5 trafficmanagermanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b10+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [81ecb0ca-bd6d-11e6-b758-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_traffic_manager_test1/providers/Microsoft.Network/trafficmanagerprofiles/mytmprofile?api-version=2015-11-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_traffic_manager_test1\/providers\/Microsoft.Network\/trafficManagerProfiles\/mytmprofile","name":"mytmprofile","type":"Microsoft.Network\/trafficManagerProfiles","location":"global","properties":{"profileStatus":"Enabled","trafficRoutingMethod":"Weighted","dnsConfig":{"relativeName":"mytrafficmanager001100a","fqdn":"mytrafficmanager001100a.trafficmanager.net","ttl":30},"monitorConfig":{"profileMonitorStatus":"Inactive","protocol":"HTTP","port":80,"path":"\/"},"endpoints":[]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 08 Dec 2016 17:41:11 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['562']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['10791']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"weight": 50, "target": "www.microsoft.com"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['61']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.5 trafficmanagermanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b10]
+          AZURECLI/TEST/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [114d3c80-bcd1-11e6-989b-a0b3ccf7272a]
+      x-ms-client-request-id: [82360f0c-bd6d-11e6-9415-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_traffic_manager_test/providers/Microsoft.Network/trafficmanagerprofiles/mytmprofile/externalEndpoints/myendpoint?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_traffic_manager_test_7stt_\/providers\/Microsoft.Network\/trafficManagerProfiles\/mytmprofile\/externalEndpoints\/myendpoint","name":"myendpoint","type":"Microsoft.Network\/trafficManagerProfiles\/externalEndpoints","properties":{"endpointStatus":"Enabled","endpointMonitorStatus":"CheckingEndpoint","target":"www.microsoft.com","weight":50,"priority":1,"endpointLocation":null}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_traffic_manager_test1\/providers\/Microsoft.Network\/trafficManagerProfiles\/mytmprofile\/externalEndpoints\/myendpoint","name":"myendpoint","type":"Microsoft.Network\/trafficManagerProfiles\/externalEndpoints","properties":{"endpointStatus":"Enabled","endpointMonitorStatus":"CheckingEndpoint","target":"www.microsoft.com","weight":50,"priority":1,"endpointLocation":null}}'}
     headers:
-      cache-control: [private]
-      content-length: ['461']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 07 Dec 2016 23:01:20 GMT']
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
+      Cache-Control: [private]
+      Content-Length: ['456']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 08 Dec 2016 17:41:11 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
       x-ms-ratelimit-remaining-subscription-writes: ['1197']
-      x-powered-by: [ASP.NET]
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -183,26 +215,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.5 trafficmanagermanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b10]
+          AZURECLI/TEST/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [11f03340-bcd1-11e6-b4df-a0b3ccf7272a]
+      x-ms-client-request-id: [82f3816c-bd6d-11e6-bfa7-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_traffic_manager_test/providers/Microsoft.Network/trafficmanagerprofiles/mytmprofile/externalEndpoints/myendpoint?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_traffic_manager_test_7stt_\/providers\/Microsoft.Network\/trafficManagerProfiles\/mytmprofile\/externalEndpoints\/myendpoint","name":"myendpoint","type":"Microsoft.Network\/trafficManagerProfiles\/externalEndpoints","properties":{"endpointStatus":"Enabled","endpointMonitorStatus":"CheckingEndpoint","target":"www.microsoft.com","weight":50,"priority":1,"endpointLocation":null}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_traffic_manager_test1\/providers\/Microsoft.Network\/trafficManagerProfiles\/mytmprofile\/externalEndpoints\/myendpoint","name":"myendpoint","type":"Microsoft.Network\/trafficManagerProfiles\/externalEndpoints","properties":{"endpointStatus":"Enabled","endpointMonitorStatus":"CheckingEndpoint","target":"www.microsoft.com","weight":50,"priority":1,"endpointLocation":null}}'}
     headers:
-      cache-control: [private]
-      content-length: ['461']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 07 Dec 2016 23:01:21 GMT']
-      server: [Microsoft-IIS/8.5]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-content-type-options: [nosniff]
-      x-powered-by: [ASP.NET]
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 08 Dec 2016 17:41:12 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['456']
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_traffic_manager.yaml
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_traffic_manager.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"name": "myfoobar1", "type": "Microsoft.Network/trafficManagerProfiles"}'
+    body: '{"type": "Microsoft.Network/trafficManagerProfiles", "name": "myfoobar1"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -11,7 +11,7 @@ interactions:
           msrest_azure/0.4.5 trafficmanagermanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [6ce0ca54-bd6d-11e6-9836-a0b3ccf7272a]
+      x-ms-client-request-id: [9f6a085a-bd96-11e6-b6f4-a0b3ccf7272a]
     method: POST
     uri: https://management.azure.com/providers/Microsoft.Network/checkTrafficManagerNameAvailability?api-version=2015-11-01
   response:
@@ -19,7 +19,7 @@ interactions:
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 08 Dec 2016 17:40:35 GMT']
+      Date: ['Thu, 08 Dec 2016 22:35:29 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -31,12 +31,12 @@ interactions:
       x-ms-ratelimit-remaining-tenant-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"parameters": {"monitorPort": {"value": 80}, "routingMethod":
-      {"value": "weighted"}, "ttl": {"value": 30}, "location": {"value": "global"},
-      "uniqueDnsName": {"value": "mytrafficmanager001100a"}, "status": {"value": "enabled"},
-      "monitorProtocol": {"value": "http"}, "trafficManagerProfileName": {"value":
-      "mytmprofile"}, "monitorPath": {"value": "/"}}, "mode": "Incremental", "templateLink":
-      {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateTrafficManagerProfile_2016-08-08/azuredeploy.json"}}}'
+    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateTrafficManagerProfile_2016-08-08/azuredeploy.json"},
+      "parameters": {"uniqueDnsName": {"value": "mytrafficmanager001100a"}, "monitorProtocol":
+      {"value": "http"}, "status": {"value": "enabled"}, "location": {"value": "global"},
+      "routingMethod": {"value": "weighted"}, "ttl": {"value": 30}, "monitorPort":
+      {"value": 80}, "monitorPath": {"value": "/"}, "trafficManagerProfileName": {"value":
+      "mytmprofile"}}, "mode": "Incremental"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -47,17 +47,17 @@ interactions:
           msrest_azure/0.4.5 trafficmanagerprofilecreationclient/2015-11-01 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [6d819d78-bd6d-11e6-889c-a0b3ccf7272a]
+      x-ms-client-request-id: [9ff4993a-bd96-11e6-8514-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_traffic_manager_test/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_traffic_manager_test1/providers/Microsoft.Resources/deployments/azurecli1481218836.75846824014","name":"azurecli1481218836.75846824014","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateTrafficManagerProfile_2016-08-08/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"location":{"type":"String","value":"global"},"monitorPath":{"type":"String","value":"/"},"monitorPort":{"type":"Int","value":80},"monitorProtocol":{"type":"String","value":"http"},"routingMethod":{"type":"String","value":"weighted"},"status":{"type":"String","value":"enabled"},"trafficManagerProfileName":{"type":"String","value":"mytmprofile"},"ttl":{"type":"Int","value":30},"uniqueDnsName":{"type":"String","value":"mytrafficmanager001100a"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-12-08T17:40:38.4602671Z","duration":"PT0.438253S","correlationId":"b29af7c1-b4c2-4c4e-b7cd-1b9797893e11","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"trafficManagerProfiles","locations":["global"]}]}],"dependencies":[]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_traffic_manager_test_9hvn_/providers/Microsoft.Resources/deployments/azurecli1481236530.764017329962","name":"azurecli1481236530.764017329962","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateTrafficManagerProfile_2016-08-08/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"location":{"type":"String","value":"global"},"monitorPath":{"type":"String","value":"/"},"monitorPort":{"type":"Int","value":80},"monitorProtocol":{"type":"String","value":"http"},"routingMethod":{"type":"String","value":"weighted"},"status":{"type":"String","value":"enabled"},"trafficManagerProfileName":{"type":"String","value":"mytmprofile"},"ttl":{"type":"Int","value":30},"uniqueDnsName":{"type":"String","value":"mytrafficmanager001100a"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-12-08T22:35:32.1712917Z","duration":"PT0.5216899S","correlationId":"a98055b4-20b8-4e8e-8104-9f8a8510b680","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"trafficManagerProfiles","locations":["global"]}]}],"dependencies":[]}}'}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_traffic_manager_test1/providers/Microsoft.Resources/deployments/azurecli1481218836.75846824014/operationStatuses/08587203880474556516?api-version=2015-11-01']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_traffic_manager_test_9hvn_/providers/Microsoft.Resources/deployments/azurecli1481236530.764017329962/operationStatuses/08587203703538280659?api-version=2015-11-01']
       Cache-Control: [no-cache]
-      Content-Length: ['1177']
+      Content-Length: ['1185']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 08 Dec 2016 17:40:37 GMT']
+      Date: ['Thu, 08 Dec 2016 22:35:31 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -74,19 +74,15 @@ interactions:
           msrest_azure/0.4.5 trafficmanagerprofilecreationclient/2015-11-01 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [6d819d78-bd6d-11e6-889c-a0b3ccf7272a]
+      x-ms-client-request-id: [9ff4993a-bd96-11e6-8514-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_traffic_manager_test1/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587203880474556516?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_traffic_manager_test/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587203703538280659?api-version=2015-11-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
+    body: {string: '{"status":"Succeeded"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 08 Dec 2016 17:41:08 GMT']
+      Date: ['Thu, 08 Dec 2016 22:36:02 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -104,20 +100,20 @@ interactions:
           msrest_azure/0.4.5 trafficmanagerprofilecreationclient/2015-11-01 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [6d819d78-bd6d-11e6-889c-a0b3ccf7272a]
+      x-ms-client-request-id: [9ff4993a-bd96-11e6-8514-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_traffic_manager_test/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_traffic_manager_test1/providers/Microsoft.Resources/deployments/azurecli1481218836.75846824014","name":"azurecli1481218836.75846824014","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateTrafficManagerProfile_2016-08-08/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"location":{"type":"String","value":"global"},"monitorPath":{"type":"String","value":"/"},"monitorPort":{"type":"Int","value":80},"monitorProtocol":{"type":"String","value":"http"},"routingMethod":{"type":"String","value":"weighted"},"status":{"type":"String","value":"enabled"},"trafficManagerProfileName":{"type":"String","value":"mytmprofile"},"ttl":{"type":"Int","value":30},"uniqueDnsName":{"type":"String","value":"mytrafficmanager001100a"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-12-08T17:40:44.8946202Z","duration":"PT6.8726061S","correlationId":"b29af7c1-b4c2-4c4e-b7cd-1b9797893e11","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"trafficManagerProfiles","locations":["global"]}]}],"dependencies":[],"outputs":{"trafficManagerProfile":{"type":"Object","value":{"profileStatus":"Enabled","trafficRoutingMethod":"Weighted","dnsConfig":{"relativeName":"mytrafficmanager001100a","fqdn":"mytrafficmanager001100a.trafficmanager.net","ttl":30},"monitorConfig":{"profileMonitorStatus":"Inactive","protocol":"HTTP","port":80,"path":"/"},"endpoints":[]}}},"outputResources":[{"id":"Microsoft.Network/trafficManagerProfiles/mytmprofile"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_traffic_manager_test_9hvn_/providers/Microsoft.Resources/deployments/azurecli1481236530.764017329962","name":"azurecli1481236530.764017329962","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateTrafficManagerProfile_2016-08-08/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"location":{"type":"String","value":"global"},"monitorPath":{"type":"String","value":"/"},"monitorPort":{"type":"Int","value":80},"monitorProtocol":{"type":"String","value":"http"},"routingMethod":{"type":"String","value":"weighted"},"status":{"type":"String","value":"enabled"},"trafficManagerProfileName":{"type":"String","value":"mytmprofile"},"ttl":{"type":"Int","value":30},"uniqueDnsName":{"type":"String","value":"mytrafficmanager001100a"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-12-08T22:35:35.7613663Z","duration":"PT4.1117645S","correlationId":"a98055b4-20b8-4e8e-8104-9f8a8510b680","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"trafficManagerProfiles","locations":["global"]}]}],"dependencies":[],"outputs":{"trafficManagerProfile":{"type":"Object","value":{"profileStatus":"Enabled","trafficRoutingMethod":"Weighted","dnsConfig":{"relativeName":"mytrafficmanager001100a","fqdn":"mytrafficmanager001100a.trafficmanager.net","ttl":30},"monitorConfig":{"profileMonitorStatus":"Inactive","protocol":"HTTP","port":80,"path":"/"},"endpoints":[]}}},"outputResources":[{"id":"Microsoft.Network/trafficManagerProfiles/mytmprofile"}]}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 08 Dec 2016 17:41:09 GMT']
+      Date: ['Thu, 08 Dec 2016 22:36:02 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
-      content-length: ['1607']
+      content-length: ['1614']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -130,15 +126,15 @@ interactions:
           msrest_azure/0.4.5 trafficmanagermanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [81658b6e-bd6d-11e6-8c4d-a0b3ccf7272a]
+      x-ms-client-request-id: [b3d74a46-bd96-11e6-9ee1-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_traffic_manager_test/providers/Microsoft.Network/trafficmanagerprofiles/mytmprofile?api-version=2015-11-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_traffic_manager_test1\/providers\/Microsoft.Network\/trafficManagerProfiles\/mytmprofile","name":"mytmprofile","type":"Microsoft.Network\/trafficManagerProfiles","location":"global","properties":{"profileStatus":"Enabled","trafficRoutingMethod":"Weighted","dnsConfig":{"relativeName":"mytrafficmanager001100a","fqdn":"mytrafficmanager001100a.trafficmanager.net","ttl":30},"monitorConfig":{"profileMonitorStatus":"Inactive","protocol":"HTTP","port":80,"path":"\/"},"endpoints":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_traffic_manager_test_9hvn_\/providers\/Microsoft.Network\/trafficManagerProfiles\/mytmprofile","name":"mytmprofile","type":"Microsoft.Network\/trafficManagerProfiles","location":"global","properties":{"profileStatus":"Enabled","trafficRoutingMethod":"Weighted","dnsConfig":{"relativeName":"mytrafficmanager001100a","fqdn":"mytrafficmanager001100a.trafficmanager.net","ttl":30},"monitorConfig":{"profileMonitorStatus":"Inactive","protocol":"HTTP","port":80,"path":"\/"},"endpoints":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 08 Dec 2016 17:41:09 GMT']
+      Date: ['Thu, 08 Dec 2016 22:36:04 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -146,7 +142,7 @@ interactions:
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      content-length: ['562']
+      content-length: ['567']
       x-ms-ratelimit-remaining-subscription-resource-requests: ['10799']
     status: {code: 200, message: OK}
 - request:
@@ -160,15 +156,15 @@ interactions:
           msrest_azure/0.4.5 trafficmanagermanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [81ecb0ca-bd6d-11e6-b758-a0b3ccf7272a]
+      x-ms-client-request-id: [b4588cbe-bd96-11e6-aea8-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_traffic_manager_test1/providers/Microsoft.Network/trafficmanagerprofiles/mytmprofile?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_traffic_manager_test/providers/Microsoft.Network/trafficmanagerprofiles/mytmprofile?api-version=2015-11-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_traffic_manager_test1\/providers\/Microsoft.Network\/trafficManagerProfiles\/mytmprofile","name":"mytmprofile","type":"Microsoft.Network\/trafficManagerProfiles","location":"global","properties":{"profileStatus":"Enabled","trafficRoutingMethod":"Weighted","dnsConfig":{"relativeName":"mytrafficmanager001100a","fqdn":"mytrafficmanager001100a.trafficmanager.net","ttl":30},"monitorConfig":{"profileMonitorStatus":"Inactive","protocol":"HTTP","port":80,"path":"\/"},"endpoints":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_traffic_manager_test_9hvn_\/providers\/Microsoft.Network\/trafficManagerProfiles\/mytmprofile","name":"mytmprofile","type":"Microsoft.Network\/trafficManagerProfiles","location":"global","properties":{"profileStatus":"Enabled","trafficRoutingMethod":"Weighted","dnsConfig":{"relativeName":"mytrafficmanager001100a","fqdn":"mytrafficmanager001100a.trafficmanager.net","ttl":30},"monitorConfig":{"profileMonitorStatus":"Inactive","protocol":"HTTP","port":80,"path":"\/"},"endpoints":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 08 Dec 2016 17:41:11 GMT']
+      Date: ['Thu, 08 Dec 2016 22:36:04 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -176,8 +172,8 @@ interactions:
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      content-length: ['562']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['10791']
+      content-length: ['567']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['10799']
     status: {code: 200, message: OK}
 - request:
     body: '{"properties": {"weight": 50, "target": "www.microsoft.com"}}'
@@ -191,22 +187,22 @@ interactions:
           msrest_azure/0.4.5 trafficmanagermanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [82360f0c-bd6d-11e6-9415-a0b3ccf7272a]
+      x-ms-client-request-id: [b4a8798c-bd96-11e6-ae2e-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_traffic_manager_test/providers/Microsoft.Network/trafficmanagerprofiles/mytmprofile/externalEndpoints/myendpoint?api-version=2015-11-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_traffic_manager_test1\/providers\/Microsoft.Network\/trafficManagerProfiles\/mytmprofile\/externalEndpoints\/myendpoint","name":"myendpoint","type":"Microsoft.Network\/trafficManagerProfiles\/externalEndpoints","properties":{"endpointStatus":"Enabled","endpointMonitorStatus":"CheckingEndpoint","target":"www.microsoft.com","weight":50,"priority":1,"endpointLocation":null}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_traffic_manager_test_9hvn_\/providers\/Microsoft.Network\/trafficManagerProfiles\/mytmprofile\/externalEndpoints\/myendpoint","name":"myendpoint","type":"Microsoft.Network\/trafficManagerProfiles\/externalEndpoints","properties":{"endpointStatus":"Enabled","endpointMonitorStatus":"CheckingEndpoint","target":"www.microsoft.com","weight":50,"priority":1,"endpointLocation":null}}'}
     headers:
       Cache-Control: [private]
-      Content-Length: ['456']
+      Content-Length: ['461']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 08 Dec 2016 17:41:11 GMT']
+      Date: ['Thu, 08 Dec 2016 22:36:06 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -219,15 +215,15 @@ interactions:
           msrest_azure/0.4.5 trafficmanagermanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [82f3816c-bd6d-11e6-bfa7-a0b3ccf7272a]
+      x-ms-client-request-id: [b55f3e8a-bd96-11e6-82eb-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_traffic_manager_test/providers/Microsoft.Network/trafficmanagerprofiles/mytmprofile/externalEndpoints/myendpoint?api-version=2015-11-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_traffic_manager_test1\/providers\/Microsoft.Network\/trafficManagerProfiles\/mytmprofile\/externalEndpoints\/myendpoint","name":"myendpoint","type":"Microsoft.Network\/trafficManagerProfiles\/externalEndpoints","properties":{"endpointStatus":"Enabled","endpointMonitorStatus":"CheckingEndpoint","target":"www.microsoft.com","weight":50,"priority":1,"endpointLocation":null}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_traffic_manager_test_9hvn_\/providers\/Microsoft.Network\/trafficManagerProfiles\/mytmprofile\/externalEndpoints\/myendpoint","name":"myendpoint","type":"Microsoft.Network\/trafficManagerProfiles\/externalEndpoints","properties":{"endpointStatus":"Enabled","endpointMonitorStatus":"CheckingEndpoint","target":"www.microsoft.com","weight":50,"priority":1,"endpointLocation":null}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 08 Dec 2016 17:41:12 GMT']
+      Date: ['Thu, 08 Dec 2016 22:36:06 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -235,6 +231,6 @@ interactions:
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      content-length: ['456']
+      content-length: ['461']
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/test_network_commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/test_network_commands.py
@@ -1073,7 +1073,6 @@ class NetworkTrafficManagerScenarioTest(ResourceGroupVCRTestBase):
                  .format(tm_name=tm_name, resource_group=self.resource_group, unique_dns_name=unique_dns_name), checks=[
                      JMESPathCheck('trafficManagerProfile.trafficRoutingMethod', 'Weighted')
                      ])
-        # TODO: TEST UPDATE
         self.cmd('network traffic-manager profile show -g {resource_group} -n {tm_name}'
                  .format(resource_group=self.resource_group, tm_name=tm_name), checks=[
                      JMESPathCheck('dnsConfig.relativeName', unique_dns_name)
@@ -1088,7 +1087,6 @@ class NetworkTrafficManagerScenarioTest(ResourceGroupVCRTestBase):
                  .format(tm_name=tm_name, endpoint_name=endpoint_name, resource_group=self.resource_group), checks=[
                      JMESPathCheck('target', 'www.microsoft.com')
                      ])
-        # TODO: TEST UPDATE
 
 class NetworkDnsScenarioTest(ResourceGroupVCRTestBase):
 

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/test_network_commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/test_network_commands.py
@@ -1068,16 +1068,27 @@ class NetworkTrafficManagerScenarioTest(ResourceGroupVCRTestBase):
         unique_dns_name = 'mytrafficmanager001100a'
 
         self.cmd('network traffic-manager profile check-dns -n myfoobar1')
-        self.cmd('network traffic-manager profile create -n {} -g {} --routing-method weighted --unique-dns-name {}'.format(tm_name, self.resource_group, unique_dns_name),
-            checks=JMESPathCheck('trafficManagerProfile.trafficRoutingMethod', 'Weighted'))
-        self.cmd('network traffic-manager profile show -g {} -n {}'.format(self.resource_group, tm_name),
-            checks=JMESPathCheck('dnsConfig.relativeName', unique_dns_name))
-        # TODO: Test update
-        self.cmd('network traffic-manager endpoint create -n {} --profile-name {} -g {} --type externalEndpoints --weight 50 --target www.microsoft.com'.format(endpoint_name, tm_name, self.resource_group),
-            checks=JMESPathCheck('type', 'Microsoft.Network/trafficManagerProfiles/externalEndpoints'))
-        self.cmd('network traffic-manager endpoint show --profile-name {} --type  externalEndpoints -n {} -g {}'.format(tm_name, endpoint_name, self.resource_group),
-            checks=JMESPathCheck('target', 'www.microsoft.com'))
-        # TODO: Test update
+        self.cmd('network traffic-manager profile create -n {tm_name} -g {resource_group}'
+                 ' --routing-method weighted --unique-dns-name {unique_dns_name}'
+                 .format(tm_name=tm_name, resource_group=self.resource_group, unique_dns_name=unique_dns_name), checks=[
+                     JMESPathCheck('trafficManagerProfile.trafficRoutingMethod', 'Weighted')
+                     ])
+        # TODO: TEST UPDATE
+        self.cmd('network traffic-manager profile show -g {resource_group} -n {tm_name}'
+                 .format(resource_group=self.resource_group, tm_name=tm_name), checks=[
+                     JMESPathCheck('dnsConfig.relativeName', unique_dns_name)
+                     ])
+        self.cmd('network traffic-manager endpoint create -n {endpoint_name} --profile-name {tm_name} -g {resource_group}'
+                 ' --type externalEndpoints --weight 50 --target www.microsoft.com'
+                 .format(endpoint_name=endpoint_name, tm_name=tm_name, resource_group=self.resource_group), checks=[
+                     JMESPathCheck('type', 'Microsoft.Network/trafficManagerProfiles/externalEndpoints')
+                     ])
+        self.cmd('network traffic-manager endpoint show --profile-name {tm_name} --type  externalEndpoints'
+                 ' -n {endpoint_name} -g {resource_group}'
+                 .format(tm_name=tm_name, endpoint_name=endpoint_name, resource_group=self.resource_group), checks=[
+                     JMESPathCheck('target', 'www.microsoft.com')
+                     ])
+        # TODO: TEST UPDATE
 
 class NetworkDnsScenarioTest(ResourceGroupVCRTestBase):
 


### PR DESCRIPTION
- Adds convenience arguments to `profile/endpoint update` commands for parity with Xplat (#818)
- Adds validator logic to partially address #1481 for `endpoint create`. 