### PR TITLE
[Network] Update Subnet Create Default

### DIFF
--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
@@ -232,8 +232,8 @@ helps['network vnet check-ip-address'] = """
 helps['network vnet create'] = """
     type: command
     short-summary: Create a virtual network.
-    long-summary: By default, the created network will have a prefix of '10.0.0.0/16' and a single
-        subnet named 'default' with a prefix of '10.0.0.0/24', unless otherwise specified.
+    long-summary: You may also create a subnet at the same time by specifying a subnet name and
+        (optionally) an address prefix.
 """
 
 helps['network vnet delete'] = """

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
@@ -232,6 +232,8 @@ helps['network vnet check-ip-address'] = """
 helps['network vnet create'] = """
     type: command
     short-summary: Create a virtual network.
+    long-summary: By default, the created network will have a prefix of '10.0.0.0/16' and a single
+        subnet named 'default' with a prefix of '10.0.0.0/24', unless otherwise specified.
 """
 
 helps['network vnet delete'] = """

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -31,7 +31,7 @@ from azure.cli.command_modules.network._validators import \
      process_ag_url_path_map_rule_create_namespace, process_auth_create_namespace,
      process_public_ip_create_namespace, validate_private_ip_address,
      process_lb_frontend_ip_namespace, process_local_gateway_create_namespace,
-     process_tm_endpoint_create_namespace,
+     process_tm_endpoint_create_namespace, process_vnet_create_namespace,
      validate_inbound_nat_rule_id_list, validate_address_pool_id_list,
      validate_inbound_nat_rule_name_or_id, validate_address_pool_name_or_id,
      validate_servers, load_cert_file,
