### PR TITLE
[CI] Remove 3.5-dev python version from travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 python:
   - "2.7"
   - "3.5"
-  - "3.5-dev" # 3.5 development branch
 install:
   - pip install -qqq virtualenv # used by package_verify script
   - python scripts/dev_setup.py


### PR DESCRIPTION
Remove 3.5-dev for now until this version on CI is fixed.