### PR TITLE
Enable zsh compatibility mode for zsh shell.

### DIFF
--- a/src/azure-cli/az.completion.sh
+++ b/src/azure-cli/az.completion.sh
@@ -1,1 +1,11 @@
+case $SHELL in
+*/zsh)
+   echo 'Enabling ZSH compatibility mode';
+   autoload bashcompinit && bashcompinit
+   ;;
+*/bash)
+   ;;
+*)
+esac
+
 eval "$(register-python-argcomplete az)"


### PR DESCRIPTION
Closes https://github.com/Azure/azure-cli/issues/1342

This is not full-proof as $SHELL is not always set to zsh (e.g. zsh isn’t your default shell).
However, it will enable the compatibility mode if it is set.

In the future, https://github.com/Azure/azure-cli/issues/630 will likely remove this file altogether.