### PR TITLE
Homebrew Formula for Azure CLI 2.0

### DIFF
--- a/homebrew/README.md
+++ b/homebrew/README.md
@@ -1,0 +1,20 @@
+Homebrew Packaging
+==============
+
+This directory contains the Homebrew formula for the CLI.
+
+```
+brew create <url> --set-name azure-cli-2
+brew edit azure-cli-2
+brew install azure-cli-2
+brew test azure-cli-2
+```
+For example url = https://github.com/Azure/azure-cli/archive/all-v0.1.0b11.tar.gz
+
+Bottles:
+```
+brew install --build-bottle azure-cli-2
+brew bottle azure-cli-2
+```
+
+After changing the formula, submit a PR to https://github.com/Homebrew/homebrew-core with the change.

--- a/homebrew/azure-cli-2.rb
+++ b/homebrew/azure-cli-2.rb
@@ -1,0 +1,84 @@
+require 'tmpdir'
+
+class AzureCli2 < Formula
+  include Language::Python::Virtualenv
+
+  desc "Azure CLI 2.0"
+  homepage "https://github.com/Azure/azure-cli"
+  # NOTE: When releasing, this should point to a version that is not '+dev'
+  url "https://github.com/Azure/azure-cli/archive/all-v0.1.0b11.tar.gz"
+  version "0.1.0b11"
+  depends_on "python"
+  sha256 "da6d4d523acbb05133b11ffe0c601c020c7da151ee0d68bc7d045783476f38d0"
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "e34b9409ae68dae52b20cc196e3fb90450c525f3017e7294cd4e31cbdb57510d" => :sierra
+  end
+
+  # Apply the 'az component' patch for src/command_modules/azure-cli-component/azure/cli/command_modules/component/custom.py
+  # Create a new patch by doing the following:
+  #     1. Modify the custom.py file (see example in homebrew/patch_component_custom.py).
+  #     2. Run git diff to get the patch: $ git diff src/command_modules/azure-cli-component/azure/cli/command_modules/component/custom.py
+  #     3. Publish the patch publicly and include the link here.
+  patch do
+    url "https://gist.githubusercontent.com/derekbekoe/b753179bff1b25343cbf38fc90c8c170/raw/e72ae0b0741fa10269fcde6e46c91122acbd5090/azure_cli_patch_component_010b11_custom.diff"
+    sha256 "7657927127349eda7ae0d8116739d397b115624151cf05d3ed4df017b34d1c72"
+  end
+
+  def completion_script; <<-EOS.undent
+    _python_argcomplete() {
+        local IFS='\v'
+        COMPREPLY=( $(IFS="$IFS"                   COMP_LINE="$COMP_LINE"                   COMP_POINT="$COMP_POINT"                   _ARGCOMPLETE_COMP_WORDBREAKS="$COMP_WORDBREAKS"                   _ARGCOMPLETE=1                   "$1" 8>&1 9>&2 1>/dev/null 2>/dev/null) )
+        if [[ $? != 0 ]]; then
+            unset COMPREPLY
+        fi
+    }
+    complete -o nospace -F _python_argcomplete "az"
+    EOS
+  end
+
+  def install
+    venv = virtualenv_create(libexec)
+    Dir.mktmpdir {|tmp_dir|
+        pkg_dirs = ['src/azure-cli', 'src/azure-cli-core', 'src/azure-cli-nspkg']
+        pkg_dirs += Dir.glob('src/command_modules/azure-cli-*/')
+        # Build the packages
+        pkg_dirs.each do |item|
+            Dir.chdir(item){
+              system libexec/"bin/python", "setup.py", "bdist_wheel", "-d", tmp_dir
+            }
+        end
+        # Install the CLI and all optional modules
+        cmd_mods = Dir.entries('src/command_modules/').select {|f| !(f =='.' || f == '..')}
+        system libexec/"bin/pip", "install", "azure-cli", *cmd_mods, "-f", tmp_dir
+    }
+    # Write the executable
+    bin_dir = libexec/"bin"
+    File.write("#{bin_dir}/az", "#!/usr/bin/env bash\n#{bin_dir}/python -m azure.cli \"$@\"")
+    bin.install_symlink "#{libexec}/bin/az"
+    # Bash tab completion
+    File.write(libexec/"az.completion", completion_script)
+    bash_completion.install libexec/"az.completion"
+  end
+
+  def caveats; <<-EOS.undent
+    To complete tab completion set up:
+      1. Modify your ~/.bash_profile (if the line doesn't already exist)
+        $ echo "[ -f #{HOMEBREW_PREFIX}/etc/bash_completion.d/az.completion ] && . #{HOMEBREW_PREFIX}/etc/bash_completion.d/az.completion" >> ~/.bash_profile
+      2. Restart your shell
+        $ exec -l $SHELL
+    ----
+    Get started with:
+      $ az configure
+    EOS
+  end
+
+  test do
+    bin_dir = libexec/"bin"
+    system bin_dir/"az", "--version"
+    assert_match "complete -o nospace -F _python_argcomplete az",
+      shell_output("bash -c 'source #{bash_completion}/az.completion && complete -p az'")
+  end
+
+end

--- a/homebrew/azure-cli-2.rb
+++ b/homebrew/azure-cli-2.rb
@@ -22,8 +22,8 @@ class AzureCli2 < Formula
   #     2. Run git diff to get the patch: $ git diff src/command_modules/azure-cli-component/azure/cli/command_modules/component/custom.py
   #     3. Publish the patch publicly and include the link here.
   patch do
-    url "https://gist.githubusercontent.com/derekbekoe/b753179bff1b25343cbf38fc90c8c170/raw/e72ae0b0741fa10269fcde6e46c91122acbd5090/azure_cli_patch_component_010b11_custom.diff"
-    sha256 "7657927127349eda7ae0d8116739d397b115624151cf05d3ed4df017b34d1c72"
+    url "https://gist.githubusercontent.com/derekbekoe/b753179bff1b25343cbf38fc90c8c170/raw/d67fd273447dbfdf0ba0f709bbf6cc95f497f21c/azure_cli_patch_component_010b11_custom.diff"
+    sha256 "72691d97d0c7bb090ab7c51f6c2e3e1dec57dc9c17a90a3821218c7380a1584e"
   end
 
   def completion_script; <<-EOS.undent

--- a/homebrew/patch_component_custom.py
+++ b/homebrew/patch_component_custom.py
@@ -1,0 +1,24 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+from azure.cli.core._util import CLIError
+
+def _raise_homebrew_error(msg):
+    raise CLIError("This operation is not available in the Homebrew version of the CLI.\n{}".format(msg))
+
+def list_components():
+    """ List the installed components """
+    _raise_homebrew_error("Use 'az --version' to list component versions.")
+
+def list_available_components():
+    """ List publicly available components that can be installed """
+    _raise_homebrew_error("No additional components available.")
+
+def remove(component_name):
+    """ Remove a component """
+    _raise_homebrew_error("Components cannot be removed.")
+
+def update(private=False, pre=False, link=None, additional_components=None):
+    """ Update the CLI and all installed components """
+    _raise_homebrew_error("Components cannot be updated.")


### PR DESCRIPTION
This PR will mean the CLI can be installed with `brew install azure-cli-2`. Merging this PR will not automatically make `brew install azure-cli-2` available as a separate PR has to be submitted to https://github.com/Homebrew/homebrew-core.

The package is built *from source*, not from the packages published on PyPI.

All command modules will be installed and now components cannot be installed after install-time.
If there's a new update to a component or a new component is added, a new Homebrew package is required.

A patch has been applied to `az component` commands as `brew` should be used to manage the Homebrew version of the CLI.

e.g.:
```
$ az component update
This operation is not available in the Homebrew version of the CLI.
Components cannot be updated. Run 'brew update'.
```

---
Example of the output from a `brew install azure-cli-2`
```
$ brew install azure-cli-2
==> Using the sandbox
==> Downloading https://github.com/Azure/azure-cli/archive/all-v0.1.0b11.tar.gz
Already downloaded: /Users/parallels/Library/Caches/Homebrew/azure-cli-2-0.1.0b11.tar.gz
==> Downloading https://gist.githubusercontent.com/derekbekoe/b753179bff1b25343cbf38fc90c8c170/raw/d67fd273447dbfdf0ba0f709bbf6cc95f497f21c/azure_cli_patch_component_010b11_custom.diff
######################################################################## 100.0%
==> Patching
==> Applying azure_cli_patch_component_010b11_custom.diff
patching file src/command_modules/azure-cli-component/azure/cli/command_modules/component/custom.py
==> Downloading https://files.pythonhosted.org/packages/5c/79/5dae7494b9f5ed061cff9a8ab8d6e1f02db352f3facf907d9eb614fb80e9/virtualenv-15.0.2.tar.gz
Already downloaded: /Users/parallels/Library/Caches/Homebrew/azure-cli-2--homebrew-virtualenv-15.0.2.tar.gz
==> ... [retracted]
==> /usr/local/Cellar/azure-cli-2/0.1.0b11/libexec/bin/pip install azure-cli azure-cli-acr azure-cli-acs azure-cli-appservice azure-cli-cloud azure-cli-component azure-cli-configure azure-cli-container azure-cli-context ...
==> Caveats
To complete tab completion set up:
  1. Modify your ~/.bash_profile (if the line doesn't already exist)
    $ echo "[ -f /usr/local/etc/bash_completion.d/az.completion ] && . /usr/local/etc/bash_completion.d/az.completion" >> ~/.bash_profile
  2. Restart your shell
    $ exec -l $SHELL
----
Get started with:
  $ az configure

Bash completion has been installed to:
  /usr/local/etc/bash_completion.d
==> Summary
🍺  /usr/local/Cellar/azure-cli-2/0.1.0b11: 5,744 files, 47.7M, built in 36 seconds
os-x--sierra-:0.1.0b11 parallels$
```