### PR TITLE
[Docs] Curl install at top of README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,26 @@ If you already have the CLI installed, run the following to update:
 
 If you don't have the CLI installed, see below.
 
+Install with interactive install script
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For OSX and Linux, you can install using curl: 
+
+.. code-block:: console
+
+   $ curl -L https://aka.ms/InstallAzureCli | bash
+
+or using wget:
+
+.. code-block:: console
+
+   $ wget -q -O - https://aka.ms/InstallAzureCli | bash
+
+Some prerequisites may be required. See our `Preview Install Guide <https://github.com/Azure/azure-cli/blob/master/doc/preview_install_guide.md>`__.
+
+If you run into an ``AttributeError: 'X509' object has no attribute '_x509'`` error, downgrade your version of the requests library from 2.12.1 to 2.11.1.
+With the default install location, use ``/usr/local/az/bin/pip install requests==2.11.1``.
+
 Install with pip
 ^^^^^^^^^^^^^^^^
 
@@ -115,26 +135,6 @@ All command modules are included in this version as the image is built directly 
 
 For installation steps for common platforms, as well as dependency troubleshooting, please take a look at our `installation guide <http://github.com/Azure/azure-cli/blob/master/doc/preview_install_guide.md>`__.
 
-
-Install with interactive install script
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-For OSX and Linux, you can install using curl: 
-
-.. code-block:: console
-
-   $ curl -L https://aka.ms/InstallAzureCli | bash
-
-or using wget:
-
-.. code-block:: console
-
-   $ wget -q -O - https://aka.ms/InstallAzureCli | bash
-
-Some prerequisites may be required. See our `Preview Install Guide <https://github.com/Azure/azure-cli/blob/master/doc/preview_install_guide.md>`__.
-
-If you run into an ``AttributeError: 'X509' object has no attribute '_x509'`` error, downgrade your version of the requests library from 2.12.1 to 2.11.1.
-With the default install location, use ``/usr/local/az/bin/pip install requests==2.11.1``.
 
 Usage
 =====

--- a/scripts/curl_install_pypi/README.md
+++ b/scripts/curl_install_pypi/README.md
@@ -6,3 +6,10 @@ The scripts in this directory are used for installing through curl and they poin
 curl https://azurecliprod.blob.core.windows.net/install | bash
 
 To update these scripts, submit a PR and request a member of the team to upload the scripts to the storage account.
+
+Uploading the script:
+```
+$ export AZURE_STORAGE_CONNECTION_STRING=$(az storage account show-connection-string -g <RG> -n <NAME> -otsv)
+$ az storage blob upload -c '$root' -n install.py -f scripts/curl_install_pypi/install.py 
+$ az storage blob upload -c '$root' -n install -f scripts/curl_install_pypi/install 
+```

--- a/scripts/curl_install_pypi/README.md
+++ b/scripts/curl_install_pypi/README.md
@@ -6,10 +6,3 @@ The scripts in this directory are used for installing through curl and they poin
 curl https://azurecliprod.blob.core.windows.net/install | bash
 
 To update these scripts, submit a PR and request a member of the team to upload the scripts to the storage account.
-
-Uploading the script:
-```
-$ export AZURE_STORAGE_CONNECTION_STRING=$(az storage account show-connection-string -g <RG> -n <NAME> -otsv)
-$ az storage blob upload -c '$root' -n install.py -f scripts/curl_install_pypi/install.py 
-$ az storage blob upload -c '$root' -n install -f scripts/curl_install_pypi/install 
-```


### PR DESCRIPTION
- curl install at top since we’ve made improvements to it and it’s the easiest for new users
- Instructions on uploading new install scripts to storage account
