### PR TITLE
The version number for azure-cli-nspkg did not include +dev

### DIFF
--- a/src/azure-cli-nspkg/setup.py
+++ b/src/azure-cli-nspkg/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup
 
-VERSION = "0.1.0b10"
+VERSION = "0.1.0b11+dev"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
(minor fix)