### PR TITLE
rbac: remove usages of session key as it offers no guarantee for reliable graph read

### DIFF
--- a/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/recordings/test_create_for_rbac.yaml
+++ b/src/command_modules/azure-cli-role/azure/cli/command_modules/role/tests/recordings/test_create_for_rbac.yaml
@@ -7,10 +7,10 @@ interactions:
       CommandName: [ad sp create-for-rbac]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/0.1.0b10]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [866fd340-bcbd-11e6-8ea0-64510658e3b3]
+      x-ms-client-request-id: [e0761064-be4f-11e6-8c2b-64510658e3b3]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28x%3Ax%20eq%20%27http%3A%2F%2Fcli_create_rbac_sp%27%29&api-version=1.6
   response:
@@ -21,8 +21,8 @@ interactions:
       Content-Length: ['166']
       Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Wed, 07 Dec 2016 20:41:29 GMT']
-      Duration: ['1635978']
+      Date: ['Fri, 09 Dec 2016 20:41:40 GMT']
+      Duration: ['1260955']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -30,58 +30,58 @@ interactions:
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET, ASP.NET]
-      ocp-aad-diagnostics-server-name: [kizqbWR/KeylpM8cFecPprS5E/uaQ4yALSy/Hz4fcwc=]
-      ocp-aad-session-key: [AldQApAK4gbGGtuwpuXP3fAVfuKLQCRaGuuU73Ofzg4Y4Nta06vi2tyjXyJwLBEX3ux9pzPAQohkZZq1OA7UY1-rBOZbW9iFzRJ8-QAvv7fRx_vRfZYuhdRMmB5hBIOFwo3--TfSwgFzpvrrjqHkFQ.iQ6Y833I-iW9ebkeY156WK0s0HrzQHKuBC6aE_gzH5s]
-      request-id: [bdfc2bbd-8bad-4c7b-88fe-838756090c30]
+      ocp-aad-diagnostics-server-name: [1l3fvSoDCV+VKoBCuHRN+HIwCACBOck3dqmtCGj+aiU=]
+      ocp-aad-session-key: [hzdfPZdbotT_EMN2cJ0UFaYHB0aSz7QBQvnYqhjZqvYq6e6466fIjGbZg3L-faJYFoQv6T4sYUoBV8vKcpbRpfZhVz8x6e1HpLjPrQ7ChAoxyZbIpteM4Ps8GWt318ibmCOX8tGBuE4PBmOjL7GD7A.MbXtAuuF7up-6hmpN0xV_N_nKAO3zEkaZ2DcxN5wJjs]
+      request-id: [52e927e8-39e6-4ee7-85ca-be6309ad33d7]
       x-ms-dirapi-data-contract-version: ['1.6']
     status: {code: 200, message: OK}
 - request:
-    body: '{"displayName": "azure-cli-2016-12-07-20-41-30", "passwordCredentials":
-      [{"value": "verySecret", "endDate": "2017-12-07T20:41:30.878446Z", "keyId":
-      "e93f88d3-2e68-442e-89c0-59a958c6cd0b", "startDate": "2016-12-07T20:41:30.878446Z"}],
-      "availableToOtherTenants": false, "homepage": "http://azure-cli-2016-12-07-20-41-30",
+    body: '{"passwordCredentials": [{"keyId": "ab6e6f54-fd82-45e8-b61e-8651041d4c44",
+      "endDate": "2017-12-09T20:41:40.13882999999999998Z", "value": "verySecret",
+      "startDate": "2016-12-09T20:41:40.13882999999999998Z"}], "availableToOtherTenants":
+      false, "homepage": "http://azure-cli-2016-12-09-20-41-40", "displayName": "azure-cli-2016-12-09-20-41-40",
       "identifierUris": ["http://cli_create_rbac_sp"]}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       CommandName: [ad sp create-for-rbac]
       Connection: [keep-alive]
-      Content-Length: ['368']
+      Content-Length: ['390']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/0.1.0b10]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [866fd340-bcbd-11e6-8ea0-64510658e3b3]
+      x-ms-client-request-id: [e0761064-be4f-11e6-8c2b-64510658e3b3]
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"ff046f95-c341-4ec2-bf18-82cc9d26e493","deletionTimestamp":null,"addIns":[],"appId":"e7596e42-db1b-4a4e-8ab5-ad6fac2c1bcb","appRoles":[],"availableToOtherTenants":false,"displayName":"azure-cli-2016-12-07-20-41-30","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://azure-cli-2016-12-07-20-41-30","identifierUris":["http://cli_create_rbac_sp"],"keyCredentials":[],"knownClientApplications":[],"mainLogo@odata.mediaEditLink":"directoryObjects/ff046f95-c341-4ec2-bf18-82cc9d26e493/Microsoft.DirectoryServices.Application/mainLogo","logoutUrl":null,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access azure-cli-2016-12-07-20-41-30 on behalf of the signed-in
-        user.","adminConsentDisplayName":"Access azure-cli-2016-12-07-20-41-30","id":"002d03af-854f-4b81-9072-d72a40d5d447","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access azure-cli-2016-12-07-20-41-30 on your behalf.","userConsentDisplayName":"Access
-        azure-cli-2016-12-07-20-41-30","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2017-12-07T20:41:30.878446Z","keyId":"e93f88d3-2e68-442e-89c0-59a958c6cd0b","startDate":"2016-12-07T20:41:30.878446Z","value":null}],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"aaca1d37-c997-4739-9ab8-e6af46321ee6","deletionTimestamp":null,"addIns":[],"appId":"7e7c7423-5658-478f-99ad-ad2e3e84e3b7","appRoles":[],"availableToOtherTenants":false,"displayName":"azure-cli-2016-12-09-20-41-40","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://azure-cli-2016-12-09-20-41-40","identifierUris":["http://cli_create_rbac_sp"],"keyCredentials":[],"knownClientApplications":[],"mainLogo@odata.mediaEditLink":"directoryObjects/aaca1d37-c997-4739-9ab8-e6af46321ee6/Microsoft.DirectoryServices.Application/mainLogo","logoutUrl":null,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access azure-cli-2016-12-09-20-41-40 on behalf of the signed-in
+        user.","adminConsentDisplayName":"Access azure-cli-2016-12-09-20-41-40","id":"8739fdcb-d0bf-4f77-93d9-3717c208bcc9","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access azure-cli-2016-12-09-20-41-40 on your behalf.","userConsentDisplayName":"Access
+        azure-cli-2016-12-09-20-41-40","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2017-12-09T20:41:40.13883Z","keyId":"ab6e6f54-fd82-45e8-b61e-8651041d4c44","startDate":"2016-12-09T20:41:40.13883Z","value":null}],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
-      Content-Length: ['1669']
+      Content-Length: ['1667']
       Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Wed, 07 Dec 2016 20:41:30 GMT']
-      Duration: ['5217004']
+      Date: ['Fri, 09 Dec 2016 20:41:40 GMT']
+      Duration: ['4281891']
       Expires: ['-1']
-      Location: ['https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/directoryObjects/ff046f95-c341-4ec2-bf18-82cc9d26e493/Microsoft.DirectoryServices.Application']
+      Location: ['https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/directoryObjects/aaca1d37-c997-4739-9ab8-e6af46321ee6/Microsoft.DirectoryServices.Application']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET, ASP.NET]
-      ocp-aad-diagnostics-server-name: [1yeML/CM88dmV36mTVrMp283LPSjy0w/x0TG1KteKio=]
-      ocp-aad-session-key: [fJ7FMf7I6dD7U-ee27EE3va4ZjtqMERAVG1NQsAiJGZVRRoVdK5JUjA7ccAIwWxRaPklXLrE3wMvD1ksAuGhHQbDIpuaQD6KDElWFQq6MKRrSie_F57u5fTMpsK1JKXMGXils3mwvL_6V1zNoDgq6g.X79pNiLRT-0lJKL1n_hA2wGYu3SWHuVvOreyYdZJxEM]
-      request-id: [9026a28b-493f-425d-b353-61e96f49f268]
+      ocp-aad-diagnostics-server-name: [3DlL0WHZ9dYR1n7sfg7IZPMFzYZMxSbRqG1Kv8gBPcQ=]
+      ocp-aad-session-key: [W-Wa7SK3L0FQ6Mo09gaqwtTTjCoX64KPSqyqg-CCmN1wd6qHnv6oaLDvzAZZFJh0TK1ewo-Zf_EoaawBxvJ_lHvog4St_uwJQlXhrFLA6IenvspI2fw4-xYxgePRlGn7spFfgQ_PEDHnrZDELhRBMg.F2KXfiEsNC_hBcCUrRCfQmMX7UUydw0upnFhu6lC62A]
+      request-id: [580dbe04-7f51-4d21-8e9b-381cbf521247]
       x-ms-dirapi-data-contract-version: ['1.6']
     status: {code: 201, message: Created}
 - request:
