### PR TITLE
[Network] ExpressRoute peering client-side validation workaround

### DIFF
--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -223,6 +223,7 @@ register_cli_argument('network express-route', 'sku_tier', **enum_choice_list(Ex
 register_cli_argument('network express-route', 'bandwidth_in_mbps', options_list=('--bandwidth',))
 register_cli_argument('network express-route', 'service_provider_name', options_list=('--provider',))
 register_cli_argument('network express-route', 'device_path', options_list=('--path',), **enum_choice_list(device_path_values))
+register_cli_argument('network express-route', 'vlan_id', type=int)
 
 register_cli_argument('network express-route auth', 'circuit_name', circuit_name_type)
 register_cli_argument('network express-route auth', 'authorization_name', name_arg_type, id_part='child_name', help='Authorization name')

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
@@ -137,6 +137,7 @@ def validate_inbound_nat_rule_name_or_id(namespace):
 
 def validate_peering_type(namespace):
     if namespace.peering_type and namespace.peering_type == 'MicrosoftPeering':
+
         if not namespace.advertised_public_prefixes:
             raise CLIError(
                 'missing required MicrosoftPeering parameter --advertised-public-prefixes')
@@ -504,7 +505,6 @@ def process_vpn_connection_create_namespace(namespace):
     namespace.vnet_gateway1_id = \
         _validate_name_or_id(namespace, namespace.vnet_gateway1_id, 'virtualNetworkGateways')
 
-    # TODO: Check for existence to preclude wonkiness
     if namespace.express_route_circuit2_id:
         namespace.express_route_circuit2_id = \
             _validate_name_or_id(

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -895,15 +895,17 @@ def create_express_route_peering(
     """
     from azure.mgmt.network.models import \
         (ExpressRouteCircuitPeering, ExpressRouteCircuitPeeringConfig)
+    from azure.mgmt.network.models import ExpressRouteCircuitPeeringType as PeeringType
+    from azure.mgmt.network.models import ExpressRouteCircuitSkuTier as SkuTier
 
     # TODO: Remove workaround when issue #1574 is fixed in the service
     # region Issue #1574 workaround
     circuit = _network_client_factory().express_route_circuits.get(
         resource_group_name, circuit_name)
-    if peering_type == 'MicrosoftPeering' and circuit.sku.tier.lower() == 'standard':
+    if peering_type == PeeringType.microsoft_peering and circuit.sku.tier == SkuTier.standard:
         raise CLIError("MicrosoftPeering cannot be created on a 'Standard' SKU circuit")
     for peering in circuit.peerings:
-        if str(peering.vlan_id) == vlan_id:
+        if peering.vlan_id == vlan_id:
             raise CLIError(
                 "VLAN ID '{}' already in use by peering '{}'".format(vlan_id, peering.name))
     #endregion
@@ -912,7 +914,7 @@ def create_express_route_peering(
         advertised_public_prefixes=advertised_public_prefixes,
         customer_asn=customer_asn,
         routing_registry_name=routing_registry_name) \
-            if peering_type == 'MicrosoftPeering' else None
+            if peering_type == PeeringType.microsoft_peering else None
     peering = ExpressRouteCircuitPeering(
         peering_type=peering_type, peer_asn=peer_asn, vlan_id=vlan_id,
         primary_peer_address_prefix=primary_peer_address_prefix,

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_express_route.yaml
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_express_route.yaml
@@ -6,16 +6,16 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [cd2eba40-c22c-11e6-afed-a0b3ccf7272a]
+      x-ms-client-request-id: [9ebed66c-c2f8-11e6-9132-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/expressRouteServiceProviders?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"value\": [\r\n    {\r\n      \"name\"\
-        : \"AT&T Netbond Test\",\r\n      \"id\": \"/subscriptions//resourceGroups//providers/Microsoft.Network/expressRouteServiceProviders/\"\
+    body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"AT&T Netbond\
+        \ Test\",\r\n      \"id\": \"/subscriptions//resourceGroups//providers/Microsoft.Network/expressRouteServiceProviders/\"\
         ,\r\n      \"type\": \"Microsoft.Network/expressRouteServiceProviders\",\r\
         \n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\
         ,\r\n        \"peeringLocations\": [\r\n          \"Area51\",\r\n        \
@@ -154,49 +154,49 @@ interactions:
         \        \"offerName\": \"10Gbps\",\r\n            \"valueInMbps\": 10000\r\
         \n          }\r\n        ]\r\n      }\r\n    }\r\n  ]\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 18:59:36 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['9452']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:40:37 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateExpressRouteCircuit_2016-08-08/azuredeploy.json"},
-      "mode": "Incremental", "parameters": {"serviceProviderName": {"value": "Microsoft
-      ER Test"}, "circuitName": {"value": "circuit1"}, "sku_tier": {"value": "Standard"},
-      "sku_family": {"value": "MeteredData"}, "bandwidthInMbps": {"value": 50}, "peeringLocation":
-      {"value": "Area51"}}}}'
+    body: '{"properties": {"parameters": {"sku_family": {"value": "MeteredData"},
+      "peeringLocation": {"value": "Area51"}, "serviceProviderName": {"value": "Microsoft
+      ER Test"}, "circuitName": {"value": "circuit1"}, "bandwidthInMbps": {"value":
+      50}, "sku_tier": {"value": "Premium"}}, "templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateExpressRouteCircuit_2016-08-08/azuredeploy.json"},
+      "mode": "Incremental"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['433']
+      Content-Length: ['432']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 expressroutecircuitcreationclient/2015-11-01 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ce9aa64f-c22c-11e6-8011-a0b3ccf7272a]
+      x-ms-client-request-id: [a02e2826-c2f8-11e6-8b95-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_express_route/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Resources/deployments/mock-deployment","name":"mock-deployment","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateExpressRouteCircuit_2016-08-08/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"bandwidthInMbps":{"type":"Int","value":50},"circuitName":{"type":"String","value":"circuit1"},"location":{"type":"String","value":"westus"},"peeringLocation":{"type":"String","value":"Area51"},"serviceProviderName":{"type":"String","value":"Microsoft
-        ER Test"},"sku_family":{"type":"String","value":"MeteredData"},"sku_tier":{"type":"String","value":"Standard"},"tags":{"type":"Object","value":{}}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-12-14T18:40:39.8656477Z","duration":"PT0.4592912S","correlationId":"e116ade0-03df-4dd9-9730-7e5035e2fece","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"expressRouteCircuits","locations":["westus"]}]}],"dependencies":[]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Resources/deployments/azurecli1481828377.635620898809","name":"azurecli1481828377.635620898809","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateExpressRouteCircuit_2016-08-08/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"bandwidthInMbps":{"type":"Int","value":50},"circuitName":{"type":"String","value":"circuit1"},"location":{"type":"String","value":"westus"},"peeringLocation":{"type":"String","value":"Area51"},"serviceProviderName":{"type":"String","value":"Microsoft
+        ER Test"},"sku_family":{"type":"String","value":"MeteredData"},"sku_tier":{"type":"String","value":"Premium"},"tags":{"type":"Object","value":{}}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-12-15T18:59:39.4954808Z","duration":"PT0.7000545S","correlationId":"443e31f0-2670-4bca-87f9-f75bb9eb0db6","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"expressRouteCircuits","locations":["westus"]}]}],"dependencies":[]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_express_route/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587198660460712980?api-version=2015-11-01']
-      cache-control: [no-cache]
-      content-length: ['1099']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:40:39 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1189']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_express_route/providers/Microsoft.Resources/deployments/azurecli1481828377.635620898809/operationStatuses/08587197785066822322?api-version=2015-11-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['1130']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 18:59:39 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -205,50 +205,24 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 expressroutecircuitcreationclient/2015-11-01 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ce9aa64f-c22c-11e6-8011-a0b3ccf7272a]
+      x-ms-client-request-id: [a02e2826-c2f8-11e6-8b95-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_express_route/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587198660460712980?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_express_route/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587197785066822322?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"status":"Running"}'}
+    body: {string: '{"status":"Succeeded"}'}
     headers:
-      cache-control: [no-cache]
-      content-length: ['20']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:41:10 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
+      Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
-          msrest_azure/0.4.6 expressroutecircuitcreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [ce9aa64f-c22c-11e6-8011-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_express_route/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587198660460712980?api-version=2015-11-01
-  response:
-    body: {string: !!python/unicode '{"status":"Succeeded"}'}
-    headers:
-      cache-control: [no-cache]
+      Date: ['Thu, 15 Dec 2016 19:00:10 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
       content-length: ['22']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:41:39 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -257,25 +231,25 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 expressroutecircuitcreationclient/2015-11-01 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ce9aa64f-c22c-11e6-8011-a0b3ccf7272a]
+      x-ms-client-request-id: [a02e2826-c2f8-11e6-8b95-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_express_route/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Resources/deployments/mock-deployment","name":"mock-deployment","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateExpressRouteCircuit_2016-08-08/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"bandwidthInMbps":{"type":"Int","value":50},"circuitName":{"type":"String","value":"circuit1"},"location":{"type":"String","value":"westus"},"peeringLocation":{"type":"String","value":"Area51"},"serviceProviderName":{"type":"String","value":"Microsoft
-        ER Test"},"sku_family":{"type":"String","value":"MeteredData"},"sku_tier":{"type":"String","value":"Standard"},"tags":{"type":"Object","value":{}}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-12-14T18:41:14.7264065Z","duration":"PT35.32005S","correlationId":"e116ade0-03df-4dd9-9730-7e5035e2fece","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"expressRouteCircuits","locations":["westus"]}]}],"dependencies":[],"outputResources":[{"id":"Microsoft.Network/expressRouteCircuits/circuit1"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Resources/deployments/azurecli1481828377.635620898809","name":"azurecli1481828377.635620898809","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateExpressRouteCircuit_2016-08-08/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"bandwidthInMbps":{"type":"Int","value":50},"circuitName":{"type":"String","value":"circuit1"},"location":{"type":"String","value":"westus"},"peeringLocation":{"type":"String","value":"Area51"},"serviceProviderName":{"type":"String","value":"Microsoft
+        ER Test"},"sku_family":{"type":"String","value":"MeteredData"},"sku_tier":{"type":"String","value":"Premium"},"tags":{"type":"Object","value":{}}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-12-15T19:00:05.5568174Z","duration":"PT26.7613911S","correlationId":"443e31f0-2670-4bca-87f9-f75bb9eb0db6","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"expressRouteCircuits","locations":["westus"]}]}],"dependencies":[],"outputResources":[{"id":"Microsoft.Network/expressRouteCircuits/circuit1"}]}}'}
     headers:
-      cache-control: [no-cache]
-      content-length: ['1176']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:41:39 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:00:10 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['1209']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -284,50 +258,36 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f46ca80f-c22c-11e6-a3f3-a0b3ccf7272a]
+      x-ms-client-request-id: [b4aa29da-c2f8-11e6-a3bf-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/expressRouteCircuits?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"value\": [\r\n    {\r\n      \"name\"\
-        : \"circuit1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
-        ,\r\n      \"etag\": \"W/\\\"1c7b2a66-4273-4d55-94f7-df05e2e06c8c\\\"\",\r\
+    body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"circuit1\",\r\
+        \n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
+        ,\r\n      \"etag\": \"W/\\\"f4408626-1b99-432c-8154-42812ea9184d\\\"\",\r\
         \n      \"type\": \"Microsoft.Network/expressRouteCircuits\",\r\n      \"\
         location\": \"westus\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\
         \n        \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\"\
-        : \"f15c676f-c083-408b-9c73-7da2237a9a45\",\r\n        \"peerings\": [],\r\
+        : \"7e8482df-610d-487b-86aa-7cccb4a4cc8e\",\r\n        \"peerings\": [],\r\
         \n        \"authorizations\": [],\r\n        \"serviceProviderProperties\"\
         : {\r\n          \"serviceProviderName\": \"Microsoft ER Test\",\r\n     \
         \     \"peeringLocation\": \"Area51\",\r\n          \"bandwidthInMbps\": 50\r\
         \n        },\r\n        \"circuitProvisioningState\": \"Enabled\",\r\n   \
-        \     \"allowClassicOperations\": false,\r\n        \"serviceKey\": \"784187e7-015a-43d6-89ef-22beab7f9d73\"\
+        \     \"allowClassicOperations\": false,\r\n        \"serviceKey\": \"f10cee8a-8fdc-4dc3-b511-121370ff4fb1\"\
         ,\r\n        \"serviceProviderProvisioningState\": \"NotProvisioned\"\r\n\
-        \      },\r\n      \"sku\": {\r\n        \"name\": \"Standard_MeteredData\"\
-        ,\r\n        \"tier\": \"Standard\",\r\n        \"family\": \"MeteredData\"\
+        \      },\r\n      \"sku\": {\r\n        \"name\": \"Premium_MeteredData\"\
+        ,\r\n        \"tier\": \"Premium\",\r\n        \"family\": \"MeteredData\"\
         \r\n      }\r\n    },\r\n    {\r\n      \"name\": \"circuit1\",\r\n      \"\
         id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/errg/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
-        ,\r\n      \"etag\": \"W/\\\"737324a4-ff9f-4e6a-8967-8727cff6cdec\\\"\",\r\
+        ,\r\n      \"etag\": \"W/\\\"f44a3b3e-4f5d-4980-ad96-8c4c7c17c9d1\\\"\",\r\
         \n      \"type\": \"Microsoft.Network/expressRouteCircuits\",\r\n      \"\
         location\": \"westus\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\
-        \n        \"provisioningState\": \"Failed\",\r\n        \"resourceGuid\":\
-        \ \"c8515ed3-58b1-4acf-b1ea-ce5b3ab48cf7\",\r\n        \"peerings\": [\r\n\
-        \          {\r\n            \"name\": \"MicrosoftPeering\",\r\n          \
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/errg/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/MicrosoftPeering\"\
-        ,\r\n            \"etag\": \"W/\\\"737324a4-ff9f-4e6a-8967-8727cff6cdec\\\"\
-        \",\r\n            \"properties\": {\r\n              \"provisioningState\"\
-        : \"Updating\",\r\n              \"peeringType\": \"MicrosoftPeering\",\r\n\
-        \              \"azureASN\": 0,\r\n              \"peerASN\": 135313,\r\n\
-        \              \"primaryPeerAddressPrefix\": \"30.0.0.0/30\",\r\n        \
-        \      \"secondaryPeerAddressPrefix\": \"30.0.0.4/30\",\r\n              \"\
-        state\": \"Disabled\",\r\n              \"vlanId\": 551,\r\n             \
-        \ \"microsoftPeeringConfig\": {\r\n                \"advertisedPublicPrefixes\"\
-        : [\r\n                  \"103.207.92.40/29\"\r\n                ],\r\n  \
-        \              \"advertisedPublicPrefixesState\": \"NotConfigured\",\r\n \
-        \               \"customerASN\": 0,\r\n                \"routingRegistryName\"\
-        : \"NONE\"\r\n              }\r\n            }\r\n          }\r\n        ],\r\
+        \n        \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\"\
+        : \"c8515ed3-58b1-4acf-b1ea-ce5b3ab48cf7\",\r\n        \"peerings\": [],\r\
         \n        \"authorizations\": [],\r\n        \"serviceProviderProperties\"\
         : {\r\n          \"serviceProviderName\": \"Microsoft ER Test\",\r\n     \
         \     \"peeringLocation\": \"Area51\",\r\n          \"bandwidthInMbps\": 50\r\
@@ -338,16 +298,16 @@ interactions:
         \n        \"tier\": \"Premium\",\r\n        \"family\": \"MeteredData\"\r\n\
         \      }\r\n    }\r\n  ]\r\n}"}
     headers:
-      cache-control: [no-cache]
-      content-length: ['3212']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:41:41 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:00:11 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['2187']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -356,41 +316,41 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f4e49730-c22c-11e6-9380-a0b3ccf7272a]
+      x-ms-client-request-id: [b5440792-c2f8-11e6-addc-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"value\": [\r\n    {\r\n      \"name\"\
-        : \"circuit1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
-        ,\r\n      \"etag\": \"W/\\\"1c7b2a66-4273-4d55-94f7-df05e2e06c8c\\\"\",\r\
+    body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"circuit1\",\r\
+        \n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
+        ,\r\n      \"etag\": \"W/\\\"f4408626-1b99-432c-8154-42812ea9184d\\\"\",\r\
         \n      \"type\": \"Microsoft.Network/expressRouteCircuits\",\r\n      \"\
         location\": \"westus\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\
         \n        \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\"\
-        : \"f15c676f-c083-408b-9c73-7da2237a9a45\",\r\n        \"peerings\": [],\r\
+        : \"7e8482df-610d-487b-86aa-7cccb4a4cc8e\",\r\n        \"peerings\": [],\r\
         \n        \"authorizations\": [],\r\n        \"serviceProviderProperties\"\
         : {\r\n          \"serviceProviderName\": \"Microsoft ER Test\",\r\n     \
         \     \"peeringLocation\": \"Area51\",\r\n          \"bandwidthInMbps\": 50\r\
         \n        },\r\n        \"circuitProvisioningState\": \"Enabled\",\r\n   \
-        \     \"allowClassicOperations\": false,\r\n        \"serviceKey\": \"784187e7-015a-43d6-89ef-22beab7f9d73\"\
+        \     \"allowClassicOperations\": false,\r\n        \"serviceKey\": \"f10cee8a-8fdc-4dc3-b511-121370ff4fb1\"\
         ,\r\n        \"serviceProviderProvisioningState\": \"NotProvisioned\"\r\n\
-        \      },\r\n      \"sku\": {\r\n        \"name\": \"Standard_MeteredData\"\
-        ,\r\n        \"tier\": \"Standard\",\r\n        \"family\": \"MeteredData\"\
+        \      },\r\n      \"sku\": {\r\n        \"name\": \"Premium_MeteredData\"\
+        ,\r\n        \"tier\": \"Premium\",\r\n        \"family\": \"MeteredData\"\
         \r\n      }\r\n    }\r\n  ]\r\n}"}
     headers:
-      cache-control: [no-cache]
-      content-length: ['1120']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:41:42 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:00:13 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1118']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -399,39 +359,38 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f55cfb80-c22c-11e6-b52e-a0b3ccf7272a]
+      x-ms-client-request-id: [b5d6d8c0-c2f8-11e6-99d8-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"circuit1\",\r\n  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
-        ,\r\n  \"etag\": \"W/\\\"1c7b2a66-4273-4d55-94f7-df05e2e06c8c\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"circuit1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
+        ,\r\n  \"etag\": \"W/\\\"f4408626-1b99-432c-8154-42812ea9184d\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/expressRouteCircuits\",\r\n  \"location\"\
         : \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Succeeded\",\r\n    \"resourceGuid\": \"f15c676f-c083-408b-9c73-7da2237a9a45\"\
+        : \"Succeeded\",\r\n    \"resourceGuid\": \"7e8482df-610d-487b-86aa-7cccb4a4cc8e\"\
         ,\r\n    \"peerings\": [],\r\n    \"authorizations\": [],\r\n    \"serviceProviderProperties\"\
         : {\r\n      \"serviceProviderName\": \"Microsoft ER Test\",\r\n      \"peeringLocation\"\
         : \"Area51\",\r\n      \"bandwidthInMbps\": 50\r\n    },\r\n    \"circuitProvisioningState\"\
         : \"Enabled\",\r\n    \"allowClassicOperations\": false,\r\n    \"serviceKey\"\
-        : \"784187e7-015a-43d6-89ef-22beab7f9d73\",\r\n    \"serviceProviderProvisioningState\"\
-        : \"NotProvisioned\"\r\n  },\r\n  \"sku\": {\r\n    \"name\": \"Standard_MeteredData\"\
-        ,\r\n    \"tier\": \"Standard\",\r\n    \"family\": \"MeteredData\"\r\n  }\r\
+        : \"f10cee8a-8fdc-4dc3-b511-121370ff4fb1\",\r\n    \"serviceProviderProvisioningState\"\
+        : \"NotProvisioned\"\r\n  },\r\n  \"sku\": {\r\n    \"name\": \"Premium_MeteredData\"\
+        ,\r\n    \"tier\": \"Premium\",\r\n    \"family\": \"MeteredData\"\r\n  }\r\
         \n}"}
     headers:
-      cache-control: [no-cache]
-      content-length: ['983']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:41:42 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:00:13 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['981']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -440,27 +399,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f5d81eee-c22c-11e6-93fe-a0b3ccf7272a]
+      x-ms-client-request-id: [b67771f4-c2f8-11e6-be43-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/stats?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"primaryBytesIn\": 0,\r\n  \"primaryBytesOut\"\
-        : 0,\r\n  \"secondaryBytesIn\": 0,\r\n  \"secondaryBytesOut\": 0\r\n}"}
+    body: {string: "{\r\n  \"primaryBytesIn\": 0,\r\n  \"primaryBytesOut\": 0,\r\n\
+        \  \"secondaryBytesIn\": 0,\r\n  \"secondaryBytesOut\": 0\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:00:14 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['105']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:41:43 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -469,91 +428,88 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f69135c0-c22c-11e6-a603-a0b3ccf7272a]
+      x-ms-client-request-id: [b71fbe50-c2f8-11e6-af22-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"circuit1\",\r\n  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
-        ,\r\n  \"etag\": \"W/\\\"1c7b2a66-4273-4d55-94f7-df05e2e06c8c\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"circuit1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
+        ,\r\n  \"etag\": \"W/\\\"f4408626-1b99-432c-8154-42812ea9184d\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/expressRouteCircuits\",\r\n  \"location\"\
         : \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
-        : \"Succeeded\",\r\n    \"resourceGuid\": \"f15c676f-c083-408b-9c73-7da2237a9a45\"\
+        : \"Succeeded\",\r\n    \"resourceGuid\": \"7e8482df-610d-487b-86aa-7cccb4a4cc8e\"\
         ,\r\n    \"peerings\": [],\r\n    \"authorizations\": [],\r\n    \"serviceProviderProperties\"\
         : {\r\n      \"serviceProviderName\": \"Microsoft ER Test\",\r\n      \"peeringLocation\"\
         : \"Area51\",\r\n      \"bandwidthInMbps\": 50\r\n    },\r\n    \"circuitProvisioningState\"\
         : \"Enabled\",\r\n    \"allowClassicOperations\": false,\r\n    \"serviceKey\"\
-        : \"784187e7-015a-43d6-89ef-22beab7f9d73\",\r\n    \"serviceProviderProvisioningState\"\
-        : \"NotProvisioned\"\r\n  },\r\n  \"sku\": {\r\n    \"name\": \"Standard_MeteredData\"\
-        ,\r\n    \"tier\": \"Standard\",\r\n    \"family\": \"MeteredData\"\r\n  }\r\
+        : \"f10cee8a-8fdc-4dc3-b511-121370ff4fb1\",\r\n    \"serviceProviderProvisioningState\"\
+        : \"NotProvisioned\"\r\n  },\r\n  \"sku\": {\r\n    \"name\": \"Premium_MeteredData\"\
+        ,\r\n    \"tier\": \"Premium\",\r\n    \"family\": \"MeteredData\"\r\n  }\r\
         \n}"}
     headers:
-      cache-control: [no-cache]
-      content-length: ['983']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:41:45 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:00:15 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['981']
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"sku": {"tier": "Standard", "name": "Standard_MeteredData",
-      "family": "MeteredData"}, "etag": "W/\"1c7b2a66-4273-4d55-94f7-df05e2e06c8c\"",
-      "location": "westus", "tags": {"test": "Test"}, "properties": {"allowClassicOperations":
-      false, "serviceKey": "784187e7-015a-43d6-89ef-22beab7f9d73", "serviceProviderProvisioningState":
-      "NotProvisioned", "circuitProvisioningState": "Enabled", "authorizations": [],
-      "peerings": [], "serviceProviderProperties": {"serviceProviderName": "Microsoft
-      ER Test", "bandwidthInMbps": 50, "peeringLocation": "Area51"}, "provisioningState":
-      "Succeeded"}, "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1"}'
+    body: '{"sku": {"tier": "Premium", "name": "Premium_MeteredData", "family": "MeteredData"},
+      "tags": {"test": "Test"}, "properties": {"authorizations": [], "serviceProviderProperties":
+      {"bandwidthInMbps": 50, "peeringLocation": "Area51", "serviceProviderName":
+      "Microsoft ER Test"}, "circuitProvisioningState": "Enabled", "serviceProviderProvisioningState":
+      "NotProvisioned", "provisioningState": "Succeeded", "peerings": [], "serviceKey":
+      "f10cee8a-8fdc-4dc3-b511-121370ff4fb1", "allowClassicOperations": false}, "location":
+      "westus", "etag": "W/\"f4408626-1b99-432c-8154-42812ea9184d\"", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['746']
+      Content-Length: ['744']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f6d1c130-c22c-11e6-82ea-a0b3ccf7272a]
+      x-ms-client-request-id: [b791b636-c2f8-11e6-84f2-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"circuit1\",\r\n  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
-        ,\r\n  \"etag\": \"W/\\\"c848964c-9968-4653-bb8a-94c4d20000d2\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"circuit1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
+        ,\r\n  \"etag\": \"W/\\\"b9200bd7-94aa-4b8a-b4af-1d28e4ac07e1\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/expressRouteCircuits\",\r\n  \"location\"\
         : \"westus\",\r\n  \"tags\": {\r\n    \"test\": \"Test\"\r\n  },\r\n  \"properties\"\
         : {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":\
-        \ \"f15c676f-c083-408b-9c73-7da2237a9a45\",\r\n    \"peerings\": [],\r\n \
+        \ \"7e8482df-610d-487b-86aa-7cccb4a4cc8e\",\r\n    \"peerings\": [],\r\n \
         \   \"authorizations\": [],\r\n    \"serviceProviderProperties\": {\r\n  \
         \    \"serviceProviderName\": \"Microsoft ER Test\",\r\n      \"peeringLocation\"\
         : \"Area51\",\r\n      \"bandwidthInMbps\": 50\r\n    },\r\n    \"circuitProvisioningState\"\
         : \"Disabled\",\r\n    \"allowClassicOperations\": false,\r\n    \"serviceKey\"\
-        : \"784187e7-015a-43d6-89ef-22beab7f9d73\",\r\n    \"serviceProviderProvisioningState\"\
-        : \"NotProvisioned\"\r\n  },\r\n  \"sku\": {\r\n    \"name\": \"Standard_MeteredData\"\
-        ,\r\n    \"tier\": \"Standard\",\r\n    \"family\": \"MeteredData\"\r\n  }\r\
+        : \"f10cee8a-8fdc-4dc3-b511-121370ff4fb1\",\r\n    \"serviceProviderProvisioningState\"\
+        : \"NotProvisioned\"\r\n  },\r\n  \"sku\": {\r\n    \"name\": \"Premium_MeteredData\"\
+        ,\r\n    \"tier\": \"Premium\",\r\n    \"family\": \"MeteredData\"\r\n  }\r\
         \n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/7169f148-6989-468f-968a-4a485eb018ab?api-version=2016-06-01']
-      cache-control: [no-cache]
-      content-length: ['1008']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:41:46 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1187']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/d3ff4819-656b-4ba3-b5b2-8420c5908dc1?api-version=2016-06-01']
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:00:17 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1006']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -562,26 +518,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f6d1c130-c22c-11e6-82ea-a0b3ccf7272a]
+      x-ms-client-request-id: [b791b636-c2f8-11e6-84f2-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/7169f148-6989-468f-968a-4a485eb018ab?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/d3ff4819-656b-4ba3-b5b2-8420c5908dc1?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:00:48 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['29']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:42:16 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -590,74 +546,73 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f6d1c130-c22c-11e6-82ea-a0b3ccf7272a]
+      x-ms-client-request-id: [b791b636-c2f8-11e6-84f2-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"circuit1\",\r\n  \"id\": \"\
-        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
-        ,\r\n  \"etag\": \"W/\\\"c848964c-9968-4653-bb8a-94c4d20000d2\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"circuit1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
+        ,\r\n  \"etag\": \"W/\\\"b9200bd7-94aa-4b8a-b4af-1d28e4ac07e1\\\"\",\r\n \
         \ \"type\": \"Microsoft.Network/expressRouteCircuits\",\r\n  \"location\"\
         : \"westus\",\r\n  \"tags\": {\r\n    \"test\": \"Test\"\r\n  },\r\n  \"properties\"\
         : {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":\
-        \ \"f15c676f-c083-408b-9c73-7da2237a9a45\",\r\n    \"peerings\": [],\r\n \
+        \ \"7e8482df-610d-487b-86aa-7cccb4a4cc8e\",\r\n    \"peerings\": [],\r\n \
         \   \"authorizations\": [],\r\n    \"serviceProviderProperties\": {\r\n  \
         \    \"serviceProviderName\": \"Microsoft ER Test\",\r\n      \"peeringLocation\"\
         : \"Area51\",\r\n      \"bandwidthInMbps\": 50\r\n    },\r\n    \"circuitProvisioningState\"\
         : \"Enabled\",\r\n    \"allowClassicOperations\": false,\r\n    \"serviceKey\"\
-        : \"784187e7-015a-43d6-89ef-22beab7f9d73\",\r\n    \"serviceProviderProvisioningState\"\
-        : \"NotProvisioned\"\r\n  },\r\n  \"sku\": {\r\n    \"name\": \"Standard_MeteredData\"\
-        ,\r\n    \"tier\": \"Standard\",\r\n    \"family\": \"MeteredData\"\r\n  }\r\
+        : \"f10cee8a-8fdc-4dc3-b511-121370ff4fb1\",\r\n    \"serviceProviderProvisioningState\"\
+        : \"NotProvisioned\"\r\n  },\r\n  \"sku\": {\r\n    \"name\": \"Premium_MeteredData\"\
+        ,\r\n    \"tier\": \"Premium\",\r\n    \"family\": \"MeteredData\"\r\n  }\r\
         \n}"}
     headers:
-      cache-control: [no-cache]
-      content-length: ['1007']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:42:16 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:00:49 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1005']
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{}'
+    body: '{}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['2']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [09ce9830-c22d-11e6-bb09-a0b3ccf7272a]
+      x-ms-client-request-id: [cb56905a-c2f8-11e6-aace-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/authorizations/auth1?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"auth1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/authorizations/auth1\"\
-        ,\r\n  \"etag\": \"W/\\\"537b2c63-bf0f-435d-807f-442612f9e9d4\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"auth1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/authorizations/auth1\"\
+        ,\r\n  \"etag\": \"W/\\\"19fab41f-cf8c-4a85-a97c-519b7f334f39\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
-        authorizationKey\": \"671f2f34-3500-43a6-a8cd-12f1ee49166a\",\r\n    \"authorizationUseStatus\"\
+        authorizationKey\": \"19d5281c-8500-48a0-a2c0-2d2d39677fc7\",\r\n    \"authorizationUseStatus\"\
         : \"Available\"\r\n  }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/7deb1da9-6d57-4bf0-a545-766bbfb52a18?api-version=2016-06-01']
-      cache-control: [no-cache]
-      content-length: ['438']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:42:17 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1193']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/8456dc1a-5ad9-4267-bc92-286143155c17?api-version=2016-06-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['438']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:00:50 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -666,26 +621,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [09ce9830-c22d-11e6-bb09-a0b3ccf7272a]
+      x-ms-client-request-id: [cb56905a-c2f8-11e6-aace-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/7deb1da9-6d57-4bf0-a545-766bbfb52a18?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/8456dc1a-5ad9-4267-bc92-286143155c17?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:01:00 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['29']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:42:27 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -694,30 +649,30 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [09ce9830-c22d-11e6-bb09-a0b3ccf7272a]
+      x-ms-client-request-id: [cb56905a-c2f8-11e6-aace-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/authorizations/auth1?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"auth1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/authorizations/auth1\"\
-        ,\r\n  \"etag\": \"W/\\\"4d9ba0ba-8407-4ec5-b969-88b787b0f4fd\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"auth1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/authorizations/auth1\"\
+        ,\r\n  \"etag\": \"W/\\\"d7f6d1b9-e19c-4ac3-a372-cc7c13f7687e\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        authorizationKey\": \"671f2f34-3500-43a6-a8cd-12f1ee49166a\",\r\n    \"authorizationUseStatus\"\
+        authorizationKey\": \"19d5281c-8500-48a0-a2c0-2d2d39677fc7\",\r\n    \"authorizationUseStatus\"\
         : \"Available\"\r\n  }\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:01:01 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['439']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:42:29 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -726,32 +681,32 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [112d7f0f-c22d-11e6-8921-a0b3ccf7272a]
+      x-ms-client-request-id: [d2be3ff8-c2f8-11e6-abe4-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/authorizations?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"value\": [\r\n    {\r\n      \"name\"\
-        : \"auth1\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/authorizations/auth1\"\
-        ,\r\n      \"etag\": \"W/\\\"4d9ba0ba-8407-4ec5-b969-88b787b0f4fd\\\"\",\r\
+    body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"auth1\",\r\n\
+        \      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/authorizations/auth1\"\
+        ,\r\n      \"etag\": \"W/\\\"d7f6d1b9-e19c-4ac3-a372-cc7c13f7687e\\\"\",\r\
         \n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\
-        ,\r\n        \"authorizationKey\": \"671f2f34-3500-43a6-a8cd-12f1ee49166a\"\
+        ,\r\n        \"authorizationKey\": \"19d5281c-8500-48a0-a2c0-2d2d39677fc7\"\
         ,\r\n        \"authorizationUseStatus\": \"Available\"\r\n      }\r\n    }\r\
         \n  ]\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:01:02 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['504']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:42:29 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -760,30 +715,30 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [11ca3440-c22d-11e6-b34f-a0b3ccf7272a]
+      x-ms-client-request-id: [d346e10a-c2f8-11e6-b718-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/authorizations/auth1?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"auth1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/authorizations/auth1\"\
-        ,\r\n  \"etag\": \"W/\\\"4d9ba0ba-8407-4ec5-b969-88b787b0f4fd\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"auth1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/authorizations/auth1\"\
+        ,\r\n  \"etag\": \"W/\\\"d7f6d1b9-e19c-4ac3-a372-cc7c13f7687e\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
-        authorizationKey\": \"671f2f34-3500-43a6-a8cd-12f1ee49166a\",\r\n    \"authorizationUseStatus\"\
+        authorizationKey\": \"19d5281c-8500-48a0-a2c0-2d2d39677fc7\",\r\n    \"authorizationUseStatus\"\
         : \"Available\"\r\n  }\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:01:03 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['439']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:42:30 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -793,27 +748,27 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [125dc1ae-c22d-11e6-b0df-a0b3ccf7272a]
+      x-ms-client-request-id: [d3d27078-c2f8-11e6-b239-a0b3ccf7272a]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/authorizations/auth1?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/b85a3526-8e7b-47be-9acc-6fb4a6a09ce8?api-version=2016-06-01']
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Wed, 14 Dec 2016 18:42:31 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/b85a3526-8e7b-47be-9acc-6fb4a6a09ce8?api-version=2016-06-01']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/057a9d3b-ac4a-46f7-9729-8f998bb3a408?api-version=2016-06-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Thu, 15 Dec 2016 19:01:04 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/057a9d3b-ac4a-46f7-9729-8f998bb3a408?api-version=2016-06-01']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1194']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -822,27 +777,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [125dc1ae-c22d-11e6-b0df-a0b3ccf7272a]
+      x-ms-client-request-id: [d3d27078-c2f8-11e6-b239-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/b85a3526-8e7b-47be-9acc-6fb4a6a09ce8?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/057a9d3b-ac4a-46f7-9729-8f998bb3a408?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:01:15 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['30']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:42:42 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -851,26 +806,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [125dc1ae-c22d-11e6-b0df-a0b3ccf7272a]
+      x-ms-client-request-id: [d3d27078-c2f8-11e6-b239-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/b85a3526-8e7b-47be-9acc-6fb4a6a09ce8?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/057a9d3b-ac4a-46f7-9729-8f998bb3a408?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:01:25 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['29']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:42:52 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -879,64 +834,104 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [1fbdad21-c22d-11e6-a789-a0b3ccf7272a]
+      x-ms-client-request-id: [e127b22c-c2f8-11e6-a362-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/authorizations?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"value\": []\r\n}"}
+    body: {string: "{\r\n  \"value\": []\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:01:26 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['19']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:42:54 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"properties": {"secondaryPeerAddressPrefix": "101.0.0.0/30",
-      "peeringType": "AzurePublicPeering", "vlanId": 100, "primaryPeerAddressPrefix":
-      "100.0.0.0/30", "peerASN": 10000}}'
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
+          msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e1baace8-c2f8-11e6-a6e8-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1?api-version=2016-06-01
+  response:
+    body: {string: "{\r\n  \"name\": \"circuit1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
+        ,\r\n  \"etag\": \"W/\\\"1602319d-85b3-4fdb-980d-75497f34bd33\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/expressRouteCircuits\",\r\n  \"location\"\
+        : \"westus\",\r\n  \"tags\": {\r\n    \"test\": \"Test\"\r\n  },\r\n  \"properties\"\
+        : {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":\
+        \ \"7e8482df-610d-487b-86aa-7cccb4a4cc8e\",\r\n    \"peerings\": [],\r\n \
+        \   \"authorizations\": [],\r\n    \"serviceProviderProperties\": {\r\n  \
+        \    \"serviceProviderName\": \"Microsoft ER Test\",\r\n      \"peeringLocation\"\
+        : \"Area51\",\r\n      \"bandwidthInMbps\": 50\r\n    },\r\n    \"circuitProvisioningState\"\
+        : \"Enabled\",\r\n    \"allowClassicOperations\": false,\r\n    \"serviceKey\"\
+        : \"f10cee8a-8fdc-4dc3-b511-121370ff4fb1\",\r\n    \"serviceProviderProvisioningState\"\
+        : \"NotProvisioned\"\r\n  },\r\n  \"sku\": {\r\n    \"name\": \"Premium_MeteredData\"\
+        ,\r\n    \"tier\": \"Premium\",\r\n    \"family\": \"MeteredData\"\r\n  }\r\
+        \n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:01:27 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1005']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"primaryPeerAddressPrefix": "100.0.0.0/30", "vlanId": 100,
+      "peeringType": "AzurePublicPeering", "secondaryPeerAddressPrefix": "101.0.0.0/30",
+      "peerASN": 10000}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['176']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [202fa8cf-c22d-11e6-a534-a0b3ccf7272a]
+      x-ms-client-request-id: [e21006ac-c2f8-11e6-8cf1-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"AzurePublicPeering\",\r\n\
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering\"\
-        ,\r\n  \"etag\": \"W/\\\"05cf35d9-2302-428d-a5e4-defeac6360a9\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"AzurePublicPeering\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering\"\
+        ,\r\n  \"etag\": \"W/\\\"6192dac8-1911-43d8-a85d-c4344f9b4e90\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
         peeringType\": \"AzurePublicPeering\",\r\n    \"azureASN\": 0,\r\n    \"peerASN\"\
         : 10000,\r\n    \"primaryPeerAddressPrefix\": \"100.0.0.0/30\",\r\n    \"\
         secondaryPeerAddressPrefix\": \"101.0.0.0/30\",\r\n    \"state\": \"Disabled\"\
         ,\r\n    \"vlanId\": 100\r\n  }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/74294626-cd9e-43ff-a141-f1dcc6cfd436?api-version=2016-06-01']
-      cache-control: [no-cache]
-      content-length: ['580']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:42:55 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/665870bf-4a9b-4d4b-a576-3befc6a6f6e3?api-version=2016-06-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['580']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:01:27 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
@@ -946,27 +941,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [202fa8cf-c22d-11e6-a534-a0b3ccf7272a]
+      x-ms-client-request-id: [e21006ac-c2f8-11e6-8cf1-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/74294626-cd9e-43ff-a141-f1dcc6cfd436?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/665870bf-4a9b-4d4b-a576-3befc6a6f6e3?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:01:38 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['30']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:43:06 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -975,26 +970,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [202fa8cf-c22d-11e6-a534-a0b3ccf7272a]
+      x-ms-client-request-id: [e21006ac-c2f8-11e6-8cf1-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/74294626-cd9e-43ff-a141-f1dcc6cfd436?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/665870bf-4a9b-4d4b-a576-3befc6a6f6e3?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:01:48 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['29']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:43:16 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1003,17 +998,16 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [202fa8cf-c22d-11e6-a534-a0b3ccf7272a]
+      x-ms-client-request-id: [e21006ac-c2f8-11e6-8cf1-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"AzurePublicPeering\",\r\n\
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering\"\
-        ,\r\n  \"etag\": \"W/\\\"c992762f-1c31-49c8-a17a-3a92bbc03f54\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"AzurePublicPeering\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering\"\
+        ,\r\n  \"etag\": \"W/\\\"8e2ec096-6fc3-4052-b4ad-d0003fb20a1f\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
         peeringType\": \"AzurePublicPeering\",\r\n    \"azureASN\": 12076,\r\n   \
         \ \"peerASN\": 10000,\r\n    \"primaryPeerAddressPrefix\": \"100.0.0.0/30\"\
@@ -1021,55 +1015,103 @@ interactions:
         : \"A51-TEST-06GMR-CIS-1-PRI-A\",\r\n    \"secondaryAzurePort\": \"A51-TEST-06GMR-CIS-2-SEC-A\"\
         ,\r\n    \"state\": \"Enabled\",\r\n    \"vlanId\": 100\r\n  }\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:01:49 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['696']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:43:16 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"properties": {"secondaryPeerAddressPrefix": "103.0.0.0/30",
-      "peeringType": "AzurePrivatePeering", "vlanId": 101, "primaryPeerAddressPrefix":
-      "102.0.0.0/30", "peerASN": 10001}}'
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
+          msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [f000d478-c2f8-11e6-93b6-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1?api-version=2016-06-01
+  response:
+    body: {string: "{\r\n  \"name\": \"circuit1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
+        ,\r\n  \"etag\": \"W/\\\"8e2ec096-6fc3-4052-b4ad-d0003fb20a1f\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/expressRouteCircuits\",\r\n  \"location\"\
+        : \"westus\",\r\n  \"tags\": {\r\n    \"test\": \"Test\"\r\n  },\r\n  \"properties\"\
+        : {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":\
+        \ \"7e8482df-610d-487b-86aa-7cccb4a4cc8e\",\r\n    \"peerings\": [\r\n   \
+        \   {\r\n        \"name\": \"AzurePublicPeering\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering\"\
+        ,\r\n        \"etag\": \"W/\\\"8e2ec096-6fc3-4052-b4ad-d0003fb20a1f\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"peeringType\": \"AzurePublicPeering\",\r\n          \"azureASN\"\
+        : 12076,\r\n          \"peerASN\": 10000,\r\n          \"primaryPeerAddressPrefix\"\
+        : \"100.0.0.0/30\",\r\n          \"secondaryPeerAddressPrefix\": \"101.0.0.0/30\"\
+        ,\r\n          \"primaryAzurePort\": \"\",\r\n          \"secondaryAzurePort\"\
+        : \"\",\r\n          \"state\": \"Enabled\",\r\n          \"vlanId\": 100\r\
+        \n        }\r\n      }\r\n    ],\r\n    \"authorizations\": [],\r\n    \"\
+        serviceProviderProperties\": {\r\n      \"serviceProviderName\": \"Microsoft\
+        \ ER Test\",\r\n      \"peeringLocation\": \"Area51\",\r\n      \"bandwidthInMbps\"\
+        : 50\r\n    },\r\n    \"circuitProvisioningState\": \"Enabled\",\r\n    \"\
+        allowClassicOperations\": false,\r\n    \"serviceKey\": \"f10cee8a-8fdc-4dc3-b511-121370ff4fb1\"\
+        ,\r\n    \"serviceProviderProvisioningState\": \"NotProvisioned\"\r\n  },\r\
+        \n  \"sku\": {\r\n    \"name\": \"Premium_MeteredData\",\r\n    \"tier\":\
+        \ \"Premium\",\r\n    \"family\": \"MeteredData\"\r\n  }\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:01:51 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1759']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"primaryPeerAddressPrefix": "102.0.0.0/30", "vlanId": 101,
+      "peeringType": "AzurePrivatePeering", "secondaryPeerAddressPrefix": "103.0.0.0/30",
+      "peerASN": 10001}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['177']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2e267d0f-c22d-11e6-9b96-a0b3ccf7272a]
+      x-ms-client-request-id: [f078b768-c2f8-11e6-a913-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePrivatePeering?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"AzurePrivatePeering\",\r\n\
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePrivatePeering\"\
-        ,\r\n  \"etag\": \"W/\\\"9d2e069c-14f1-4b83-888e-b3c3b75bbe26\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"AzurePrivatePeering\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePrivatePeering\"\
+        ,\r\n  \"etag\": \"W/\\\"3684c0b1-bafc-4541-874f-72089ed8a7b8\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
         peeringType\": \"AzurePrivatePeering\",\r\n    \"azureASN\": 0,\r\n    \"\
         peerASN\": 10001,\r\n    \"primaryPeerAddressPrefix\": \"102.0.0.0/30\",\r\
         \n    \"secondaryPeerAddressPrefix\": \"103.0.0.0/30\",\r\n    \"state\":\
         \ \"Disabled\",\r\n    \"vlanId\": 101\r\n  }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/1e7ea8f3-fd42-4aab-9568-91aa16b696ae?api-version=2016-06-01']
-      cache-control: [no-cache]
-      content-length: ['583']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:43:18 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1193']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/eb90afad-68b0-4a7d-b0b9-8abed59ac274?api-version=2016-06-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['583']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:01:52 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -1078,27 +1120,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2e267d0f-c22d-11e6-9b96-a0b3ccf7272a]
+      x-ms-client-request-id: [f078b768-c2f8-11e6-a913-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1e7ea8f3-fd42-4aab-9568-91aa16b696ae?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/eb90afad-68b0-4a7d-b0b9-8abed59ac274?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:02:02 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['30']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:43:28 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1107,26 +1149,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2e267d0f-c22d-11e6-9b96-a0b3ccf7272a]
+      x-ms-client-request-id: [f078b768-c2f8-11e6-a913-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1e7ea8f3-fd42-4aab-9568-91aa16b696ae?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/eb90afad-68b0-4a7d-b0b9-8abed59ac274?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
-      cache-control: [no-cache]
-      content-length: ['29']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:43:38 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:02:13 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1135,17 +1178,44 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2e267d0f-c22d-11e6-9b96-a0b3ccf7272a]
+      x-ms-client-request-id: [f078b768-c2f8-11e6-a913-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/eb90afad-68b0-4a7d-b0b9-8abed59ac274?api-version=2016-06-01
+  response:
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:02:23 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['29']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
+          msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [f078b768-c2f8-11e6-a913-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePrivatePeering?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"AzurePrivatePeering\",\r\n\
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePrivatePeering\"\
-        ,\r\n  \"etag\": \"W/\\\"996c82a9-69cc-487d-85c8-37be5d53d462\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"AzurePrivatePeering\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePrivatePeering\"\
+        ,\r\n  \"etag\": \"W/\\\"c8668db8-53e5-4171-8fce-634bf7ff4711\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
         peeringType\": \"AzurePrivatePeering\",\r\n    \"azureASN\": 12076,\r\n  \
         \  \"peerASN\": 10001,\r\n    \"primaryPeerAddressPrefix\": \"102.0.0.0/30\"\
@@ -1153,39 +1223,96 @@ interactions:
         : \"A51-TEST-06GMR-CIS-1-PRI-A\",\r\n    \"secondaryAzurePort\": \"A51-TEST-06GMR-CIS-2-SEC-A\"\
         ,\r\n    \"state\": \"Enabled\",\r\n    \"vlanId\": 101\r\n  }\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:02:23 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['699']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:43:39 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"properties": {"secondaryPeerAddressPrefix": "105.0.0.0/30",
-      "microsoftPeeringConfig": {"routingRegistryName": "LEVEL3", "advertisedPublicPrefixes":
-      ["104.0.0.0/30"], "customerASN": 10000}, "primaryPeerAddressPrefix": "104.0.0.0/30",
-      "peerASN": 10002, "vlanId": 103, "peeringType": "MicrosoftPeering"}}'
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
+          msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [046653c6-c2f9-11e6-bdbf-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1?api-version=2016-06-01
+  response:
+    body: {string: "{\r\n  \"name\": \"circuit1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1\"\
+        ,\r\n  \"etag\": \"W/\\\"c8668db8-53e5-4171-8fce-634bf7ff4711\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/expressRouteCircuits\",\r\n  \"location\"\
+        : \"westus\",\r\n  \"tags\": {\r\n    \"test\": \"Test\"\r\n  },\r\n  \"properties\"\
+        : {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":\
+        \ \"7e8482df-610d-487b-86aa-7cccb4a4cc8e\",\r\n    \"peerings\": [\r\n   \
+        \   {\r\n        \"name\": \"AzurePublicPeering\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering\"\
+        ,\r\n        \"etag\": \"W/\\\"c8668db8-53e5-4171-8fce-634bf7ff4711\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"peeringType\": \"AzurePublicPeering\",\r\n          \"azureASN\"\
+        : 12076,\r\n          \"peerASN\": 10000,\r\n          \"primaryPeerAddressPrefix\"\
+        : \"100.0.0.0/30\",\r\n          \"secondaryPeerAddressPrefix\": \"101.0.0.0/30\"\
+        ,\r\n          \"primaryAzurePort\": \"\",\r\n          \"secondaryAzurePort\"\
+        : \"\",\r\n          \"state\": \"Enabled\",\r\n          \"vlanId\": 100\r\
+        \n        }\r\n      },\r\n      {\r\n        \"name\": \"AzurePrivatePeering\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePrivatePeering\"\
+        ,\r\n        \"etag\": \"W/\\\"c8668db8-53e5-4171-8fce-634bf7ff4711\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"peeringType\": \"AzurePrivatePeering\",\r\n          \"azureASN\"\
+        : 12076,\r\n          \"peerASN\": 10001,\r\n          \"primaryPeerAddressPrefix\"\
+        : \"102.0.0.0/30\",\r\n          \"secondaryPeerAddressPrefix\": \"103.0.0.0/30\"\
+        ,\r\n          \"primaryAzurePort\": \"\",\r\n          \"secondaryAzurePort\"\
+        : \"\",\r\n          \"state\": \"Enabled\",\r\n          \"vlanId\": 101\r\
+        \n        }\r\n      }\r\n    ],\r\n    \"authorizations\": [],\r\n    \"\
+        serviceProviderProperties\": {\r\n      \"serviceProviderName\": \"Microsoft\
+        \ ER Test\",\r\n      \"peeringLocation\": \"Area51\",\r\n      \"bandwidthInMbps\"\
+        : 50\r\n    },\r\n    \"circuitProvisioningState\": \"Enabled\",\r\n    \"\
+        allowClassicOperations\": false,\r\n    \"serviceKey\": \"f10cee8a-8fdc-4dc3-b511-121370ff4fb1\"\
+        ,\r\n    \"serviceProviderProvisioningState\": \"NotProvisioned\"\r\n  },\r\
+        \n  \"sku\": {\r\n    \"name\": \"Premium_MeteredData\",\r\n    \"tier\":\
+        \ \"Premium\",\r\n    \"family\": \"MeteredData\"\r\n  }\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:02:25 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['2511']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"properties": {"primaryPeerAddressPrefix": "104.0.0.0/30", "peerASN":
+      10002, "microsoftPeeringConfig": {"routingRegistryName": "LEVEL3", "advertisedPublicPrefixes":
+      ["104.0.0.0/30"], "customerASN": 10000}, "vlanId": 103, "peeringType": "MicrosoftPeering",
+      "secondaryPeerAddressPrefix": "105.0.0.0/30"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['303']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [3b7cf2a1-c22d-11e6-b868-a0b3ccf7272a]
+      x-ms-client-request-id: [04b1fe00-c2f9-11e6-aa60-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/MicrosoftPeering?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"MicrosoftPeering\",\r\n  \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/MicrosoftPeering\"\
-        ,\r\n  \"etag\": \"W/\\\"5b010361-c124-4bb6-80e9-fade4f5f3ed3\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"MicrosoftPeering\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/MicrosoftPeering\"\
+        ,\r\n  \"etag\": \"W/\\\"58c5a99c-a41f-4c19-9833-def326213d54\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
         peeringType\": \"MicrosoftPeering\",\r\n    \"azureASN\": 0,\r\n    \"peerASN\"\
         : 10002,\r\n    \"primaryPeerAddressPrefix\": \"104.0.0.0/30\",\r\n    \"\
@@ -1195,17 +1322,17 @@ interactions:
         \      \"advertisedPublicPrefixesState\": \"NotConfigured\",\r\n      \"customerASN\"\
         : 10000,\r\n      \"routingRegistryName\": \"LEVEL3\"\r\n    }\r\n  }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/b6e5e97c-24a6-4732-bc41-c29545213c0d?api-version=2016-06-01']
-      cache-control: [no-cache]
-      content-length: ['811']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:43:41 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1192']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/1f907c53-f253-4eed-8e0d-cf71784fa50e?api-version=2016-06-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['811']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:02:26 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -1214,28 +1341,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [3b7cf2a1-c22d-11e6-b868-a0b3ccf7272a]
+      x-ms-client-request-id: [04b1fe00-c2f9-11e6-aa60-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/b6e5e97c-24a6-4732-bc41-c29545213c0d?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/1f907c53-f253-4eed-8e0d-cf71784fa50e?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"Failed\",\r\n  \"error\"\
-        : {\r\n    \"code\": \"InternalServerError\",\r\n    \"message\": \"An error\
-        \ occured.\",\r\n    \"details\": []\r\n  }\r\n}"}
+    body: {string: "{\r\n  \"status\": \"Failed\",\r\n  \"error\": {\r\n    \"code\"\
+        : \"InternalServerError\",\r\n    \"message\": \"An error occured.\",\r\n\
+        \    \"details\": []\r\n  }\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:02:37 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['138']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:43:51 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1244,17 +1371,16 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [424f29e1-c22d-11e6-9d65-a0b3ccf7272a]
+      x-ms-client-request-id: [0b78699c-c2f9-11e6-a1b7-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/MicrosoftPeering?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"MicrosoftPeering\",\r\n  \"\
-        id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/MicrosoftPeering\"\
-        ,\r\n  \"etag\": \"W/\\\"d987851e-1e66-4520-974a-446ed96d3e2c\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"MicrosoftPeering\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/MicrosoftPeering\"\
+        ,\r\n  \"etag\": \"W/\\\"58ac83dc-ea14-44f4-a6d8-2be177e84493\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Failed\",\r\n    \"peeringType\"\
         : \"MicrosoftPeering\",\r\n    \"azureASN\": 0,\r\n    \"peerASN\": 10002,\r\
         \n    \"primaryPeerAddressPrefix\": \"104.0.0.0/30\",\r\n    \"secondaryPeerAddressPrefix\"\
@@ -1264,16 +1390,16 @@ interactions:
         : \"NotConfigured\",\r\n      \"customerASN\": 10000,\r\n      \"routingRegistryName\"\
         : \"LEVEL3\"\r\n    }\r\n  }\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:02:37 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['809']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:43:52 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1283,27 +1409,27 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [42b20a61-c22d-11e6-b88f-a0b3ccf7272a]
+      x-ms-client-request-id: [0bfd230a-c2f9-11e6-8c56-a0b3ccf7272a]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/MicrosoftPeering?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/511f7e79-0f34-44cd-8f56-347ac1a63c1d?api-version=2016-06-01']
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Wed, 14 Dec 2016 18:43:52 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/511f7e79-0f34-44cd-8f56-347ac1a63c1d?api-version=2016-06-01']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1191']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/84afedb3-f6a6-4f4e-a714-34f3284c3377?api-version=2016-06-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Thu, 15 Dec 2016 19:02:38 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/84afedb3-f6a6-4f4e-a714-34f3284c3377?api-version=2016-06-01']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -1312,26 +1438,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [42b20a61-c22d-11e6-b88f-a0b3ccf7272a]
+      x-ms-client-request-id: [0bfd230a-c2f9-11e6-8c56-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/511f7e79-0f34-44cd-8f56-347ac1a63c1d?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/84afedb3-f6a6-4f4e-a714-34f3284c3377?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:02:51 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['29']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:44:02 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1340,17 +1466,17 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [4977e58f-c22d-11e6-8ada-a0b3ccf7272a]
+      x-ms-client-request-id: [13f4ec92-c2f9-11e6-9aea-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"value\": [\r\n    {\r\n      \"name\"\
-        : \"AzurePublicPeering\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering\"\
-        ,\r\n      \"etag\": \"W/\\\"dc594b13-8742-4906-ac59-ee9941d139c0\\\"\",\r\
+    body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"AzurePublicPeering\"\
+        ,\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering\"\
+        ,\r\n      \"etag\": \"W/\\\"b7d15243-b0d5-4c3e-ae27-f1f1762692de\\\"\",\r\
         \n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\
         ,\r\n        \"peeringType\": \"AzurePublicPeering\",\r\n        \"azureASN\"\
         : 12076,\r\n        \"peerASN\": 10000,\r\n        \"primaryPeerAddressPrefix\"\
@@ -1359,7 +1485,7 @@ interactions:
         \     \"secondaryAzurePort\": \"A51-TEST-06GMR-CIS-2-SEC-A\",\r\n        \"\
         state\": \"Enabled\",\r\n        \"vlanId\": 100\r\n      }\r\n    },\r\n\
         \    {\r\n      \"name\": \"AzurePrivatePeering\",\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePrivatePeering\"\
-        ,\r\n      \"etag\": \"W/\\\"dc594b13-8742-4906-ac59-ee9941d139c0\\\"\",\r\
+        ,\r\n      \"etag\": \"W/\\\"b7d15243-b0d5-4c3e-ae27-f1f1762692de\\\"\",\r\
         \n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\
         ,\r\n        \"peeringType\": \"AzurePrivatePeering\",\r\n        \"azureASN\"\
         : 12076,\r\n        \"peerASN\": 10001,\r\n        \"primaryPeerAddressPrefix\"\
@@ -1369,16 +1495,16 @@ interactions:
         state\": \"Enabled\",\r\n        \"vlanId\": 101\r\n      }\r\n    }\r\n \
         \ ]\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:02:52 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['1559']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:44:05 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1387,17 +1513,16 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [4a8fbe30-c22d-11e6-9ee1-a0b3ccf7272a]
+      x-ms-client-request-id: [15033eb0-c2f9-11e6-ae8c-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"AzurePublicPeering\",\r\n\
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering\"\
-        ,\r\n  \"etag\": \"W/\\\"dc594b13-8742-4906-ac59-ee9941d139c0\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"AzurePublicPeering\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering\"\
+        ,\r\n  \"etag\": \"W/\\\"b7d15243-b0d5-4c3e-ae27-f1f1762692de\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
         peeringType\": \"AzurePublicPeering\",\r\n    \"azureASN\": 12076,\r\n   \
         \ \"peerASN\": 10000,\r\n    \"primaryPeerAddressPrefix\": \"100.0.0.0/30\"\
@@ -1405,41 +1530,40 @@ interactions:
         : \"A51-TEST-06GMR-CIS-1-PRI-A\",\r\n    \"secondaryAzurePort\": \"A51-TEST-06GMR-CIS-2-SEC-A\"\
         ,\r\n    \"state\": \"Enabled\",\r\n    \"vlanId\": 100\r\n  }\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:02:53 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['696']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:44:06 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '{"id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering",
-      "etag": "W/\"dc594b13-8742-4906-ac59-ee9941d139c0\"", "name": "AzurePublicPeering",
-      "properties": {"secondaryAzurePort": "A51-TEST-06GMR-CIS-2-SEC-A", "secondaryPeerAddressPrefix":
-      "101.0.0.0/30", "state": "Enabled", "vlanId": 200, "azureASN": 12076, "primaryPeerAddressPrefix":
-      "100.0.0.0/30", "peeringType": "AzurePublicPeering", "peerASN": 10000, "primaryAzurePort":
-      "A51-TEST-06GMR-CIS-1-PRI-A", "provisioningState": "Succeeded"}}'
+    body: '{"properties": {"primaryPeerAddressPrefix": "100.0.0.0/30", "provisioningState":
+      "Succeeded", "secondaryPeerAddressPrefix": "101.0.0.0/30", "secondaryAzurePort":
+      "A51-TEST-06GMR-CIS-2-SEC-A", "peerASN": 10000, "vlanId": 200, "azureASN": 12076,
+      "state": "Enabled", "peeringType": "AzurePublicPeering", "primaryAzurePort":
+      "A51-TEST-06GMR-CIS-1-PRI-A"}, "name": "AzurePublicPeering", "etag": "W/\"b7d15243-b0d5-4c3e-ae27-f1f1762692de\"",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['626']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [4ac96bcf-c22d-11e6-821e-a0b3ccf7272a]
+      x-ms-client-request-id: [154d741c-c2f9-11e6-aab4-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"AzurePublicPeering\",\r\n\
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering\"\
-        ,\r\n  \"etag\": \"W/\\\"ecb54008-d6f0-4bfc-993d-322453170cb0\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"AzurePublicPeering\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering\"\
+        ,\r\n  \"etag\": \"W/\\\"e2558bec-455f-4ed8-8bb3-44eb60b7bcae\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
         peeringType\": \"AzurePublicPeering\",\r\n    \"azureASN\": 12076,\r\n   \
         \ \"peerASN\": 10000,\r\n    \"primaryPeerAddressPrefix\": \"100.0.0.0/30\"\
@@ -1447,19 +1571,19 @@ interactions:
         : \"A51-TEST-06GMR-CIS-1-PRI-A\",\r\n    \"secondaryAzurePort\": \"A51-TEST-06GMR-CIS-2-SEC-A\"\
         ,\r\n    \"state\": \"Enabled\",\r\n    \"vlanId\": 200\r\n  }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/9340a6e4-954f-4095-be26-cb3ba7c3ec1d?api-version=2016-06-01']
-      cache-control: [no-cache]
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/e05efab2-232d-4eb6-b6ab-3ec39510e838?api-version=2016-06-01']
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:02:54 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['695']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:44:06 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1468,27 +1592,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [4ac96bcf-c22d-11e6-821e-a0b3ccf7272a]
+      x-ms-client-request-id: [154d741c-c2f9-11e6-aab4-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/9340a6e4-954f-4095-be26-cb3ba7c3ec1d?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/e05efab2-232d-4eb6-b6ab-3ec39510e838?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:03:05 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['30']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:44:17 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1497,26 +1621,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [4ac96bcf-c22d-11e6-821e-a0b3ccf7272a]
+      x-ms-client-request-id: [154d741c-c2f9-11e6-aab4-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/9340a6e4-954f-4095-be26-cb3ba7c3ec1d?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/e05efab2-232d-4eb6-b6ab-3ec39510e838?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:03:14 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['29']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:44:27 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1525,17 +1649,16 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [4ac96bcf-c22d-11e6-821e-a0b3ccf7272a]
+      x-ms-client-request-id: [154d741c-c2f9-11e6-aab4-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"AzurePublicPeering\",\r\n\
-        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering\"\
-        ,\r\n  \"etag\": \"W/\\\"0ba169d0-21ad-43a3-8920-6d05ffd27b6f\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"AzurePublicPeering\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/AzurePublicPeering\"\
+        ,\r\n  \"etag\": \"W/\\\"3f6543d5-ca10-42ae-a84e-af36889a3c55\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
         peeringType\": \"AzurePublicPeering\",\r\n    \"azureASN\": 12076,\r\n   \
         \ \"peerASN\": 10000,\r\n    \"primaryPeerAddressPrefix\": \"100.0.0.0/30\"\
@@ -1543,16 +1666,16 @@ interactions:
         : \"A51-TEST-06GMR-CIS-1-PRI-A\",\r\n    \"secondaryAzurePort\": \"A51-TEST-06GMR-CIS-2-SEC-A\"\
         ,\r\n    \"state\": \"Enabled\",\r\n    \"vlanId\": 200\r\n  }\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:03:18 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['696']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:44:27 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1562,27 +1685,27 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [57f771d1-c22d-11e6-9070-a0b3ccf7272a]
+      x-ms-client-request-id: [24520638-c2f9-11e6-a5e7-a0b3ccf7272a]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/azureprivatepeering/arpTables/primary?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode 'null'}
+    body: {string: 'null'}
     headers:
-      cache-control: [no-cache]
-      content-length: ['4']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:44:28 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/9ae754d9-9535-4426-a919-3e0a2aabdc6d?api-version=2016-06-01']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1185']
+      Cache-Control: [no-cache]
+      Content-Length: ['4']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:03:19 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/372549f4-4268-4b8b-91f0-84535ad23455?api-version=2016-06-01']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -1591,26 +1714,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [57f771d1-c22d-11e6-9070-a0b3ccf7272a]
+      x-ms-client-request-id: [24520638-c2f9-11e6-a5e7-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operationResults/9ae754d9-9535-4426-a919-3e0a2aabdc6d?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operationResults/372549f4-4268-4b8b-91f0-84535ad23455?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode 'null'}
+    body: {string: 'null'}
     headers:
-      cache-control: [no-cache]
-      content-length: ['4']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:44:38 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/9ae754d9-9535-4426-a919-3e0a2aabdc6d?api-version=2016-06-01']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
+      Cache-Control: [no-cache]
+      Content-Length: ['4']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:03:29 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/372549f4-4268-4b8b-91f0-84535ad23455?api-version=2016-06-01']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -1619,27 +1742,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [57f771d1-c22d-11e6-9070-a0b3ccf7272a]
+      x-ms-client-request-id: [24520638-c2f9-11e6-a5e7-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operationResults/9ae754d9-9535-4426-a919-3e0a2aabdc6d?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operationResults/372549f4-4268-4b8b-91f0-84535ad23455?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"value\": []\r\n}"}
+    body: {string: "{\r\n  \"value\": []\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:03:39 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/372549f4-4268-4b8b-91f0-84535ad23455?api-version=2016-06-01']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['19']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:44:48 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/9ae754d9-9535-4426-a919-3e0a2aabdc6d?api-version=2016-06-01']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1649,26 +1772,26 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [64bbe08f-c22d-11e6-9963-a0b3ccf7272a]
+      x-ms-client-request-id: [3114bc54-c2f9-11e6-bf04-a0b3ccf7272a]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1/peerings/azureprivatepeering/routeTables/primary?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode 'null'}
+    body: {string: 'null'}
     headers:
-      cache-control: [no-cache]
-      content-length: ['4']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:44:50 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/75ea9e5a-ee9e-4c02-a82a-fe9f4f76f157?api-version=2016-06-01']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
+      Cache-Control: [no-cache]
+      Content-Length: ['4']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:03:40 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/bf361eb6-f1ad-4f32-ab56-02e6b2d73e60?api-version=2016-06-01']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 202, message: Accepted}
 - request:
@@ -1678,26 +1801,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [64bbe08f-c22d-11e6-9963-a0b3ccf7272a]
+      x-ms-client-request-id: [3114bc54-c2f9-11e6-bf04-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operationResults/75ea9e5a-ee9e-4c02-a82a-fe9f4f76f157?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operationResults/bf361eb6-f1ad-4f32-ab56-02e6b2d73e60?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode 'null'}
+    body: {string: 'null'}
     headers:
-      cache-control: [no-cache]
-      content-length: ['4']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:45:00 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/75ea9e5a-ee9e-4c02-a82a-fe9f4f76f157?api-version=2016-06-01']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
+      Cache-Control: [no-cache]
+      Content-Length: ['4']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:03:51 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/bf361eb6-f1ad-4f32-ab56-02e6b2d73e60?api-version=2016-06-01']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -1706,27 +1829,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [64bbe08f-c22d-11e6-9963-a0b3ccf7272a]
+      x-ms-client-request-id: [3114bc54-c2f9-11e6-bf04-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operationResults/75ea9e5a-ee9e-4c02-a82a-fe9f4f76f157?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operationResults/bf361eb6-f1ad-4f32-ab56-02e6b2d73e60?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"value\": []\r\n}"}
+    body: {string: "{\r\n  \"value\": []\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:04:02 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/bf361eb6-f1ad-4f32-ab56-02e6b2d73e60?api-version=2016-06-01']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['19']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:45:11 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/75ea9e5a-ee9e-4c02-a82a-fe9f4f76f157?api-version=2016-06-01']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1736,27 +1859,27 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [7212a440-c22d-11e6-a72c-a0b3ccf7272a]
+      x-ms-client-request-id: [3f029f1e-c2f9-11e6-b665-a0b3ccf7272a]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits/circuit1?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/c3048591-c1e7-46b7-9dde-151485b91941?api-version=2016-06-01']
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Wed, 14 Dec 2016 18:45:13 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/c3048591-c1e7-46b7-9dde-151485b91941?api-version=2016-06-01']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/eeb65f2f-aa27-4ef1-836a-36d1d2258b96?api-version=2016-06-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Thu, 15 Dec 2016 19:04:04 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/eeb65f2f-aa27-4ef1-836a-36d1d2258b96?api-version=2016-06-01']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -1765,27 +1888,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [7212a440-c22d-11e6-a72c-a0b3ccf7272a]
+      x-ms-client-request-id: [3f029f1e-c2f9-11e6-b665-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/c3048591-c1e7-46b7-9dde-151485b91941?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/eeb65f2f-aa27-4ef1-836a-36d1d2258b96?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:04:14 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['30']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:45:24 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1794,27 +1917,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [7212a440-c22d-11e6-a72c-a0b3ccf7272a]
+      x-ms-client-request-id: [3f029f1e-c2f9-11e6-b665-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/c3048591-c1e7-46b7-9dde-151485b91941?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/eeb65f2f-aa27-4ef1-836a-36d1d2258b96?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:04:25 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['30']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:45:34 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1823,27 +1946,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [7212a440-c22d-11e6-a72c-a0b3ccf7272a]
+      x-ms-client-request-id: [3f029f1e-c2f9-11e6-b665-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/c3048591-c1e7-46b7-9dde-151485b91941?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/eeb65f2f-aa27-4ef1-836a-36d1d2258b96?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:04:36 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['30']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:45:44 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1852,27 +1975,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [7212a440-c22d-11e6-a72c-a0b3ccf7272a]
+      x-ms-client-request-id: [3f029f1e-c2f9-11e6-b665-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/c3048591-c1e7-46b7-9dde-151485b91941?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/eeb65f2f-aa27-4ef1-836a-36d1d2258b96?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"InProgress\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:04:46 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['30']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:45:55 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1881,26 +2004,55 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [7212a440-c22d-11e6-a72c-a0b3ccf7272a]
+      x-ms-client-request-id: [3f029f1e-c2f9-11e6-b665-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/c3048591-c1e7-46b7-9dde-151485b91941?api-version=2016-06-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/eeb65f2f-aa27-4ef1-836a-36d1d2258b96?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    body: {string: "{\r\n  \"status\": \"InProgress\"\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:04:56 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['30']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
+          msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [3f029f1e-c2f9-11e6-b665-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/eeb65f2f-aa27-4ef1-836a-36d1d2258b96?api-version=2016-06-01
+  response:
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:05:06 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['29']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:46:05 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1909,25 +2061,25 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.12.4 msrest/0.4.4
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
           msrest_azure/0.4.6 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9285adcf-c22d-11e6-af3d-a0b3ccf7272a]
+      x-ms-client-request-id: [65a6b686-c2f9-11e6-9742-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route/providers/Microsoft.Network/expressRouteCircuits?api-version=2016-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"value\": []\r\n}"}
+    body: {string: "{\r\n  \"value\": []\r\n}"}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 15 Dec 2016 19:05:09 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['19']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 14 Dec 2016 18:46:06 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
     status: {code: 200, message: OK}
 version: 1


### PR DESCRIPTION
Closes #1575.

Prevents attempting to create MicrosoftPeering settings with SKU type "Standard" as the server does not currently validate this.

Prevents attempting to create peering settings if the VLAN id is already in use on that circuit as the server does not currently validate this.