### PR TITLE
[Docs] Fix docs ‘resource group’ to ‘group’

### DIFF
--- a/scripts/smoke_test_install/README.md
+++ b/scripts/smoke_test_install/README.md
@@ -26,8 +26,8 @@ This is so that the resource group will remain after the tests have executed.
 With this, you can ssh into the VMs and do any required debugging then delete the resource group afterwards.
 
 ```
-az resource group create -l <LOCATION> -n <NAME>
-az resource group delete -n <NAME>
+az group create -l <LOCATION> -n <NAME>
+az group delete -n <NAME>
 ```
 
 NOTE: Keep resource group names short and the test names short.

--- a/src/azure-cli/README.rst
+++ b/src/azure-cli/README.rst
@@ -68,7 +68,7 @@ The following block creates a new resource group in the 'westus' region, then cr
 
 .. code-block:: console
 
-   $ az resource group create -l westus -n MyGroup
+   $ az group create -l westus -n MyGroup
    Name     Location
    -------  ----------
    MyGroup  westus


### PR DESCRIPTION
Couple of places where we still reference 'resource group' instead of 'group'.