### PR TITLE
[Do not merge]vm: capture shouldn't use own poller

### DIFF
--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -295,9 +295,7 @@ def capture_vm(resource_group_name, vm_name, vhd_name_prefix,
     '''
     client = _compute_client_factory()
     parameter = VirtualMachineCaptureParameters(vhd_name_prefix, storage_container, overwrite)
-    poller = client.virtual_machines.capture(resource_group_name, vm_name, parameter)
-    result = LongRunningOperation()(poller)
-    print(json.dumps(result.output, indent=2)) # pylint: disable=no-member
+    return client.virtual_machines.capture(resource_group_name, vm_name, parameter)
 
 def reset_windows_admin(
         resource_group_name, vm_name, username, password):


### PR DESCRIPTION
fix #1390
Verified using default poller works just fine