-    body: '{"appId": "e7596e42-db1b-4a4e-8ab5-ad6fac2c1bcb", "accountEnabled": true}'
+    body: '{"accountEnabled": true, "appId": "7e7c7423-5658-478f-99ad-ad2e3e84e3b7"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -89,36 +89,36 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['73']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/0.1.0b10]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [866fd340-bcbd-11e6-8ea0-64510658e3b3]
+      x-ms-client-request-id: [e0761064-be4f-11e6-8c2b-64510658e3b3]
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"5440acd7-e9c6-4119-a4b8-e3f957adcf2e","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2016-12-07-20-41-30","appId":"e7596e42-db1b-4a4e-8ab5-ad6fac2c1bcb","appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2016-12-07-20-41-30","errorUrl":null,"homepage":"http://azure-cli-2016-12-07-20-41-30","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access azure-cli-2016-12-07-20-41-30 on behalf of the signed-in
-        user.","adminConsentDisplayName":"Access azure-cli-2016-12-07-20-41-30","id":"002d03af-854f-4b81-9072-d72a40d5d447","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access azure-cli-2016-12-07-20-41-30 on your behalf.","userConsentDisplayName":"Access
-        azure-cli-2016-12-07-20-41-30","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["e7596e42-db1b-4a4e-8ab5-ad6fac2c1bcb","http://cli_create_rbac_sp"],"servicePrincipalType":"Application","tags":[]}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/@Element","odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"cda5291d-37a9-44f0-8940-64717dc06cbd","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2016-12-09-20-41-40","appId":"7e7c7423-5658-478f-99ad-ad2e3e84e3b7","appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2016-12-09-20-41-40","errorUrl":null,"homepage":"http://azure-cli-2016-12-09-20-41-40","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access azure-cli-2016-12-09-20-41-40 on behalf of the signed-in
+        user.","adminConsentDisplayName":"Access azure-cli-2016-12-09-20-41-40","id":"8739fdcb-d0bf-4f77-93d9-3717c208bcc9","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access azure-cli-2016-12-09-20-41-40 on your behalf.","userConsentDisplayName":"Access
+        azure-cli-2016-12-09-20-41-40","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["7e7c7423-5658-478f-99ad-ad2e3e84e3b7","http://cli_create_rbac_sp"],"servicePrincipalType":"Application","tags":[]}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
       Content-Length: ['1454']
       Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Wed, 07 Dec 2016 20:41:33 GMT']
-      Duration: ['3884463']
+      Date: ['Fri, 09 Dec 2016 20:41:40 GMT']
+      Duration: ['3432344']
       Expires: ['-1']
-      Location: ['https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/directoryObjects/5440acd7-e9c6-4119-a4b8-e3f957adcf2e/Microsoft.DirectoryServices.ServicePrincipal']
+      Location: ['https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/directoryObjects/cda5291d-37a9-44f0-8940-64717dc06cbd/Microsoft.DirectoryServices.ServicePrincipal']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET, ASP.NET]
-      ocp-aad-diagnostics-server-name: [lyW4+NGrYGveYCvHoTqqxn2sbznKoxnTkModdhBact8=]
-      ocp-aad-session-key: [pXIy4LxhDVJKdKUzzZNx1J7Wm1WLwJTIGphvPLfSKoQLn7G5JC9cbugJpJdXJtlXR6Uf0HxJ7loULsTojut44nbC5GnLduMeSU1auvxr6L279MJpcRk6DW7OIh3w_fWX6peYP5lLOnrtvYioUmCWNw.0o8wkd451halojl9EU2cBGe04UJ4jjk8f-Xajq8iykg]
-      request-id: [31f280e1-e1e2-4ad1-945b-6cb5329e819d]
+      ocp-aad-diagnostics-server-name: [idCFdvS08KcWm23eEQ/NFOhEHlkip0SFh+wWMsXwOUM=]
+      ocp-aad-session-key: [T4xaHnoajezHizC3C_E6zWLd94ml30Niu_XTEGuVXyvgIZlJUVVsbA3Py_-Zv2SXGaaKzJ1Dm-f6wFLKzOgooIPI0CbfBZtnkhl6JH7ogVcTNMnC5RB82xo5-SnhH10mK85Hzp-aSLuSq67C7k7Esw.eap9sJ9-1tJQ3bCiwgXQqmChHNSWhUmqnFFDPcKeLVM]
+      request-id: [8aef4aa5-3971-417c-8e00-f852dd21ed18]
       x-ms-dirapi-data-contract-version: ['1.6']
     status: {code: 201, message: Created}
 - request:
