### PR TITLE
[CI] Allow failures on 3.5-dev Python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: python
 python:
   - "2.7"
   - "3.5"
+  - "3.5-dev" # 3.5 development branch
+matrix:
+  allow_failures:
+  - python: 3.5-dev
 install:
   - pip install -qqq virtualenv # used by package_verify script
   - python scripts/dev_setup.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 matrix:
   allow_failures:
   - python: 3.5-dev
+  fast_finish: true
 install:
   - pip install -qqq virtualenv # used by package_verify script
   - python scripts/dev_setup.py


### PR DESCRIPTION
Since 3.5-dev refers to the development version of Python beyond 3.5.2, it is a moving target that can break (it updates every day or two).
So still run CI on 3.5-dev but don’t cause a failure in this version to fail CI.