@@ -338,11 +338,12 @@ register_cli_argument('network route-table', 'route_table_name', name_arg_type, 
 register_cli_argument('network vnet', 'virtual_network_name', virtual_network_name_type, options_list=('--name', '-n'), id_part='name')
 
 register_cli_argument('network vnet create', 'location', location_type)
-register_cli_argument('network vnet create', 'subnet_prefix', options_list=('--subnet-prefix',), metavar='SUBNET_PREFIX', default='10.0.0.0/24')
-register_cli_argument('network vnet create', 'subnet_name', options_list=('--subnet-name',), metavar='SUBNET_NAME', default='Subnet1')
-register_cli_argument('network vnet create', 'virtual_network_prefix', options_list=('--address-prefix',), metavar='PREFIX', default='10.0.0.0/16')
+register_cli_argument('network vnet create', 'subnet_prefix', help='IP address prefix for the new subnet. If omitted, automatically reserves a portion of the VNet address space.')
+register_cli_argument('network vnet create', 'subnet_name', help='Name of a new subnet to create within the VNet.')
+register_cli_argument('network vnet create', 'virtual_network_prefix', options_list=('--address-prefix',), metavar='PREFIX')
 register_cli_argument('network vnet create', 'virtual_network_name', virtual_network_name_type, options_list=('--name', '-n'), required=True, completer=None)
-register_cli_argument('network vnet create', 'dns_servers', nargs='+')
+register_cli_argument('network vnet create', 'dns_servers', nargs='+', validator=process_vnet_create_namespace)
+register_cli_argument('network vnet create', 'create_subnet', ignore_type)
 
 register_cli_argument('network vnet subnet', 'subnet_name', arg_type=subnet_name_type, options_list=('--name', '-n'), id_part='child_name')
 register_cli_argument('network vnet update', 'address_prefixes', nargs='+')
@@ -355,7 +356,7 @@ register_cli_argument('network vnet peering create', 'allow_gateway_transit', ac
 register_cli_argument('network vnet peering create', 'allow_forwarded_traffic', action='store_true', help='Allows forwarded traffic from the VMs in the remote VNET.')
 register_cli_argument('network vnet peering create', 'use_remote_gateways', action='store_true', help='Allows VNET to use the remote VNET\'s gateway. Remote VNET gateway must have --allow-gateway-transit enabled for remote peering. Only 1 peering can have this flag enabled. Cannot be set if the VNET already has a gateway.')
 
-register_cli_argument('network vnet subnet', 'address_prefix', metavar='PREFIX', help='the address prefix in CIDR format.')
+register_cli_argument('network vnet subnet', 'address_prefix', metavar='PREFIX', help='the address prefix in CIDR format. If omitted, automatically reserves a portion of the VNet address space.')
 register_cli_argument('network vnet subnet', 'virtual_network_name', virtual_network_name_type)
 register_cli_argument('network vnet subnet', 'network_security_group', validator=get_nsg_validator())
 register_cli_argument('network vnet subnet', 'route_table', help='Name or ID of a route table to associate with the subnet.')

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -356,7 +356,7 @@ register_cli_argument('network vnet peering create', 'allow_gateway_transit', ac
 register_cli_argument('network vnet peering create', 'allow_forwarded_traffic', action='store_true', help='Allows forwarded traffic from the VMs in the remote VNET.')
 register_cli_argument('network vnet peering create', 'use_remote_gateways', action='store_true', help='Allows VNET to use the remote VNET\'s gateway. Remote VNET gateway must have --allow-gateway-transit enabled for remote peering. Only 1 peering can have this flag enabled. Cannot be set if the VNET already has a gateway.')
 
-register_cli_argument('network vnet subnet', 'address_prefix', metavar='PREFIX', help='the address prefix in CIDR format. If omitted, automatically reserves a portion of the VNet address space.')
+register_cli_argument('network vnet subnet', 'address_prefix', metavar='PREFIX', help='the address prefix in CIDR format.')
 register_cli_argument('network vnet subnet', 'virtual_network_name', virtual_network_name_type)
 register_cli_argument('network vnet subnet', 'network_security_group', validator=get_nsg_validator())
 register_cli_argument('network vnet subnet', 'route_table', help='Name or ID of a route table to associate with the subnet.')

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
@@ -469,8 +469,7 @@ def process_vnet_create_namespace(namespace):
         prefix_components = namespace.virtual_network_prefix.split('/', 1)
         address = prefix_components[0]
         bit_mask = int(prefix_components[1])
-        residual_bits = 32 - bit_mask
-        subnet_mask = 32 - int(residual_bits / 2)
+        subnet_mask = 24 if bit_mask < 24 else bit_mask
         namespace.subnet_prefix = '{}/{}'.format(address, subnet_mask)
 
 def load_cert_file(param_name):

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
@@ -458,6 +458,21 @@ def process_tm_endpoint_create_namespace(namespace):
             error_message = '{}\nOmit the following: {}'.format(error_message, ', '.join(extra_options)) # pylint: disable=line-too-long
         raise CLIError(error_message)
 
+def process_vnet_create_namespace(namespace):
+
+    if namespace.subnet_prefix and not namespace.subnet_name:
+        raise ValueError('incorrect usage: --subnet-name NAME [--subnet-prefix PREFIX]')
+
+    namespace.create_subnet = bool(namespace.subnet_name)
+
+    if namespace.create_subnet and not namespace.subnet_prefix:
+        prefix_components = namespace.virtual_network_prefix.split('/', 1)
+        address = prefix_components[0]
+        bit_mask = int(prefix_components[1])
+        residual_bits = 32 - bit_mask
+        subnet_mask = 32 - int(residual_bits / 2)
+        namespace.subnet_prefix = '{}/{}'.format(address, subnet_mask)
+
 def load_cert_file(param_name):
     def load_cert_validator(namespace):
         attr = getattr(namespace, param_name)

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -698,7 +698,7 @@ def _set_route_table(ncf, resource_group_name, route_table, subnet):
         subnet.route_table = None
 
 def create_subnet(resource_group_name, virtual_network_name, subnet_name,
-                  address_prefix=None, network_security_group=None,
+                  address_prefix, network_security_group=None,
                   route_table=None):
     '''Create a virtual network (VNet) subnet.
     :param str address_prefix: address prefix in CIDR format.
@@ -706,15 +706,6 @@ def create_subnet(resource_group_name, virtual_network_name, subnet_name,
         group to associate with the subnet.
     '''
     ncf = _network_client_factory()
-    if not address_prefix:
-        vnet = ncf.virtual_networks.get(resource_group_name, virtual_network_name)
-        prefix_components = vnet.address_space.address_prefixes[0].split('/', 1)
-        address = prefix_components[0]
-        bit_mask = int(prefix_components[1])
-        residual_bits = 32 - bit_mask
-        subnet_mask = 32 - int(residual_bits / 2)
-        address_prefix = '{}/{}'.format(address, subnet_mask)
-
     subnet = Subnet(name=subnet_name, address_prefix=address_prefix)
 
     if network_security_group:

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -698,9 +698,9 @@ def _set_route_table(ncf, resource_group_name, route_table, subnet):
         subnet.route_table = None
 
 def create_subnet(resource_group_name, virtual_network_name, subnet_name,
-                  address_prefix='10.0.0.0/24', network_security_group=None,
+                  address_prefix='10.0.1.0/24', network_security_group=None,
                   route_table=None):
-    '''Create a virtual network (VNet) subnet
+    '''Create a virtual network (VNet) subnet.
     :param str address_prefix: address prefix in CIDR format.
     :param str network_security_group: Name or ID of network security
         group to associate with the subnet.

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_vnet/azuredeploy.json
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_vnet/azuredeploy.json
@@ -2,6 +2,13 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "createSubnet": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Flag to create a new subnet."
+      }
+    },
     "dnsServers": {
       "type": "array",
       "defaultValue": [ ],
@@ -18,16 +25,16 @@
     },
     "subnetName": {
       "type": "string",
-      "defaultValue": "Subnet1",
+      "defaultValue": "",
       "metadata": {
-        "description": "Name of the subnet."
+        "description": "Name of a new subnet to create within the VNet."
       }
     },
     "subnetPrefix": {
       "type": "string",
-      "defaultValue": "10.0.0.0/24",
+      "defaultValue": "",
       "metadata": {
-        "description": "IP address prefix for the subnet."
+        "description": "IP address prefix for the new subnet."
       }
     },
     "tags": {
@@ -52,14 +59,25 @@
     }
   },
   "variables": {
-    "NewVNetName": "[parameters('virtualNetworkName')]",
-    "NewVNetPrefix": "[parameters('virtualNetworkPrefix')]",
-    "NewVNetSubnet1Name": "[parameters('subnetName')]",
-    "NewVNetSubnet1Prefix": "[parameters('subnetPrefix')]"
+    "subnetProperties": {
+      "true": {
+        "value": [
+          {
+            "name": "[parameters('subnetName')]",
+            "properties": {
+              "addressPrefix": "[parameters('subnetPrefix')]"
+            }
+          }
+        ]
+      },
+      "false": {
+        "value": null
+      }
+    }
   },
   "resources": [
     {
-      "name": "[variables('NewVNetName')]",
+      "name": "[parameters('virtualNetworkName')]",
       "type": "Microsoft.Network/virtualNetworks",
       "location": "[parameters('location')]",
       "apiVersion": "2015-06-15",
@@ -68,27 +86,20 @@
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
-            "[variables('NewVNetPrefix')]"
+            "[parameters('virtualNetworkPrefix')]"
           ]
         },
         "dhcpOptions": {
           "dnsServers": "[parameters('dnsServers')]"
         },