@@ -128,10 +128,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [89644db4-bcbd-11e6-9301-64510658e3b3]
+      x-ms-client-request-id: [e39f5194-be4f-11e6-bebd-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions?$filter=roleName%20eq%20%27Contributor%27&api-version=2015-07-01
   response:
@@ -140,7 +140,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 07 Dec 2016 20:41:31 GMT']
+      Date: ['Fri, 09 Dec 2016 20:41:40 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -154,27 +154,27 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: '{"properties": {"roleDefinitionId": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
-      "principalId": "5440acd7-e9c6-4119-a4b8-e3f957adcf2e"}}'
+      "principalId": "cda5291d-37a9-44f0-8940-64717dc06cbd"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['233']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [89adb6e4-bcbd-11e6-adf4-64510658e3b3]
+      x-ms-client-request-id: [e3cc2dee-be4f-11e6-96b1-64510658e3b3]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/57377ec4-db54-416c-9693-c88ae0f13e20?api-version=2015-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/c18d9d01-2da7-4cfa-9048-ffdc91c4bf8c?api-version=2015-07-01
   response:
-    body: {string: '{"error":{"code":"PrincipalNotFound","message":"Principal 5440acd7e9c64119a4b8e3f957adcf2e
+    body: {string: '{"error":{"code":"PrincipalNotFound","message":"Principal cda5291d37a944f0894064717dc06cbd
         does not exist in the directory 54826b22-38d6-4fb2-bad9-b7b93a3e9c5a."}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['163']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 07 Dec 2016 20:41:33 GMT']
+      Date: ['Fri, 09 Dec 2016 20:41:41 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -182,7 +182,7 @@ interactions:
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 400, message: Bad Request}
 - request:
     body: null
@@ -191,10 +191,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8d2055cc-bcbd-11e6-8004-64510658e3b3]
+      x-ms-client-request-id: [e71ab39e-be4f-11e6-8fed-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions?$filter=roleName%20eq%20%27Contributor%27&api-version=2015-07-01
   response:
@@ -203,7 +203,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 07 Dec 2016 20:41:38 GMT']
+      Date: ['Fri, 09 Dec 2016 20:41:46 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -217,26 +217,153 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: '{"properties": {"roleDefinitionId": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
-      "principalId": "5440acd7-e9c6-4119-a4b8-e3f957adcf2e"}}'
+      "principalId": "cda5291d-37a9-44f0-8940-64717dc06cbd"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['233']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8d6a2090-bcbd-11e6-bdbf-64510658e3b3]
+      x-ms-client-request-id: [e750f7dc-be4f-11e6-9f09-64510658e3b3]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/21f65a86-d2a0-4336-89ed-48066abfde39?api-version=2015-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/fd729eff-33b3-46e6-ae36-4f9324b2ab89?api-version=2015-07-01
   response:
-    body: {string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5440acd7-e9c6-4119-a4b8-e3f957adcf2e","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/roleAssignments/21f65a86-d2a0-4336-89ed-48066abfde39","type":"Microsoft.Authorization/roleAssignments","name":"21f65a86-d2a0-4336-89ed-48066abfde39"}'}
+    body: {string: '{"error":{"code":"PrincipalNotFound","message":"Principal cda5291d37a944f0894064717dc06cbd
+        does not exist in the directory 54826b22-38d6-4fb2-bad9-b7b93a3e9c5a."}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Length: ['686']
+      Content-Length: ['163']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 07 Dec 2016 20:41:39 GMT']
+      Date: ['Fri, 09 Dec 2016 20:41:47 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Set-Cookie: [x-ms-gateway-slice=productionb; path=/]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 400, message: Bad Request}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [ea94b694-be4f-11e6-807a-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions?$filter=roleName%20eq%20%27Contributor%27&api-version=2015-07-01
+  response:
+    body: {string: '{"value":[{"properties":{"roleName":"Contributor","type":"BuiltInRole","description":"Lets
+        you manage everything except access to resources.","assignableScopes":["/"],"permissions":[{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write"]}],"createdOn":"0001-01-01T08:00:00.0000000Z","updatedOn":"2016-05-31T23:13:58.6741320Z","createdBy":null,"updatedBy":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","type":"Microsoft.Authorization/roleDefinitions","name":"b24988ac-6180-42a0-ab88-20f7382dd24c"}],"nextLink":null}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 09 Dec 2016 20:41:52 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Set-Cookie: [x-ms-gateway-slice=productionb; path=/]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['665']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"roleDefinitionId": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
+      "principalId": "cda5291d-37a9-44f0-8940-64717dc06cbd"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['233']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [eabb7c7e-be4f-11e6-9a37-64510658e3b3]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/0fd49765-4792-465c-9bf8-2876b03e82d6?api-version=2015-07-01
+  response:
+    body: {string: '{"error":{"code":"PrincipalNotFound","message":"Principal cda5291d37a944f0894064717dc06cbd
+        does not exist in the directory 54826b22-38d6-4fb2-bad9-b7b93a3e9c5a."}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['163']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 09 Dec 2016 20:41:53 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Set-Cookie: [x-ms-gateway-slice=productionb; path=/]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+    status: {code: 400, message: Bad Request}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [ee1c8cb4-be4f-11e6-9e0f-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions?$filter=roleName%20eq%20%27Contributor%27&api-version=2015-07-01
+  response:
+    body: {string: '{"value":[{"properties":{"roleName":"Contributor","type":"BuiltInRole","description":"Lets
+        you manage everything except access to resources.","assignableScopes":["/"],"permissions":[{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write"]}],"createdOn":"0001-01-01T08:00:00.0000000Z","updatedOn":"2016-05-31T23:13:58.6741320Z","createdBy":null,"updatedBy":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","type":"Microsoft.Authorization/roleDefinitions","name":"b24988ac-6180-42a0-ab88-20f7382dd24c"}],"nextLink":null}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 09 Dec 2016 20:41:58 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Set-Cookie: [x-ms-gateway-slice=productionb; path=/]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['665']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"roleDefinitionId": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
+      "principalId": "cda5291d-37a9-44f0-8940-64717dc06cbd"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['233']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [ee53ae28-be4f-11e6-b3a1-64510658e3b3]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/4255d595-77c2-4f0e-bf29-14aee5f2bc1a?api-version=2015-07-01
+  response:
+    body: {string: '{"error":{"code":"PrincipalNotFound","message":"Principal cda5291d37a944f0894064717dc06cbd
+        does not exist in the directory 54826b22-38d6-4fb2-bad9-b7b93a3e9c5a."}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['163']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 09 Dec 2016 20:41:58 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -245,6 +372,131 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-ratelimit-remaining-subscription-writes: ['1197']
+    status: {code: 400, message: Bad Request}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [f1a73ed2-be4f-11e6-8f62-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions?$filter=roleName%20eq%20%27Contributor%27&api-version=2015-07-01
+  response:
+    body: {string: '{"value":[{"properties":{"roleName":"Contributor","type":"BuiltInRole","description":"Lets
+        you manage everything except access to resources.","assignableScopes":["/"],"permissions":[{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write"]}],"createdOn":"0001-01-01T08:00:00.0000000Z","updatedOn":"2016-05-31T23:13:58.6741320Z","createdBy":null,"updatedBy":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","type":"Microsoft.Authorization/roleDefinitions","name":"b24988ac-6180-42a0-ab88-20f7382dd24c"}],"nextLink":null}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 09 Dec 2016 20:42:04 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Set-Cookie: [x-ms-gateway-slice=productionb; path=/]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['665']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"roleDefinitionId": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
+      "principalId": "cda5291d-37a9-44f0-8940-64717dc06cbd"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['233']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [f1c9fc90-be4f-11e6-8ea3-64510658e3b3]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/7d071f96-de65-4c11-a6c8-2366ce577bfa?api-version=2015-07-01
+  response:
+    body: {string: '{"error":{"code":"PrincipalNotFound","message":"Principal cda5291d37a944f0894064717dc06cbd
+        does not exist in the directory 54826b22-38d6-4fb2-bad9-b7b93a3e9c5a."}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['163']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 09 Dec 2016 20:42:05 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Set-Cookie: [x-ms-gateway-slice=productionb; path=/]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+    status: {code: 400, message: Bad Request}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [f513f22e-be4f-11e6-b0ec-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions?$filter=roleName%20eq%20%27Contributor%27&api-version=2015-07-01
+  response:
+    body: {string: '{"value":[{"properties":{"roleName":"Contributor","type":"BuiltInRole","description":"Lets
+        you manage everything except access to resources.","assignableScopes":["/"],"permissions":[{"actions":["*"],"notActions":["Microsoft.Authorization/*/Delete","Microsoft.Authorization/*/Write"]}],"createdOn":"0001-01-01T08:00:00.0000000Z","updatedOn":"2016-05-31T23:13:58.6741320Z","createdBy":null,"updatedBy":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","type":"Microsoft.Authorization/roleDefinitions","name":"b24988ac-6180-42a0-ab88-20f7382dd24c"}],"nextLink":null}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 09 Dec 2016 20:42:09 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Set-Cookie: [x-ms-gateway-slice=productionb; path=/]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['665']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"roleDefinitionId": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
+      "principalId": "cda5291d-37a9-44f0-8940-64717dc06cbd"}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['233']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [f53996ae-be4f-11e6-bcf8-64510658e3b3]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3124b869-875b-420c-af90-2d67d98ed97e?api-version=2015-07-01
+  response:
+    body: {string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"cda5291d-37a9-44f0-8940-64717dc06cbd","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/roleAssignments/3124b869-875b-420c-af90-2d67d98ed97e","type":"Microsoft.Authorization/roleAssignments","name":"3124b869-875b-420c-af90-2d67d98ed97e"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['686']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 09 Dec 2016 20:42:11 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Set-Cookie: [x-ms-gateway-slice=productionb; path=/]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -254,26 +506,26 @@ interactions:
       CommandName: [ad sp create-for-rbac]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/0.1.0b10]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [866fd340-bcbd-11e6-8ea0-64510658e3b3]
+      x-ms-client-request-id: [e0761064-be4f-11e6-8c2b-64510658e3b3]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28x%3Ax%20eq%20%27http%3A%2F%2Fcli_create_rbac_sp%27%29&api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"5440acd7-e9c6-4119-a4b8-e3f957adcf2e","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2016-12-07-20-41-30","appId":"e7596e42-db1b-4a4e-8ab5-ad6fac2c1bcb","appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2016-12-07-20-41-30","errorUrl":null,"homepage":"http://azure-cli-2016-12-07-20-41-30","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access azure-cli-2016-12-07-20-41-30 on behalf of the signed-in
-        user.","adminConsentDisplayName":"Access azure-cli-2016-12-07-20-41-30","id":"002d03af-854f-4b81-9072-d72a40d5d447","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access azure-cli-2016-12-07-20-41-30 on your behalf.","userConsentDisplayName":"Access
-        azure-cli-2016-12-07-20-41-30","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://cli_create_rbac_sp","e7596e42-db1b-4a4e-8ab5-ad6fac2c1bcb"],"servicePrincipalType":"Application","tags":[]}]}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"cda5291d-37a9-44f0-8940-64717dc06cbd","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2016-12-09-20-41-40","appId":"7e7c7423-5658-478f-99ad-ad2e3e84e3b7","appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2016-12-09-20-41-40","errorUrl":null,"homepage":"http://azure-cli-2016-12-09-20-41-40","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access azure-cli-2016-12-09-20-41-40 on behalf of the signed-in
+        user.","adminConsentDisplayName":"Access azure-cli-2016-12-09-20-41-40","id":"8739fdcb-d0bf-4f77-93d9-3717c208bcc9","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access azure-cli-2016-12-09-20-41-40 on your behalf.","userConsentDisplayName":"Access
+        azure-cli-2016-12-09-20-41-40","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://cli_create_rbac_sp","7e7c7423-5658-478f-99ad-ad2e3e84e3b7"],"servicePrincipalType":"Application","tags":[]}]}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
       Content-Length: ['1502']
       Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Wed, 07 Dec 2016 20:41:40 GMT']
-      Duration: ['1336586']
+      Date: ['Fri, 09 Dec 2016 20:42:12 GMT']
+      Duration: ['1747537']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -281,9 +533,9 @@ interactions:
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET, ASP.NET]
-      ocp-aad-diagnostics-server-name: [+MzH+2dNYIt6p0PwxNqlMcq3itHIDSnhoyEZsBf+jpA=]
-      ocp-aad-session-key: [_pUpNqzGrvrC2d0E_CVgXyAl0M7dtgNZoUZwa0lR9FwrjqwzGQcNi5eLTkk_IWlYq3UggInfII6XNEohILz65LaQ2axbPIaD1XxRNEAoInrEm8VZleqaH2ustgy8iiXjmhVr7jg4xBkZHPqbGJabRw.oao37W4_N16tjjvhLT2gVnEmfCK8RtxwQ43HsP3qFgo]
-      request-id: [0062802c-6c74-4382-b518-6727083fdad3]
+      ocp-aad-diagnostics-server-name: [Rqi9SNMjpM2VdY3oPX7t1hoksRSH2GqDuH2d5VsjisM=]
+      ocp-aad-session-key: [PMuWdDTfLIG52R_cETwEmzDw_kTaT2xFaC83UfwHBaL7FnE3kHcPBgY1q2hYPAgb97HLvCgJBPs0XkjqKaUv2kPsF34Jy5-ndP80IICgDPaqZ_gJ3DqSQSoZuWouBtKiQc5tPyGsKKI_DEmUYB41Xw.D2ivoiksvsftmZzbS7Slw6Tv-QVpUB7mlfvQrpDJX7g]
+      request-id: [36c7baf4-e7ad-4f76-80bb-719c4a49e8c3]
       x-ms-dirapi-data-contract-version: ['1.6']
     status: {code: 200, message: OK}
 - request:
@@ -293,10 +545,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8e7a5cf4-bcbd-11e6-a01d-64510658e3b3]
+      x-ms-client-request-id: [f660611e-be4f-11e6-9d94-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_create_rbac_sp/providers/Microsoft.Authorization/roleDefinitions?$filter=roleName%20eq%20%27Contributor%27&api-version=2015-07-01
   response:
@@ -305,7 +557,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 07 Dec 2016 20:41:40 GMT']
+      Date: ['Fri, 09 Dec 2016 20:42:12 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -319,26 +571,26 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: '{"properties": {"roleDefinitionId": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
-      "principalId": "5440acd7-e9c6-4119-a4b8-e3f957adcf2e"}}'
+      "principalId": "cda5291d-37a9-44f0-8940-64717dc06cbd"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['233']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8ea99de4-bcbd-11e6-ba20-64510658e3b3]
+      x-ms-client-request-id: [f6890e5c-be4f-11e6-97b3-64510658e3b3]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_create_rbac_sp/providers/Microsoft.Authorization/roleAssignments/fed95984-bcbf-4e39-8f1e-f6d6d1808132?api-version=2015-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_create_rbac_sp/providers/Microsoft.Authorization/roleAssignments/3de99cfa-402c-44e5-ae4d-89a379b36e47?api-version=2015-07-01
   response:
-    body: {string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5440acd7-e9c6-4119-a4b8-e3f957adcf2e","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_create_rbac_sp","createdOn":"2016-12-07T20:41:41.7748229Z","updatedOn":"2016-12-07T20:41:41.7748229Z","createdBy":null,"updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_create_rbac_sp/providers/Microsoft.Authorization/roleAssignments/fed95984-bcbf-4e39-8f1e-f6d6d1808132","type":"Microsoft.Authorization/roleAssignments","name":"fed95984-bcbf-4e39-8f1e-f6d6d1808132"}'}
+    body: {string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"cda5291d-37a9-44f0-8940-64717dc06cbd","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_create_rbac_sp","createdOn":"2016-12-09T20:42:13.1838384Z","updatedOn":"2016-12-09T20:42:13.1838384Z","createdBy":null,"updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_create_rbac_sp/providers/Microsoft.Authorization/roleAssignments/3de99cfa-402c-44e5-ae4d-89a379b36e47","type":"Microsoft.Authorization/roleAssignments","name":"3de99cfa-402c-44e5-ae4d-89a379b36e47"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['754']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 07 Dec 2016 20:41:41 GMT']
+      Date: ['Fri, 09 Dec 2016 20:42:13 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -346,7 +598,7 @@ interactions:
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -356,26 +608,26 @@ interactions:
       CommandName: [role assignment list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/0.1.0b10]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [866fd340-bcbd-11e6-8ea0-64510658e3b3]
+      x-ms-client-request-id: [e0761064-be4f-11e6-8c2b-64510658e3b3]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%27http%3A%2F%2Fcli_create_rbac_sp%27%29&api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"5440acd7-e9c6-4119-a4b8-e3f957adcf2e","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2016-12-07-20-41-30","appId":"e7596e42-db1b-4a4e-8ab5-ad6fac2c1bcb","appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2016-12-07-20-41-30","errorUrl":null,"homepage":"http://azure-cli-2016-12-07-20-41-30","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access azure-cli-2016-12-07-20-41-30 on behalf of the signed-in
-        user.","adminConsentDisplayName":"Access azure-cli-2016-12-07-20-41-30","id":"002d03af-854f-4b81-9072-d72a40d5d447","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access azure-cli-2016-12-07-20-41-30 on your behalf.","userConsentDisplayName":"Access
-        azure-cli-2016-12-07-20-41-30","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://cli_create_rbac_sp","e7596e42-db1b-4a4e-8ab5-ad6fac2c1bcb"],"servicePrincipalType":"Application","tags":[]}]}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"cda5291d-37a9-44f0-8940-64717dc06cbd","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2016-12-09-20-41-40","appId":"7e7c7423-5658-478f-99ad-ad2e3e84e3b7","appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2016-12-09-20-41-40","errorUrl":null,"homepage":"http://azure-cli-2016-12-09-20-41-40","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access azure-cli-2016-12-09-20-41-40 on behalf of the signed-in
+        user.","adminConsentDisplayName":"Access azure-cli-2016-12-09-20-41-40","id":"8739fdcb-d0bf-4f77-93d9-3717c208bcc9","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access azure-cli-2016-12-09-20-41-40 on your behalf.","userConsentDisplayName":"Access
+        azure-cli-2016-12-09-20-41-40","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://cli_create_rbac_sp","7e7c7423-5658-478f-99ad-ad2e3e84e3b7"],"servicePrincipalType":"Application","tags":[]}]}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
       Content-Length: ['1502']
       Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Wed, 07 Dec 2016 20:41:41 GMT']
-      Duration: ['1334309']
+      Date: ['Fri, 09 Dec 2016 20:42:14 GMT']
+      Duration: ['1365434']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -383,9 +635,9 @@ interactions:
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET, ASP.NET]
-      ocp-aad-diagnostics-server-name: [gVe9/FM4oqqnojytneR8sUurfqQA9QW5mYrgVR1bKQo=]
-      ocp-aad-session-key: [j2K6MnEbKz2fy9H91BhL2sAwCMWWMNcxbvxSVlzVNjH5R6ETNPfTzG7nU7ZsnEkMO_9-0yHspFBO0NVHX32CcZ4ibGRIRJ3UniPXqppfUP7NsuhKfmFIbLjwv6IO8Gzmb2IWfPnIXIC80fmnEzuEtA.zWmpHrR7BXQD9h_DMRvo4NiVntRSyJ6QGItfoA-Ka7o]
-      request-id: [bec509bd-6ddc-4365-855a-a9a65561eda1]
+      ocp-aad-diagnostics-server-name: [idCFdvS08KcWm23eEQ/NFOhEHlkip0SFh+wWMsXwOUM=]
+      ocp-aad-session-key: [WLvtmOeYOEIy27obMvJuZTqsEX_RDUewhU88vD30mL6ttrWghxVKLA4n0mGCaCUY6nvbNGnRwg8w57s_FSvJkdmf-P67-uBcTXYLSfyvmdnClhRbVleTYIvcBvNDqD4tbicJwRnGRRYga41bAaW70A.OdESciQb0ZMmrFlIdjCTrMVQtKqNrQPhpSxDqzAxed4]
+      request-id: [2d7287f9-1bae-4a85-89cb-b09b381de32b]
       x-ms-dirapi-data-contract-version: ['1.6']
     status: {code: 200, message: OK}
 - request:
@@ -395,18 +647,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8fe7af78-bcbd-11e6-9266-64510658e3b3]
+      x-ms-client-request-id: [f7a81390-be4f-11e6-91f6-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments?$filter=principalId%20eq%20%275440acd7-e9c6-4119-a4b8-e3f957adcf2e%27&api-version=2015-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments?$filter=principalId%20eq%20%27cda5291d-37a9-44f0-8940-64717dc06cbd%27&api-version=2015-07-01
   response:
-    body: {string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5440acd7-e9c6-4119-a4b8-e3f957adcf2e","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/roleAssignments/21f65a86-d2a0-4336-89ed-48066abfde39","type":"Microsoft.Authorization/roleAssignments","name":"21f65a86-d2a0-4336-89ed-48066abfde39"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5440acd7-e9c6-4119-a4b8-e3f957adcf2e","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_create_rbac_sp","createdOn":"2016-12-07T20:41:42.3705810Z","updatedOn":"2016-12-07T20:41:42.3705810Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_create_rbac_sp/providers/Microsoft.Authorization/roleAssignments/fed95984-bcbf-4e39-8f1e-f6d6d1808132","type":"Microsoft.Authorization/roleAssignments","name":"fed95984-bcbf-4e39-8f1e-f6d6d1808132"}],"nextLink":null}'}
+    body: {string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"cda5291d-37a9-44f0-8940-64717dc06cbd","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/roleAssignments/3124b869-875b-420c-af90-2d67d98ed97e","type":"Microsoft.Authorization/roleAssignments","name":"3124b869-875b-420c-af90-2d67d98ed97e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"cda5291d-37a9-44f0-8940-64717dc06cbd","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_create_rbac_sp","createdOn":"2016-12-09T20:42:14.0439349Z","updatedOn":"2016-12-09T20:42:14.0439349Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_create_rbac_sp/providers/Microsoft.Authorization/roleAssignments/3de99cfa-402c-44e5-ae4d-89a379b36e47","type":"Microsoft.Authorization/roleAssignments","name":"3de99cfa-402c-44e5-ae4d-89a379b36e47"}],"nextLink":null}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 07 Dec 2016 20:41:42 GMT']
+      Date: ['Fri, 09 Dec 2016 20:42:14 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -425,10 +677,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9025a3c0-bcbd-11e6-95fb-64510658e3b3]
+      x-ms-client-request-id: [f7e2b21c-be4f-11e6-abe7-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions?api-version=2015-07-01
   response:
@@ -956,7 +1208,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 07 Dec 2016 20:41:43 GMT']
+      Date: ['Fri, 09 Dec 2016 20:42:15 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -969,7 +1221,7 @@ interactions:
       content-length: ['46733']
     status: {code: 200, message: OK}
 - request:
-    body: '{"objectIds": ["5440acd7-e9c6-4119-a4b8-e3f957adcf2e"], "includeDirectoryObjectReferences":
+    body: '{"objectIds": ["cda5291d-37a9-44f0-8940-64717dc06cbd"], "includeDirectoryObjectReferences":
       true}'
     headers:
       Accept: [application/json]
@@ -978,26 +1230,26 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['97']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/0.1.0b10]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [866fd340-bcbd-11e6-8ea0-64510658e3b3]
+      x-ms-client-request-id: [e0761064-be4f-11e6-8c2b-64510658e3b3]
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/getObjectsByObjectIds?api-version=1.6-internal
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"5440acd7-e9c6-4119-a4b8-e3f957adcf2e","deletionTimestamp":null,"accountEnabled":true,"appBranding":null,"appCategory":null,"appData":null,"appDisplayName":"azure-cli-2016-12-07-20-41-30","appId":"e7596e42-db1b-4a4e-8ab5-ad6fac2c1bcb","appMetadata":null,"appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"authenticationPolicy":null,"displayName":"azure-cli-2016-12-07-20-41-30","errorUrl":null,"homepage":"http://azure-cli-2016-12-07-20-41-30","keyCredentials":[],"logoutUrl":null,"microsoftFirstParty":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access azure-cli-2016-12-07-20-41-30 on behalf of the signed-in
-        user.","adminConsentDisplayName":"Access azure-cli-2016-12-07-20-41-30","id":"002d03af-854f-4b81-9072-d72a40d5d447","isEnabled":true,"lang":null,"origin":"Application","type":"User","userConsentDescription":"Allow
-        the application to access azure-cli-2016-12-07-20-41-30 on your behalf.","userConsentDisplayName":"Access
-        azure-cli-2016-12-07-20-41-30","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://cli_create_rbac_sp","e7596e42-db1b-4a4e-8ab5-ad6fac2c1bcb"],"tags":[],"useCustomTokenSigningKey":null}]}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"cda5291d-37a9-44f0-8940-64717dc06cbd","deletionTimestamp":null,"accountEnabled":true,"appBranding":null,"appCategory":null,"appData":null,"appDisplayName":"azure-cli-2016-12-09-20-41-40","appId":"7e7c7423-5658-478f-99ad-ad2e3e84e3b7","appMetadata":null,"appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"authenticationPolicy":null,"displayName":"azure-cli-2016-12-09-20-41-40","errorUrl":null,"homepage":"http://azure-cli-2016-12-09-20-41-40","keyCredentials":[],"logoutUrl":null,"microsoftFirstParty":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access azure-cli-2016-12-09-20-41-40 on behalf of the signed-in
+        user.","adminConsentDisplayName":"Access azure-cli-2016-12-09-20-41-40","id":"8739fdcb-d0bf-4f77-93d9-3717c208bcc9","isEnabled":true,"lang":null,"origin":"Application","type":"User","userConsentDescription":"Allow
+        the application to access azure-cli-2016-12-09-20-41-40 on your behalf.","userConsentDisplayName":"Access
+        azure-cli-2016-12-09-20-41-40","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://cli_create_rbac_sp","7e7c7423-5658-478f-99ad-ad2e3e84e3b7"],"tags":[],"useCustomTokenSigningKey":null}]}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
       Content-Length: ['1580']
       Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Wed, 07 Dec 2016 20:41:43 GMT']
-      Duration: ['2313441']
+      Date: ['Fri, 09 Dec 2016 20:42:15 GMT']
+      Duration: ['1874131']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1005,9 +1257,9 @@ interactions:
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET, ASP.NET]
-      ocp-aad-diagnostics-server-name: [vQw7cHgPiB6jev2emnFqImQSObLZzk9AXRvfXyidT18=]
-      ocp-aad-session-key: [nKGFXglPIds4ttULRPZ7Uvq7UH5BfCU9lccJg6z_huVkEz4DCa-7vFVYb3sGJ1denY8aTrkCqqb0vnylcZzYCR4bbpuH3EY4LqAc7i2y69Ty4ee_Pngsp7rJ3VhvZcQubbIQFoooVQdfCsXSmXfPFw.BK8K5L_8FhotLl6tmvb8kM_VQxYoUHH_Z5TlcpkyEC8]
-      request-id: [e8df0c6b-361e-49a5-b196-3ce3f1962da7]
+      ocp-aad-diagnostics-server-name: [VN6JFju2ntHZdAkZZ1BZ44JK9tpKF11dfK3idB4Oz2w=]
+      ocp-aad-session-key: [mk_DVoPrZEr-INdXT6xh9x65FRz1YkcA6HxJDZIVEbmR-ty5TrJKl6FARZAY9llRtRuW9cAjoGI2X35tU1_HZmgjOhCqjCKCMEeJLDpy3KIiacd75csvf-w-L4IAji-ApNOjFhVKGfS15TAWHHauWg.-TWx2zLjLxMT0lpEjZ1lyK8eSZXKsnkURDo_biaEgV4]
+      request-id: [73ee0e36-ad0a-491d-87e8-87b831380612]
       x-ms-dirapi-data-contract-version: [1.6-internal]
     status: {code: 200, message: OK}
 - request:
@@ -1018,35 +1270,35 @@ interactions:
       CommandName: [role assignment list]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/0.1.0b10]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [866fd340-bcbd-11e6-8ea0-64510658e3b3]
+      x-ms-client-request-id: [e0761064-be4f-11e6-8c2b-64510658e3b3]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%27http%3A%2F%2Fcli_create_rbac_sp%27%29&api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"5440acd7-e9c6-4119-a4b8-e3f957adcf2e","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2016-12-07-20-41-30","appId":"e7596e42-db1b-4a4e-8ab5-ad6fac2c1bcb","appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2016-12-07-20-41-30","errorUrl":null,"homepage":"http://azure-cli-2016-12-07-20-41-30","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access azure-cli-2016-12-07-20-41-30 on behalf of the signed-in
-        user.","adminConsentDisplayName":"Access azure-cli-2016-12-07-20-41-30","id":"002d03af-854f-4b81-9072-d72a40d5d447","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access azure-cli-2016-12-07-20-41-30 on your behalf.","userConsentDisplayName":"Access
-        azure-cli-2016-12-07-20-41-30","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://cli_create_rbac_sp","e7596e42-db1b-4a4e-8ab5-ad6fac2c1bcb"],"servicePrincipalType":"Application","tags":[]}]}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"cda5291d-37a9-44f0-8940-64717dc06cbd","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2016-12-09-20-41-40","appId":"7e7c7423-5658-478f-99ad-ad2e3e84e3b7","appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2016-12-09-20-41-40","errorUrl":null,"homepage":"http://azure-cli-2016-12-09-20-41-40","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access azure-cli-2016-12-09-20-41-40 on behalf of the signed-in
+        user.","adminConsentDisplayName":"Access azure-cli-2016-12-09-20-41-40","id":"8739fdcb-d0bf-4f77-93d9-3717c208bcc9","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access azure-cli-2016-12-09-20-41-40 on your behalf.","userConsentDisplayName":"Access
+        azure-cli-2016-12-09-20-41-40","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://cli_create_rbac_sp","7e7c7423-5658-478f-99ad-ad2e3e84e3b7"],"servicePrincipalType":"Application","tags":[]}]}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
       Content-Length: ['1457']
       Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Wed, 07 Dec 2016 20:41:42 GMT']
-      Duration: ['1238670']
+      Date: ['Fri, 09 Dec 2016 20:42:15 GMT']
+      Duration: ['1267143']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET, ASP.NET]
-      ocp-aad-diagnostics-server-name: [hruhICbW44m6jzbLovw5Qk2GWpHr55qlq6TGVFGtCFA=]
-      ocp-aad-session-key: [-rxzZiHVUPH8vP1uQyGQ2HkZHBbd8D_12VGdaHbBuOo3jGQDXXCECpuHi7m61vJa9laOI5hktxorr357SxrFLZImqMpUB0-i2EHpbBkzRwgSwH2_lmdKCQzzv3YxTx7TwEmK-sPM8fc-SwMW4DoGhw.QAcJi0z9lp-2MqYHwNkVPJLR9qeJKK7lCJbNbIpSY9s]
-      request-id: [6eae3965-81bf-43f7-9e94-50050710ef06]
+      ocp-aad-diagnostics-server-name: [Vysq2vNZzcPtnjT1P5DAD3ODEK1mXogz2xu8HZBYqqY=]
+      ocp-aad-session-key: [x-wPTb8p20rv4H_IVGmTl0o6auL5-0qoRIqtYf28k3upaPch87NgJimr19OA-VYVWsw6Yhuc5fhs82NisqAuL0AWPvzw8vfpyGDAd-oV7OHa7P_bH4lP0YVZ9qbuYReCbyxL596gCEo4hGrl6NVLcQ.n6dOul3Kej3dT-zUckruqyDPVuTKs52q-qNBi3xn3Dg]
+      request-id: [b7964f24-5904-4f57-9da3-82886e25f0e0]
       x-ms-dirapi-data-contract-version: ['1.6']
     status: {code: 200, message: OK}
 - request:
