### PR TITLE
appservice: add webapp start

### DIFF
--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_help.py
@@ -248,6 +248,11 @@ helps['appservice web restart'] = """
     short-summary: restart a web app
 """
 
+helps['appservice web start'] = """
+    type: command
+    short-summary: start a web app
+"""
+
 helps['appservice web show'] = """
     type: command
     short-summary: show a web app

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/commands.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/commands.py
@@ -14,6 +14,7 @@ cli_command(__name__, 'appservice web list', 'azure.cli.command_modules.appservi
 cli_command(__name__, 'appservice web show', 'azure.cli.command_modules.appservice.custom#show_webapp')
 cli_command(__name__, 'appservice web delete', 'azure.cli.command_modules.appservice.custom#delete_webapp')
 cli_command(__name__, 'appservice web stop', 'azure.cli.command_modules.appservice.custom#stop_webapp')
+cli_command(__name__, 'appservice web start', 'azure.cli.command_modules.appservice.custom#start_webapp')
 cli_command(__name__, 'appservice web restart', 'azure.cli.command_modules.appservice.custom#restart_webapp')
 
 cli_command(__name__, 'appservice web config update', 'azure.cli.command_modules.appservice.custom#update_site_configs')

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/custom.py
@@ -88,6 +88,9 @@ def delete_webapp(resource_group_name, name, slot=None):
 def stop_webapp(resource_group_name, name, slot=None):
     return _generic_site_operation(resource_group_name, name, 'stop_site', slot)
 
+def start_webapp(resource_group_name, name, slot=None):
+    return _generic_site_operation(resource_group_name, name, 'start_site', slot)
+
 def restart_webapp(resource_group_name, name, slot=None):
     return _generic_site_operation(resource_group_name, name, 'restart_site', slot)
 

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/recordings/test_webapp_e2e.yaml
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/recordings/test_webapp_e2e.yaml
@@ -7,35 +7,26 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          resourcemanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+          resourcemanagementclient/0.30.2 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [40575b42-a16f-11e6-9a44-f4b7e2e85440]
+      x-ms-client-request-id: [22e0c234-c353-11e6-8892-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/azurecli-webapp-e2e?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/azurecli-webapp-e2e2?api-version=2016-09-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXezH6zrfFoW21f5JFuttvO9/KPRR8tskRP8+JdlNc3QITW4ypt23dBnq7pa5XVb5M1H
-        j34x/rosGmpSLC9et1kLWK/X02mez/LZR7/kl/w/6uj+Ob8AAAA=
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2","name":"azurecli-webapp-e2e2","location":"westus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Length: ['266']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 03 Nov 2016 02:43:07 GMT']
+      Date: ['Fri, 16 Dec 2016 05:47:31 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
+      content-length: ['230']
     status: {code: 200, message: OK}
 - request:
-    body: !!binary |
-      eyJza3UiOiB7ImNhcGFjaXR5IjogMSwgInRpZXIiOiAiQkFTSUMiLCAibmFtZSI6ICJCMSJ9LCAi
-      cHJvcGVydGllcyI6IHsibmFtZSI6ICJ3ZWJhcHAtZTJlLXBsYW4ifSwgImxvY2F0aW9uIjogIndl
-      c3R1cyJ9
+    body: '{"properties": {"name": "webapp-e2e-plan"}, "location": "westus", "sku":
+      {"tier": "BASIC", "capacity": 1, "name": "B1"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -43,38 +34,28 @@ interactions:
       Content-Length: ['120']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [411acd66-a16f-11e6-a2c7-f4b7e2e85440]
+      x-ms-client-request-id: [2316e1ac-c353-11e6-ba50-f4b7e2e85440]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e/providers/Microsoft.Web/serverfarms/webapp-e2e-plan?api-version=2015-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/serverfarms/webapp-e2e-plan?api-version=2015-08-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXezH6zrfFoW21f5JFuttvO9/O6qri6LWV43d78opnXVVOft+Lv55G6T15d5fZ7Vi+au
-        a769KrPlR6OPltkiJ5z6X7TXK3wxCIualNU0wxio2Xfzpk2/ek0fttlF89Gj5bosRx8RSqu8bouc
-        PvnFH8nLz+jlMyLDzoa+r6r6bV6/Ln5AX1M796e+KB+8KfL6BYOQ3pbrxSSvvzz/Ln9LXe6OPpqu
-        6zpftvIRIPD7vU8Vrn7+IgKoabN2Tb9SK8L39SqbEqiPIvOwDVJ89Zo+aLgRvepNN71zm/mmt7LZ
-        oli+LtrcH+K8atpieXG6vCzqarkgXIe/eVlX50VpX11k74rFetEb2z2aJqK69PLRTxZ1u87Kp/ms
-        oLnNZy/pK4PMq/WyLRZ5F6dptVit2/yLakYfEXka+l7+kO8v8upVfiFjB22ETYgvAOj1NCsJ7Y8e
-        nWdlk7s5xHeEHIHrDwyTJaB9XntbLO3ngbRQt5FpIhSoFTiS3tLOFzPmzI+usqtmm3h3tj3Jrrd3
-        Pr3/+396b3fvo19CY3u7Bicr4z7ZJSjE3TV+z5piSn82xE34E1+dZ4uivMZf9Mc0I3YoWvpz95f8
-        kv8Hru0EdQoEAAA=
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/serverfarms/webapp-e2e-plan","name":"webapp-e2e-plan","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
+        US","tags":null,"properties":{"serverFarmId":0,"name":"webapp-e2e-plan","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":0,"currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":0,"webSpace":"azurecli-webapp-e2e2-WestUSwebspace","subscription":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":false,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"azurecli-webapp-e2e2","reserved":false,"mdmId":"waws-prod-bay-069_4240","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded"},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Thu, 03 Nov 2016 02:43:23 GMT']
+      Date: ['Fri, 16 Dec 2016 05:47:38 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
+      content-length: ['1146']
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
@@ -85,38 +66,28 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [4a589582-a16f-11e6-a879-f4b7e2e85440]
+      x-ms-client-request-id: [279847c2-c353-11e6-b7c0-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e/providers/Microsoft.Web/serverfarms?api-version=2015-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/serverfarms?api-version=2015-08-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
-        zsP7D3fu1nlTretp/nldrVfN3ewH6zqflsX2VT7JVqvtfC+/u6qry2KW183dL4ppXTXVeTv+bj65
-        2+T1ZV6fZ/Wiueuab6/KbPnR6KNltiDUPup/0V6v8MUgLGpSVtMMY6Bm382bNv3qNX3YZhfNR4+W
-        67IcfUQorfK6LXL65Bd/JC8/o5fPiAw7G/q+quq3ef26+AF9Te3cn/qifPCmyOsXDEJ6W64Xk7z+
-        8vy7/C11uTv6aLqu63zZykeAwO/3PlW4+vmLCKCmzdo1/UqtCN/Xq2xKoD6KzMM2SPHVa/qg4Ub0
-        qjfd9M5t5pveymaLYvm6aHN/iPOqaYvlxenysqir5YJwHf7mZV2dF6V9dZG9KxbrRW9s92iaiOrS
-        y0c/WdTtOiuf5rOC5jafvaSvDDKv1su2WORdnKbVYrVu8y+qGX1E5Gnoe/lDvr/Iq1f5hYwdtBE2
-        Ib4AoNfTrCS0P3p0npVN7uYQ3xFyBK4/MEyWgPZ57W2xtJ8H0kLdRqaJUKBW4Eh6SztfzJgzP7rK
-        rppt4t3Z9iS73t759P7v/+m93b2PfgmN7e0anKyM+2SXoBB31/g9a4op/dkQN+FPfHWeLYryGn/R
-        H9OM2KFo6c/dX/JLvk8jzd+1z4vlW4MzVAN++yX/D3tt6AAwBAAA
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/serverfarms/webapp-e2e-plan","name":"webapp-e2e-plan","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
+        US","tags":null,"properties":{"serverFarmId":0,"name":"webapp-e2e-plan","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":0,"currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":0,"webSpace":"azurecli-webapp-e2e2-WestUSwebspace","subscription":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":false,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"azurecli-webapp-e2e2","reserved":false,"mdmId":"waws-prod-bay-069_4240","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded"},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}],"nextLink":null,"id":null}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Thu, 03 Nov 2016 02:43:47 GMT']
+      Date: ['Fri, 16 Dec 2016 05:47:40 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
+      content-length: ['1184']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -126,116 +97,154 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [58a3b4ec-a16f-11e6-a376-f4b7e2e85440]
+      x-ms-client-request-id: [28685d2e-c353-11e6-aa69-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/serverfarms?api-version=2015-08-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
-        zsP7D3fu1nlTretp/nldrVfN3ewH6zqflsX2VT7JVqvtfC+/u6qry2KW183dL4ppXTXVeTv+bj65
-        2+T1ZV6fZ/Wiueuab6/KbPnR6KNltiDUPup/0V6v8EUI66KsJllJ35bVNAP61OK7edOmX72mD9vs
-        ovno0XJdlqOPCJtVXrdFTp/84o8Eh2eEwxlRYP/Te58+/PTehs6vqvptXr8ufkBf7/h/4nX7wZsi
-        r18wCOlzuV5M8vrL8+/yt9Tx7uij6bqu82UrHwGCadz7AqCDr150wcm3TZu1a/oLaOST16tsSjA/
-        iszINijz1Wv6oOFG9Ko38QZcNlsUy9dFm/sjmVdNWywvTpeXRV0tF4TM8Dcv6+q8KO2ri+xdsVgv
-        esgTuUFc6eWjnyzqdp2VT/NZQROZz17SV4QgI/NqvWyLRd7FaVotVus2/6Ka0Uc0+Ia+lz/k+4u8
-        epVf8Mg8niAmAKDX06wktE1bM1P4inAjaP1xufnw+eptsbSfB0JBvUbmgDCgVuA++9ZixkyIP34J
-        jeLtGgyqnPhkl14gpq3xe9YUU/qzId7An/jqPFsU5TX+oj+mGU1r0dKfu7/kl4x+9oQbpAF+7yPh
-        5h0jUPidsBv49mdT1vc/PTh48OAmDESgIYbMDe5PwLAf/L9Z4O2IQKP/10j9LiENEks3Pz/EHjAx
-        E4QGNQU32lc3yf5rCDgxMWT/dZstZ1k9o09U/PlbK/4Y4g9L/Bui4XvJPr9gBEsHF/vqZ1Xq7z/Y
-        uX9/Y/ci0hBE5gT3JwDYD24UeWqp4isfAYJp3PsCoIOvegIj395O5GU4oM7/e+Sd5oXIK738/BB3
-        ngXCgdqBB+17m2T9GaSZWBey/qzO8brKOX9j5fwZ/eHkfOcblXNvCBdFu/8+Ek7tWYr2CT0dUeSb
-        W8v3aWbm0Z8DwoemlYhEn/Tk+9Pd3Yef0oQO9y7iC6Ejwvl/4n37wY3iTQytoiofAYJp3PsCoIOv
-        evIh38bFuzMh2yDL/2sE+4fqvmPkwhDEAQD0QxHsDv2pd2oBtrNvbBJp9s+JWyHSP2eue2cIX0em
-        7xN6OqTINz/bMv3g4abeRWYhaTzp7k+8bz/4kUzfUqZ/uM45hi4cQSwAQP8fEGr2uoldIdQ/lz75
-        tFy3Tbv76b39vVvJNFGwxczu39/fuaceIqGnoxr49tayjTdkJv1ZILxoYolY9ElXtu/tPfz0wQOy
-        IZsxEPmF1PH8uz8Bw35wo3xTS5VV+QgQTOPeFwAdfNUTE/l2SL7txOgw6Mv/V8g2TQgRWHr52RZt
-        jFwYgjgAgH5Iom1pTz3Tt2A523qTWLOTTZwKsf65c7+B/d7Bg08fvpdIf/rpw/sYrw6l+/HPshAf
-        7O4Ndi3SCZkiWvl/4mX7wf/7pJfn4EfSSxBp6gHohyi9THvqmb4Fr9nW/3+V3ocP9+9jvDqU7sc/
-        29K74xLh3a5FOiFTRCv/T7xsP7hReolzVRLlI0AwjXtfAHTwVU8Q5Nv/r0kv4QnSSjc/Et9QfNlr
-        Jh6F+P7c+9T37j/cf/BeIry/e3//gTIcoaejGvj2Z1WgD+59uuty3AMYXDFXQtp47kWM8Sdg2A9u
-        lGtqqTIqHwGCadz7AqCDr3oiIt9ukmueGCUkffn/CrmmCaEpll7+/yzWTHvqmb4Fy9nWm8SabS9x
-        KsT659Yq7+/v7d5/L5F+sLO/74WhOqKBb39WRfrhp5/e74fJHQxEZCFoRED/T8CwH/y/T6R5YnQY
-        9OWPRPqHKNJMe+qZvgXL2db/nxHp/ds52u+e5quyugap3hC5v00E3Pv0008PCEUd1YYWP6uivfvp
-        7t7BbbAQ8YXQETH9PwHHfvD/SvHe/3+bJ06TQjIsvfz/XLz339cRZyEmbv25F+8H93Z2b+eEbxAb
-        HdWGFj+r4k0J7v9/izdP0o/EmyASFwDQD1G8mfbUM30LtrOt/78i3nt7n/5/X7wPiN1uxkLEF0JH
-        xPT/BBz7wf8bxZsm6UfiTRCJCwDohyreRHvqmb4F29nW/x8R70939nb/Py7eB/fu39+/DRYivhA6
-        Iqb/J+DYD/5fKN6YpB+JN0EkLgCgH6Z4g/bUM30LtrOt/78h3gd7Dw72/j8u3hR7f/rwNliI+ELo
-        iJj+n4BjP/h/n3jzJP1IvAkicQEA/RDFm2lPPdO3YDvb+v8j4n2ws3s755wox9no/Yef7u8orxF6
-        OqKBb39WxZqc8n1ntQcwEJGFoBEB/T8Bw37w/0KRxsToMOjLH4n0D1OkQXvqmb4Fy9nW/18R6Xu3
-        jLeJciwyDw8e7gBJHUr3459tIb7/6WDXIp2QKaKV/ydeth/cKL3EuSqJ8hEgmMa9LwA6+KonCPLt
-        ZumlOfihSO9N0muR3iU8QVoh1P+/xZeITz3Tt2A223qT+L4GtxGPQnxft9lyltUz+kRFmL+1IoxR
-        ORHe/VkR4f17+7cS4Q3OrI5sQ4ufZcE+2HGCvQELkWFIHvOB+xNw7Ac3yji1VHmVjwDBNO59AdDB
-        V19LxmmS/l8m4zQpJMfSy/+/RZxoTz3Tt2A723qTiLMdJm6FiP/cWuiHezt7O/+fF+8HD4ndbsZC
-        xBdCR8T0/wQc+8H/+8SbJ+lH4k0QiQsA6Ico3kx76pm+BdvZ1v+vF+9mUV/s7e3ev5VwN9WCpIYn
-        TcfgffKzKLz7u3sPdnfdarXXqwgjRIhI4/+J9+wH/68SVkPyH4kqQaQ5B6AfjqgaylO/9B1YzLb9
-        /4Sg3tvdffD/fkH99H6sVxFEiA+Rxv8T79kPbhRUYlMVOvkIEEzj3hcAHXzV43r5doOgguT/LxNU
-        whI0lW7+fyypID31S9+Bx2zbTZLKYS+xJiT15zQoBv4Pdh/czmf2pETH4X3ysy2teyRR/V5FGiFD
-        PKfuT7xnP/h/nbSC5D+SVvAATToA/fCkFaSnfuk78Jht+/8daX1w797/+6V1xy0feb2KNEKGeE7d
-        n3jPfnCjtFJLlTz5CBBM494XAB181WN9+XaTtBLJ/18mrTQFRFLp5f/PwkqUp37pO7CYbbtJWNnV
-        Jc6EsP5cOcGzfFHdSkbRcBszScgo/v5HP5tSur+zd+/BvWi3IoYQHiKM/ydetB/cKKbEpCpy8hEg
-        mMa9LwA6+KrH8/JtXEwZexDh/z0SSgiCnNLN/z9FFFSnLuljsJZttkk62VgSR0I6fy5N6YwIli3f
-        VttEj3b3VrK6uD6vKjTHtBJqOqLuxz+LMnvv3u69/YOHg12LXEKaeIrdn3jZfvD/Lrmlz+00/EiC
-        wQ00/QD0Q5Jgn/7UOTUAy9kX/r8gyz+dXWbsLeztPryVJOOFbeKybLVik7dNLxJ+OqyBb3tyDajf
-        jFzv3//0/qf3XNp4AAMRXwgdz7/7EzDsB/9vEm8MxMzMj4QbLEE8AEA/FOH2qU9d09fgOtv8/1Oi
-        fe99RBsTu31vD5GDjqf78dcW5l9MpCI8aBqJOvi7J8oP79P67GDHIqOQLJ5m9ydeth/8v1KGaQp+
-        JMPgBJp8APoGZBjcdCsJJtpTx/Q1mM02//+WBO/dLm2FF3yJ0fF0P/7aEgxq0RxuluH9h7tucajb
-        tcgoJIun2f2Jl+0H/++U4b3/tyWyCFGQVrr5/6IMy++3k2JmH/oa7Gab/39BiokcbX2xu3Nw73Zm
-        GO0xrbsP7+3vbp9m4DhCT0c18O2tRRpvyDT6U0B40awSseiTrkgT5Q8e3HM56QEMRHIhbzz57k/A
-        sB/cKNnUUqVUPgIE07j3BUAHX/VkRL6NSzYGohOjw6Av/18h2DQhRGDp5WdbrjFyYQjiAAD6ocg1
-        wTK0p57pW7Ccbb1JrDkTTZwKsf65ylEr9nsHtxLo19W6nZ8Qmeqs/Oq1Tp+OJvrdZmEWsn50vl5O
-        MQIKdOlDT8IZZKowZWb9WSGMaaKJgPRJV9T3P9052N11iW0GpZAsdiLIED8iq/8nINgP/l8o6HsH
-        2+GAqMn/G8SdkP3hiTtTIOQOYgdA/Ibl/qOQQQMJom8JqMyJfAc2pJcEwCbx/30g5MS9EP+n1/Rh
-        MaUPVAPwl1YD/D70x8+uBri3c+/e3q10ANpjkvf29w721Y0k9Ah/4D3w7WY94Ik83pC59OeB8KKp
-        JVrRJ11Jh1E/8Pz0AQxEliGBRED/T8CwH/y/T9Z5YnQY9OX/G6T8h2rUMXJhCOIAAPqGhVt+D2SC
-        eiVYhvbUM30LlrOtN0k1m27iVEj1z61R/3T/4e1ibTTHhN5/uOt5wTqe+Je3lme8IdPnk56wotkk
-        KtEnMXn+9J7LncUREHGFkBHx/D8Bwn7w/z5xxqToKOi7n3fSjJELO9D8A9APUZpBeuqYvgS/2cb/
-        rxfmIltW5F/cSpSbapFjNgkfHYL3ya2F1ulcn8LUP00aUYM+6Qrt/u7eg11PaL1eRRIhP0QZ/0+8
-        Zz+4UVKJTVXq5CNAMI17XwB08FWP6+XbAUlViv+/zOoSkiCpdPOzLagYurAAzTkA/XAEVSlP3dJX
-        4DDbdJOYcgaMGBNi+nOZH3tH89O+Icp9flLnNCm7e7u3i6vfPSVpqa5BNLz+bSLl3t6DffgeOsQN
-        LX4WxZrSYvce7D28DRYixhA+5gb3J+DYD24Uc2qpIisfAYJp3PsCoIOvekIj38bFXGaLhuHN1vuL
-        PEGSTvr8P/zNbUWeZofEWgj2/0+Jj00CoUDNwIj2tU3Sz6aY+BfS/3NlpLvDuPfp/U//vy/59x7c
-        BguRbMgjUdX/E3DsB/9vlnzM1o8knyASOwDQz4nkYxIIBWoGRrSv/b9e8jGEV/rZ7r2d2xn8p/l5
-        ti5bYKlj8T75WRTr/f17B/d3XFrc61XEFMJFJPL/xHv2g/9XiXGX9D+SYYJIcw9APxwZ7s4A9U9t
-        wHL2nf+PCfD+zv8HBNhlu71eRUAhVkQi/0+8Zz/4f7EA7+/8SIAJIs09AP1cCPD+DvVPbcBy9p3/
-        bwnwwf7/B+SXZq/fq8gnpIoo5P+J9+wH/++VX7vaRi1+JL4/B+J7sE/dUxMwnH3l/1PSu0crP/8v
-        F9/9B7TaHOtVxBNCRSTy/8R79oP/14ovSP8j+SWINPcA9MOXX8wA9U9twHL2nf9PCfC9nb3/twfA
-        +w8e3qPp6/cqAgqxIhL5f+I9+8H/awUYpP+RABNEmnsA+uELMGaA+qc2YDn7zv+3BPj+/9v9Z8gv
-        cVa/V5FPSBVRyP8T79kP/t8rv/d/5D+DE2jqAejnQHzv/3/ef97f2d/7f7n43ju493Av1quIJ4SK
-        SOT/iffsB/+vFV+Q/kfySxBp7gHohy+/mAHqn9qA5ew7P8sC7E3wNyHAezv/r7e/B/f+fxkAg/Q/
-        EmCCSHMPQD8HAkwzQP1TG7Ccfef/YwJ87/8LAfD/H1eAQfofCTBBpLkHoJ8LAb73//kAeP/evf8P
-        uNAHD2O9ioBCrIhE/p94z37w/14BJtL/SIAJIs09AP0cCDDNAPVPbcBy9p3/bwnw/sGn/68X4P2H
-        /78UYCL9jwSYINLcA9DPgQDTDFD/1AYsZ9/5/5QA39+9///6ReCDew8OYr2KgEKsiET+n3jPfvD/
-        WgEG6X8kwASR5h6AfvgCjBmg/qkNWM6+8/8tAf509+H/+wX44P+PWWiQ/kcCTBBp7gHo50CAaQao
-        f2oDlrPv/H9KgD99sL/7/3YBfnBwQNPX71UEFGJFJPL/xHv2g//XCjBI/yMBJog09wD0wxdgzAD1
-        T23Acvad/08J8IO93R9mDPy6Wrfz9IRoX2elTJ9PekKEZpPoQ5/0JHnngPLRD2Ldi6RCvohW/p94
-        z37w/1pJxhxsM2WUMD8/JZopEPIGMQMg/vBFG1NC/VMb8KB95/9Tov1wf+/+D1G0nUL2KU790yQS
-        WeiTnkSTbX54bz/Wq0gs5IxI5P+J9+wH36xEA7Qg/cESDdL3bPNH/vwaYCw8YGRfavrsPPzN/xsl
-        2bECzT0A/fAFGDNA/VMbsJx95/9bAnzw8Idpm92s+RSn/mkSiSz0SUSAKTr+/+MKMUj/IwEmiDT3
-        APRzIMA0A9Q/tQHL2Xf+vyXADx/8v32FmKLjB/djvYqAQqyIRP6feM9+8P9eASbS/0iACSLNPQD9
-        HAgwzQD1T23Acvad/7cL8PX6IlteXN1KbLUtEXb9jlDSUXQ+/VkV3wcHuwfOge70LCIKwSIi+X/i
-        XfvB/5tEWAfwI8EliDTrAPRDEVylO/VK34DFbMv/H4rrNmaTUNJRdD792RTXe3sHB5/2xNX0LOII
-        ISIi+X/iXfvBjeJK7KqiJx8Bgmnc+wKgg6963C/f/khc8Yd8//9VcX0NoSTOhLi+brPlLKtn9ImK
-        LH9rRRYjciK7+7MhskSm9bv3kVt+YXtFmOmAep//bMouR7ou1O31LdIJmeJpdn/ibfvB/wulV4YA
-        ivy/R4QJ0Z8nMkwdsa9GX4PfbPP/rwny7eLc4A1j93RU0e9uLdG8eJBnNJPHTZHRd/48EGo0tUQx
-        +qQn2PcfPNjdJbHbhIYIL0SO59/9CQj2g/+3CveeLC6BOiAOtfr5J+SWAoY/iCEA74cu6+8bE7M4
-        E+t+LWH/Po0of9c+L5ZvBfyIhR+//ZL/B8enFGSP2AAA
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/serverfarms/webapp-e2e-plan","name":"webapp-e2e-plan","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":null,"properties":{"serverFarmId":4881600,"name":"webapp-e2e-plan","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"azurecli-webapp-e2e2-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"azurecli-webapp-e2e2","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-hostname/providers/Microsoft.Web/serverfarms/webapp-hostname-plan","name":"webapp-hostname-plan","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":null,"properties":{"serverFarmId":4468877,"name":"webapp-hostname-plan","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"azurecli-webapp-hostname-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"azurecli-webapp-hostname","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-scale/providers/Microsoft.Web/serverfarms/webapp-scale-plan","name":"webapp-scale-plan","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":null,"properties":{"serverFarmId":4457055,"name":"webapp-scale-plan","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":0,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"azurecli-webapp-scale-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":1,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"azurecli-webapp-scale","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"F1","tier":"Free","size":"F1","family":"F","capacity":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-git4/providers/Microsoft.Web/serverfarms/webapp-git-plan4","name":"webapp-git-plan4","type":"Microsoft.Web/global","kind":"app","location":"East
+        US","tags":null,"properties":{"serverFarmId":4611960,"name":"webapp-git-plan4","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"cli-webapp-git4-EastUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"East
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"cli-webapp-git4","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-git4/providers/Microsoft.Web/serverfarms/webapp-git-plan5","name":"webapp-git-plan5","type":"Microsoft.Web/global","kind":"app","location":"East
+        US","tags":null,"properties":{"serverFarmId":4611979,"name":"webapp-git-plan5","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"cli-webapp-git4-EastUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"East
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"cli-webapp-git4","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-webapp-slot2/providers/Microsoft.Web/serverfarms/webapp-slot-plan","name":"webapp-slot-plan","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":null,"properties":{"serverFarmId":4689529,"name":"webapp-slot-plan","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"cli-webapp-slot2-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"cli-webapp-slot2","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clutst16342/providers/Microsoft.Web/serverfarms/testplan45403-WestUS","name":"testplan45403-WestUS","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":null,"properties":{"serverFarmId":3296773,"name":"testplan45403-WestUS","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":0,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"clutst16342-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":1,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"clutst16342","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"F1","tier":"Free","size":"F1","family":"F","capacity":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clutst35947/providers/Microsoft.Web/serverfarms/testplan41547-WestUS","name":"testplan41547-WestUS","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":null,"properties":{"serverFarmId":3283615,"name":"testplan41547-WestUS","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":0,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"clutst35947-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":1,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"clutst35947","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"F1","tier":"Free","size":"F1","family":"F","capacity":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clutst44215/providers/Microsoft.Web/serverfarms/testplan70443-WestUS","name":"testplan70443-WestUS","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":null,"properties":{"serverFarmId":3296653,"name":"testplan70443-WestUS","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":0,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"clutst44215-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":1,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"clutst44215","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"F1","tier":"Free","size":"F1","family":"F","capacity":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clutst88016/providers/Microsoft.Web/serverfarms/testplan49640-WestUS","name":"testplan49640-WestUS","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":null,"properties":{"serverFarmId":3296744,"name":"testplan49640-WestUS","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":0,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"clutst88016-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":1,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"clutst88016","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"F1","tier":"Free","size":"F1","family":"F","capacity":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/demo/providers/Microsoft.Web/serverfarms/demo-plan","name":"demo-plan","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":null,"properties":{"serverFarmId":4402373,"name":"demo-plan","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"demo-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"demo","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/destanko-test1/providers/Microsoft.Web/serverfarms/myfootestplan","name":"myfootestplan","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":null,"properties":{"serverFarmId":3313489,"name":"myfootestplan","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"destanko-test1-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"destanko-test1","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg086595022/providers/Microsoft.Web/serverfarms/java-asp-c8c61198f","name":"java-asp-c8c61198f","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4872273,"name":"java-asp-c8c61198f","workerSize":1,"workerSizeId":1,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrg086595022-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrg086595022","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"S2","tier":"Standard","size":"S2","family":"S","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg0e8931947/providers/Microsoft.Web/serverfarms/java-asp-8e2265653","name":"java-asp-8e2265653","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4867141,"name":"java-asp-8e2265653","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrg0e8931947-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrg0e8931947","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg17f306976/providers/Microsoft.Web/serverfarms/java-asp-cb243446a","name":"java-asp-cb243446a","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4870965,"name":"java-asp-cb243446a","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrg17f306976-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrg17f306976","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg24c469732/providers/Microsoft.Web/serverfarms/java-asp-a52312849","name":"java-asp-a52312849","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4871479,"name":"java-asp-a52312849","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrg24c469732-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrg24c469732","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg2f976954d/providers/Microsoft.Web/serverfarms/java-asp-2da07267b","name":"java-asp-2da07267b","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4865187,"name":"java-asp-2da07267b","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrg2f976954d-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrg2f976954d","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg2f976954d/providers/Microsoft.Web/serverfarms/java-asp-c0c790434","name":"java-asp-c0c790434","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4865194,"name":"java-asp-c0c790434","workerSize":1,"workerSizeId":1,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrg2f976954d-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrg2f976954d","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"S2","tier":"Standard","size":"S2","family":"S","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg38484370a/providers/Microsoft.Web/serverfarms/java-asp-9b611326c","name":"java-asp-9b611326c","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4870911,"name":"java-asp-9b611326c","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrg38484370a-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrg38484370a","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg42415681a/providers/Microsoft.Web/serverfarms/java-asp-0ae546756","name":"java-asp-0ae546756","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4865074,"name":"java-asp-0ae546756","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrg42415681a-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrg42415681a","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg428460935/providers/Microsoft.Web/serverfarms/java-asp-42c791316","name":"java-asp-42c791316","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4865314,"name":"java-asp-42c791316","workerSize":1,"workerSizeId":1,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrg428460935-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrg428460935","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"S2","tier":"Standard","size":"S2","family":"S","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg50f596312/providers/Microsoft.Web/serverfarms/java-asp-7ca832497","name":"java-asp-7ca832497","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4865308,"name":"java-asp-7ca832497","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":0,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrg50f596312-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":1,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrg50f596312","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"F1","tier":"Free","size":"F1","family":"F","capacity":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg52e85429e/providers/Microsoft.Web/serverfarms/java-asp-0f541256b","name":"java-asp-0f541256b","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4871034,"name":"java-asp-0f541256b","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrg52e85429e-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrg52e85429e","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg5a917087f/providers/Microsoft.Web/serverfarms/java-asp-eb1834375","name":"java-asp-eb1834375","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4872291,"name":"java-asp-eb1834375","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":3,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrg5a917087f-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrg5a917087f","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":3}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg610504764/providers/Microsoft.Web/serverfarms/java-asp-162018189","name":"java-asp-162018189","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4872258,"name":"java-asp-162018189","workerSize":1,"workerSizeId":1,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrg610504764-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrg610504764","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"S2","tier":"Standard","size":"S2","family":"S","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg610504764/providers/Microsoft.Web/serverfarms/java-asp-6bb766292","name":"java-asp-6bb766292","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4872256,"name":"java-asp-6bb766292","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrg610504764-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrg610504764","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg633083023/providers/Microsoft.Web/serverfarms/java-asp-75a004891","name":"java-asp-75a004891","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4867201,"name":"java-asp-75a004891","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrg633083023-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrg633083023","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg64597595c/providers/Microsoft.Web/serverfarms/java-asp-6f0857283","name":"java-asp-6f0857283","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4870996,"name":"java-asp-6f0857283","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrg64597595c-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrg64597595c","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg655041849/providers/Microsoft.Web/serverfarms/java-asp-a35892956","name":"java-asp-a35892956","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4866943,"name":"java-asp-a35892956","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrg655041849-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrg655041849","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg67e674429/providers/Microsoft.Web/serverfarms/java-asp-5d753342f","name":"java-asp-5d753342f","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4867117,"name":"java-asp-5d753342f","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrg67e674429-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrg67e674429","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg70184503b/providers/Microsoft.Web/serverfarms/java-asp-ef2463112","name":"java-asp-ef2463112","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4865096,"name":"java-asp-ef2463112","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrg70184503b-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrg70184503b","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg70997016f/providers/Microsoft.Web/serverfarms/java-asp-eda36053e","name":"java-asp-eda36053e","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4871497,"name":"java-asp-eda36053e","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrg70997016f-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrg70997016f","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg719857562/providers/Microsoft.Web/serverfarms/java-asp-7b6670844","name":"java-asp-7b6670844","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4865417,"name":"java-asp-7b6670844","workerSize":1,"workerSizeId":1,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrg719857562-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrg719857562","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"S2","tier":"Standard","size":"S2","family":"S","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg7d989427f/providers/Microsoft.Web/serverfarms/java-asp-4b5848010","name":"java-asp-4b5848010","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4865356,"name":"java-asp-4b5848010","workerSize":1,"workerSizeId":1,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrg7d989427f-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrg7d989427f","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"S2","tier":"Standard","size":"S2","family":"S","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg842111603/providers/Microsoft.Web/serverfarms/java-asp-0e8271038","name":"java-asp-0e8271038","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4865532,"name":"java-asp-0e8271038","workerSize":1,"workerSizeId":1,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrg842111603-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrg842111603","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"S2","tier":"Standard","size":"S2","family":"S","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg902825955/providers/Microsoft.Web/serverfarms/java-asp-dcb59042d","name":"java-asp-dcb59042d","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4871890,"name":"java-asp-dcb59042d","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrg902825955-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrg902825955","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg915545687/providers/Microsoft.Web/serverfarms/java-asp-d4e171654","name":"java-asp-d4e171654","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4870684,"name":"java-asp-d4e171654","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrg915545687-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrg915545687","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg9b9912262/providers/Microsoft.Web/serverfarms/java-asp-3c246213a","name":"java-asp-3c246213a","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4865080,"name":"java-asp-3c246213a","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrg9b9912262-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrg9b9912262","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg9ba90196b/providers/Microsoft.Web/serverfarms/java-asp-706302765","name":"java-asp-706302765","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4870753,"name":"java-asp-706302765","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrg9ba90196b-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrg9ba90196b","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrga3a572326/providers/Microsoft.Web/serverfarms/java-asp-40792814b","name":"java-asp-40792814b","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4865540,"name":"java-asp-40792814b","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrga3a572326-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrga3a572326","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrgabc80764f/providers/Microsoft.Web/serverfarms/java-asp-0ac417534","name":"java-asp-0ac417534","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4870882,"name":"java-asp-0ac417534","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrgabc80764f-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrgabc80764f","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrgb34785020/providers/Microsoft.Web/serverfarms/java-asp-f3872002a","name":"java-asp-f3872002a","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4865563,"name":"java-asp-f3872002a","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrgb34785020-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrgb34785020","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrgb9e799183/providers/Microsoft.Web/serverfarms/java-asp-84c16238c","name":"java-asp-84c16238c","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4866953,"name":"java-asp-84c16238c","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrgb9e799183-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrgb9e799183","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrgcc2175867/providers/Microsoft.Web/serverfarms/java-asp-a3d923626","name":"java-asp-a3d923626","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4871096,"name":"java-asp-a3d923626","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrgcc2175867-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrgcc2175867","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrgd19221638/providers/Microsoft.Web/serverfarms/java-asp-4ad69758d","name":"java-asp-4ad69758d","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4865038,"name":"java-asp-4ad69758d","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":0,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrgd19221638-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":1,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrgd19221638","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"F1","tier":"Free","size":"F1","family":"F","capacity":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrgd75996769/providers/Microsoft.Web/serverfarms/java-asp-d69893392","name":"java-asp-d69893392","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4871905,"name":"java-asp-d69893392","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrgd75996769-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrgd75996769","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrgd80585740/providers/Microsoft.Web/serverfarms/java-asp-144698625","name":"java-asp-144698625","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4870938,"name":"java-asp-144698625","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrgd80585740-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrgd80585740","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrgdc6416501/providers/Microsoft.Web/serverfarms/java-asp-78b67307b","name":"java-asp-78b67307b","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4871918,"name":"java-asp-78b67307b","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrgdc6416501-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrgdc6416501","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrge16799933/providers/Microsoft.Web/serverfarms/java-asp-604999790","name":"java-asp-604999790","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4871091,"name":"java-asp-604999790","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrge16799933-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrge16799933","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrge3e23282a/providers/Microsoft.Web/serverfarms/java-asp-279430644","name":"java-asp-279430644","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4871071,"name":"java-asp-279430644","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrge3e23282a-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrge3e23282a","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrge4a249649/providers/Microsoft.Web/serverfarms/java-asp-18161479d","name":"java-asp-18161479d","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4865472,"name":"java-asp-18161479d","workerSize":1,"workerSizeId":1,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrge4a249649-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrge4a249649","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"S2","tier":"Standard","size":"S2","family":"S","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrge4a411100/providers/Microsoft.Web/serverfarms/java-asp-d53199017","name":"java-asp-d53199017","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4871486,"name":"java-asp-d53199017","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrge4a411100-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrge4a411100","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrge5670430c/providers/Microsoft.Web/serverfarms/java-asp-faa879322","name":"java-asp-faa879322","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4870849,"name":"java-asp-faa879322","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrge5670430c-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrge5670430c","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrgec707778e/providers/Microsoft.Web/serverfarms/java-asp-10c724351","name":"java-asp-10c724351","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4865135,"name":"java-asp-10c724351","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrgec707778e-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrgec707778e","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrgfb175103c/providers/Microsoft.Web/serverfarms/java-asp-ae5197870","name":"java-asp-ae5197870","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4866972,"name":"java-asp-ae5197870","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrgfb175103c-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrgfb175103c","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrgfc389509e/providers/Microsoft.Web/serverfarms/java-asp-aff413587","name":"java-asp-aff413587","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":{},"properties":{"serverFarmId":4865107,"name":"java-asp-aff413587","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"javacsmrgfc389509e-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":{},"kind":"app","resourceGroup":"javacsmrgfc389509e","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg10839/providers/Microsoft.Web/serverfarms/testplan19341-EastUS","name":"testplan19341-EastUS","type":"Microsoft.Web/global","kind":"app","location":"East
+        US","tags":null,"properties":{"serverFarmId":3238734,"name":"testplan19341-EastUS","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":0,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"testrg10839-EastUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":1,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"East
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"testrg10839","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"F1","tier":"Free","size":"F1","family":"F","capacity":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg30332/providers/Microsoft.Web/serverfarms/testplan24284-WestUS","name":"testplan24284-WestUS","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":null,"properties":{"serverFarmId":3238815,"name":"testplan24284-WestUS","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":0,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"testrg30332-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":1,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"testrg30332","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"F1","tier":"Free","size":"F1","family":"F","capacity":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg6493/providers/Microsoft.Web/serverfarms/testplan5911-EastUS","name":"testplan5911-EastUS","type":"Microsoft.Web/global","kind":"app","location":"East
+        US","tags":null,"properties":{"serverFarmId":3238636,"name":"testplan5911-EastUS","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":0,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"testrg6493-EastUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":1,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"East
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"testrg6493","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"F1","tier":"Free","size":"F1","family":"F","capacity":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tianorg1/providers/Microsoft.Web/serverfarms/someplan","name":"someplan","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":null,"properties":{"serverFarmId":4127136,"name":"someplan","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"tianorg1-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"tianorg1","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/xDeploymentTestGroup6025/providers/Microsoft.Web/serverfarms/xDeploymentTestHost25602","name":"xDeploymentTestHost25602","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":null,"properties":{"serverFarmId":4745627,"name":"xDeploymentTestHost25602","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":0,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"xDeploymentTestGroup6025-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":1,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"xDeploymentTestGroup6025","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"F1","tier":"Free","size":"F1","family":"F","capacity":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Web/serverfarms/yugangwlinux","name":"yugangwlinux","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":null,"properties":{"serverFarmId":4478184,"name":"yugangwlinux","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":0,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"yugangw-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":1,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"yugangw","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"F1","tier":"Free","size":"F1","family":"F","capacity":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Web/serverfarms/yugangw-plan","name":"yugangw-plan","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":null,"properties":{"serverFarmId":4328864,"name":"yugangw-plan","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"yugangw-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":1,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"yugangw","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangwlinux/providers/Microsoft.Web/serverfarms/yugangwlinux-p","name":"yugangwlinux-p","type":"Microsoft.Web/global","kind":"app","location":"West
+        US","tags":null,"properties":{"serverFarmId":4483833,"name":"yugangwlinux-p","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":null,"currentWorkerSizeId":null,"currentNumberOfWorkers":null,"status":0,"webSpace":"yugangwlinux-WestUSwebspace","subscription":null,"adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":null,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"yugangwlinux","reserved":null,"mdmId":null,"targetWorkerCount":null,"targetWorkerSizeId":null,"provisioningState":null},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}],"nextLink":null,"id":null}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Thu, 03 Nov 2016 02:43:51 GMT']
+      Date: ['Fri, 16 Dec 2016 05:47:46 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
+      content-length: ['69000']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -245,38 +254,28 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [5b909794-a16f-11e6-8166-f4b7e2e85440]
+      x-ms-client-request-id: [2cda8d50-c353-11e6-96df-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e/providers/Microsoft.Web/serverfarms/webapp-e2e-plan?api-version=2015-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/serverfarms/webapp-e2e-plan?api-version=2015-08-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXezH6zrfFoW21f5JFuttvO9/O6qri6LWV43d78opnXVVOft+Lv55G6T15d5fZ7Vi+au
-        a769KrPlR6OPltkiJ5z6X7TXK3wxCIualNU0wxio2Xfzpk2/ek0fttlF89Gj5bosRx8RSqu8bouc
-        PvnFH8nLz+jlMyLDzoa+r6r6bV6/Ln5AX1M796e+KB+8KfL6BYOQ3pbrxSSvvzz/Ln9LXe6OPpqu
-        6zpftvIRIPD7vU8Vrn7+IgKoabN2Tb9SK8L39SqbEqiPIvOwDVJ89Zo+aLgRvepNN71zm/mmt7LZ
-        oli+LtrcH+K8atpieXG6vCzqarkgXIe/eVlX50VpX11k74rFetEb2z2aJqK69PLRTxZ1u87Kp/ms
-        oLnNZy/pK4PMq/WyLRZ5F6dptVit2/yLakYfEXka+l7+kO8v8upVfiFjB22ETYgvAOj1NCsJ7Y8e
-        nWdlk7s5xHeEHIHrDwyTJaB9XntbLO3ngbRQt5FpIhSoFTiS3tLOFzPmzI+usqtmm3h3tj3Jrrd3
-        Pr3/+396b3fvo19CY3u7Bicr4z7ZJSjE3TV+z5piSn82xE34E1+dZ4uivMZf9Mc0I3YoWvpz95f8
-        kv8Hru0EdQoEAAA=
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/serverfarms/webapp-e2e-plan","name":"webapp-e2e-plan","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
+        US","tags":null,"properties":{"serverFarmId":0,"name":"webapp-e2e-plan","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":0,"currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":0,"webSpace":"azurecli-webapp-e2e2-WestUSwebspace","subscription":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":false,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"azurecli-webapp-e2e2","reserved":false,"mdmId":"waws-prod-bay-069_4240","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded"},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Thu, 03 Nov 2016 02:43:53 GMT']
+      Date: ['Fri, 16 Dec 2016 05:47:48 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
+      content-length: ['1146']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -286,76 +285,61 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [5c5be3be-a16f-11e6-8de5-f4b7e2e85440]
+      x-ms-client-request-id: [2de560e8-c353-11e6-897b-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e/providers/Microsoft.Web/serverfarms/webapp-e2e-plan?api-version=2015-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/serverfarms/webapp-e2e-plan?api-version=2015-08-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXezH6zrfFoW21f5JFuttvO9/O6qri6LWV43d78opnXVVOft+Lv55G6T15d5fZ7Vi+au
-        a769KrPlR6OPltkiJ5z6X7TXK3wxCIualNU0wxio2Xfzpk2/ek0fttlF89Gj5bosRx8RSqu8bouc
-        PvnFH8nLz+jlMyLDzoa+r6r6bV6/Ln5AX1M796e+KB+8KfL6BYOQ3pbrxSSvvzz/Ln9LXe6OPpqu
-        6zpftvIRIPD7vU8Vrn7+IgKoabN2Tb9SK8L39SqbEqiPIvOwDVJ89Zo+aLgRvepNN71zm/mmt7LZ
-        oli+LtrcH+K8atpieXG6vCzqarkgXIe/eVlX50VpX11k74rFetEb2z2aJqK69PLRTxZ1u87Kp/ms
-        oLnNZy/pK4PMq/WyLRZ5F6dptVit2/yLakYfEXka+l7+kO8v8upVfiFjB22ETYgvAOj1NCsJ7Y8e
-        nWdlk7s5xHeEHIHrDwyTJaB9XntbLO3ngbRQt5FpIhSoFTiS3tLOFzPmzI+usqtmm3h3tj3Jrrd3
-        Pr3/+396b3fvo19CY3u7Bicr4z7ZJSjE3TV+z5piSn82xE34E1+dZ4uivMZf9Mc0I3YoWvpz95f8
-        kv8Hru0EdQoEAAA=
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/serverfarms/webapp-e2e-plan","name":"webapp-e2e-plan","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
+        US","tags":null,"properties":{"serverFarmId":0,"name":"webapp-e2e-plan","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":0,"currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":0,"webSpace":"azurecli-webapp-e2e2-WestUSwebspace","subscription":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":3,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":false,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"azurecli-webapp-e2e2","reserved":false,"mdmId":"waws-prod-bay-069_4240","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded"},"sku":{"name":"B1","tier":"Basic","size":"B1","family":"B","capacity":1}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Thu, 03 Nov 2016 02:43:54 GMT']
+      Date: ['Fri, 16 Dec 2016 05:47:50 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
+      content-length: ['1146']
     status: {code: 200, message: OK}
 - request:
-    body: !!binary |
-      eyJza3UiOiB7ImNhcGFjaXR5IjogMSwgInRpZXIiOiAiU1RBTkRBUkQiLCAic2l6ZSI6ICJCMSIs
-      ICJmYW1pbHkiOiAiQiIsICJuYW1lIjogIlMxIn0sICJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wYjFm
-      NjQ3MS0xYmYwLTRkZGEtYWVjMy1jYjkyNzJmMDk1OTAvcmVzb3VyY2VHcm91cHMvYXp1cmVjbGkt
-      d2ViYXBwLWUyZS9wcm92aWRlcnMvTWljcm9zb2Z0LldlYi9zZXJ2ZXJmYXJtcy93ZWJhcHAtZTJl
-      LXBsYW4iLCAibG9jYXRpb24iOiAiV2VzdCBVUyIsICJwcm9wZXJ0aWVzIjogeyJuYW1lIjogIndl
-      YmFwcC1lMmUtcGxhbiIsICJyZXNlcnZlZCI6IGZhbHNlLCAibWF4aW11bU51bWJlck9mV29ya2Vy
-      cyI6IDMsICJwZXJTaXRlU2NhbGluZyI6IGZhbHNlfSwgInR5cGUiOiAiTWljcm9zb2Z0LldlYi9z
-      ZXJ2ZXJmYXJtcyIsICJuYW1lIjogIndlYmFwcC1lMmUtcGxhbiJ9
+    body: '{"location": "West US", "type": "Microsoft.Web/serverfarms", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/serverfarms/webapp-e2e-plan",
+      "sku": {"family": "B", "tier": "STANDARD", "size": "B1", "capacity": 1, "name":
+      "S1"}, "properties": {"perSiteScaling": false, "reserved": false, "name": "webapp-e2e-plan",
+      "maximumNumberOfWorkers": 3}, "kind": "app", "name": "webapp-e2e-plan"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['438']
+      Content-Length: ['460']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [5c9913de-a16f-11e6-9098-f4b7e2e85440]
+      x-ms-client-request-id: [2e44453a-c353-11e6-ac7f-f4b7e2e85440]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e/providers/Microsoft.Web/serverfarms/webapp-e2e-plan?api-version=2015-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/serverfarms/webapp-e2e-plan?api-version=2015-08-01
   response:
     body: {string: ''}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Thu, 03 Nov 2016 02:43:54 GMT']
+      Date: ['Fri, 16 Dec 2016 05:47:51 GMT']
       Expires: ['-1']
-      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/azurecli-webapp-e2e/providers/Microsoft.Web/serverFarms/webapp-e2e-plan/operationresults/0a543a6b-16d9-404f-97f1-164895527f31?api-version=2015-08-01']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/serverFarms/webapp-e2e-plan/operationresults/58249988-252e-4c85-8340-ac57f2cfca30?api-version=2015-08-01']
       Pragma: [no-cache]
       Retry-After: ['15']
       Server: [Microsoft-IIS/8.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -365,38 +349,28 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [5c9913de-a16f-11e6-9098-f4b7e2e85440]
+      x-ms-client-request-id: [2e44453a-c353-11e6-ac7f-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e/providers/Microsoft.Web/serverFarms/webapp-e2e-plan/operationresults/0a543a6b-16d9-404f-97f1-164895527f31?api-version=2015-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/serverFarms/webapp-e2e-plan/operationresults/58249988-252e-4c85-8340-ac57f2cfca30?api-version=2015-08-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXezH6zrfFoW21f5JFuttvO9/O6qri6LWV43d78opnXVVOft+Lv55G6T15d5fZ7Vi+au
-        a769KrPlR6OPltkiJ5z6X7TXK3wxCIualNU0wxio2Xfzpk2/ek0fttlF89Gj5bosRx8RSqu8bouc
-        PvnFH8nLz+jlMyLDzoa+r6r6bV6/Ln5AX1M796e+KB+8KfL6BYOQ3pbrxSSvvzz/Ln9LXe6OPpqu
-        6zpftvIRIPD7vU8Vrn7+IgKoabN2Tb9SK8L39SqbEqiPIvOwDVJ89Zo+aLgRvepNN71zm/mmt7LZ
-        oli+LtrcH+K8atpieXG6vCzqarkgXIe/eVlX50VpX11k74rFetEfG40IZJduPvrJom7XWfk0nxU0
-        ufnsJX1lsHm1XrbFIu8iNa0Wq3Wbf1HN6COC1tD38od8f5FXr/ILGTyII3xCjAFAr6dZSXh/9Og8
-        K5vcTSK+I+wIXH9kmC0B7TPb22JpPw/EhbqNzBOhQK3AkvSWdr6YMWt+dJVdNdvEvLPtSXa9vfPp
-        /d//03u7ex/9Ehrb2zVYWTn39S5BIfau8XubLWdZPaNPGuIofIJvz7NFUV7jL/pjmhFLFC39uftL
-        fsn/AwQ90dwOBAAA
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/serverfarms/webapp-e2e-plan","name":"webapp-e2e-plan","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
+        US","tags":null,"properties":{"serverFarmId":0,"name":"webapp-e2e-plan","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":0,"currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":0,"webSpace":"azurecli-webapp-e2e2-WestUSwebspace","subscription":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":false,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"azurecli-webapp-e2e2","reserved":false,"mdmId":"waws-prod-bay-069_4240","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded"},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Thu, 03 Nov 2016 02:44:11 GMT']
+      Date: ['Fri, 16 Dec 2016 05:48:08 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
+      content-length: ['1150']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -406,43 +380,31 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [66fbd2ec-a16f-11e6-a126-f4b7e2e85440]
+      x-ms-client-request-id: [3934bcd8-c353-11e6-88dd-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e/providers/Microsoft.Web/serverfarms/webapp-e2e-plan?api-version=2015-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/serverfarms/webapp-e2e-plan?api-version=2015-08-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXezH6zrfFoW21f5JFuttvO9/O6qri6LWV43d78opnXVVOft+Lv55G6T15d5fZ7Vi+au
-        a769KrPlR6OPltkiJ5z6X7TXK3wxCIualNU0wxio2Xfzpk2/ek0fttlF89Gj5bosRx8RSqu8bouc
-        PvnFH8nLz+jlMyLDzoa+r6r6bV6/Ln5AX1M796e+KB+8KfL6BYOQ3pbrxSSvvzz/Ln9LXe6OPpqu
-        6zpftvIRIPD7vU8Vrn7+IgKoabN2Tb9SK8L39SqbEqiPIvOwDVJ89Zo+aLgRvepNN71zm/mmt7LZ
-        oli+LtrcH+K8atpieXG6vCzqarkgXIe/eVlX50VpX11k74rFetEfG40IZJduPvrJom7XWfk0nxU0
-        ufnsJX1lsHm1XrbFIu8iNa0Wq3Wbf1HN6COC1tD38od8f5FXr/ILGTyII3xCjAFAr6dZSXh/9Og8
-        K5vcTSK+I+wIXH9kmC0B7TPb22JpPw/EhbqNzBOhQK3AkvSWdr6YMWt+dJVdNdvEvLPtSXa9vfPp
-        /d//03u7ex/9Ehrb2zVYWTn39S5BIfau8XubLWdZPaNPGuIofIJvz7NFUV7jL/pjmhFLFC39uftL
-        fsn/AwQ90dwOBAAA
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/serverfarms/webapp-e2e-plan","name":"webapp-e2e-plan","type":"Microsoft.Web/serverfarms","kind":"app","location":"West
+        US","tags":null,"properties":{"serverFarmId":0,"name":"webapp-e2e-plan","workerSize":0,"workerSizeId":0,"workerTierName":null,"numberOfWorkers":1,"currentWorkerSize":0,"currentWorkerSizeId":0,"currentNumberOfWorkers":1,"status":0,"webSpace":"azurecli-webapp-e2e2-WestUSwebspace","subscription":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","adminSiteName":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"maximumNumberOfWorkers":10,"planName":"VirtualDedicatedPlan","adminRuntimeSiteName":null,"computeMode":0,"siteMode":null,"geoRegion":"West
+        US","perSiteScaling":false,"numberOfSites":0,"hostingEnvironmentId":null,"tags":null,"kind":"app","resourceGroup":"azurecli-webapp-e2e2","reserved":false,"mdmId":"waws-prod-bay-069_4240","targetWorkerCount":0,"targetWorkerSizeId":0,"provisioningState":"Succeeded"},"sku":{"name":"S1","tier":"Standard","size":"S1","family":"S","capacity":1}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Thu, 03 Nov 2016 02:44:13 GMT']
+      Date: ['Fri, 16 Dec 2016 05:48:09 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
+      content-length: ['1150']
     status: {code: 200, message: OK}
 - request:
-    body: !!binary |
-      eyJwcm9wZXJ0aWVzIjogeyJzZXJ2ZXJGYXJtSWQiOiAid2ViYXBwLWUyZS1wbGFuIn0sICJsb2Nh
-      dGlvbiI6ICJXZXN0IFVTIn0=
+    body: '{"properties": {"serverFarmId": "webapp-e2e-plan"}, "location": "West US"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -450,48 +412,28 @@ interactions:
       Content-Length: ['74']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [67cb4818-a16f-11e6-91d0-f4b7e2e85440]
+      x-ms-client-request-id: [39ab7b58-c353-11e6-9d40-f4b7e2e85440]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e/providers/Microsoft.Web/sites/webapp-e2e?api-version=2015-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/sites/webapp-e2e3?api-version=2015-08-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXezH6zrfFoW21f5JFuttvO9/O6qri6LWV43d78opnXVVOft+Lv55G5TtHlz1zX8aPTR
-        MlvkhEjwWXu9wmeRd+nLsppmwJYafDdv2vSr1/Rhm100Hz1arsty9BF1vsrrtqDWj35xFH7TZi0+
-        fLVeLovlBX0yr5r2BbWkV77ntR3z4Ohv7ny8zNuPvj/C969X2RQQ+Ptw8NvA6qvX9EHDjai7vDx/
-        XizfUvt5266aR3fvXmVXzTYhOtueZNfbO5/eH2erotPbVbGcVVfc66P9+/t3v8ZUARaQiM5SB1Eh
-        MF7R7wnzOl9V9HFVX7+mL0EgGkPQorpa5rWh/LrJLvLXQtyd0Uf5MpuUObFZW6/z0UfZbFEsT8PP
-        tMm3b01+pr75upkuIk1ohvDHy4ANFnmbzbI2M6gS7e2336M3COTrvG2JG+gDNPkl9NllVpTZpCiL
-        9tqNqmnKE7x5XhAf4nW0Hn00bWr6HaCmxPfmUyDyRTWjN+Vvw2evm5IhUsPvRXg0MiqCpe8wFsXq
-        SdbkM4LzKm/WZWs6uCzqdp2VZy/NB+18vZis6mJpm7TVVysiBcEJ/z6zIM03rhPXMUbwhuVz55eM
-        YqjHJ+X/fejv/hLMVbVYrcMpavL6Mq+fZfWi/8kZMe4PXWdy7+fUuy+c26syWxJVCTC+J7zOs7Ih
-        iSqzpqXhEHvmszfFIv+qnRLOezu7n27v7m7v3Huzs/dof//R7r3xw4N7BKAh6SapfZVPK+rm+ml+
-        ntF8KME8DTmtlm2+bI+jMlGvly31Ff8STHBSLc+LC0PQWb4qq+sFgWOCulFRP22dnZNofZEtCava
-        UwzyavN2TW8Q8OUsq2fUflXni2K9OF6tnjJUkEKbThfQWsdlU71uq9UK3yiR2qy+yNvXV9nqdVlZ
-        zgJv0GBPl8SF1RLoDX9D2uW8KGmA0mCBKXtNM1GQxodhmqBrmKsLIsNV5ulPeYEmn6Ac01CXRKyO
-        VpQvoWXsF4o4EAGY5mnRhN/MqkVWLH8yr2nmSTERa57NCAj9RSxlen1LJsX8Xq3bSbVezs5Wx7MZ
-        sVFD6D76aH9nfHBvvPvg4fje7kj/ONgdH+zbP+j/D3f8v2iQYA7qPa9fFz+gIdKkz4gTrr/IF2Q6
-        wIU/sa6ge+mLZt2s8uUMzFlaSQWLmBG9yrMG1p3anq+XU4zk9F0+XeOXr4hYzUk2nVMn8uYie/eC
-        NERef3n+3ap+6411XpGabbPFikbVM7fAuazA2mfL88q90p1m8Kd853sYRC0nzQQ+Is7UwUxEybAw
-        tXNfRzTkL/kl/w8HeqzklAkAAA==
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/sites/webapp-e2e3","name":"webapp-e2e3","type":"Microsoft.Web/sites","kind":"app","location":"West
+        US","tags":null,"properties":{"name":"webapp-e2e3","state":"Running","hostNames":["webapp-e2e3.azurewebsites.net"],"webSpace":"azurecli-webapp-e2e2-WestUSwebspace","selfLink":"https://waws-prod-bay-069.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/azurecli-webapp-e2e2-WestUSwebspace/sites/webapp-e2e3","repositorySiteName":"webapp-e2e3","owner":null,"usageState":0,"enabled":true,"adminEnabled":true,"enabledHostNames":["webapp-e2e3.azurewebsites.net","webapp-e2e3.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":0,"sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-e2e3.azurewebsites.net","sslState":0,"ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":0,"hostType":0},{"name":"webapp-e2e3.scm.azurewebsites.net","sslState":0,"ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":0,"hostType":1}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/serverfarms/webapp-e2e-plan","reserved":false,"lastModifiedTimeUtc":"2016-12-16T05:48:11.0866667","storageRecoveryDefaultState":"Running","contentAvailabilityState":0,"runtimeAvailabilityState":0,"siteConfig":null,"deploymentId":"webapp-e2e3","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"WebSites","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"13.93.224.99,13.93.229.16,13.93.230.177,13.93.226.129","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-069","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"azurecli-webapp-e2e2","defaultHostName":"webapp-e2e3.azurewebsites.net"}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Thu, 03 Nov 2016 02:44:22 GMT']
+      Date: ['Fri, 16 Dec 2016 05:48:13 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      content-length: ['2519']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -501,47 +443,27 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [6eb17dca-a16f-11e6-b5f6-f4b7e2e85440]
+      x-ms-client-request-id: [3cf46766-c353-11e6-a5d8-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e/providers/Microsoft.Web/sites?api-version=2015-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/sites?api-version=2015-08-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXN3Z7J7/un+g93t3cn5zvb+bJZtZ/n03vZ08nDvwd75
-        zsP7D3fu1nlTretp/nldrVfN3ewH6zqflsX2VT7JVqvtfC+/u6qry2KW183dL4ppXTXVeTv+bj65
-        2xRt3tx1DT8afbTMFoTPR8Fn7fUKn0XepS/LapoBW2rw3bxp069e04dtdtF89Gi5LsvRR9T5Kq/b
-        glo/+sVR+E2btfjw1Xq5LJYX9Mm8atoX1JJe+Z7XdsyDo7+58/Eybz/6/gjfv15lU0Dg78PBbwOr
-        r17TBw03ou7y8vx5sXxL7edtu2oe3b17lV0124TobHuSXW/vfHp/nK2KTm9XxXJWXXGvj/bv79/9
-        GlMFWEAiOksdRIXAeEW/J8zrfFXRx1V9/Zq+BIFoDEGL6mqZ14by6ya7yF8LcXdGH+XLbFLmxGZt
-        vc5HH2WzRbE8DT/TJt++NfmZ+ubrZrqINKEZwh8vAzZY5G02y9rMoEq0t99+j94gkK/ztiVuoA/Q
-        5JfQZ5dZUWaToizaazeqpilP8OZ5QXyI19F69NG0qel3gJoS35tPgcgX1YzelL8Nn71uSoZIDUkU
-        ezwaGRXB0ncYi2L1JGvyGcF5lTfrsjUdXBZ1u87Ks5fmg3a+XkxWdbG0TdrqqxWRguCEf59ZkOYb
-        14nrGCN4w/K580tGMdTjk/L/PvR3fwnmqlqs1uEUNXl9mdfPsnrR/+SMGPeHrjO593Pq3RfO7VWZ
-        LYmqBBjfE17nWdmQRJVZ09JwiD3z2ZtikX/VTgnnvZ3dT7d3d7d37r3Z2Xu0v/9od3+8c4/eb0i4
-        SWhf5dOKerl+mp9nNB1KL09BTqtlmy/b46hI1OtlS13FvwQPnFTL8+LC0HOWr8rqekHgmJ5uUNRP
-        W2fnJFlfZEvCqvb0grzavF3TGwR8OcvqGbVf1fmiWC+OV6unDBWU0KbTBZTWcdlUr9tqtcI3SqM2
-        qy/y9vVVtnpdVpaxwBo02NMlMWG1BHrD35ByOS9KGqA0WGDGXtNEFKTwYZcm6BrW6oLIcJV56lNe
-        oLknKMc01CURq6MU5UsoGfuFIg5EAKZ5WjThN7NqkRXLn8xrmnjSS8SZZzMCQn8RR5le35JFMb9X
-        63ZSrZezs9XxbEZc1BC6jz7a3xkf3BvvPng4vrc70j8OdscH+/YP+v/DHf8vGiSYg3rP69fFD2iI
-        NOkz4oTrL/IFWQ4w4U+sK6he+qJZN6t8OQNvllZQwSJmRK/yrIFxp7bn6+UUIzl9l0/X+OUrIlZz
-        kk3n1Im8ucjevSAFkddfnn+3qt96Y51XpGXbbLGiUfWsLXAuK7D22fK8cq90pxn8Kd/5DgZRywkz
-        gY9IM3UwE1EyLEzt3NcRBflLoI6W+btWPAXpCT4afvsl/w+MaaxouQkAAA==
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/sites/webapp-e2e3","name":"webapp-e2e3","type":"Microsoft.Web/sites","kind":"app","location":"West
+        US","tags":null,"properties":{"name":"webapp-e2e3","state":"Running","hostNames":["webapp-e2e3.azurewebsites.net"],"webSpace":"azurecli-webapp-e2e2-WestUSwebspace","selfLink":"https://waws-prod-bay-069.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/azurecli-webapp-e2e2-WestUSwebspace/sites/webapp-e2e3","repositorySiteName":"webapp-e2e3","owner":null,"usageState":0,"enabled":true,"adminEnabled":true,"enabledHostNames":["webapp-e2e3.azurewebsites.net","webapp-e2e3.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":0,"sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-e2e3.azurewebsites.net","sslState":0,"ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":0,"hostType":0},{"name":"webapp-e2e3.scm.azurewebsites.net","sslState":0,"ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":0,"hostType":1}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/serverfarms/webapp-e2e-plan","reserved":false,"lastModifiedTimeUtc":"2016-12-16T05:48:11.1466667","storageRecoveryDefaultState":"Running","contentAvailabilityState":0,"runtimeAvailabilityState":0,"siteConfig":null,"deploymentId":"webapp-e2e3","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"WebSites","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"13.93.224.99,13.93.229.16,13.93.230.177,13.93.226.129","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-069","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"azurecli-webapp-e2e2","defaultHostName":"webapp-e2e3.azurewebsites.net"}}],"nextLink":null,"id":null}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Thu, 03 Nov 2016 02:44:25 GMT']
+      Date: ['Fri, 16 Dec 2016 05:48:15 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
+      content-length: ['2557']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -551,48 +473,28 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [6f9ff234-a16f-11e6-bd46-f4b7e2e85440]
+      x-ms-client-request-id: [3dac018a-c353-11e6-b840-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e/providers/Microsoft.Web/sites/webapp-e2e?api-version=2015-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/sites/webapp-e2e3?api-version=2015-08-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXezH6zrfFoW21f5JFuttvO9/O6qri6LWV43d78opnXVVOft+Lv55G5TtHlz1zX8aPTR
-        MlvkhEjwWXu9wmeRd+nLsppmwJYafDdv2vSr1/Rhm100Hz1arsty9BF1vsrrtqDWj35xFH7TZi0+
-        fLVeLovlBX0yr5r2BbWkV77ntR3z4Ohv7ny8zNuPvj/C969X2RQQ+Ptw8NvA6qvX9EHDjai7vDx/
-        XizfUvt5266aR3fvXmVXzTYhOtueZNfbO5/eH2erotPbVbGcVVfc66P9+/t3v8ZUARaQiM5SB1Eh
-        MF7R7wnzOl9V9HFVX7+mL0EgGkPQorpa5rWh/LrJLvLXQtyd0Uf5MpuUObFZW6/z0UfZbFEsT8PP
-        tMm3b01+pr75upkuIk1ohvDHy4ANFnmbzbI2M6gS7e2336M3COTrvG2JG+gDNPkl9NllVpTZpCiL
-        9tqNqmnKE7x5XhAf4nW0Hn00bWr6HaCmxPfmUyDyRTWjN+Vvw2evm5IhUsPvRXg0MiqCpe8wFsXq
-        SdbkM4LzKm/WZWs6uCzqdp2VZy/NB+18vZis6mJpm7TVVysiBcEJ/z6zIM03rhPXMUbwhuVz55eM
-        YqjHJ+X/fejv/hLMVbVYrcMpavL6Mq+fZfWi/8kZMe4PXWdy7+fUuy+c26syWxJVCTC+J7zOs7Ih
-        iSqzpqXhEHvmszfFIv+qnRLOezu7n27v7m7v3Huzs/dof//R7v545x6935Bwk9C+yqcV9XL9ND/P
-        aDqUXp6CnFbLNl+2x1GRqNfLlrqKfwkeOKmW58WFoecsX5XV9YLAMT3doKifts7OSbK+yJaEVe3p
-        BXm1ebumNwj4cpbVM2q/qvNFsV4cr1ZPGSoooU2nCyit47KpXrfVaoVvlEZtVl/k7eurbPW6rCxj
-        gTVosKdLYsJqCfSGvyHlcl6UNEBpsMCMvaaJKEjhwy5N0DWs1QWR4Srz1Ke8QHNPUI5pqEsiVkcp
-        ypdQMvYLRRyIAEzztGjCb2bVIiuWP5nXNPGkl4gzz2YEhP4ijjK9viWLYn6v1u2kWi9nZ6vj2Yy4
-        qCF0H320vzM+uDfeffBwfG93pH8c7I4P9u0f9P+HO/5fNEgwB/We16+LH9AQadJnxAnXX+QLshxg
-        wp9YV1C99EWzblb5cgbeLK2ggkXMiF7lWQPjTm3P18spRnL6Lp+u8ctXRKzmJJvOqRN5c5G9e0EK
-        Iq+/PP9uVb/1xjqvSMu22WJFo+pZW+BcVmDts+V55V7pTjP4U77zHQyilhNmAh+RZupgJqJkWJja
-        ua8jCvKX/JL/Bzs2/nGTCQAA
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/sites/webapp-e2e3","name":"webapp-e2e3","type":"Microsoft.Web/sites","kind":"app","location":"West
+        US","tags":null,"properties":{"name":"webapp-e2e3","state":"Running","hostNames":["webapp-e2e3.azurewebsites.net"],"webSpace":"azurecli-webapp-e2e2-WestUSwebspace","selfLink":"https://waws-prod-bay-069.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/azurecli-webapp-e2e2-WestUSwebspace/sites/webapp-e2e3","repositorySiteName":"webapp-e2e3","owner":null,"usageState":0,"enabled":true,"adminEnabled":true,"enabledHostNames":["webapp-e2e3.azurewebsites.net","webapp-e2e3.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":0,"sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-e2e3.azurewebsites.net","sslState":0,"ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":0,"hostType":0},{"name":"webapp-e2e3.scm.azurewebsites.net","sslState":0,"ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":0,"hostType":1}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/serverfarms/webapp-e2e-plan","reserved":false,"lastModifiedTimeUtc":"2016-12-16T05:48:11.1466667","storageRecoveryDefaultState":"Running","contentAvailabilityState":0,"runtimeAvailabilityState":0,"siteConfig":null,"deploymentId":"webapp-e2e3","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"WebSites","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"13.93.224.99,13.93.229.16,13.93.230.177,13.93.226.129","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-069","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"azurecli-webapp-e2e2","defaultHostName":"webapp-e2e3.azurewebsites.net"}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Thu, 03 Nov 2016 02:44:26 GMT']
-      ETag: ['"1D2357C29C726E0"']
+      Date: ['Fri, 16 Dec 2016 05:48:17 GMT']
+      ETag: ['"1D2575FFC2CC0AB"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
+      content-length: ['2519']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -602,53 +504,31 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [705e5450-a16f-11e6-8788-f4b7e2e85440]
+      x-ms-client-request-id: [3eb9fa5c-c353-11e6-a036-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e/providers/Microsoft.Web/sites/webapp-e2e?api-version=2015-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/sites/webapp-e2e3?api-version=2015-08-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXezH6zrfFoW21f5JFuttvO9/O6qri6LWV43d78opnXVVOft+Lv55G5TtHlz1zX8aPTR
-        MlvkhEjwWXu9wmeRd+nLsppmwJYafDdv2vSr1/Rhm100Hz1arsty9BF1vsrrtqDWj35xFH7TZi0+
-        fLVeLovlBX0yr5r2BbWkV77ntR3z4Ohv7ny8zNuPvj/C969X2RQQ+Ptw8NvA6qvX9EHDjai7vDx/
-        XizfUvt5266aR3fvXmVXzTYhOtueZNfbO5/eH2erotPbVbGcVVfc66P9+/t3v8ZUARaQiM5SB1Eh
-        MF7R7wnzOl9V9HFVX7+mL0EgGkPQorpa5rWh/LrJLvLXQtyd0Uf5MpuUObFZW6/z0UfZbFEsT8PP
-        tMm3b01+pr75upkuIk1ohvDHy4ANFnmbzbI2M6gS7e2336M3COTrvG2JG+gDNPkl9NllVpTZpCiL
-        9tqNqmnKE7x5XhAf4nW0Hn00bWr6HaCmxPfmUyDyRTWjN+Vvw2evm5IhUsPvRXg0MiqCpe8wFsXq
-        SdbkM4LzKm/WZWs6uCzqdp2VZy/NB+18vZis6mJpm7TVVysiBcEJ/z6zIM03rhPXMUbwhuVz55eM
-        YqjHJ+X/fejv/hLMVbVYrcMpavL6Mq+fZfWi/8kZMe4PXWdy7+fUuy+c26syWxJVCTC+J7zOs7Ih
-        iSqzpqXhEHvmszfFIv+qnRLOezu7n27v7m7v3Huzs/dof//R7v545x6935Bwk9C+yqcV9XL9ND/P
-        aDqUXp6CnFbLNl+2x1GRqNfLlrqKfwkeOKmW58WFoecsX5XV9YLAMT3doKifts7OSbK+yJaEVe3p
-        BXm1ebumNwj4cpbVM2q/qvNFsV4cr1ZPGSoooU2nCyit47KpXrfVaoVvlEZtVl/k7eurbPW6rCxj
-        gTVosKdLYsJqCfSGvyHlcl6UNEBpsMCMvaaJKEjhwy5N0DWs1QWR4Srz1Ke8QHNPUI5pqEsiVkcp
-        ypdQMvYLRRyIAEzztGjCb2bVIiuWP5nXNPGkl4gzz2YEhP4ijjK9viWLYn6v1u2kWi9nZ6vj2Yy4
-        qCF0H320vzM+uDfeffBwfG93pH8c7I4P9u0f9P+HO/5fNEgwB/We16+LH9AQadJnxAnXX+QLshxg
-        wp9YV1C99EWzblb5cgbeLK2ggkXMiF7lWQPjTm3P18spRnL6Lp+u8ctXRKzmJJvOqRN5c5G9e0EK
-        Iq+/PP9uVb/1xjqvSMu22WJFo+pZW+BcVmDts+V55V7pTjP4U77zHQyilhNmAh+RZupgJqJkWJja
-        ua8jCvKX/JL/Bzs2/nGTCQAA
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/sites/webapp-e2e3","name":"webapp-e2e3","type":"Microsoft.Web/sites","kind":"app","location":"West
+        US","tags":null,"properties":{"name":"webapp-e2e3","state":"Running","hostNames":["webapp-e2e3.azurewebsites.net"],"webSpace":"azurecli-webapp-e2e2-WestUSwebspace","selfLink":"https://waws-prod-bay-069.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/azurecli-webapp-e2e2-WestUSwebspace/sites/webapp-e2e3","repositorySiteName":"webapp-e2e3","owner":null,"usageState":0,"enabled":true,"adminEnabled":true,"enabledHostNames":["webapp-e2e3.azurewebsites.net","webapp-e2e3.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":0,"sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-e2e3.azurewebsites.net","sslState":0,"ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":0,"hostType":0},{"name":"webapp-e2e3.scm.azurewebsites.net","sslState":0,"ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":0,"hostType":1}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/serverfarms/webapp-e2e-plan","reserved":false,"lastModifiedTimeUtc":"2016-12-16T05:48:11.1466667","storageRecoveryDefaultState":"Running","contentAvailabilityState":0,"runtimeAvailabilityState":0,"siteConfig":null,"deploymentId":"webapp-e2e3","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"WebSites","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"13.93.224.99,13.93.229.16,13.93.230.177,13.93.226.129","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-069","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"azurecli-webapp-e2e2","defaultHostName":"webapp-e2e3.azurewebsites.net"}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Thu, 03 Nov 2016 02:44:28 GMT']
-      ETag: ['"1D2357C29C726E0"']
+      Date: ['Fri, 16 Dec 2016 05:48:18 GMT']
+      ETag: ['"1D2575FFC2CC0AB"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
+      content-length: ['2519']
     status: {code: 200, message: OK}
 - request:
-    body: !!binary |
-      eyJsb2NhdGlvbiI6ICJXZXN0IFVTIiwgInByb3BlcnRpZXMiOiB7InNjbVR5cGUiOiAiTG9jYWxH
-      aXQifX0=
+    body: '{"properties": {"scmType": "LocalGit"}, "location": "West US"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -656,49 +536,28 @@ interactions:
       Content-Length: ['62']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [70ad8bdc-a16f-11e6-9b40-f4b7e2e85440]
+      x-ms-client-request-id: [3f26caf8-c353-11e6-8077-f4b7e2e85440]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e/providers/Microsoft.Web/sites/webapp-e2e/config/web?api-version=2015-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/sites/webapp-e2e3/config/web?api-version=2015-08-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXezH6zrfFoW21f5JFuttvO9/O6qri6LWV43d78opnXVVOft+Lv55G5TtHlz1zX8aPTR
-        MlvkhEjwWXu9wmeRd+nLsppmwJYafDdv2vSr1/Rhm100Hz1arsty9BF1vsrrtqDWj37xR8v1YpLX
-        X55/t6rfEkIfPdodfTTLz7N12T6tputFvmzpw+999FQ+G8/bBcHz/iq9P7NmRX8Vy1n+Dl/5v6NZ
-        UTRNm9X8Gv2p3eCtd/SnNF3NAWJeNW2xvLCty4++T6TI22c1keOKUP1JwlUGebk/3qE36D332f3x
-        p/joup1XS/cpfbSsZnnwQZ3/ojVR6U2dTam/02U2KXOa+POsbHJ8u6ja/Gk+WV9c3Py1BSx0nrft
-        6nnF33RfLKuL5mlBbNFW9fXr4gf582JRtB89uncfVGmzghqf1nVVD7y/Wk/KopnTN181ea0s8rsF
-        POKavMyahkhGbwte1OZ13jJ5zUcL6nOWtZn5e1otl4QcDeZ1WwcNsymBzH+v/Np8Ms+WszKvvyCo
-        fsOZ8s6rqqJxyWfNdPFGOPc58Wj5OY149NG6ye/tPSla4b+XdTXNG4LS1msaJ43odTV9m7dNlwJZ
-        eZVdN18SsfWDn84us84E4KOTaknkXOZ19MPOCzSGk2qxoBE9p28JT8KP/sou8tnLYpWX9OEXxEAf
-        PdoZfXRZ1O06K49Xq7IQgSOsv/eLzecvs3ZOAO4ShNX8uqEm5iPI6e/7+15dXdUgDX1d52WVzboD
-        VDiGS1hageUvIUG4KpbH63Z+PFsUNEFZKxjpp2/yZbZs3cfTddNWC8LzZVWVZzOak6K99l/VDqPt
-        AmDasF7TV4v8+Cl4T5DqfNjlOIzvSVZmS8gYaxhSjWDAV+sS4/oejSl/R0qJILC6+cUfkZyvvlrZ
-        738JAYGI0B8CMlu31bfzrOySzXyub/7ij4h/Ly5omu2LzNb6J4FtRfK/FA0vHxP1Sde8ELGiKcKU
-        gbTdzsznTpx+8UdEMGkjgKAEjlfFyzo/L94JB8gX6yWhOqfhEmu0+eykLOj3Y0bONGmrtzlNUlXn
-        tmP5IivL6oo0xLsWwl++ymfMJV/VJaEgTVS3kjyxoTEfkx2ibs4sJPn7dT6tcyumpKTX7g3t63g9
-        o5Ykm/bz2awAsllJOqpYvsxoxuyXRXOc0Sttxf1DxIC8Uu2iqi7KXAbsMPE/DfGRb74kcPPXUzJd
-        tpfzbJpPquot8ayD430YgjFfRAC1V0VLpCS10JDSqj3t1vkmhLgw9vd4Oq2I/wV5h0r8+80wetgR
-        i04rx76rdWNZKFsVZHiLJc+D/ZCo/voqW70uK+Vg+RxuQfnF9etf1BOZAoRa1yTtr8gS1gXzoHb4
-        S37J/wMM3ds9CQkAAA==
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/sites/webapp-e2e3","name":"webapp-e2e3","type":"Microsoft.Web/sites","location":"West
+        US","tags":null,"properties":{"numberOfWorkers":1,"defaultDocuments":["Default.htm","Default.html","Default.asp","index.htm","index.html","iisstart.htm","default.aspx","index.php","hostingstart.html"],"netFrameworkVersion":"v4.0","phpVersion":"5.6","pythonVersion":"","nodeVersion":"","requestTracingEnabled":false,"remoteDebuggingEnabled":false,"remoteDebuggingVersion":null,"httpLoggingEnabled":false,"logsDirectorySizeLimit":35,"detailedErrorLoggingEnabled":false,"publishingUsername":"$webapp-e2e3","publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":"LocalGit","use32BitWorkerProcess":true,"webSocketsEnabled":false,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":"","managedPipelineMode":0,"virtualApplications":[{"virtualPath":"/","physicalPath":"site\\wwwroot","preloadEnabled":false,"virtualDirectories":null}],"winAuthAdminState":0,"winAuthTenantState":0,"customAppPoolIdentityAdminState":false,"customAppPoolIdentityTenantState":false,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":1,"routingRules":[],"experiments":{"rampUpRules":[]},"limits":null,"autoHealEnabled":false,"autoHealRules":{"triggers":null,"actions":null},"tracingOptions":null,"vnetName":"","siteAuthEnabled":false,"siteAuthSettings":{"enabled":null,"httpApiPrefixPath":null,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"googleClientId":null,"googleClientSecret":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountOAuthScopes":null},"cors":null,"push":null,"apiDefinition":null,"autoSwapSlotName":null,"localMySqlEnabled":false,"ipSecurityRestrictions":null}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Thu, 03 Nov 2016 02:44:28 GMT']
+      Date: ['Fri, 16 Dec 2016 05:48:19 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      content-length: ['2323']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -708,31 +567,26 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [7180c45a-a16f-11e6-80ac-f4b7e2e85440]
+      x-ms-client-request-id: [40205400-c353-11e6-831e-f4b7e2e85440]
     method: GET
     uri: https://management.azure.com/providers/Microsoft.Web/publishingUsers/web?api-version=2015-08-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0fLdVmOPlpmi/yjRx9d5ZOPRh+11yv88UUxraumOm/H380nd1frSVk082J58VWT181daVpW06wt
-        qqWB02YXjfl9VVervG6LnD75xdqDfhPAesHffHS9vsiWF1cE1H39Mmuaq6q2aPa/+XbWzDd/+zor
-        W9NikbfZLGsz83fRPM3LvM2pg/OsbPLRR8108VVdyPe/5Jf8P6wPe7MjAQAA
+    body: {string: '{"id":null,"name":"web","type":"Microsoft.Web/publishingUsers/web","location":null,"tags":null,"properties":{"name":null,"publishingUserName":"yugangw","publishingPassword":null,"publishingPasswordHash":null,"publishingPasswordHashSalt":null,"metadata":null,"isDeleted":false,"scmUri":null}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Thu, 03 Nov 2016 02:44:29 GMT']
+      Date: ['Fri, 16 Dec 2016 05:48:20 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
+      content-length: ['291']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -742,35 +596,28 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [71e26754-a16f-11e6-b7b4-f4b7e2e85440]
+      x-ms-client-request-id: [4075fcb4-c353-11e6-8b30-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e/providers/Microsoft.Web/sites/webapp-e2e/sourcecontrols/web?api-version=2015-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/sites/webapp-e2e3/sourcecontrols/web?api-version=2015-08-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXezH6zrfFoW21f5JFuttvO9/O6qri6LWV43d78opnXVVOft+Lv55G5TtHlz12sokKbV
-        sq2rkr/5aPTRMlvkhBv9oc3os/Z6hc9i4EIY1LasphnGQ+2/mzdt+tVr+rDNLpqPHi3XZTn6iNBb
-        5XVb5PTJL/6ozlfVV3VJredtu2oe3QUa2vO4mS7GPEL6jLsbL/OWwE3qbDmdG4BF80W2XGfl2bLN
-        L2rt/Dwrm3z00SxfldX1Il+2r6qynGTTt6fLbFLmRH5tQW/n9XRdFxkhoZ8RipdFQ3CK5cXrNmsx
-        +Nfr6TTPZ/TmL/kl/w9kaciJwAEAAA==
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/sites/webapp-e2e3/sourcecontrols/web","name":"webapp-e2e3","type":"Microsoft.Web/sites/sourcecontrols","location":"West
+        US","tags":null,"properties":{"repoUrl":"https://webapp-e2e3.scm.azurewebsites.net","branch":null,"isManualIntegration":false,"deploymentRollbackEnabled":false,"isMercurial":false,"provisioningState":"Succeeded"}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Thu, 03 Nov 2016 02:44:30 GMT']
-      ETag: ['"1D2357C32076D10"']
+      Date: ['Fri, 16 Dec 2016 05:48:21 GMT']
+      ETag: ['"1D257600125D820"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
+      content-length: ['458']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -780,35 +627,28 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [726ef3c8-a16f-11e6-81fb-f4b7e2e85440]
+      x-ms-client-request-id: [41409878-c353-11e6-b7b7-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e/providers/Microsoft.Web/sites/webapp-e2e/sourcecontrols/web?api-version=2015-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/sites/webapp-e2e3/sourcecontrols/web?api-version=2015-08-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXezH6zrfFoW21f5JFuttvO9/O6qri6LWV43d78opnXVVOft+Lv55G5TtHlz12sokKbV
-        sq2rkr/5aPTRMlvkhBv9oc3os/Z6hc9i4EIY1LasphnGQ+2/mzdt+tVr+rDNLpqPHi3XZTn6iNBb
-        5XVb5PTJL/6ozlfVV3VJredtu2oe3QUa2vO4mS7GPEL6jLsbL/OWwE3qbDmdG4BF80W2XGfl2bLN
-        L2rt/Dwrm3z00SxfldX1Il+2r6qynGTTt6fLbFLmRH5tQW/n9XRdFxkhoZ8RipdFQ3CK5cXrNmsx
-        +Nfr6TTPZ/TmL/kl/w9kaciJwAEAAA==
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/sites/webapp-e2e3/sourcecontrols/web","name":"webapp-e2e3","type":"Microsoft.Web/sites/sourcecontrols","location":"West
+        US","tags":null,"properties":{"repoUrl":"https://webapp-e2e3.scm.azurewebsites.net","branch":null,"isManualIntegration":false,"deploymentRollbackEnabled":false,"isMercurial":false,"provisioningState":"Succeeded"}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Thu, 03 Nov 2016 02:44:31 GMT']
-      ETag: ['"1D2357C32076D10"']
+      Date: ['Fri, 16 Dec 2016 05:48:22 GMT']
+      ETag: ['"1D257600125D820"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
+      content-length: ['458']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -818,56 +658,34 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [73241a3a-a16f-11e6-8ac4-f4b7e2e85440]
+      x-ms-client-request-id: [41d0662c-c353-11e6-afc1-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e/providers/Microsoft.Web/sites/webapp-e2e?api-version=2015-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/sites/webapp-e2e3?api-version=2015-08-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXezH6zrfFoW21f5JFuttvO9/O6qri6LWV43d78opnXVVOft+Lv55G5TtHlz1zX8aPTR
-        MlvkhEjwWXu9wmeRd+nLsppmwJYafDdv2vSr1/Rhm100Hz1arsty9BF1vsrrtqDWj35xFH7TZi0+
-        fLVeLovlBX0yr5r2BbWkV77ntR3z4Ohv7ny8zNuPvj/C969X2RQQ+Ptw8NvA6qvX9EHDjai7vDx/
-        XizfUvt5266aR3fvXmVXzTYhOtueZNfbO5/eH2erotPbVbGcVVfc66P9+/t3v8ZUARaQiM5SB1Eh
-        MF7R7wnzOl9V9HFVX7+mL0EgGkPQorpa5rWh/LrJLvLXQtyd0Uf5MpuUObFZW6/z0UfZbFEsT8PP
-        tMm3b01+pr75upkuIk1ohvDHy4ANFnmbzbI2M6gS7e2336M3COTrvG2JG+gDNPkl9NllVpTZpCiL
-        9tqNqmnKE7x5XhAf4nW0Hn00bWr6HaCmxPfmUyDyRTWjN+Vvw2evm5IhUsPvRXg0MiqCpe8wFsXq
-        SdbkM4LzKm/WZWs6uCzqdp2VZy/NB+18vZis6mJpm7TVVysiBcEJ/z6zIM03rhPXMUbwhuVz55eM
-        YqjHJ+X/fejv/hLMVbVYrcMpavL6Mq+fZfWi/8kZMe4PXWdy7+fUuy+c26syWxJVCTC+J7zOs7Ih
-        iSqzpqXhEHvmszfFIv+qnRLOezu7n27v7m7v3Huzs/dof//R3oPxwYN7BKAh6SapfZVPK+rm+ml+
-        ntF8KME8DTmtlm2+bI+jMlGvly31Ff8STHBSLc+LC0PQWb4qq+sFgWOCulFRP22dnZNofZEtCava
-        UwzyavN2TW8Q8OUsq2fUflXni2K9OF6tnjJUkEKbThfQWsdlU71uq9UK3yiR2qy+yNvXV9nqdVlZ
-        zgJv0GBPl8SF1RLoDX9D2uW8KGmA0mCBKXtNM1GQxodhmqBrmKsLIsNV5ulPeYEmn6Ac01CXRKyO
-        VpQvoWXsF4o4EAGY5mnRhN/MqkVWLH8yr2nmSTERa57NCAj9RSxlen1LJsX8Xq3bSbVezs5Wx7MZ
-        sVFD6D76aH9nfHBvvPvg4fje7kj/ONgdH+zbP+j/D3f8v2iQYA7qPa9fFz+gIdKkz4gTrr/IF2Q6
-        wIU/sa6ge+mLZt2s8uUMzFlaSQWLmBG9yrMG1p3anq+XU4zk9F0+XeOXr4hYzUk2nVMn8uYie/eC
-        NERef3n+3ap+6411XpGabbPFikbVM7fAuazA2mfL88q90p1m8Kd853sYRC0nzQQ+Is7UwUxEybAw
-        tXNfRzTkL/kl/w/fk/RdlAkAAA==
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/sites/webapp-e2e3","name":"webapp-e2e3","type":"Microsoft.Web/sites","kind":"app","location":"West
+        US","tags":null,"properties":{"name":"webapp-e2e3","state":"Running","hostNames":["webapp-e2e3.azurewebsites.net"],"webSpace":"azurecli-webapp-e2e2-WestUSwebspace","selfLink":"https://waws-prod-bay-069.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/azurecli-webapp-e2e2-WestUSwebspace/sites/webapp-e2e3","repositorySiteName":"webapp-e2e3","owner":null,"usageState":0,"enabled":true,"adminEnabled":true,"enabledHostNames":["webapp-e2e3.azurewebsites.net","webapp-e2e3.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":0,"sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-e2e3.azurewebsites.net","sslState":0,"ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":0,"hostType":0},{"name":"webapp-e2e3.scm.azurewebsites.net","sslState":0,"ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":0,"hostType":1}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/serverfarms/webapp-e2e-plan","reserved":false,"lastModifiedTimeUtc":"2016-12-16T05:48:19.49","storageRecoveryDefaultState":"Running","contentAvailabilityState":0,"runtimeAvailabilityState":0,"siteConfig":null,"deploymentId":"webapp-e2e3","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"WebSites","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"13.93.224.99,13.93.229.16,13.93.230.177,13.93.226.129","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-069","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"azurecli-webapp-e2e2","defaultHostName":"webapp-e2e3.azurewebsites.net"}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Thu, 03 Nov 2016 02:44:31 GMT']
-      ETag: ['"1D2357C32076D10"']
+      Date: ['Fri, 16 Dec 2016 05:48:23 GMT']
+      ETag: ['"1D257600125D820"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
+      content-length: ['2514']
     status: {code: 200, message: OK}
 - request:
-    body: !!binary |
-      eyJsb2NhdGlvbiI6ICJXZXN0IFVTIiwgInByb3BlcnRpZXMiOiB7ImZhaWxlZFJlcXVlc3RzVHJh
-      Y2luZyI6IHsiZW5hYmxlZCI6IHRydWV9LCAiZGV0YWlsZWRFcnJvck1lc3NhZ2VzIjogeyJlbmFi
-      bGVkIjogdHJ1ZX0sICJodHRwTG9ncyI6IHsiZmlsZVN5c3RlbSI6IHsiZW5hYmxlZCI6IHRydWUs
-      ICJyZXRlbnRpb25Jbk1iIjogMTAwLCAicmV0ZW50aW9uSW5EYXlzIjogM319LCAiYXBwbGljYXRp
-      b25Mb2dzIjogeyJmaWxlU3lzdGVtIjogeyJsZXZlbCI6ICJWZXJib3NlIn19fX0=
+    body: '{"properties": {"failedRequestsTracing": {"enabled": true}, "httpLogs":
+      {"fileSystem": {"retentionInDays": 3, "retentionInMb": 100, "enabled": true}},
+      "applicationLogs": {"fileSystem": {"level": "Verbose"}}, "detailedErrorMessages":
+      {"enabled": true}}, "location": "West US"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -875,33 +693,83 @@ interactions:
       Content-Length: ['275']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [735c727e-a16f-11e6-865e-f4b7e2e85440]
+      x-ms-client-request-id: [42608942-c353-11e6-a8d4-f4b7e2e85440]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e/providers/Microsoft.Web/sites/webapp-e2e/config/logs?api-version=2015-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/sites/webapp-e2e3/config/logs?api-version=2015-08-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXezH6zrfFoW21f5JFuttvO9/O6qri6LWV43d78opnXVVOft+Lv55G5TtHlz12s4rZbn
-        xcXdsrpoPhp9tMwWOSGlf7XXK/wVgyCvUZuymmZAndp9N2/a9KvX9GGb0fuPluuyHH1EmKzyui1y
-        +uQXf0TdloW88Ryd0EfnRZm/vm7afIG/yvwyLwnYT+b1pGryj37J6CMe35tsQs3aqs4uCCfX7svz
-        c+qwyZqvavoTXZo3npTV5FYvjD6q8zZfAqez5dPsmrDCx7+EAM3bdhXH03vli8lHj3Z3diJg7o0+
-        ypdAnGa6rdc5QYyhdgMyPpTzrGxyYHaeETqzV/kvWhPVmzd1Ni2WFwBmm2qHs7zlpqd1XdVf5E1D
-        nRLQbsNf8kv+H9soh8+RAgAA
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/sites/webapp-e2e3/config/logs","name":"logs","type":"Microsoft.Web/sites/config","location":"West
+        US","tags":null,"properties":{"applicationLogs":{"fileSystem":{"level":"Verbose"},"azureTableStorage":{"level":"Off","sasUrl":null},"azureBlobStorage":{"level":"Off","sasUrl":null,"retentionInDays":null}},"httpLogs":{"fileSystem":{"retentionInMb":100,"retentionInDays":3,"enabled":true},"azureBlobStorage":{"sasUrl":null,"retentionInDays":3,"enabled":false}},"failedRequestsTracing":{"enabled":true},"detailedErrorMessages":{"enabled":true}}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Thu, 03 Nov 2016 02:44:34 GMT']
+      Date: ['Fri, 16 Dec 2016 05:48:25 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['665']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [43a1c8d8-c353-11e6-b6b0-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/sites/webapp-e2e3/config/web?api-version=2015-08-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/sites/webapp-e2e3/config/web","name":"webapp-e2e3","type":"Microsoft.Web/sites/config","location":"West
+        US","tags":null,"properties":{"numberOfWorkers":1,"defaultDocuments":["Default.htm","Default.html","Default.asp","index.htm","index.html","iisstart.htm","default.aspx","index.php","hostingstart.html"],"netFrameworkVersion":"v4.0","phpVersion":"5.6","pythonVersion":"","nodeVersion":"","requestTracingEnabled":true,"requestTracingExpirationTime":"9999-12-31T23:59:00Z","remoteDebuggingEnabled":false,"remoteDebuggingVersion":null,"httpLoggingEnabled":true,"logsDirectorySizeLimit":100,"detailedErrorLoggingEnabled":true,"publishingUsername":"$webapp-e2e3","publishingPassword":null,"appSettings":null,"metadata":null,"connectionStrings":null,"machineKey":null,"handlerMappings":null,"documentRoot":null,"scmType":"LocalGit","use32BitWorkerProcess":true,"webSocketsEnabled":false,"alwaysOn":false,"javaVersion":null,"javaContainer":null,"javaContainerVersion":null,"appCommandLine":"","managedPipelineMode":0,"virtualApplications":[{"virtualPath":"/","physicalPath":"site\\wwwroot","preloadEnabled":false,"virtualDirectories":null}],"winAuthAdminState":0,"winAuthTenantState":0,"customAppPoolIdentityAdminState":false,"customAppPoolIdentityTenantState":false,"runtimeADUser":null,"runtimeADUserPassword":null,"loadBalancing":1,"routingRules":[],"experiments":{"rampUpRules":[]},"limits":null,"autoHealEnabled":false,"autoHealRules":{"triggers":null,"actions":null},"tracingOptions":null,"vnetName":"","siteAuthEnabled":false,"siteAuthSettings":{"enabled":null,"httpApiPrefixPath":null,"unauthenticatedClientAction":null,"tokenStoreEnabled":null,"allowedExternalRedirectUrls":null,"defaultProvider":null,"clientId":null,"clientSecret":null,"issuer":null,"allowedAudiences":null,"additionalLoginParams":null,"isAadAutoProvisioned":false,"googleClientId":null,"googleClientSecret":null,"googleOAuthScopes":null,"facebookAppId":null,"facebookAppSecret":null,"facebookOAuthScopes":null,"twitterConsumerKey":null,"twitterConsumerSecret":null,"microsoftAccountClientId":null,"microsoftAccountClientSecret":null,"microsoftAccountOAuthScopes":null},"cors":null,"push":null,"apiDefinition":null,"autoSwapSlotName":null,"localMySqlEnabled":false,"ipSecurityRestrictions":null}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Fri, 16 Dec 2016 05:48:26 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['2393']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [44aa66a4-c353-11e6-96ea-f4b7e2e85440]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/sites/webapp-e2e3/stop?api-version=2015-08-01
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Fri, 16 Dec 2016 05:48:27 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
       x-ms-ratelimit-remaining-subscription-writes: ['1198']
@@ -914,49 +782,28 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [74dc4092-a16f-11e6-8934-f4b7e2e85440]
+      x-ms-client-request-id: [455305a6-c353-11e6-91cf-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e/providers/Microsoft.Web/sites/webapp-e2e/config/web?api-version=2015-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/sites/webapp-e2e3?api-version=2015-08-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXezH6zrfFoW21f5JFuttvO9/O6qri6LWV43d78opnXVVOft+Lv55G5TtHlz12s4rZbn
-        xQU++Wj00TJb5IQT/aFf02ft9QqfxcDIu9SmrKYZ8Kd2382bNv3qNX3YZhfNR4+W67IcfUTorPK6
-        LXL65Bd/tFwvJnn95fl3q/otofjRo93RR7P8PFuX7dNqul7ky5Y+/N5HT+Wz8bxdEDzvr9L7M2tW
-        9FexnOXv8JX/O5oVRdO0Wc2v0Z/aDd56R39K09UcIOZV0xbLC9u6/Oj7RJG8fVYTVa4I1Z8kXGWQ
-        l/vjHXqD3nOf3R9/io+u23m1dJ/SR8tqlgcf1PkvWhOV3tTZlPo7XWaTMidWaOt13vvy3aqombRv
-        Cp6ah/Rs7+5t39t9s3fv0f2Hj3Z2fopBLqo2f5pP1hcXeM3APM/KhoEGX1tsZHLmbbt6XvE39kVB
-        pqwumqcFMVdb1devix/kz4tF0dJ87eyAlG1WUOPTuq7q+Pur9aQsmjl98VWT18pdv1vAXq7Jy6xp
-        iMz0sqBFbV7nLU+J+WhBXc6yNjN/EwMuCTkay+u2DhpmUwKZ/175tflkni1nZV5/QVD9hjPlt1dV
-        ReOSz5rp4o0w/XPi6/JzGvHoo3WT39t7UrTCsy/rapo3BEXGSSN6XU3f5m1jCaCUz8qr7Lr5kmit
-        H/x0dpl16I+PTqolUXOZ19EPOy/QGE6qxYJG9Jy+JTwJP/oru8hnL4tVXtKHXxDTffSIZumyqNt1
-        Vh6vVmUhQkpYf+8Xm89fZu2cANwlCKv5dUNNzEcQ8d/39726uqpBGvq6zssqm3UHqHAMl7CEA8tf
-        QsJzVSyP1+38eLYoaIKyVjDST9/ky2zZuo+n66atFoTny6oqz2Y0J0V77b+qHUbbBcC0Yb2mrxb5
-        8VPwniDV+bDLcRjfk6zMlhA94nJqXq3BgK/WJcb1PRpT/o4UGUFgFfWLPyLdsPpqZb//JQQEIkJ/
-        CMhs3VbfzrOySzbzub75iz8i/r24oGm2LzJb658EthWF8KXYCfmYqE/66YWIFU0Rpgyk7XZmPnfi
-        9Is/IoJJGwEEHXC8Kl7W+XnxTjhAvlgvCdU5DZdYo81nJ2VBvx8zcqZJW73NaZKqOrcdyxdZWVZX
-        pCDetRD+8lU+Yy75qi4JBWmi+pjkic2V+ZisGXVzZiHJ36/zaZ1bMSXFvnZvaF/H6xm1JNm0n89m
-        BZDNSlJRxfJlRjNmvyya44xeaSvuHyIG5JVqF1V1UeYyYIeJ/2mIj3zzJYGbv56SubO9nGfTfFJV
-        b4lnHRzvwxCM+SICqL0qWiIlqYWGlFbtabfONyHEhTHdx9NpRfwvyDtU4t9vhtHDjlh0Wjn2Xa0b
-        y0LZqiBjXSx5HuyHRPXXV9nqdVkpB8vncCXKL65f/6KeyBQg1LomaX9FBrIumAe1w1/yS/4f/7qr
-        KE8JAAA=
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/sites/webapp-e2e3","name":"webapp-e2e3","type":"Microsoft.Web/sites","kind":"app","location":"West
+        US","tags":null,"properties":{"name":"webapp-e2e3","state":"Stopped","hostNames":["webapp-e2e3.azurewebsites.net"],"webSpace":"azurecli-webapp-e2e2-WestUSwebspace","selfLink":"https://waws-prod-bay-069.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/azurecli-webapp-e2e2-WestUSwebspace/sites/webapp-e2e3","repositorySiteName":"webapp-e2e3","owner":null,"usageState":0,"enabled":true,"adminEnabled":true,"enabledHostNames":["webapp-e2e3.azurewebsites.net","webapp-e2e3.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":0,"sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-e2e3.azurewebsites.net","sslState":0,"ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":0,"hostType":0},{"name":"webapp-e2e3.scm.azurewebsites.net","sslState":0,"ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":0,"hostType":1}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/serverfarms/webapp-e2e-plan","reserved":false,"lastModifiedTimeUtc":"2016-12-16T05:48:27.79","storageRecoveryDefaultState":"Running","contentAvailabilityState":0,"runtimeAvailabilityState":0,"siteConfig":null,"deploymentId":"webapp-e2e3","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"WebSites","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"13.93.224.99,13.93.229.16,13.93.230.177,13.93.226.129","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-069","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"azurecli-webapp-e2e2","defaultHostName":"webapp-e2e3.azurewebsites.net"}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Thu, 03 Nov 2016 02:44:35 GMT']
+      Date: ['Fri, 16 Dec 2016 05:48:29 GMT']
+      ETag: ['"1D25760061852E0"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
+      content-length: ['2514']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -967,97 +814,17 @@ interactions:
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [75b6ba7a-a16f-11e6-b8ad-f4b7e2e85440]
+      x-ms-client-request-id: [461ea11e-c353-11e6-b6eb-f4b7e2e85440]
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e/providers/Microsoft.Web/sites/webapp-e2e/stop?api-version=2015-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/sites/webapp-e2e3/start?api-version=2015-08-01
   response:
     body: {string: ''}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['0']
-      Date: ['Thu, 03 Nov 2016 02:44:36 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [767f7158-a16f-11e6-8830-f4b7e2e85440]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e/providers/Microsoft.Web/sites/webapp-e2e?api-version=2015-08-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXezH6zrfFoW21f5JFuttvO9/O6qri6LWV43d78opnXVVOft+Lv55G5TtHlz1zX8aPTR
-        MlvkhEjwWXu9wmeRd+nLsppmwJYafDdv2vSr1/Rhm100Hz1arsty9BF1vsrrtqDWj35xFH7TZi0+
-        fN1Wq1U+o0/mVdO+oJb0yve8tmMeHP3NnY+XefvR90f4/vUqmwICfx8OfhtYffWaPmi4EXWXl+fP
-        i+Vbaj9v21Xz6O7dq+yq2SZEZ9uT7Hp759P742xVdHq7Kpaz6op7fbR/f//u15gqwAIS0VnqICoE
-        xiv6PWFe56uKPq7q69f0JQhEYwhaVFfLvDaUXzfZRf5aiLsz+ihfZpOSyPuordf56KNstiiWp+Fn
-        2uTbtyY/U9983UwXkSY0Q/jjZcAGi7zNZlmbGVSJ9vbb79EbBPJ13rbF0vDRL6HPLrOizCZFWbTX
-        blRNU57gzfOC+BCvo/Xoo2lT0+8ANSW+N58CkS+qGb0pfxs+e92UDJEafi/Co5FRESx9h7EoVk+y
-        Jp8RnFd5sy5b08FlUbfrrDx7aT5o5+vFZFUXS9ukrb5aESkITvj3mQVpvnGduI4xgjcsnzu/ZBRD
-        PT4p/+9Df/eXYK6qxWodTlGT15d5/SyrF/1Pzohxf+g6k3s/p9594dxeldmSqEqA8T3hdZ6VDUlU
-        mTUtDYfYM5+9KRb5V+2UcN7b2f10e3d3e+fem529R/v7j+7dHx/Q6w3JNsnsq3xaUSfXT/PzjGZD
-        yfXRq/VySRJB7abVss2X7XFUIur1sqWe4l+CBU6q5XlxYcg5y1dldb0gcExONybqp62zcxKsL7Il
-        YVV7akFebd6u6Q0CvpxlNfT2qs4XxXpxvFo9ZagghDadLqCzjsumMmrekKjN6ou8fX2VrV6XleUr
-        cAYN9nRJPFgtgd7wN6RbzouSBigNFpiw1zQPBel7mKUJuoaxuiAyXGWe9pQXaOoJyjENdUnE6uhE
-        +RI6xn6hiAMRgGmeFk34zaxaZMXyJ/Oa5p3UEjHm2YyA0F/EUKbXt2RQzO/Vup1U6+XsbHU8mxET
-        NYTuo4/2d8YH98a7Dx6O7+2O9I+D3fHBvv2D/v9wx/+LBgnmoN7z+nXxAxoiTfqMOOH6i3xBhgM8
-        +BPrCpqXvmjWzSpfzsCapZVTsIgZ0as8a2Dbqe35ejnFSE7f5dM1fvmKiNWcZNM5dSJvLrJ3L0g/
-        5PWX59+t6rfeWOcVKdk2W6xoVD1jC5zLCqx9tjyv3CvdaQZ/yne+f0HUcrJM4CPCTB3MRJQMC1M7
-        93VEP/6SX/L/AC+i6GqSCQAA
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json]
-      Date: ['Thu, 03 Nov 2016 02:44:38 GMT']
-      ETag: ['"1D2357C36C0FD80"']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-IIS/8.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Powered-By: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [771bd926-a16f-11e6-b062-f4b7e2e85440]
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e/providers/Microsoft.Web/sites/webapp-e2e?api-version=2015-08-01
-  response:
-    body: {string: ''}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['0']
-      Date: ['Thu, 03 Nov 2016 02:44:44 GMT']
-      ETag: ['"1D2357C36C0FD80"']
+      Date: ['Fri, 16 Dec 2016 05:48:30 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
@@ -1074,28 +841,85 @@ interactions:
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          websitemanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [7adff4e4-a16f-11e6-ae41-f4b7e2e85440]
+      x-ms-client-request-id: [46cb5218-c353-11e6-8a05-f4b7e2e85440]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e/providers/Microsoft.Web/serverfarms?api-version=2015-08-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/sites/webapp-e2e3?api-version=2015-08-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS9748+Wubv2ufF8u1Hj5brshx9VMzkt1/y/wA/IGq2JgAAAA==
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/sites/webapp-e2e3","name":"webapp-e2e3","type":"Microsoft.Web/sites","kind":"app","location":"West
+        US","tags":null,"properties":{"name":"webapp-e2e3","state":"Running","hostNames":["webapp-e2e3.azurewebsites.net"],"webSpace":"azurecli-webapp-e2e2-WestUSwebspace","selfLink":"https://waws-prod-bay-069.api.azurewebsites.windows.net:454/subscriptions/00000000-0000-0000-0000-000000000000/webspaces/azurecli-webapp-e2e2-WestUSwebspace/sites/webapp-e2e3","repositorySiteName":"webapp-e2e3","owner":null,"usageState":0,"enabled":true,"adminEnabled":true,"enabledHostNames":["webapp-e2e3.azurewebsites.net","webapp-e2e3.scm.azurewebsites.net"],"siteProperties":{"metadata":null,"properties":[],"appSettings":null},"availabilityState":0,"sslCertificates":null,"csrs":[],"cers":null,"siteMode":null,"hostNameSslStates":[{"name":"webapp-e2e3.azurewebsites.net","sslState":0,"ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":0,"hostType":0},{"name":"webapp-e2e3.scm.azurewebsites.net","sslState":0,"ipBasedSslResult":null,"virtualIP":null,"thumbprint":null,"toUpdate":null,"toUpdateIpBasedSsl":null,"ipBasedSslState":0,"hostType":1}],"computeMode":null,"serverFarm":null,"serverFarmId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/serverfarms/webapp-e2e-plan","reserved":false,"lastModifiedTimeUtc":"2016-12-16T05:48:30.2733333","storageRecoveryDefaultState":"Running","contentAvailabilityState":0,"runtimeAvailabilityState":0,"siteConfig":null,"deploymentId":"webapp-e2e3","trafficManagerHostNames":null,"sku":"Standard","premiumAppDeployed":null,"scmSiteAlsoStopped":false,"targetSwapSlot":null,"hostingEnvironment":null,"hostingEnvironmentProfile":null,"microService":"WebSites","gatewaySiteName":null,"clientAffinityEnabled":true,"clientCertEnabled":false,"hostNamesDisabled":false,"domainVerificationIdentifiers":null,"kind":"app","outboundIpAddresses":"13.93.224.99,13.93.229.16,13.93.230.177,13.93.226.129","containerSize":0,"dailyMemoryTimeQuota":0,"suspendedTill":null,"siteDisabledReason":0,"functionExecutionUnitsCache":null,"maxNumberOfWorkers":null,"homeStamp":"waws-prod-bay-069","cloningInfo":null,"hostingEnvironmentId":null,"tags":null,"resourceGroup":"azurecli-webapp-e2e2","defaultHostName":"webapp-e2e3.azurewebsites.net"}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Thu, 03 Nov 2016 02:44:45 GMT']
+      Date: ['Fri, 16 Dec 2016 05:48:31 GMT']
+      ETag: ['"1D2576007934015"']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-IIS/8.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Powered-By: [ASP.NET]
+      content-length: ['2519']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [4793efbe-c353-11e6-9bad-f4b7e2e85440]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/sites/webapp-e2e3?api-version=2015-08-01
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Fri, 16 Dec 2016 05:48:38 GMT']
+      ETag: ['"1D2576007934015"']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.10586) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          websitemanagementclient/0.30.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [4b374e78-c353-11e6-972a-f4b7e2e85440]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/azurecli-webapp-e2e2/providers/Microsoft.Web/serverfarms?api-version=2015-08-01
+  response:
+    body: {string: '{"value":[],"nextLink":null,"id":null}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Fri, 16 Dec 2016 05:48:39 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+      content-length: ['38']
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/test_webapp_commands.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/tests/test_webapp_commands.py
@@ -10,13 +10,13 @@ from azure.cli.core.test_utils.vcr_test_base import (ResourceGroupVCRTestBase,
 class WebappBasicE2ETest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(WebappBasicE2ETest, self).__init__(__file__, test_method, resource_group='azurecli-webapp-e2e')
+        super(WebappBasicE2ETest, self).__init__(__file__, test_method, resource_group='azurecli-webapp-e2e2')
 
     def test_webapp_e2e(self):
         self.execute()
 
     def body(self):
-        webapp_name = 'webapp-e2e'
+        webapp_name = 'webapp-e2e3'
         plan = 'webapp-e2e-plan'
         result = self.cmd('appservice plan create -g {} -n {}'.format(self.resource_group, plan))
         self.cmd('appservice plan list -g {}'.format(self.resource_group), checks=[
@@ -39,7 +39,6 @@ class WebappBasicE2ETest(ResourceGroupVCRTestBase):
             ])
 
         result = self.cmd('appservice web create -g {} -n {} --plan {}'.format(self.resource_group, webapp_name, plan), checks=[
-            JMESPathCheck('resourceGroup', self.resource_group),
             JMESPathCheck('state', 'Running'),
             JMESPathCheck('name', webapp_name),
             JMESPathCheck('hostNames[0]', webapp_name + '.azurewebsites.net')
@@ -77,6 +76,13 @@ class WebappBasicE2ETest(ResourceGroupVCRTestBase):
             JMESPathCheck('state', 'Stopped'),
             JMESPathCheck('name', webapp_name)
             ])
+
+        self.cmd('appservice web start -g {} -n {}'.format(self.resource_group, webapp_name))
+        self.cmd('appservice web show -g {} -n {}'.format(self.resource_group, webapp_name), checks=[
+            JMESPathCheck('state', 'Running'),
+            JMESPathCheck('name', webapp_name)
+            ])
+
         self.cmd('appservice web delete -g {} -n {}'.format(self.resource_group, webapp_name))
         #test empty service plan should be automatically deleted.
         result = self.cmd('appservice plan list -g {}'.format(self.resource_group), checks=[


### PR DESCRIPTION
Fix #1501 
`appservice` commands work are supposed to be frozen till we migrate to new SDK. But the SDK's swagger spec is not finalized yet, so the good version for cli to depend on won't come out soon. Based on that, for now I will still address important issue as long as the fix is simple which won't accumulate debt for future migrations.