-        "subnets": [
-          {
-            "name": "[variables('NewVNetSubnet1Name')]",
-            "properties": {
-              "addressPrefix": "[variables('NewVNetSubnet1Prefix')]"
-            }
-          }
-        ]
+        "subnets": "[variables('subnetProperties')[concat(parameters('createSubnet'))]['value']]"
       }
     }
   ],
   "outputs": {
     "NewVNet": {
       "type": "object",
-      "value": "[reference(variables('NewVNetName'))]"
+      "value": "[reference(parameters('virtualNetworkName'))]"
     }
   }
 }

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_vnet/azuredeploy_empty.json
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_vnet/azuredeploy_empty.json
@@ -18,16 +18,16 @@
     },
     "subnetName": {
       "type": "string",
-      "defaultValue": "Subnet1",
+      "defaultValue": "",
       "metadata": {
-        "description": "Name of the subnet."
+        "description": "Name of a new subnet to create within the VNet."
       }
     },
     "subnetPrefix": {
       "type": "string",
-      "defaultValue": "10.0.0.0/24",
+      "defaultValue": "",
       "metadata": {
-        "description": "IP address prefix for the subnet."
+        "description": "IP address prefix for the new subnet."
       }
     },
     "tags": {

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_vnet/lib/models/basic_dependency.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_vnet/lib/models/basic_dependency.py
@@ -15,8 +15,7 @@ from msrest.serialization import Model
 
 
 class BasicDependency(Model):
-    """
-    Deployment dependency information.
+    """Deployment dependency information.
 
     :param id: Gets or sets the ID of the dependency.
     :type id: str

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_vnet/lib/models/dependency.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_vnet/lib/models/dependency.py
@@ -15,12 +15,11 @@ from msrest.serialization import Model
 
 
 class Dependency(Model):
-    """
-    Deployment dependency information.
+    """Deployment dependency information.
 
     :param depends_on: Gets the list of dependencies.
     :type depends_on: list of :class:`BasicDependency
-     <default.models.BasicDependency>`
+     <Default.models.BasicDependency>`
     :param id: Gets or sets the ID of the dependency.
     :type id: str
     :param resource_type: Gets or sets the dependency resource type.

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_vnet/lib/models/deployment_extended.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_vnet/lib/models/deployment_extended.py
@@ -15,8 +15,7 @@ from msrest.serialization import Model
 
 
 class DeploymentExtended(Model):
-    """
-    Deployment information.
+    """Deployment information.
 
     :param id: Gets or sets the ID of the deployment.
     :type id: str
@@ -24,7 +23,7 @@ class DeploymentExtended(Model):
     :type name: str
     :param properties: Gets or sets deployment properties.
     :type properties: :class:`DeploymentPropertiesExtended
-     <default.models.DeploymentPropertiesExtended>`
+     <Default.models.DeploymentPropertiesExtended>`
     """ 
 
     _validation = {

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_vnet/lib/models/deployment_properties_extended.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_vnet/lib/models/deployment_properties_extended.py
@@ -15,8 +15,7 @@ from msrest.serialization import Model
 
 
 class DeploymentPropertiesExtended(Model):
-    """
-    Deployment properties with additional details.
+    """Deployment properties with additional details.
 
     :param provisioning_state: Gets or sets the state of the provisioning.
     :type provisioning_state: str
@@ -29,27 +28,26 @@ class DeploymentPropertiesExtended(Model):
     :type outputs: object
     :param providers: Gets the list of resource providers needed for the
      deployment.
-    :type providers: list of :class:`Provider <default.models.Provider>`
+    :type providers: list of :class:`Provider <Default.models.Provider>`
     :param dependencies: Gets the list of deployment dependencies.
     :type dependencies: list of :class:`Dependency
-     <default.models.Dependency>`
+     <Default.models.Dependency>`
     :param template: Gets or sets the template content. Use only one of
      Template or TemplateLink.
     :type template: object
     :param template_link: Gets or sets the URI referencing the template. Use
      only one of Template or TemplateLink.
-    :type template_link: :class:`TemplateLink <default.models.TemplateLink>`
+    :type template_link: :class:`TemplateLink <Default.models.TemplateLink>`
     :param parameters: Deployment parameters. Use only one of Parameters or
      ParametersLink.
     :type parameters: object
     :param parameters_link: Gets or sets the URI referencing the parameters.
      Use only one of Parameters or ParametersLink.
     :type parameters_link: :class:`ParametersLink
-     <default.models.ParametersLink>`
+     <Default.models.ParametersLink>`
     :param mode: Gets or sets the deployment mode. Possible values include:
      'Incremental', 'Complete'
-    :type mode: str or :class:`DeploymentMode
-     <vnetcreationclient.models.DeploymentMode>`
+    :type mode: str or :class:`DeploymentMode <Default.models.DeploymentMode>`
     """ 
 
     _attribute_map = {

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_vnet/lib/models/deployment_vnet.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_vnet/lib/models/deployment_vnet.py
@@ -15,27 +15,27 @@ from msrest.serialization import Model
 
 
 class DeploymentVnet(Model):
-    """
-    Deployment operation parameters.
+    """Deployment operation parameters.
 
     Variables are only populated by the server, and will be ignored when
     sending a request.
 
     :ivar uri: URI referencing the template. Default value:
-     "https://azuresdkci.blob.core.windows.net/templatehost/CreateVnet_2016-09-07/azuredeploy.json"
+     "https://azuresdkci.blob.core.windows.net/templatehost/CreateVnet_2016-12-9/azuredeploy.json"
      .
     :vartype uri: str
     :param content_version: If included it must match the ContentVersion in
      the template.
     :type content_version: str
+    :param create_subnet: Flag to create a new subnet. Default value: False .
+    :type create_subnet: bool
     :param dns_servers: List of DNS server IP addresses.
     :type dns_servers: list of object
     :param location: Virtual network location.
     :type location: str
-    :param subnet_name: Name of the subnet. Default value: "Subnet1" .
+    :param subnet_name: Name of a new subnet to create within the VNet.
     :type subnet_name: str
-    :param subnet_prefix: IP address for the subnet. Default value:
-     "10.0.0.0/24" .
+    :param subnet_prefix: IP address prefix for the new subnet.
     :type subnet_prefix: str
     :param tags: Tags object.
     :type tags: object
@@ -51,6 +51,7 @@ class DeploymentVnet(Model):
 
     _validation = {
         'uri': {'required': True, 'constant': True},
+        'create_subnet': {'required': True},
         'virtual_network_name': {'required': True},
         'mode': {'required': True, 'constant': True},
     }
@@ -58,6 +59,7 @@ class DeploymentVnet(Model):
     _attribute_map = {
         'uri': {'key': 'properties.templateLink.uri', 'type': 'str'},
         'content_version': {'key': 'properties.templateLink.contentVersion', 'type': 'str'},
+        'create_subnet': {'key': 'properties.parameters.createSubnet.value', 'type': 'bool'},
         'dns_servers': {'key': 'properties.parameters.dnsServers.value', 'type': '[object]'},
         'location': {'key': 'properties.parameters.location.value', 'type': 'str'},
         'subnet_name': {'key': 'properties.parameters.subnetName.value', 'type': 'str'},
@@ -68,12 +70,13 @@ class DeploymentVnet(Model):
         'mode': {'key': 'properties.mode', 'type': 'str'},
     }
 
-    uri = "https://azuresdkci.blob.core.windows.net/templatehost/CreateVnet_2016-09-07/azuredeploy.json"
+    uri = "https://azuresdkci.blob.core.windows.net/templatehost/CreateVnet_2016-12-9/azuredeploy.json"
 
     mode = "Incremental"
 
-    def __init__(self, virtual_network_name, content_version=None, dns_servers=None, location=None, subnet_name="Subnet1", subnet_prefix="10.0.0.0/24", tags=None, virtual_network_prefix="10.0.0.0/16"):
+    def __init__(self, virtual_network_name, content_version=None, create_subnet=False, dns_servers=None, location=None, subnet_name=None, subnet_prefix=None, tags=None, virtual_network_prefix="10.0.0.0/16"):
         self.content_version = content_version
+        self.create_subnet = create_subnet
         self.dns_servers = dns_servers
         self.location = location
         self.subnet_name = subnet_name

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_vnet/lib/models/parameters_link.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_vnet/lib/models/parameters_link.py
@@ -15,8 +15,7 @@ from msrest.serialization import Model
 
 
 class ParametersLink(Model):
-    """
-    Entity representing the reference to the deployment paramaters.
+    """Entity representing the reference to the deployment paramaters.
 
     :param uri: URI referencing the template.
     :type uri: str

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_vnet/lib/models/provider.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_vnet/lib/models/provider.py
@@ -15,8 +15,7 @@ from msrest.serialization import Model
 
 
 class Provider(Model):
-    """
-    Resource provider information.
+    """Resource provider information.
 
     :param id: Gets or sets the provider id.
     :type id: str
@@ -28,7 +27,7 @@ class Provider(Model):
     :param resource_types: Gets or sets the collection of provider resource
      types.
     :type resource_types: list of :class:`ProviderResourceType
-     <default.models.ProviderResourceType>`
+     <Default.models.ProviderResourceType>`
     """ 
 
     _attribute_map = {

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_vnet/lib/models/provider_resource_type.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_vnet/lib/models/provider_resource_type.py
@@ -15,8 +15,7 @@ from msrest.serialization import Model
 
 
 class ProviderResourceType(Model):
-    """
-    Resource type managed by the resource provider.
+    """Resource type managed by the resource provider.
 
     :param resource_type: Gets or sets the resource type.
     :type resource_type: str

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_vnet/lib/models/template_link.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_vnet/lib/models/template_link.py
@@ -15,14 +15,13 @@ from msrest.serialization import Model
 
 
 class TemplateLink(Model):
-    """
-    Entity representing the reference to the template.
+    """Entity representing the reference to the template.
 
     Variables are only populated by the server, and will be ignored when
     sending a request.
 
     :ivar uri: URI referencing the template. Default value:
-     "https://azuresdkci.blob.core.windows.net/templatehost/CreateVnet_2016-09-07/azuredeploy.json"
+     "https://azuresdkci.blob.core.windows.net/templatehost/CreateVnet_2016-12-9/azuredeploy.json"
      .
     :vartype uri: str
     :param content_version: If included it must match the ContentVersion in
@@ -39,7 +38,7 @@ class TemplateLink(Model):
         'content_version': {'key': 'contentVersion', 'type': 'str'},
     }
 
-    uri = "https://azuresdkci.blob.core.windows.net/templatehost/CreateVnet_2016-09-07/azuredeploy.json"
+    uri = "https://azuresdkci.blob.core.windows.net/templatehost/CreateVnet_2016-12-9/azuredeploy.json"
 
     def __init__(self, content_version=None):
         self.content_version = content_version

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_vnet/lib/operations/vnet_operations.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_vnet/lib/operations/vnet_operations.py
@@ -37,15 +37,16 @@ class VnetOperations(object):
         self.config = config
 
     def create_or_update(
-            self, resource_group_name, deployment_name, virtual_network_name, content_version=None, dns_servers=None, location=None, subnet_name="Subnet1", subnet_prefix="10.0.0.0/24", tags=None, virtual_network_prefix="10.0.0.0/16", custom_headers=None, raw=False, **operation_config):
-        """
-        Create or update a virtual machine.
+            self, resource_group_name, deployment_name, virtual_network_name, create_subnet=False, content_version=None, dns_servers=None, location=None, subnet_name=None, subnet_prefix=None, tags=None, virtual_network_prefix="10.0.0.0/16", custom_headers=None, raw=False, **operation_config):
+        """Create a new Vnet.
 
         :param resource_group_name: The name of the resource group. The name
          is case insensitive.
         :type resource_group_name: str
         :param deployment_name: The name of the deployment.
         :type deployment_name: str
+        :param create_subnet: Flag to create a new subnet.
+        :type create_subnet: bool
         :param virtual_network_name: Name of the virtual network.
         :type virtual_network_name: str
         :param content_version: If included it must match the ContentVersion
@@ -55,9 +56,9 @@ class VnetOperations(object):
         :type dns_servers: list of object
         :param location: Virtual network location.
         :type location: str
-        :param subnet_name: Name of the subnet.
+        :param subnet_name: Name of a new subnet to create within the VNet.
         :type subnet_name: str
-        :param subnet_prefix: IP address for the subnet.
+        :param subnet_prefix: IP address prefix for the new subnet.
         :type subnet_prefix: str
         :param tags: Tags object.
         :type tags: object
@@ -70,11 +71,11 @@ class VnetOperations(object):
         :rtype:
          :class:`AzureOperationPoller<msrestazure.azure_operation.AzureOperationPoller>`
          instance that returns :class:`DeploymentExtended
-         <default.models.DeploymentExtended>`
+         <Default.models.DeploymentExtended>`
         :rtype: :class:`ClientRawResponse<msrest.pipeline.ClientRawResponse>`
          if raw=true
         """
-        parameters = models.DeploymentVnet(content_version=content_version, dns_servers=dns_servers, location=location, subnet_name=subnet_name, subnet_prefix=subnet_prefix, tags=tags, virtual_network_name=virtual_network_name, virtual_network_prefix=virtual_network_prefix)
+        parameters = models.DeploymentVnet(content_version=content_version, create_subnet=create_subnet, dns_servers=dns_servers, location=location, subnet_name=subnet_name, subnet_prefix=subnet_prefix, tags=tags, virtual_network_name=virtual_network_name, virtual_network_prefix=virtual_network_prefix)
 
         # Construct URL
         url = '/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Resources/deployments/{deploymentName}'

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_vnet/lib/vnet_creation_client.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_vnet/lib/vnet_creation_client.py
@@ -24,7 +24,7 @@ class VnetCreationClientConfiguration(AzureConfiguration):
     Note that all parameters used to create this instance are saved as instance
     attributes.
 
-    :param credentials: Gets Azure subscription credentials.
+    :param credentials: Credentials needed for the client to connect to Azure.
     :type credentials: :mod:`A msrestazure Credentials
      object<msrestazure.azure_active_directory>`
     :param subscription_id: Gets subscription credentials which uniquely
@@ -85,7 +85,7 @@ class VnetCreationClient(object):
     :ivar vnet: Vnet operations
     :vartype vnet: .operations.VnetOperations
 
-    :param credentials: Gets Azure subscription credentials.
+    :param credentials: Credentials needed for the client to connect to Azure.
     :type credentials: :mod:`A msrestazure Credentials
      object<msrestazure.azure_active_directory>`
     :param subscription_id: Gets subscription credentials which uniquely

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_vnet/swagger_create_vnet.json
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/mgmt_vnet/swagger_create_vnet.json
@@ -1,486 +1,503 @@
 {
-  "swagger": "2.0", 
+  "swagger": "2.0",
   "info": {
-    "title": "VnetCreationClient", 
+    "title": "VnetCreationClient",
     "version": "2015-11-01"
-  }, 
-  "host": "management.azure.com", 
+  },
+  "host": "management.azure.com",
   "schemes": [
     "https"
-  ], 
+  ],
   "consumes": [
     "application/json"
-  ], 
+  ],
   "produces": [
     "application/json"
-  ], 
+  ],
   "security": [
     {
       "azure_auth": [
         "user_impersonation"
       ]
     }
-  ], 
+  ],
   "securityDefinitions": {
     "azure_auth": {
-      "type": "oauth2", 
-      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize", 
-      "flow": "implicit", 
-      "description": "Azure Active Directory OAuth2 Flow", 
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
       "scopes": {
         "user_impersonation": "impersonate your user account"
       }
     }
-  }, 
+  },
   "paths": {
     "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Resources/deployments/{deploymentName}": {
       "put": {
         "tags": [
           "Vnet"
-        ], 
-        "operationId": "Vnet_CreateOrUpdate", 
-        "description": "Create or update a virtual machine.", 
+        ],
+        "operationId": "Vnet_CreateOrUpdate",
+        "description": "Create a new Vnet.",
         "parameters": [
           {
-            "name": "resourceGroupName", 
-            "in": "path", 
-            "required": true, 
-            "type": "string", 
-            "description": "The name of the resource group. The name is case insensitive.", 
-            "pattern": "^[-\\w\\._]+$", 
-            "minLength": 1, 
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group. The name is case insensitive.",
+            "pattern": "^[-\\w\\._]+$",
+            "minLength": 1,
             "maxLength": 64
-          }, 
+          },
           {
-            "name": "deploymentName", 
-            "in": "path", 
-            "required": true, 
-            "type": "string", 
-            "description": "The name of the deployment.", 
-            "pattern": "^[-\\w\\._]+$", 
-            "minLength": 1, 
+            "name": "deploymentName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the deployment.",
+            "pattern": "^[-\\w\\._]+$",
+            "minLength": 1,
             "maxLength": 64
-          }, 
+          },
           {
-            "name": "parameters", 
-            "x-ms-client-flatten": true, 
-            "in": "body", 
-            "required": true, 
+            "name": "parameters",
+            "x-ms-client-flatten": true,
+            "in": "body",
+            "required": true,
             "schema": {
               "$ref": "#/definitions/Deployment_Vnet"
-            }, 
+            },
             "description": "Additional parameters supplied to the operation."
-          }, 
+          },
           {
             "$ref": "#/parameters/ApiVersionParameter"
-          }, 
+          },
           {
             "$ref": "#/parameters/SubscriptionIdParameter"
           }
-        ], 
+        ],
         "responses": {
           "200": {
-            "description": "", 
+            "description": "",
             "schema": {
               "$ref": "#/definitions/DeploymentExtended"
             }
-          }, 
+          },
           "201": {
-            "description": "", 
+            "description": "",
             "schema": {
               "$ref": "#/definitions/DeploymentExtended"
             }
           }
-        }, 
+        },
         "x-ms-long-running-operation": true
       }
     }
-  }, 
+  },
   "definitions": {
     "Deployment_Vnet": {
       "properties": {
         "properties": {
-          "$ref": "#/definitions/DeploymentProperties_Vnet", 
-          "description": "Gets or sets the deployment properties.", 
+          "$ref": "#/definitions/DeploymentProperties_Vnet",
+          "description": "Gets or sets the deployment properties.",
           "x-ms-client-flatten": true
         }
-      }, 
+      },
       "description": "Deployment operation parameters."
-    }, 
+    },
     "DeploymentProperties_Vnet": {
       "properties": {
         "templateLink": {
-          "$ref": "#/definitions/TemplateLink", 
-          "description": "Gets or sets the URI referencing the template. Use only one of Template or TemplateLink.", 
+          "$ref": "#/definitions/TemplateLink",
+          "description": "Gets or sets the URI referencing the template. Use only one of Template or TemplateLink.",
           "x-ms-client-flatten": true
-        }, 
+        },
         "parameters": {
-          "$ref": "#/definitions/VnetParameters", 
-          "type": "object", 
-          "description": "Deployment parameters. Use only one of Parameters or ParametersLink.", 
+          "$ref": "#/definitions/VnetParameters",
+          "type": "object",
+          "description": "Deployment parameters. Use only one of Parameters or ParametersLink.",
           "x-ms-client-flatten": true
-        }, 
+        },
         "mode": {
-          "type": "string", 
-          "description": "Gets or sets the deployment mode.", 
+          "type": "string",
+          "description": "Gets or sets the deployment mode.",
           "enum": [
             "Incremental"
-          ], 
+          ],
           "x-ms-enum": {
-            "name": "DeploymentMode", 
+            "name": "DeploymentMode",
             "modelAsString": false
           }
         }
-      }, 
+      },
       "required": [
-        "templateLink", 
-        "parameters", 
+        "templateLink",
+        "parameters",
         "mode"
-      ], 
+      ],
       "description": "Deployment properties."
-    }, 
+    },
     "TemplateLink": {
       "properties": {
         "uri": {
-          "type": "string", 
-          "description": "URI referencing the template.", 
+          "type": "string",
+          "description": "URI referencing the template.",
           "enum": [
-            "https://azuresdkci.blob.core.windows.net/templatehost/CreateVnet_2016-09-07/azuredeploy.json"
+            "https://azuresdkci.blob.core.windows.net/templatehost/CreateVnet_2016-12-9/azuredeploy.json"
           ]
-        }, 
+        },
         "contentVersion": {
-          "type": "string", 
+          "type": "string",
           "description": "If included it must match the ContentVersion in the template."
         }
-      }, 
+      },
       "required": [
         "uri"
-      ], 
+      ],
       "description": "Entity representing the reference to the template."
-    }, 
+    },
     "VnetParameters": {
       "properties": {
+        "createSubnet": {
+          "type": "object",
+          "$ref": "#/definitions/DeploymentParameter_createSubnet",
+          "x-ms-client-flatten": true
+        },
         "dnsServers": {
-          "type": "object", 
-          "$ref": "#/definitions/DeploymentParameter_dnsServers", 
+          "type": "object",
+          "$ref": "#/definitions/DeploymentParameter_dnsServers",
           "x-ms-client-flatten": true
-        }, 
+        },
         "location": {
-          "type": "object", 
-          "$ref": "#/definitions/DeploymentParameter_location", 
+          "type": "object",
+          "$ref": "#/definitions/DeploymentParameter_location",
           "x-ms-client-flatten": true
-        }, 
+        },
         "subnetName": {
-          "type": "object", 
-          "$ref": "#/definitions/DeploymentParameter_subnetName", 
+          "type": "object",
+          "$ref": "#/definitions/DeploymentParameter_subnetName",
           "x-ms-client-flatten": true
-        }, 
+        },
         "subnetPrefix": {
-          "type": "object", 
-          "$ref": "#/definitions/DeploymentParameter_subnetPrefix", 
+          "type": "object",
+          "$ref": "#/definitions/DeploymentParameter_subnetPrefix",
           "x-ms-client-flatten": true
-        }, 
+        },
         "tags": {
-          "type": "object", 
-          "$ref": "#/definitions/DeploymentParameter_tags", 
+          "type": "object",
+          "$ref": "#/definitions/DeploymentParameter_tags",
           "x-ms-client-flatten": true
-        }, 
+        },
         "virtualNetworkName": {
-          "type": "object", 
-          "$ref": "#/definitions/DeploymentParameter_virtualNetworkName", 
+          "type": "object",
+          "$ref": "#/definitions/DeploymentParameter_virtualNetworkName",
           "x-ms-client-flatten": true
-        }, 
+        },
         "virtualNetworkPrefix": {
-          "type": "object", 
-          "$ref": "#/definitions/DeploymentParameter_virtualNetworkPrefix", 
+          "type": "object",
+          "$ref": "#/definitions/DeploymentParameter_virtualNetworkPrefix",
           "x-ms-client-flatten": true
         }
-      }, 
+      },
       "required": [
+        "createSubnet",
         "virtualNetworkName"
       ]
-    }, 
-    "DeploymentParameter_dnsServers": {
+    },
+    "DeploymentParameter_createSubnet": {
       "properties": {
         "value": {
-          "type": "array", 
-          "items": {
-            "type": "object"
-          }, 
-          "description": "List of DNS server IP addresses.", 
-          "x-ms-client-name": "dnsServers"
+          "type": "boolean",
+          "description": "Flag to create a new subnet.",
+          "x-ms-client-name": "createSubnet",
+          "default": "False"
         }
-      }
-    }, 
-    "DeploymentParameter_location": {
-      "properties": {
-        "value": {
-          "type": "string", 
-          "description": "Virtual network location.", 
-          "x-ms-client-name": "location"
-        }
-      }
-    }, 
-    "DeploymentParameter_subnetName": {
-      "properties": {
-        "value": {
-          "type": "string", 
-          "description": "Name of the subnet.", 
-          "x-ms-client-name": "subnetName", 
-          "default": "Subnet1"
-        }
-      }
-    }, 
-    "DeploymentParameter_subnetPrefix": {
-      "properties": {
-        "value": {
-          "type": "string", 
-          "description": "IP address for the subnet.", 
-          "x-ms-client-name": "subnetPrefix", 
-          "default": "10.0.0.0/24"
-        }
-      }
-    }, 
-    "DeploymentParameter_tags": {
-      "properties": {
-        "value": {
-          "type": "object", 
-          "description": "Tags object.", 
-          "x-ms-client-name": "tags"
-        }
-      }
-    }, 
-    "DeploymentParameter_virtualNetworkName": {
-      "properties": {
-        "value": {
-          "type": "string", 
-          "description": "Name of the virtual network.", 
-          "x-ms-client-name": "virtualNetworkName"
-        }
-      }, 
+      },
       "required": [
         "value"
       ]
-    }, 
+    },
+    "DeploymentParameter_dnsServers": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          },
+          "description": "List of DNS server IP addresses.",
+          "x-ms-client-name": "dnsServers"
+        }
+      }
+    },
+    "DeploymentParameter_location": {
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "Virtual network location.",
+          "x-ms-client-name": "location"
+        }
+      }
+    },
+    "DeploymentParameter_subnetName": {
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "Name of a new subnet to create within the VNet.",
+          "x-ms-client-name": "subnetName"
+        }
+      }
+    },
+    "DeploymentParameter_subnetPrefix": {
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "IP address prefix for the new subnet.",
+          "x-ms-client-name": "subnetPrefix"
+        }
+      }
+    },
+    "DeploymentParameter_tags": {
+      "properties": {
+        "value": {
+          "type": "object",
+          "description": "Tags object.",
+          "x-ms-client-name": "tags"
+        }
+      }
+    },
+    "DeploymentParameter_virtualNetworkName": {
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "Name of the virtual network.",
+          "x-ms-client-name": "virtualNetworkName"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
     "DeploymentParameter_virtualNetworkPrefix": {
       "properties": {
         "value": {
-          "type": "string", 
-          "description": "IP address prefix for the virtual network.", 
-          "x-ms-client-name": "virtualNetworkPrefix", 
+          "type": "string",
+          "description": "IP address prefix for the virtual network.",
+          "x-ms-client-name": "virtualNetworkPrefix",
           "default": "10.0.0.0/16"
         }
       }
-    }, 
+    },
     "ParametersLink": {
       "properties": {
         "uri": {
-          "type": "string", 
+          "type": "string",
           "description": "URI referencing the template."
-        }, 
+        },
         "contentVersion": {
-          "type": "string", 
+          "type": "string",
           "description": "If included it must match the ContentVersion in the template."
         }
-      }, 
+      },
       "required": [
         "uri"
-      ], 
+      ],
       "description": "Entity representing the reference to the deployment paramaters."
-    }, 
+    },
     "ProviderResourceType": {
       "properties": {
         "resourceType": {
-          "type": "string", 
+          "type": "string",
           "description": "Gets or sets the resource type."
-        }, 
+        },
         "locations": {
-          "type": "array", 
+          "type": "array",
           "items": {
             "type": "string"
-          }, 
+          },
           "description": "Gets or sets the collection of locations where this resource type can be created in."
-        }, 
+        },
         "apiVersions": {
-          "type": "array", 
+          "type": "array",
           "items": {
             "type": "string"
-          }, 
+          },
           "description": "Gets or sets the api version."
-        }, 
+        },
         "properties": {
-          "type": "object", 
+          "type": "object",
           "additionalProperties": {
             "type": "string"
-          }, 
+          },
           "description": "Gets or sets the properties."
         }
-      }, 
+      },
       "description": "Resource type managed by the resource provider."
-    }, 
+    },
     "Provider": {
       "properties": {
         "id": {
-          "type": "string", 
+          "type": "string",
           "description": "Gets or sets the provider id."
-        }, 
+        },
         "namespace": {
-          "type": "string", 
+          "type": "string",
           "description": "Gets or sets the namespace of the provider."
-        }, 
+        },
         "registrationState": {
-          "type": "string", 
+          "type": "string",
           "description": "Gets or sets the registration state of the provider."
-        }, 
+        },
         "resourceTypes": {
-          "type": "array", 
+          "type": "array",
           "items": {
             "$ref": "#/definitions/ProviderResourceType"
-          }, 
+          },
           "description": "Gets or sets the collection of provider resource types."
         }
-      }, 
+      },
       "description": "Resource provider information."
-    }, 
+    },
     "BasicDependency": {
       "properties": {
         "id": {
-          "type": "string", 
+          "type": "string",
           "description": "Gets or sets the ID of the dependency."
-        }, 
+        },
         "resourceType": {
-          "type": "string", 
+          "type": "string",
           "description": "Gets or sets the dependency resource type."
-        }, 
+        },
         "resourceName": {
-          "type": "string", 
+          "type": "string",
           "description": "Gets or sets the dependency resource name."
         }
-      }, 
+      },
       "description": "Deployment dependency information."
-    }, 
+    },
     "Dependency": {
       "properties": {
         "dependsOn": {
-          "type": "array", 
+          "type": "array",
           "items": {
             "$ref": "#/definitions/BasicDependency"
-          }, 
+          },
           "description": "Gets the list of dependencies."
-        }, 
+        },
         "id": {
-          "type": "string", 
+          "type": "string",
           "description": "Gets or sets the ID of the dependency."
-        }, 
+        },
         "resourceType": {
-          "type": "string", 
+          "type": "string",
           "description": "Gets or sets the dependency resource type."
-        }, 
+        },
         "resourceName": {
-          "type": "string", 
+          "type": "string",
           "description": "Gets or sets the dependency resource name."
         }
-      }, 
+      },
       "description": "Deployment dependency information."
-    }, 
+    },
     "DeploymentPropertiesExtended": {
       "properties": {
         "provisioningState": {
-          "type": "string", 
+          "type": "string",
           "description": "Gets or sets the state of the provisioning."
-        }, 
+        },
         "correlationId": {
-          "type": "string", 
+          "type": "string",
           "description": "Gets or sets the correlation ID of the deployment."
-        }, 
+        },
         "timestamp": {
-          "type": "string", 
-          "format": "date-time", 
+          "type": "string",
+          "format": "date-time",
           "description": "Gets or sets the timestamp of the template deployment."
-        }, 
+        },
         "outputs": {
-          "type": "object", 
+          "type": "object",
           "description": "Gets or sets key/value pairs that represent deploymentoutput."
-        }, 
+        },
         "providers": {
-          "type": "array", 
+          "type": "array",
           "items": {
             "$ref": "#/definitions/Provider"
-          }, 
+          },
           "description": "Gets the list of resource providers needed for the deployment."
-        }, 
+        },
         "dependencies": {
-          "type": "array", 
+          "type": "array",
           "items": {
             "$ref": "#/definitions/Dependency"
-          }, 
+          },
           "description": "Gets the list of deployment dependencies."
-        }, 
+        },
         "template": {
-          "type": "object", 
+          "type": "object",
           "description": "Gets or sets the template content. Use only one of Template or TemplateLink."
-        }, 
+        },
         "TemplateLink": {
-          "$ref": "#/definitions/TemplateLink", 
+          "$ref": "#/definitions/TemplateLink",
           "description": "Gets or sets the URI referencing the template. Use only one of Template or TemplateLink."
-        }, 
+        },
         "parameters": {
-          "type": "object", 
+          "type": "object",
           "description": "Deployment parameters. Use only one of Parameters or ParametersLink."
-        }, 
+        },
         "parametersLink": {
-          "$ref": "#/definitions/ParametersLink", 
+          "$ref": "#/definitions/ParametersLink",
           "description": "Gets or sets the URI referencing the parameters. Use only one of Parameters or ParametersLink."
-        }, 
+        },
         "mode": {
-          "type": "string", 
-          "description": "Gets or sets the deployment mode.", 
+          "type": "string",
+          "description": "Gets or sets the deployment mode.",
           "enum": [
-            "Incremental", 
+            "Incremental",
             "Complete"
-          ], 
+          ],
           "x-ms-enum": {
-            "name": "DeploymentMode", 
+            "name": "DeploymentMode",
             "modelAsString": false
           }
         }
-      }, 
+      },
       "description": "Deployment properties with additional details."
-    }, 
+    },
     "DeploymentExtended": {
       "properties": {
         "id": {
-          "type": "string", 
+          "type": "string",
           "description": "Gets or sets the ID of the deployment."
-        }, 
+        },
         "name": {
-          "type": "string", 
+          "type": "string",
           "description": "Gets or sets the name of the deployment."
-        }, 
+        },
         "properties": {
-          "$ref": "#/definitions/DeploymentPropertiesExtended", 
+          "$ref": "#/definitions/DeploymentPropertiesExtended",
           "description": "Gets or sets deployment properties."
         }
-      }, 
+      },
       "required": [
         "name"
-      ], 
+      ],
       "description": "Deployment information."
     }
-  }, 
+  },
   "parameters": {
     "SubscriptionIdParameter": {
-      "name": "subscriptionId", 
-      "in": "path", 
-      "required": true, 
-      "type": "string", 
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
       "description": "Gets subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
-    }, 
+    },
     "ApiVersionParameter": {
-      "name": "api-version", 
-      "in": "query", 
-      "required": true, 
-      "type": "string", 
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
       "description": "Client Api Version."
     }
   }


### PR DESCRIPTION
Closes #1503.

- Updates the long-summary for `vnet create` to note that subnet creation is optional at the time of VNet creation.

- Makes the creation of a subnet at the time of VNet creation optional. If omitted, the VNet will be created with no subnet. **BREAKING CHANGE**

- `vnet create` dynamically determines the default subnet prefix. If the VNet mask is < 24 bits, the subnet mask is 24 bits. If the VNet mask is greater than 24 bits, the subnet mask is the same size as the VNet mask. **BREAKING CHANGE**

- For `subnet create` --address-prefix is now a required parameter. Any default could only be used once, after which relying on it will cause an error without complex logic to determine a viable prefix. **BREAKING CHANGE**