@@ -1056,18 +1308,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [911b3dd8-bcbd-11e6-a44d-64510658e3b3]
+      x-ms-client-request-id: [f8c93aa8-be4f-11e6-b5a5-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments?$filter=principalId%20eq%20%275440acd7-e9c6-4119-a4b8-e3f957adcf2e%27&api-version=2015-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments?$filter=principalId%20eq%20%27cda5291d-37a9-44f0-8940-64717dc06cbd%27&api-version=2015-07-01
   response:
-    body: {string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5440acd7-e9c6-4119-a4b8-e3f957adcf2e","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/roleAssignments/21f65a86-d2a0-4336-89ed-48066abfde39","type":"Microsoft.Authorization/roleAssignments","name":"21f65a86-d2a0-4336-89ed-48066abfde39"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5440acd7-e9c6-4119-a4b8-e3f957adcf2e","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_create_rbac_sp","createdOn":"2016-12-07T20:41:42.3705810Z","updatedOn":"2016-12-07T20:41:42.3705810Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_create_rbac_sp/providers/Microsoft.Authorization/roleAssignments/fed95984-bcbf-4e39-8f1e-f6d6d1808132","type":"Microsoft.Authorization/roleAssignments","name":"fed95984-bcbf-4e39-8f1e-f6d6d1808132"}],"nextLink":null}'}
+    body: {string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"cda5291d-37a9-44f0-8940-64717dc06cbd","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/roleAssignments/3124b869-875b-420c-af90-2d67d98ed97e","type":"Microsoft.Authorization/roleAssignments","name":"3124b869-875b-420c-af90-2d67d98ed97e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"cda5291d-37a9-44f0-8940-64717dc06cbd","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_create_rbac_sp","createdOn":"2016-12-09T20:42:14.0439349Z","updatedOn":"2016-12-09T20:42:14.0439349Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_create_rbac_sp/providers/Microsoft.Authorization/roleAssignments/3de99cfa-402c-44e5-ae4d-89a379b36e47","type":"Microsoft.Authorization/roleAssignments","name":"3de99cfa-402c-44e5-ae4d-89a379b36e47"}],"nextLink":null}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 07 Dec 2016 20:41:45 GMT']
+      Date: ['Fri, 09 Dec 2016 20:42:16 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1086,10 +1338,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9179d778-bcbd-11e6-bcee-64510658e3b3]
+      x-ms-client-request-id: [f8eb3176-be4f-11e6-bd36-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_create_rbac_sp/providers/Microsoft.Authorization/roleDefinitions?api-version=2015-07-01
   response:
@@ -1617,7 +1869,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 07 Dec 2016 20:41:45 GMT']
+      Date: ['Fri, 09 Dec 2016 20:42:16 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1630,7 +1882,7 @@ interactions:
       content-length: ['46733']
     status: {code: 200, message: OK}
 - request:
-    body: '{"objectIds": ["5440acd7-e9c6-4119-a4b8-e3f957adcf2e"], "includeDirectoryObjectReferences":
+    body: '{"objectIds": ["cda5291d-37a9-44f0-8940-64717dc06cbd"], "includeDirectoryObjectReferences":
       true}'
     headers:
       Accept: [application/json]
@@ -1639,26 +1891,26 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['97']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/0.1.0b10]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [866fd340-bcbd-11e6-8ea0-64510658e3b3]
+      x-ms-client-request-id: [e0761064-be4f-11e6-8c2b-64510658e3b3]
     method: POST
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/getObjectsByObjectIds?api-version=1.6-internal
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"5440acd7-e9c6-4119-a4b8-e3f957adcf2e","deletionTimestamp":null,"accountEnabled":true,"appBranding":null,"appCategory":null,"appData":null,"appDisplayName":"azure-cli-2016-12-07-20-41-30","appId":"e7596e42-db1b-4a4e-8ab5-ad6fac2c1bcb","appMetadata":null,"appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"authenticationPolicy":null,"displayName":"azure-cli-2016-12-07-20-41-30","errorUrl":null,"homepage":"http://azure-cli-2016-12-07-20-41-30","keyCredentials":[],"logoutUrl":null,"microsoftFirstParty":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access azure-cli-2016-12-07-20-41-30 on behalf of the signed-in
-        user.","adminConsentDisplayName":"Access azure-cli-2016-12-07-20-41-30","id":"002d03af-854f-4b81-9072-d72a40d5d447","isEnabled":true,"lang":null,"origin":"Application","type":"User","userConsentDescription":"Allow
-        the application to access azure-cli-2016-12-07-20-41-30 on your behalf.","userConsentDisplayName":"Access
-        azure-cli-2016-12-07-20-41-30","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://cli_create_rbac_sp","e7596e42-db1b-4a4e-8ab5-ad6fac2c1bcb"],"tags":[],"useCustomTokenSigningKey":null}]}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"cda5291d-37a9-44f0-8940-64717dc06cbd","deletionTimestamp":null,"accountEnabled":true,"appBranding":null,"appCategory":null,"appData":null,"appDisplayName":"azure-cli-2016-12-09-20-41-40","appId":"7e7c7423-5658-478f-99ad-ad2e3e84e3b7","appMetadata":null,"appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"authenticationPolicy":null,"displayName":"azure-cli-2016-12-09-20-41-40","errorUrl":null,"homepage":"http://azure-cli-2016-12-09-20-41-40","keyCredentials":[],"logoutUrl":null,"microsoftFirstParty":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access azure-cli-2016-12-09-20-41-40 on behalf of the signed-in
+        user.","adminConsentDisplayName":"Access azure-cli-2016-12-09-20-41-40","id":"8739fdcb-d0bf-4f77-93d9-3717c208bcc9","isEnabled":true,"lang":null,"origin":"Application","type":"User","userConsentDescription":"Allow
+        the application to access azure-cli-2016-12-09-20-41-40 on your behalf.","userConsentDisplayName":"Access
+        azure-cli-2016-12-09-20-41-40","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://cli_create_rbac_sp","7e7c7423-5658-478f-99ad-ad2e3e84e3b7"],"tags":[],"useCustomTokenSigningKey":null}]}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
       Content-Length: ['1580']
       Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Wed, 07 Dec 2016 20:41:45 GMT']
-      Duration: ['1984310']
+      Date: ['Fri, 09 Dec 2016 20:42:17 GMT']
+      Duration: ['1983968']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1666,9 +1918,9 @@ interactions:
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET, ASP.NET]
-      ocp-aad-diagnostics-server-name: [kizqbWR/KeylpM8cFecPprS5E/uaQ4yALSy/Hz4fcwc=]
-      ocp-aad-session-key: [x97pXsbrKUknznd_N1fm7ENDx7ED8Nd-6NcVDZaLWIU53Qt2j4C2V8VjtpWJH_qlKhV9nxijswq6887rjxevGLf59s2JeGIarjq2Q4z8hv0RmKV45PtQFgGT1e8hYHs0hvfFplsnEwwOA2-6glehHQ.n3SmuoApnJ1f9DiK4nF7xjlcXZtheM81a1JmQezjK64]
-      request-id: [31528239-fc65-46ba-b6e0-631dd5447f41]
+      ocp-aad-diagnostics-server-name: [wUAYkBKal6oqagFY7aouGCtQCtmejpC9YPiTOfHJ8us=]
+      ocp-aad-session-key: [6RHX6ayjJn-u2wlQZt8cWPI1NOrFkKYXv6ZP7J9h39yhFJDoelSZCOXrvypxZ5sjMoQNCTrNTLk4opNh9Ka27t1f3FkxNNwQpomn0JeuEyVDKrdxb_qpkMR2o-cVtgaCgDieFSY1JLZ3ZgB7slqLyQ._sHIuE1YBJxAkUxuldXOGqXuryTGixQAmg3FfGTQ-XA]
+      request-id: [950f0ea9-14a9-4b95-bb86-ecc25d3b3bb8]
       x-ms-dirapi-data-contract-version: [1.6-internal]
     status: {code: 200, message: OK}
 - request:
@@ -1679,26 +1931,26 @@ interactions:
       CommandName: [role assignment delete]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/0.1.0b10]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [866fd340-bcbd-11e6-8ea0-64510658e3b3]
