### PR TITLE
Fix issues with @syntax

### DIFF
--- a/src/azure-cli-core/azure/cli/core/application.py
+++ b/src/azure-cli-core/azure/cli/core/application.py
@@ -202,13 +202,15 @@ class Application(object):
     @staticmethod
     def _maybe_load_file(arg):
         ix = arg.find('@')
-        if ix == -1:
+        if ix == -1: # not found
+            return arg
+
+        if ix == len(arg) - 1: # allow simply the value '@' (used by DNS for example)
             return arg
 
         if ix == 0:
             return Application._load_file(arg[1:])
-
-        if arg[ix - 1] == '=':
+        elif arg[ix - 1] == '=':
             return arg[:ix] + Application._load_file(arg[ix + 1:])
 
         return arg

--- a/src/azure-cli-core/azure/cli/core/application.py
+++ b/src/azure-cli-core/azure/cli/core/application.py
@@ -225,7 +225,7 @@ class Application(object):
             if path == '-':
                 content = sys.stdin.read()
             else:
-                with open(path, 'r') as input_file:
+                with open(os.path.expanduser(path), 'r') as input_file:
                     content = input_file.read()
 
             return content[0:-1] if content[-1] == '\n' else content


### PR DESCRIPTION
Fixes #1109. Expand user when using @~/path syntax
Fixes #1577. Allows use of '@' as a value (for DNS commands for example)