+      x-ms-client-request-id: [e0761064-be4f-11e6-8c2b-64510658e3b3]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%27http%3A%2F%2Fcli_create_rbac_sp%27%29&api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"5440acd7-e9c6-4119-a4b8-e3f957adcf2e","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2016-12-07-20-41-30","appId":"e7596e42-db1b-4a4e-8ab5-ad6fac2c1bcb","appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2016-12-07-20-41-30","errorUrl":null,"homepage":"http://azure-cli-2016-12-07-20-41-30","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access azure-cli-2016-12-07-20-41-30 on behalf of the signed-in
-        user.","adminConsentDisplayName":"Access azure-cli-2016-12-07-20-41-30","id":"002d03af-854f-4b81-9072-d72a40d5d447","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access azure-cli-2016-12-07-20-41-30 on your behalf.","userConsentDisplayName":"Access
-        azure-cli-2016-12-07-20-41-30","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://cli_create_rbac_sp","e7596e42-db1b-4a4e-8ab5-ad6fac2c1bcb"],"servicePrincipalType":"Application","tags":[]}]}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"cda5291d-37a9-44f0-8940-64717dc06cbd","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2016-12-09-20-41-40","appId":"7e7c7423-5658-478f-99ad-ad2e3e84e3b7","appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2016-12-09-20-41-40","errorUrl":null,"homepage":"http://azure-cli-2016-12-09-20-41-40","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access azure-cli-2016-12-09-20-41-40 on behalf of the signed-in
+        user.","adminConsentDisplayName":"Access azure-cli-2016-12-09-20-41-40","id":"8739fdcb-d0bf-4f77-93d9-3717c208bcc9","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access azure-cli-2016-12-09-20-41-40 on your behalf.","userConsentDisplayName":"Access
+        azure-cli-2016-12-09-20-41-40","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://cli_create_rbac_sp","7e7c7423-5658-478f-99ad-ad2e3e84e3b7"],"servicePrincipalType":"Application","tags":[]}]}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
       Content-Length: ['1502']
       Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Wed, 07 Dec 2016 20:41:46 GMT']
-      Duration: ['1406658']
+      Date: ['Fri, 09 Dec 2016 20:42:17 GMT']
+      Duration: ['1441756']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1706,9 +1958,9 @@ interactions:
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET, ASP.NET]
-      ocp-aad-diagnostics-server-name: [cacoZvdto6Z3Whgt2xq+Z1yMQXMysjJ+dwSlYIYTsB8=]
-      ocp-aad-session-key: [PAoJ861EEr5sqtraUxlhSjfW4z2Gh1XrMqfjqHV5C_cEcDf1BWDK6HycgcOyFp1YEpm5uT48D8J_87iQZrDy9XO8r2f7mrgU9pDWDrvu0fI-BXLSsfT2Zrmx5D_pshtZht74do2V0B7H4ZeEy31M0Q.Ak3n89vyrukQemwaGaw2Fren1AgtBGCGZtP9AlJ3Ykg]
-      request-id: [e89ff322-fa6a-417b-bd27-bee4b654541c]
+      ocp-aad-diagnostics-server-name: [lyW4+NGrYGveYCvHoTqqxn2sbznKoxnTkModdhBact8=]
+      ocp-aad-session-key: [zTh-QsHObVMlHiTmQl8Il0mEgtZAE-oSWC8j73cphmOuG_Kg4hG8jqXNqhhUjflEWZ30gLcnaxRn0G0m9oYpkY9_Jk5zaE6mnjxS5hFwZkU4oPZ-i8roYHDZycTQ4NMAds2yYRUEcWpZFAhyppJFWQ.qi7C4IJJ0HEqOiXxSOHkBpj_rE18PDhggC_RIXN55z0]
+      request-id: [7e9d15aa-fa73-48bd-8ec2-e93a17582e65]
       x-ms-dirapi-data-contract-version: ['1.6']
     status: {code: 200, message: OK}
 - request:
@@ -1718,18 +1970,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [92857052-bcbd-11e6-90ab-64510658e3b3]
+      x-ms-client-request-id: [f9cd75e6-be4f-11e6-b303-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments?$filter=principalId%20eq%20%275440acd7-e9c6-4119-a4b8-e3f957adcf2e%27&api-version=2015-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments?$filter=principalId%20eq%20%27cda5291d-37a9-44f0-8940-64717dc06cbd%27&api-version=2015-07-01
   response:
-    body: {string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5440acd7-e9c6-4119-a4b8-e3f957adcf2e","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/roleAssignments/21f65a86-d2a0-4336-89ed-48066abfde39","type":"Microsoft.Authorization/roleAssignments","name":"21f65a86-d2a0-4336-89ed-48066abfde39"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5440acd7-e9c6-4119-a4b8-e3f957adcf2e","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_create_rbac_sp","createdOn":"2016-12-07T20:41:42.3705810Z","updatedOn":"2016-12-07T20:41:42.3705810Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_create_rbac_sp/providers/Microsoft.Authorization/roleAssignments/fed95984-bcbf-4e39-8f1e-f6d6d1808132","type":"Microsoft.Authorization/roleAssignments","name":"fed95984-bcbf-4e39-8f1e-f6d6d1808132"}],"nextLink":null}'}
+    body: {string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"cda5291d-37a9-44f0-8940-64717dc06cbd","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/roleAssignments/3124b869-875b-420c-af90-2d67d98ed97e","type":"Microsoft.Authorization/roleAssignments","name":"3124b869-875b-420c-af90-2d67d98ed97e"},{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"cda5291d-37a9-44f0-8940-64717dc06cbd","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_create_rbac_sp","createdOn":"2016-12-09T20:42:14.0439349Z","updatedOn":"2016-12-09T20:42:14.0439349Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_create_rbac_sp/providers/Microsoft.Authorization/roleAssignments/3de99cfa-402c-44e5-ae4d-89a379b36e47","type":"Microsoft.Authorization/roleAssignments","name":"3de99cfa-402c-44e5-ae4d-89a379b36e47"}],"nextLink":null}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 07 Dec 2016 20:41:46 GMT']
+      Date: ['Fri, 09 Dec 2016 20:42:18 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1749,18 +2001,18 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [92a29af0-bcbd-11e6-a932-64510658e3b3]
+      x-ms-client-request-id: [f9f36850-be4f-11e6-9fff-64510658e3b3]
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_create_rbac_sp/providers/Microsoft.Authorization/roleAssignments/fed95984-bcbf-4e39-8f1e-f6d6d1808132?api-version=2015-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_create_rbac_sp/providers/Microsoft.Authorization/roleAssignments/3de99cfa-402c-44e5-ae4d-89a379b36e47?api-version=2015-07-01
   response:
-    body: {string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5440acd7-e9c6-4119-a4b8-e3f957adcf2e","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_create_rbac_sp","createdOn":"2016-12-07T20:41:42.3705810Z","updatedOn":"2016-12-07T20:41:42.3705810Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_create_rbac_sp/providers/Microsoft.Authorization/roleAssignments/fed95984-bcbf-4e39-8f1e-f6d6d1808132","type":"Microsoft.Authorization/roleAssignments","name":"fed95984-bcbf-4e39-8f1e-f6d6d1808132"}'}
+    body: {string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"cda5291d-37a9-44f0-8940-64717dc06cbd","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_create_rbac_sp","createdOn":"2016-12-09T20:42:14.0439349Z","updatedOn":"2016-12-09T20:42:14.0439349Z","createdBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55","updatedBy":"e7e158d3-7cdc-47cd-8825-5859d7ab2b55"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_create_rbac_sp/providers/Microsoft.Authorization/roleAssignments/3de99cfa-402c-44e5-ae4d-89a379b36e47","type":"Microsoft.Authorization/roleAssignments","name":"3de99cfa-402c-44e5-ae4d-89a379b36e47"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 07 Dec 2016 20:41:48 GMT']
+      Date: ['Fri, 09 Dec 2016 20:42:18 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1771,7 +2023,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['788']
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1781,26 +2033,26 @@ interactions:
       CommandName: [role assignment delete]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/0.1.0b10]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [866fd340-bcbd-11e6-8ea0-64510658e3b3]
+      x-ms-client-request-id: [e0761064-be4f-11e6-8c2b-64510658e3b3]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/servicePrincipals?$filter=servicePrincipalNames%2Fany%28c%3Ac%20eq%20%27http%3A%2F%2Fcli_create_rbac_sp%27%29&api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"5440acd7-e9c6-4119-a4b8-e3f957adcf2e","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2016-12-07-20-41-30","appId":"e7596e42-db1b-4a4e-8ab5-ad6fac2c1bcb","appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2016-12-07-20-41-30","errorUrl":null,"homepage":"http://azure-cli-2016-12-07-20-41-30","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access azure-cli-2016-12-07-20-41-30 on behalf of the signed-in
-        user.","adminConsentDisplayName":"Access azure-cli-2016-12-07-20-41-30","id":"002d03af-854f-4b81-9072-d72a40d5d447","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access azure-cli-2016-12-07-20-41-30 on your behalf.","userConsentDisplayName":"Access
-        azure-cli-2016-12-07-20-41-30","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://cli_create_rbac_sp","e7596e42-db1b-4a4e-8ab5-ad6fac2c1bcb"],"servicePrincipalType":"Application","tags":[]}]}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal","value":[{"odata.type":"Microsoft.DirectoryServices.ServicePrincipal","objectType":"ServicePrincipal","objectId":"cda5291d-37a9-44f0-8940-64717dc06cbd","deletionTimestamp":null,"accountEnabled":true,"addIns":[],"alternativeNames":[],"appDisplayName":"azure-cli-2016-12-09-20-41-40","appId":"7e7c7423-5658-478f-99ad-ad2e3e84e3b7","appOwnerTenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","appRoleAssignmentRequired":false,"appRoles":[],"displayName":"azure-cli-2016-12-09-20-41-40","errorUrl":null,"homepage":"http://azure-cli-2016-12-09-20-41-40","keyCredentials":[],"logoutUrl":null,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access azure-cli-2016-12-09-20-41-40 on behalf of the signed-in
+        user.","adminConsentDisplayName":"Access azure-cli-2016-12-09-20-41-40","id":"8739fdcb-d0bf-4f77-93d9-3717c208bcc9","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access azure-cli-2016-12-09-20-41-40 on your behalf.","userConsentDisplayName":"Access
+        azure-cli-2016-12-09-20-41-40","value":"user_impersonation"}],"passwordCredentials":[],"preferredTokenSigningKeyThumbprint":null,"publisherName":"AzureSDKTeam","replyUrls":[],"samlMetadataUrl":null,"servicePrincipalNames":["http://cli_create_rbac_sp","7e7c7423-5658-478f-99ad-ad2e3e84e3b7"],"servicePrincipalType":"Application","tags":[]}]}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
       Content-Length: ['1502']
       Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Wed, 07 Dec 2016 20:41:47 GMT']
-      Duration: ['1359621']
+      Date: ['Fri, 09 Dec 2016 20:42:19 GMT']
+      Duration: ['1505409']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1808,9 +2060,9 @@ interactions:
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET, ASP.NET]
-      ocp-aad-diagnostics-server-name: [+MzH+2dNYIt6p0PwxNqlMcq3itHIDSnhoyEZsBf+jpA=]
-      ocp-aad-session-key: [nJG9N0VvqmAvVDQwnnYSYFTNVHESSHNpDl1AktuThDiXISU9jrY3NXZS_ls48heFrHCWF8vKF9UDdGsWMyF2WU3WkLTW5rMkfxEdQB_M_pfvOZj9VdmLaB1pIfv8he10R0VZlMOpJ93b9YTAzvjFjA.9scSDe-cM2-jCr_olc8NgpfVZoAB7b3xm9-ekApQZ7Q]
-      request-id: [dec933ac-91d0-432b-b732-bf5e3d9cb06d]
+      ocp-aad-diagnostics-server-name: [5q1QBvY4JEbYxExoTOFN8jS7rI6cNysIhk+BBVr0cFc=]
+      ocp-aad-session-key: [VHKDGRFNFQXjvm5gV_c3Tf4OkVsTGDfhAfHvbVINqP_ErqQJ8pmQasGyncOm60fs2Tw1hkLX_LkXUlbJcTs03psLva--KiyYwtMqua-73uB1to-3ZLat7ImyFW_C-LExVRAX2xfHn_Wx65Vl3VibTg.FGnjwEzar5PqUnhJn6RvaGlVs5S78IX1aUJ1IVPvNb4]
+      request-id: [c35438d9-0164-412f-b98f-15bc84b4dc47]
       x-ms-dirapi-data-contract-version: ['1.6']
     status: {code: 200, message: OK}
 - request:
@@ -1820,18 +2072,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [936cf2e8-bcbd-11e6-8c6d-64510658e3b3]
+      x-ms-client-request-id: [fa8a6a6e-be4f-11e6-a423-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments?$filter=principalId%20eq%20%275440acd7-e9c6-4119-a4b8-e3f957adcf2e%27&api-version=2015-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments?$filter=principalId%20eq%20%27cda5291d-37a9-44f0-8940-64717dc06cbd%27&api-version=2015-07-01
   response:
-    body: {string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5440acd7-e9c6-4119-a4b8-e3f957adcf2e","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/roleAssignments/21f65a86-d2a0-4336-89ed-48066abfde39","type":"Microsoft.Authorization/roleAssignments","name":"21f65a86-d2a0-4336-89ed-48066abfde39"}],"nextLink":null}'}
+    body: {string: '{"value":[{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"cda5291d-37a9-44f0-8940-64717dc06cbd","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/roleAssignments/3124b869-875b-420c-af90-2d67d98ed97e","type":"Microsoft.Authorization/roleAssignments","name":"3124b869-875b-420c-af90-2d67d98ed97e"}],"nextLink":null}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 07 Dec 2016 20:41:48 GMT']
+      Date: ['Fri, 09 Dec 2016 20:42:19 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1851,18 +2103,18 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          authorizationmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [93879d58-bcbd-11e6-86ad-64510658e3b3]
+      x-ms-client-request-id: [faace852-be4f-11e6-8df4-64510658e3b3]
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/21f65a86-d2a0-4336-89ed-48066abfde39?api-version=2015-07-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/3124b869-875b-420c-af90-2d67d98ed97e?api-version=2015-07-01
   response:
-    body: {string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"5440acd7-e9c6-4119-a4b8-e3f957adcf2e","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/roleAssignments/21f65a86-d2a0-4336-89ed-48066abfde39","type":"Microsoft.Authorization/roleAssignments","name":"21f65a86-d2a0-4336-89ed-48066abfde39"}'}
+    body: {string: '{"properties":{"roleDefinitionId":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c","principalId":"cda5291d-37a9-44f0-8940-64717dc06cbd","scope":"/subscriptions/00000000-0000-0000-0000-000000000000/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Authorization/roleAssignments/3124b869-875b-420c-af90-2d67d98ed97e","type":"Microsoft.Authorization/roleAssignments","name":"3124b869-875b-420c-af90-2d67d98ed97e"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 07 Dec 2016 20:41:49 GMT']
+      Date: ['Fri, 09 Dec 2016 20:42:19 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1873,7 +2125,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['720']
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1883,36 +2135,35 @@ interactions:
       CommandName: [ad app delete]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/0.1.0b10]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [866fd340-bcbd-11e6-8ea0-64510658e3b3]
+      x-ms-client-request-id: [e0761064-be4f-11e6-8c2b-64510658e3b3]
     method: GET
     uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications?$filter=identifierUris%2Fany%28s%3As%20eq%20%27http%3A%2F%2Fcli_create_rbac_sp%27%29&api-version=1.6
   response:
-    body: {string: '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.Application","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"ff046f95-c341-4ec2-bf18-82cc9d26e493","deletionTimestamp":null,"addIns":[],"appId":"e7596e42-db1b-4a4e-8ab5-ad6fac2c1bcb","appRoles":[],"availableToOtherTenants":false,"displayName":"azure-cli-2016-12-07-20-41-30","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://azure-cli-2016-12-07-20-41-30","identifierUris":["http://cli_create_rbac_sp"],"keyCredentials":[],"knownClientApplications":[],"logoutUrl":null,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
-        the application to access azure-cli-2016-12-07-20-41-30 on behalf of the signed-in
-        user.","adminConsentDisplayName":"Access azure-cli-2016-12-07-20-41-30","id":"002d03af-854f-4b81-9072-d72a40d5d447","isEnabled":true,"type":"User","userConsentDescription":"Allow
-        the application to access azure-cli-2016-12-07-20-41-30 on your behalf.","userConsentDisplayName":"Access
-        azure-cli-2016-12-07-20-41-30","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2017-12-07T20:41:30.878446Z","keyId":"e93f88d3-2e68-442e-89c0-59a958c6cd0b","startDate":"2016-12-07T20:41:30.878446Z","value":null}],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null}]}'}
+    body: {string: '{"odata.metadata":"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects","value":[{"odata.type":"Microsoft.DirectoryServices.Application","objectType":"Application","objectId":"aaca1d37-c997-4739-9ab8-e6af46321ee6","deletionTimestamp":null,"addIns":[],"appId":"7e7c7423-5658-478f-99ad-ad2e3e84e3b7","appRoles":[],"availableToOtherTenants":false,"displayName":"azure-cli-2016-12-09-20-41-40","errorUrl":null,"groupMembershipClaims":null,"homepage":"http://azure-cli-2016-12-09-20-41-40","identifierUris":["http://cli_create_rbac_sp"],"keyCredentials":[],"knownClientApplications":[],"mainLogo@odata.mediaEditLink":"directoryObjects/aaca1d37-c997-4739-9ab8-e6af46321ee6/Microsoft.DirectoryServices.Application/mainLogo","logoutUrl":null,"oauth2AllowImplicitFlow":false,"oauth2AllowUrlPathMatching":false,"oauth2Permissions":[{"adminConsentDescription":"Allow
+        the application to access azure-cli-2016-12-09-20-41-40 on behalf of the signed-in
+        user.","adminConsentDisplayName":"Access azure-cli-2016-12-09-20-41-40","id":"8739fdcb-d0bf-4f77-93d9-3717c208bcc9","isEnabled":true,"type":"User","userConsentDescription":"Allow
+        the application to access azure-cli-2016-12-09-20-41-40 on your behalf.","userConsentDisplayName":"Access
+        azure-cli-2016-12-09-20-41-40","value":"user_impersonation"}],"oauth2RequirePostResponse":false,"passwordCredentials":[{"customKeyIdentifier":null,"endDate":"2017-12-09T20:41:40.13883Z","keyId":"ab6e6f54-fd82-45e8-b61e-8651041d4c44","startDate":"2016-12-09T20:41:40.13883Z","value":null}],"publicClient":null,"recordConsentConditions":null,"replyUrls":[],"requiredResourceAccess":[],"samlMetadataUrl":null}]}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
-      Content-Length: ['1576']
+      Content-Length: ['1670']
       Content-Type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Wed, 07 Dec 2016 20:41:51 GMT']
-      Duration: ['1328090']
+      Date: ['Fri, 09 Dec 2016 20:42:20 GMT']
+      Duration: ['1441560']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET, ASP.NET]
-      ocp-aad-diagnostics-server-name: [Yb9aW/Jhj6Lw6czWkbHD70v8NVcJXO7JiIBvivZihyU=]
-      ocp-aad-session-key: [alD7QqEBVvuyk73O68gc89Cjakjfaqr8TVd15ay5cbEBvlBuPrDV64EouTtefsDMdNKHswadf6Hwxm9f1PkHHzml1fje0DWaFUHwfG7scBLfnfBiPvxdJN7PuiPHRmBodZwaQF7jQjXywKT2riOR4w.26PCK7ZPENOWRcQ39jeUgSL6015JjMHfAV8oGoqDSDA]
-      request-id: [647625ea-ba1b-40c4-9a33-a33b8c85d9ba]
+      ocp-aad-diagnostics-server-name: [m9M7FwYn4nG+o6gcMPqNm7KXN8+wB02LW2dyryhOK00=]
+      ocp-aad-session-key: [gnINBA8ISUguIzEO33foY_eKGm1mzCUr7_sMXTwohnl5hMLku54JfzWjL6JfSC5SRS753SPqe7B13nZsxS1GIQH1MDSYwM8sN357MzjROUYIXAhPz2Mjy0phKFkQMton2eUWrn1qMhsxs__61-hWjw.XJ-LG97AWUbZHfOafyL7AmcEyVPK8QGON9HWN9M4KTc]
+      request-id: [1ba50d2b-b716-445d-b035-8118c7c43d87]
       x-ms-dirapi-data-contract-version: ['1.6']
     status: {code: 200, message: OK}
 - request:
@@ -1924,20 +2175,20 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/0.1.0b10]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.5
+          graphrbacmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/0.1.0b10+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [866fd340-bcbd-11e6-8ea0-64510658e3b3]
+      x-ms-client-request-id: [e0761064-be4f-11e6-8c2b-64510658e3b3]
     method: DELETE
-    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/ff046f95-c341-4ec2-bf18-82cc9d26e493?api-version=1.6
+    uri: https://graph.windows.net/00000000-0000-0000-0000-000000000000/applications/aaca1d37-c997-4739-9ab8-e6af46321ee6?api-version=1.6
   response:
     body: {string: ''}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
       DataServiceVersion: [1.0;]
-      Date: ['Wed, 07 Dec 2016 20:41:52 GMT']
-      Duration: ['3971354']
+      Date: ['Fri, 09 Dec 2016 20:42:21 GMT']
+      Duration: ['4364802']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.5]
@@ -1945,9 +2196,9 @@ interactions:
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET, ASP.NET]
-      ocp-aad-diagnostics-server-name: [2+eIYSD8Z5neC7dxwfkKHHZxTQx6o1ZQq4AE0IT92X8=]
-      ocp-aad-session-key: [WmpWq_NsZJCP1sNwzoG8V91SxmZ3UWzk5zw6t_6Iu7P3VAC6v6axDg1TLBs0GqFeIiZXkxMUdLy1mCAQPukA2HknQoG5t1AOc0GLMtVTLWkwQRNX24H1LHlddZAN2fY7N45el6B-vpvv-_fefew5Tw.kDFYVxNhWkgj5d3NfPAjWWE0cFH0QQY0AZhUd5aDm7Y]
-      request-id: [793bc559-82d2-499e-a9a1-9a6c2f267633]
+      ocp-aad-diagnostics-server-name: [JVlo9m2eEzdwoyBD/e4ZM9GTtwNdqo5bFN6pbBiJspY=]
+      ocp-aad-session-key: [VTZFU6pLgpmVJZFwjyUsZwbD5Rv02fkqDhSb7Wi4QoOOSqApIRfMU3r9sKtcigUrqQheOsewIdxFL2Iay5Y0eTJFZaSdt-wnN4A2ld59m4fXHF18Iko7u0aTudz2w10iu4JjWIrfLAHF9njWMwyIVA.BvylAxGgCPaoNfAfODkcsLvAPKzOKR4fu33YITTHOME]
+      request-id: [ea0445fd-dc12-446e-b489-398110efcc37]
       x-ms-dirapi-data-contract-version: ['1.6']
     status: {code: 204, message: No Content}
 version: 1


### PR DESCRIPTION
This used to work for first party applications like cli, but now AAD service no longer support it.
Hence I am cleaning up the code and just use retries.