### PR TITLE
[Network] DNS Record Set Create Updates

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/parameters.py
+++ b/src/azure-cli-core/azure/cli/core/commands/parameters.py
@@ -150,5 +150,3 @@ no_wait_type = CliArgumentType(
 register_cli_argument('', 'resource_group_name', resource_group_name_type)
 register_cli_argument('', 'location', location_type)
 register_cli_argument('', 'deployment_name', deployment_name_type)
-
-

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
@@ -7,13 +7,405 @@ from azure.cli.core.help_files import helps #pylint: disable=unused-import
 
 #pylint: disable=line-too-long, too-many-lines
 
+helps['network'] = """
+    type: group
+    short-summary: Manages Network resources
+"""
+
+helps['network dns'] = """
+    type: group
+    short-summary: Host your DNS domain in Azure
+"""
+
+# region Application Gateway
+
+helps['network application-gateway'] = """
+    type: group
+    short-summary: Provides application-level routing and load balancing services
+"""
+
+helps['network application-gateway create'] = """
+    type: command
+    short-summary: Create a new application gateway.
+"""
+
+helps['network application-gateway delete'] = """
+    type: command
+    short-summary: Delete an application gateway.
+"""
+
+helps['network application-gateway list'] = """
+    type: command
+    short-summary: List application gateways in a resource group or subscription.
+"""
+
+helps['network application-gateway show'] = """
+    type: command
+    short-summary: Show details of an application gateway.
+"""
+
+helps['network application-gateway start'] = """
+    type: command
+    short-summary: Start an application gateway.
+"""
+
+helps['network application-gateway stop'] = """
+    type: command
+    short-summary: Stop an application gateway.
+"""
+
+helps['network application-gateway update'] = """
+    type: command
+    short-summary: Update an application gateway.
+"""
+#endregion
+
+# region Application Gateway Address Pool
+
+helps['network application-gateway address-pool'] = """
+    type: group
+    short-summary: Manage application gateway backend address pools.
+"""
+
+helps['network application-gateway address-pool create'] = """
+    type: command
+    short-summary: Create a new application gateway backend address pool.
+"""
+
+helps['network application-gateway address-pool delete'] = """
+    type: command
+    short-summary: Delete an application gateway backend address pool.
+"""
+
+helps['network application-gateway address-pool list'] = """
+    type: command
+    short-summary: List backend address pools in an application gateway.
+"""
+
+helps['network application-gateway address-pool show'] = """
+    type: command
+    short-summary: Show details of an application gateway backend address pool.
+"""
+# endregion
+
+# region Application Gateway Frontend IP
+
+helps['network application-gateway frontend-ip'] = """
+    type: group
+    short-summary: Manage application gateway front-end IP addresses
+"""
+
+helps['network application-gateway frontend-ip create'] = """
+    type: command
+    short-summary: Create a new application gateway front-end IP address.
+"""
+
+helps['network application-gateway frontend-ip delete'] = """
+    type: command
+    short-summary: Delete an application gateway front-end IP address.
+"""
+
+helps['network application-gateway frontend-ip list'] = """
+    type: command
+    short-summary: List front-end IP addresses in an application gateway.
+"""
+
+helps['network application-gateway frontend-ip show'] = """
+    type: command
+    short-summary: Show details of an application gateway front-end IP address.
+"""
+#endregion
+
+# region Application Gateway frontend port
+
+helps['network application-gateway frontend-port'] = """
+    type: group
+    short-summary: Manage application gateway front-end ports
+"""
+
+helps['network application-gateway frontend-port create'] = """
+    type: command
+    short-summary: Create a new application gateway front-end port.
+"""
+
+helps['network application-gateway frontend-port delete'] = """
+    type: command
+    short-summary: Delete an application gateway front-end port.
+"""
+
+helps['network application-gateway frontend-port list'] = """
+    type: command
+    short-summary: List front-end ports in an application gateway.
+"""
+
+helps['network application-gateway frontend-port show'] = """
+    type: command
+    short-summary: Show details of an application gateway front-end port.
+"""
+#endregion
+
+# region Application Gateway HTTP listener
+
+helps['network application-gateway http-listener'] = """
+    type: group
+    short-summary: Manage application gateway HTTP listeners
+"""
+
+helps['network application-gateway http-listener create'] = """
+    type: command
+    short-summary: Create a new application gateway HTTP listener.
+"""
+
+helps['network application-gateway http-listener delete'] = """
+    type: command
+    short-summary: Delete an application gateway HTTP listener.
+"""
+
+helps['network application-gateway http-listener list'] = """
+    type: command
+    short-summary: List HTTP listeners in an application gateway.
+"""
+
+helps['network application-gateway http-listener show'] = """
+    type: command
+    short-summary: Show details of an application gateway HTTP listener.
+"""
+#endregion
+
+# region Application Gateway HTTP settings
+
+helps['network application-gateway http-settings'] = """
+    type: group
+    short-summary: Manage application gateway HTTP settings
+"""
+
+helps['network application-gateway http-settings create'] = """
+    type: command
+    short-summary: Create new application gateway HTTP settings.
+"""
+
+helps['network application-gateway http-settings delete'] = """
+    type: command
+    short-summary: Delete application gateway HTTP settings.
+"""
+
+helps['network application-gateway http-settings list'] = """
+    type: command
+    short-summary: List HTTP settings in an application gateway.
+"""
+
+helps['network application-gateway http-settings show'] = """
+    type: command
+    short-summary: Show details of an application gateway HTTP settings.
+"""
+#endregion
+
+# region Application Gateway probe
+
+helps['network application-gateway probe'] = """
+    type: group
+    short-summary: Gather information, such as utilization, to be evaluated by rules
+"""
+helps['network application-gateway probe create'] = """
+    type: command
+    short-summary: Create a new application gateway probe.
+"""
+
+helps['network application-gateway probe delete'] = """
+    type: command
+    short-summary: Delete an application gateway probe.
+"""
+
+helps['network application-gateway probe list'] = """
+    type: command
+    short-summary: List probes in an application gateway.
+"""
+
+helps['network application-gateway probe show'] = """
+    type: command
+    short-summary: Show details of an application gateway probe.
+"""
+#endregion
+
+# region Application Gateway rules
+
+helps['network application-gateway rule'] = """
+    type: group
+    short-summary: Evaluate probe information and define routing rules
+"""
+helps['network application-gateway rule create'] = """
+    type: command
+    short-summary: Create a new application gateway rule.
+"""
+
+helps['network application-gateway rule delete'] = """
+    type: command
+    short-summary: Delete an application gateway rule.
+"""
+
+helps['network application-gateway rule list'] = """
+    type: command
+    short-summary: List rules in an application gateway.
+"""
+
+helps['network application-gateway rule show'] = """
+    type: command
+    short-summary: Show details of an application gateway rule.
+"""
+#endregion
+
+# region Application Gateway SSL Certs
+
+helps['network application-gateway ssl-cert'] = """
+    type: group
+    short-summary: Manage application gateway SSL certificates
+"""
+helps['network application-gateway ssl-cert create'] = """
+    type: command
+    short-summary: Upload an SSL certificate for an application gateway.
+"""
+
+helps['network application-gateway ssl-cert delete'] = """
+    type: command
+    short-summary: Delete an application gateway SSL certificate.
+"""
+
+helps['network application-gateway ssl-cert list'] = """
+    type: command
+    short-summary: List SSL certificates in an application gateway.
+"""
+
+helps['network application-gateway ssl-cert show'] = """
+    type: command
+    short-summary: Show details of an application gateway SSL certificate.
+"""
+#endregion
+
+# region Application Gateway URL path map
+
+helps['network application-gateway url-path-map'] = """
+    type: group
+    short-summary: Manage application gateway URL path maps
+"""
+helps['network application-gateway url-path-map create'] = """
+    type: command
+    short-summary: Create a new application gateway URL path map.
+"""
+
+helps['network application-gateway url-path-map delete'] = """
+    type: command
+    short-summary: Delete an application gateway URL path map.
+"""
+
+helps['network application-gateway url-path-map list'] = """
+    type: command
+    short-summary: List URL path maps in an application gateway.
+"""
+
+helps['network application-gateway url-path-map show'] = """
+    type: command
+    short-summary: Show details of an application gateway URL path map.
+"""
+#endregion
+
+# region Application Gateway URL path map rules
+
+helps['network application-gateway url-path-map rule'] = """
+    type: group
+    short-summary: Manage application gateway URL path map rules
+"""
+
+helps['network application-gateway url-path-map rule create'] = """
+    type: command
+    short-summary: Create a new application gateway URL path map rule.
+"""
+
+helps['network application-gateway url-path-map rule delete'] = """
+    type: command
+    short-summary: Delete an application gateway URL path map rule.
+"""
+#endregion
+
+# region DNS record-set
+
+helps['network dns record-set'] = """
+    type: group
+    short-summary: Manage DNS record sets.
+"""
+
 helps['network dns record-set create'] = """
-            type: command
-            parameters:
-                - name: --type
-                  short-summary: The type of DNS records in the record set.
-                - name: --ttl
-                  short-summary: Record set TTL (time-to-live).
+    type: command
+    short-summary: Create an empty record set within a DNS zone.
+    long-summary: |
+        If a matching record set already exists, it will be overwritten unless --if-none-match is supplied.
+"""
+
+helps['network dns record-set delete'] = """
+    type: command
+    short-summary: Deletes a record set within a DNS zone.
+"""
+
+helps['network dns record-set list'] = """
+    type: command
+    short-summary: Lists all record sets within a DNS zone.
+"""
+
+helps['network dns record-set show'] = """
+    type: command
+    short-summary: Show details of a record set within a DNS zone.
+"""
+
+helps['network dns record-set update'] = """
+    type: command
+    short-summary: Update properties of a record set within a DNS zone.
+"""
+# endregion
+
+# region DNS records
+
+helps['network dns record'] = """
+    type: group
+    short-summary: Manage DNS records contained in a record set
+"""
+
+helps['network dns record a'] = """
+    type: group
+    short-summary: Manage DNS A records
+"""
+
+helps['network dns record aaaa'] = """
+    type: group
+    short-summary: Manage DNS AAAA records
+"""
+
+helps['network dns record cname'] = """
+    type: group
+    short-summary: Manage DNS CNAME records
+"""
+
+helps['network dns record mx'] = """
+    type: group
+    short-summary: Manage DNS MX (mail) records
+"""
+
+helps['network dns record ns'] = """
+    type: group
+    short-summary: Manage DNS NS (nameserver) records
+"""
+
+helps['network dns record ptr'] = """
+    type: group
+    short-summary: Manage DNS PTR (pointer) records
+"""
+
+helps['network dns record srv'] = """
+    type: group
+    short-summary: Manage DNS SRV records
+"""
+
+helps['network dns record txt'] = """
+    type: group
+    short-summary: Manage DNS TXT records
 """
 
 for t in ['add', 'remove']:
@@ -97,13 +489,430 @@ helps['network dns record update-soa'] = """
                 - name: --minimum-ttl
                   short-summary: Minimum TTL (time-to-live, seconds).
 """
+#endregion
 
-helps['network vnet subnet'] = """
+# region DNS Zone
+helps['network dns zone'] = """
     type: group
-    short-summary: Manage network interfaces.
+    short-summary: Manage DNS zones
 """
 
-# Network Interface (NIC)
+helps['network dns zone create'] = """
+    type: command
+    short-summary: Creates a new DNS zone.
+    parameters:
+        - name: --if-none-match
+          short-summary: Create only if there isn't an existing DNS zone matches the given one.
+"""
+
+helps['network dns zone delete'] = """
+    type: command
+    short-summary: Deletes a DNS zone and all associated records.
+    long-summary: |
+        WARNING: This operation cannot be undone.
+"""
+
+helps['network dns zone export'] = """
+    type: command
+    short-summary: Export a DNS zone as a DNS zone file.
+"""
+
+helps['network dns zone import'] = """
+    type: command
+    short-summary: Create a DNS zone using a DNS zone file.
+"""
+
+helps['network dns zone list'] = """
+    type: command
+    short-summary: List DNS zones in a resource group or subscription.
+"""
+
+helps['network dns zone show'] = """
+    type: command
+    short-summary: Gets DNS zone parameters. Does not show DNS records within the zone.
+"""
+
+helps['network dns zone update'] = """
+    type: command
+    short-summary: Updates DNS zone properties. Does not modify DNS records within the zone.
+    parameters:
+        - name: --if-match
+          short-summary: Update only if the resource with the same ETAG exists.
+"""
+#endregion
+
+# region Express Route
+
+helps['network express-route'] = """
+    type: group
+    short-summary: Dedicated private network fiber connections to Azure
+"""
+
+helps['network express-route create'] = """
+    type: command
+    short-summary: Create an ExpressRoute circuit.
+"""
+
+helps['network express-route delete'] = """
+    type: command
+    short-summary: Delete an ExpressRoute circuit.
+"""
+
+helps['network express-route get-stats'] = """
+    type: command
+    short-summary: Show stats of an ExpressRoute circuit.
+"""
+
+helps['network express-route list'] = """
+    type: command
+    short-summary: List ExpressRoute circuits in a subscription or resource group.
+"""
+
+helps['network express-route list-arp-tables'] = """
+    type: command
+    short-summary: List the currently advertised ARP table of an ExpressRoute circuit.
+"""
+
+helps['network express-route list-route-tables'] = """
+    type: command
+    short-summary: List the currently advertised route tables of an ExpressRoute circuit.
+"""
+
+helps['network express-route show'] = """
+    type: command
+    short-summary: Show details of an ExpressRoute circuit.
+"""
+
+helps['network express-route update'] = """
+    type: command
+    short-summary: Update settings of an ExpressRoute circuit.
+"""
+
+helps['network express-route list-service-providers'] = """
+    type: command
+    short-summary: List available ExpressRoute service providers.
+"""
+#endregion
+
+# region Express Route auth
+
+helps['network express-route auth'] = """
+    type: group
+    short-summary: Manage ExpressRoute circuit authentication
+"""
+
+helps['network express-route auth create'] = """
+    type: command
+    short-summary: Create an authorization setting in an ExpressRoute circuit.
+"""
+
+helps['network express-route auth delete'] = """
+    type: command
+    short-summary: Delete an authorization setting in an ExpressRoute circuit.
+"""
+
+helps['network express-route auth list'] = """
+    type: command
+    short-summary: List authorization settings of an ExpressRoute circuit.
+"""
+
+helps['network express-route auth show'] = """
+    type: command
+    short-summary: Show details of an authorization setting in an ExpressRoute circuit.
+"""
+#endregion
+
+# region Express Route peering
+
+helps['network express-route peering'] = """
+    type: group
+    short-summary: Manage ExpressRoute peering
+"""
+
+helps['network express-route peering create'] = """
+    type: command
+    short-summary: Create peering settings in an ExpressRoute circuit.
+"""
+
+helps['network express-route peering delete'] = """
+    type: command
+    short-summary: Delete peering settings in an ExpressRoute circuit.
+"""
+
+helps['network express-route peering list'] = """
+    type: command
+    short-summary: List peering settings of an ExpressRoute circuit.
+"""
+
+helps['network express-route peering show'] = """
+    type: command
+    short-summary: Show peering details of an ExpressRoute circuit.
+"""
+
+helps['network express-route peering update'] = """
+    type: command
+    short-summary: Update peering settings in an ExpressRoute circuit.
+"""
+#endregion
+
+# region Load Balancer
+
+helps['network lb'] = """
+    type: group
+    short-summary: Deliver high availability and network performance to your applications
+"""
+
+helps['network lb create'] = """
+    type: command
+    short-summary: Create a new load balancer.
+"""
+
+helps['network lb delete'] = """
+    type: command
+    short-summary: Delete a load balancer.
+"""
+
+helps['network lb list'] = """
+    type: command
+    short-summary: List load balancers in a resource group or subscription.
+"""
+
+helps['network lb show'] = """
+    type: command
+    short-summary: Show details of a load balancer.
+"""
+
+helps['network lb update'] = """
+    type: command
+    short-summary: Update a load balancer.
+"""
+#endregion
+
+# region Load Balancer address pool
+
+helps['network lb address-pool'] = """
+    type: group
+    short-summary: Manage load balancer backend address pools
+"""
+
+helps['network lb address-pool create'] = """
+    type: command
+    short-summary: Create a new load balancer backend address pool.
+"""
+
+helps['network lb address-pool delete'] = """
+    type: command
+    short-summary: Delete a load balancer backend address pool.
+"""
+
+helps['network lb address-pool list'] = """
+    type: command
+    short-summary: List backend address pools in a load balancer.
+"""
+
+helps['network lb address-pool show'] = """
+    type: command
+    short-summary: Show details of a load balancer backend address pool.
+"""
+#endregion
+
+# region Load Balancer frontend IP
+
+helps['network lb frontend-ip'] = """
+    type: group
+    short-summary: Manage load balancer front-end IP addresses
+"""
+
+helps['network lb frontend-ip create'] = """
+    type: command
+    short-summary: Create a new load balancer front-end IP address.
+"""
+
+helps['network lb frontend-ip delete'] = """
+    type: command
+    short-summary: Delete a load balancer front-end IP address.
+"""
+
+helps['network lb frontend-ip list'] = """
+    type: command
+    short-summary: List front-end IP addresses in a load balancer.
+"""
+
+helps['network lb frontend-ip show'] = """
+    type: command
+    short-summary: Show details of a load balancer front-end IP address.
+"""
+
+helps['network lb frontend-ip update'] = """
+    type: command
+    short-summary: Update a load balancer front-end IP address.
+"""
+#endregion
+
+# region Load Balancer inbound NAT pool
+
+helps['network lb inbound-nat-pool'] = """
+    type: group
+    short-summary: Manage load balancer inbound NAT address pools
+"""
+
+helps['network lb inbound-nat-pool create'] = """
+    type: command
+    short-summary: Create a new load balancer inbound NAT address pool.
+"""
+
+helps['network lb inbound-nat-pool delete'] = """
+    type: command
+    short-summary: Delete a load balancer inbound NAT address pool.
+"""
+
+helps['network lb inbound-nat-pool list'] = """
+    type: command
+    short-summary: List inbound NAT address pools in a load balancer.
+"""
+
+helps['network lb inbound-nat-pool show'] = """
+    type: command
+    short-summary: Show details of a load balancer inbound NAT address pool.
+"""
+
+helps['network lb inbound-nat-pool update'] = """
+    type: command
+    short-summary: Update a load balancer inbound NAT address pool.
+"""
+#endregion
+
+# region Load Balancer inbound NAT rule
+
+helps['network lb inbound-nat-rule'] = """
+    type: group
+    short-summary: Manage load balancer inbound NAT rules
+"""
+
+helps['network lb inbound-nat-rule create'] = """
+    type: command
+    short-summary: Create a new load balancer inbound NAT rule.
+"""
+
+helps['network lb inbound-nat-rule delete'] = """
+    type: command
+    short-summary: Delete a load balancer inbound NAT rule.
+"""
+
+helps['network lb inbound-nat-rule list'] = """
+    type: command
+    short-summary: List inbound NAT rules in a load balancer.
+"""
+
+helps['network lb inbound-nat-rule show'] = """
+    type: command
+    short-summary: Show details of a load balancer inbound NAT rule.
+"""
+
+helps['network lb inbound-nat-rule update'] = """
+    type: command
+    short-summary: Update a load balancer inbound NAT rule.
+"""
+#endregion
+
+# region Load Balancer probe
+
+helps['network lb probe'] = """
+    type: group
+    short-summary: Evaluate probe information and define routing rules
+"""
+
+helps['network lb probe create'] = """
+    type: command
+    short-summary: Create a new load balancer probe.
+"""
+
+helps['network lb probe delete'] = """
+    type: command
+    short-summary: Delete a load balancer probe.
+"""
+
+helps['network lb probe list'] = """
+    type: command
+    short-summary: List probes in a load balancer.
+"""
+
+helps['network lb probe show'] = """
+    type: command
+    short-summary: Show details of a load balancer probe.
+"""
+
+helps['network lb probe update'] = """
+    type: command
+    short-summary: Update a load balancer probe.
+"""
+#endregion
+
+# region Load Balancer rule
+
+helps['network lb rule'] = """
+    type: group
+    short-summary: Gather information, such as utilization, to be evaluated by rules
+"""
+
+helps['network lb rule create'] = """
+    type: command
+    short-summary: Create a new load balancing rule.
+"""
+
+helps['network lb rule delete'] = """
+    type: command
+    short-summary: Delete a load balancing rule.
+"""
+
+helps['network lb rule list'] = """
+    type: command
+    short-summary: List load balancing rules in a load balancer.
+"""
+
+helps['network lb rule show'] = """
+    type: command
+    short-summary: Show details of a load balancing rule.
+"""
+
+helps['network lb rule update'] = """
+    type: command
+    short-summary: Update a load balancing rule.
+"""
+#endregion
+
+# region Local Gateway
+
+helps['network local-gateway'] = """
+    type: group
+    short-summary: Manage local gateways
+"""
+
+helps['network local-gateway create'] = """
+    type: command
+    short-summary: Create a new local VPN gateway.
+"""
+
+helps['network local-gateway delete'] = """
+    type: command
+    short-summary: Delete a local VPN gateway.
+"""
+helps['network local-gateway list'] = """
+    type: command
+    short-summary: List local VPN gateways in a resource group.
+"""
+helps['network local-gateway show'] = """
+    type: command
+    short-summary: Show details of a local VPN gateway.
+"""
+
+helps['network local-gateway update'] = """
+    type: command
+    short-summary: Update an existing local VPN gateway.
+"""
+#endregion
+
+# region Network Interface (NIC)
 
 helps['network nic'] = """
     type: group
@@ -146,8 +955,9 @@ helps['network nic update'] = """
     type: command
     short-summary: Update a network interface.
 """
+#endregion
 
-# NIC ip-config
+# region NIC ip-config
 
 helps['network nic ip-config'] = """
     type: group
@@ -182,8 +992,9 @@ helps['network nic ip-config update'] = """
     type: command
     short-summary: Update an IP configurations on a NIC.
 """
+#endregion
 
-# NIC IP config address pool
+# region NIC IP config address pool
 
 helps['network nic ip-config address-pool'] = """
     type: group
@@ -199,8 +1010,9 @@ helps['network nic ip-config address-pool remove'] = """
     type: command
     short-summary: Remove a backend address pool reference from an IP configuration.
 """
+#endregion
 
-# NIC IP config inbound NAT rules
+# region NIC IP config inbound NAT rules
 
 helps['network nic ip-config inbound-nat-rule'] = """
     type: group
@@ -216,828 +1028,9 @@ helps['network nic ip-config inbound-nat-rule remove'] = """
     type: command
     short-summary: Remove an inbound NAT rule reference from an IP configuration.
 """
+#endregion
 
-# Virtual Network (VNET)
-
-helps['network vnet subnet'] = """
-    type: group
-    short-summary: Manage virtual networks.
-"""
-
-helps['network vnet check-ip-address'] = """
-    type: command
-    short-summary: Check whether a private IP address is available for use.
-"""
-
-helps['network vnet create'] = """
-    type: command
-    short-summary: Create a virtual network.
-    long-summary: You may also create a subnet at the same time by specifying a subnet name and
-        (optionally) an address prefix.
-"""
-
-helps['network vnet delete'] = """
-    type: command
-    short-summary: Delete a virtual network.
-"""
-
-helps['network vnet list'] = """
-    type: command
-    short-summary: List virtual networks within a resource group or subscription.
-"""
-
-helps['network vnet show'] = """
-    type: command
-    short-summary: Show details on a virtual network.
-"""
-
-helps['network vnet update'] = """
-    type: command
-    short-summary: Update a virtual network.
-"""
-
-# VNET Subnet
-
-helps['network vnet subnet'] = """
-    type: group
-    short-summary: Manage virtual network subnets.
-"""
-
-helps['network vnet subnet create'] = """
-    type: command
-    short-summary: Create a virtual network subnet.
-"""
-
-helps['network vnet subnet delete'] = """
-    type: command
-    short-summary: Delete a virtual network subnet.
-"""
-
-helps['network vnet subnet list'] = """
-    type: command
-    short-summary: List subnets within a virtual network.
-"""
-
-helps['network vnet subnet show'] = """
-    type: command
-    short-summary: Show details on a virtual network subnet.
-"""
-
-helps['network vnet subnet update'] = """
-    type: command
-    short-summary: Update a virtual network subnet.
-"""
-
-# Virtual Network (VNET) Peering
-
-helps['network vnet peering'] = """
-    type: group
-    short-summary: Manage peering connections between virtual networks.
-"""
-
-helps['network vnet peering create'] = """
-    type: command
-    short-summary: Create a virtual network peering.
-"""
-
-helps['network vnet peering delete'] = """
-    type: command
-    short-summary: Delete a virtual network peering.
-"""
-
-helps['network vnet peering list'] = """
-    type: command
-    short-summary: List peerings within a virtual network.
-"""
-
-helps['network vnet peering show'] = """
-    type: command
-    short-summary: Show details on a virtual network peering.
-"""
-
-helps['network vnet peering update'] = """
-    type: command
-    short-summary: Update a virtual network peering.
-"""
-
-helps['network'] = """
-    type: group
-    short-summary: Manages Network resources
-"""
-
-# Application Gateway
-
-helps['network application-gateway'] = """
-    type: group
-    short-summary: Provides application-level routing and load balancing services
-"""
-
-helps['network application-gateway create'] = """
-    type: command
-    short-summary: Create a new application gateway.
-"""
-
-helps['network application-gateway delete'] = """
-    type: command
-    short-summary: Delete an application gateway.
-"""
-
-helps['network application-gateway list'] = """
-    type: command
-    short-summary: List application gateways in a resource group or subscription.
-"""
-
-helps['network application-gateway show'] = """
-    type: command
-    short-summary: Show details of an application gateway.
-"""
-
-helps['network application-gateway start'] = """
-    type: command
-    short-summary: Start an application gateway.
-"""
-
-helps['network application-gateway stop'] = """
-    type: command
-    short-summary: Stop an application gateway.
-"""
-
-helps['network application-gateway update'] = """
-    type: command
-    short-summary: Update an application gateway.
-"""
-
-# Application Gateway Address Pool
-
-helps['network application-gateway address-pool'] = """
-    type: group
-    short-summary: Manage application gateway backend address pools.
-"""
-
-helps['network application-gateway address-pool create'] = """
-    type: command
-    short-summary: Create a new application gateway backend address pool.
-"""
-
-helps['network application-gateway address-pool delete'] = """
-    type: command
-    short-summary: Delete an application gateway backend address pool.
-"""
-
-helps['network application-gateway address-pool list'] = """
-    type: command
-    short-summary: List backend address pools in an application gateway.
-"""
-
-helps['network application-gateway address-pool show'] = """
-    type: command
-    short-summary: Show details of an application gateway backend address pool.
-"""
-
-# Application Gateway Frontend IP
-
-helps['network application-gateway frontend-ip'] = """
-    type: group
-    short-summary: Manage application gateway front-end IP addresses
-"""
-
-helps['network application-gateway frontend-ip create'] = """
-    type: command
-    short-summary: Create a new application gateway front-end IP address.
-"""
-
-helps['network application-gateway frontend-ip delete'] = """
-    type: command
-    short-summary: Delete an application gateway front-end IP address.
-"""
-
-helps['network application-gateway frontend-ip list'] = """
-    type: command
-    short-summary: List front-end IP addresses in an application gateway.
-"""
-
-helps['network application-gateway frontend-ip show'] = """
-    type: command
-    short-summary: Show details of an application gateway front-end IP address.
-"""
-
-# Application Gateway frontend port
-
-helps['network application-gateway frontend-port'] = """
-    type: group
-    short-summary: Manage application gateway front-end ports
-"""
-
-helps['network application-gateway frontend-port create'] = """
-    type: command
-    short-summary: Create a new application gateway front-end port.
-"""
-
-helps['network application-gateway frontend-port delete'] = """
-    type: command
-    short-summary: Delete an application gateway front-end port.
-"""
-
-helps['network application-gateway frontend-port list'] = """
-    type: command
-    short-summary: List front-end ports in an application gateway.
-"""
-
-helps['network application-gateway frontend-port show'] = """
-    type: command
-    short-summary: Show details of an application gateway front-end port.
-"""
-
-# Application Gateway HTTP listener
-
-helps['network application-gateway http-listener'] = """
-    type: group
-    short-summary: Manage application gateway HTTP listeners
-"""
-
-helps['network application-gateway http-listener create'] = """
-    type: command
-    short-summary: Create a new application gateway HTTP listener.
-"""
-
-helps['network application-gateway http-listener delete'] = """
-    type: command
-    short-summary: Delete an application gateway HTTP listener.
-"""
-
-helps['network application-gateway http-listener list'] = """
-    type: command
-    short-summary: List HTTP listeners in an application gateway.
-"""
-
-helps['network application-gateway http-listener show'] = """
-    type: command
-    short-summary: Show details of an application gateway HTTP listener.
-"""
-
-# Application Gateway HTTP settings
-
-helps['network application-gateway http-settings'] = """
-    type: group
-    short-summary: Manage application gateway HTTP settings
-"""
-
-helps['network application-gateway http-settings create'] = """
-    type: command
-    short-summary: Create new application gateway HTTP settings.
-"""
-
-helps['network application-gateway http-settings delete'] = """
-    type: command
-    short-summary: Delete application gateway HTTP settings.
-"""
-
-helps['network application-gateway http-settings list'] = """
-    type: command
-    short-summary: List HTTP settings in an application gateway.
-"""
-
-helps['network application-gateway http-settings show'] = """
-    type: command
-    short-summary: Show details of an application gateway HTTP settings.
-"""
-
-# Application Gateway probe
-
-helps['network application-gateway probe'] = """
-    type: group
-    short-summary: Gather information, such as utilization, to be evaluated by rules
-"""
-helps['network application-gateway probe create'] = """
-    type: command
-    short-summary: Create a new application gateway probe.
-"""
-
-helps['network application-gateway probe delete'] = """
-    type: command
-    short-summary: Delete an application gateway probe.
-"""
-
-helps['network application-gateway probe list'] = """
-    type: command
-    short-summary: List probes in an application gateway.
-"""
-
-helps['network application-gateway probe show'] = """
-    type: command
-    short-summary: Show details of an application gateway probe.
-"""
-
-# Application Gateway rules
-
-helps['network application-gateway rule'] = """
-    type: group
-    short-summary: Evaluate probe information and define routing rules
-"""
-helps['network application-gateway rule create'] = """
-    type: command
-    short-summary: Create a new application gateway rule.
-"""
-
-helps['network application-gateway rule delete'] = """
-    type: command
-    short-summary: Delete an application gateway rule.
-"""
-
-helps['network application-gateway rule list'] = """
-    type: command
-    short-summary: List rules in an application gateway.
-"""
-
-helps['network application-gateway rule show'] = """
-    type: command
-    short-summary: Show details of an application gateway rule.
-"""
-# Application Gateway SSL Certs
-
-helps['network application-gateway ssl-cert'] = """
-    type: group
-    short-summary: Manage application gateway SSL certificates
-"""
-helps['network application-gateway ssl-cert create'] = """
-    type: command
-    short-summary: Upload an SSL certificate for an application gateway.
-"""
-
-helps['network application-gateway ssl-cert delete'] = """
-    type: command
-    short-summary: Delete an application gateway SSL certificate.
-"""
-
-helps['network application-gateway ssl-cert list'] = """
-    type: command
-    short-summary: List SSL certificates in an application gateway.
-"""
-
-helps['network application-gateway ssl-cert show'] = """
-    type: command
-    short-summary: Show details of an application gateway SSL certificate.
-"""
-# Application Gateway URL path map
-
-helps['network application-gateway url-path-map'] = """
-    type: group
-    short-summary: Manage application gateway URL path maps
-"""
-helps['network application-gateway url-path-map create'] = """
-    type: command
-    short-summary: Create a new application gateway URL path map.
-"""
-
-helps['network application-gateway url-path-map delete'] = """
-    type: command
-    short-summary: Delete an application gateway URL path map.
-"""
-
-helps['network application-gateway url-path-map list'] = """
-    type: command
-    short-summary: List URL path maps in an application gateway.
-"""
-
-helps['network application-gateway url-path-map show'] = """
-    type: command
-    short-summary: Show details of an application gateway URL path map.
-"""
-# Application Gateway URL path map rules
-
-helps['network application-gateway url-path-map rule'] = """
-    type: group
-    short-summary: Manage application gateway URL path map rules
-"""
-helps['network application-gateway url-path-map rule create'] = """
-    type: command
-    short-summary: Create a new application gateway URL path map rule.
-"""
-
-helps['network application-gateway url-path-map rule delete'] = """
-    type: command
-    short-summary: Delete an application gateway URL path map rule.
-"""
-
-# DNS
-
-helps['network dns'] = """
-    type: group
-    short-summary: Host your DNS domain in Azure
-"""
-helps['network dns record'] = """
-    type: group
-    short-summary: Manage DNS records contained in a record set
-"""
-helps['network dns record a'] = """
-    type: group
-    short-summary: Manage DNS A records
-"""
-helps['network dns record aaaa'] = """
-    type: group
-    short-summary: Manage DNS AAAA records
-"""
-helps['network dns record cname'] = """
-    type: group
-    short-summary: Manage DNS CNAME records
-"""
-helps['network dns record mx'] = """
-    type: group
-    short-summary: Manage DNS MX (mail) records
-"""
-helps['network dns record ns'] = """
-    type: group
-    short-summary: Manage DNS NS (nameserver) records
-"""
-helps['network dns record ptr'] = """
-    type: group
-    short-summary: Manage DNS PTR (pointer) records
-"""
-helps['network dns record srv'] = """
-    type: group
-    short-summary: Manage DNS SRV records
-"""
-helps['network dns record txt'] = """
-    type: group
-    short-summary: Manage DNS TXT records
-"""
-helps['network dns record-set'] = """
-    type: group
-    short-summary: Manage DNS record-set
-"""
-helps['network dns zone'] = """
-    type: group
-    short-summary: Manage DNS zones
-"""
-helps['network dns zone create'] = """
-    type: command
-    short-summary: Creates or updates DNS zone properties. Does not modify DNS records within the zone.
-    parameters:
-        - name: --if-none-match
-          short-summary: Create only if there isn't an existing DNS zone matches the given one.
-"""
-helps['network dns zone delete'] = """
-    type: command
-    short-summary: Deletes a DNS zone. WARNING All DNS records in the zone will also be deleted. This operation cannot be undone.
-"""
-helps['network dns zone export'] = """
-    type: command
-    short-summary: Export a DNS zone as a DNS zone file.
-"""
-helps['network dns zone import'] = """
-    type: command
-    short-summary: Export a DNS zone as a DNS zone file.
-"""
-helps['network dns zone list'] = """
-    type: command
-    short-summary: List DNS zones in a resource group or subscription.
-"""
-helps['network dns zone show'] = """
-    type: command
-    short-summary: Gets DNS zone parameters. Does not show DNS records within the zone.
-"""
-helps['network dns zone update'] = """
-    type: command
-    short-summary: Updates DNS zone properties. Does not modify DNS records within the zone.
-    parameters:
-        - name: --if-match
-          short-summary: Update only if the resource with the same ETAG exists.
-"""
-helps['network express-route'] = """
-    type: group
-    short-summary: Dedicated private network fiber connections to Azure
-"""
-helps['network express-route create'] = """
-    type: command
-    short-summary: Create an ExpressRoute circuit.
-"""
-helps['network express-route delete'] = """
-    type: command
-    short-summary: Delete an ExpressRoute circuit.
-"""
-helps['network express-route get-stats'] = """
-    type: command
-    short-summary: Show stats of an ExpressRoute circuit.
-"""
-helps['network express-route list'] = """
-    type: command
-    short-summary: List ExpressRoute circuits in a subscription or resource group.
-"""
-helps['network express-route list-arp-tables'] = """
-    type: command
-    short-summary: List the currently advertised ARP table of an ExpressRoute circuit.
-"""
-helps['network express-route list-route-tables'] = """
-    type: command
-    short-summary: List the currently advertised route tables of an ExpressRoute circuit.
-"""
-helps['network express-route show'] = """
-    type: command
-    short-summary: Show details of an ExpressRoute circuit.
-"""
-helps['network express-route update'] = """
-    type: command
-    short-summary: Update settings of an ExpressRoute circuit.
-"""
-helps['network express-route auth'] = """
-    type: group
-    short-summary: Manage ExpressRoute circuit authentication
-"""
-helps['network express-route auth create'] = """
-    type: command
-    short-summary: Create an authorization setting in an ExpressRoute circuit.
-"""
-helps['network express-route auth delete'] = """
-    type: command
-    short-summary: Delete an authorization setting in an ExpressRoute circuit.
-"""
-helps['network express-route auth list'] = """
-    type: command
-    short-summary: List authorization settings of an ExpressRoute circuit.
-"""
-helps['network express-route auth show'] = """
-    type: command
-    short-summary: Show details of an authorization setting in an ExpressRoute circuit.
-"""
-helps['network express-route peering'] = """
-    type: group
-    short-summary: Manage ExpressRoute peering
-"""
-helps['network express-route peering create'] = """
-    type: command
-    short-summary: Create peering settings in an ExpressRoute circuit.
-"""
-helps['network express-route peering delete'] = """
-    type: command
-    short-summary: Delete peering settings in an ExpressRoute circuit.
-"""
-helps['network express-route peering list'] = """
-    type: command
-    short-summary: List peering settings of an ExpressRoute circuit.
-"""
-helps['network express-route peering show'] = """
-    type: command
-    short-summary: Show peering details of an ExpressRoute circuit.
-"""
-helps['network express-route peering update'] = """
-    type: command
-    short-summary: Update peering settings in an ExpressRoute circuit.
-"""
-helps['network express-route list-service-providers'] = """
-    type: command
-    short-summary: List available ExpressRoute service providers.
-"""
-
-# Load Balancer
-
-helps['network lb'] = """
-    type: group
-    short-summary: Deliver high availability and network performance to your applications
-"""
-
-helps['network lb create'] = """
-    type: command
-    short-summary: Create a new load balancer.
-"""
-
-helps['network lb delete'] = """
-    type: command
-    short-summary: Delete a load balancer.
-"""
-
-helps['network lb list'] = """
-    type: command
-    short-summary: List load balancers in a resource group or subscription.
-"""
-
-helps['network lb show'] = """
-    type: command
-    short-summary: Show details of a load balancer.
-"""
-
-helps['network lb update'] = """
-    type: command
-    short-summary: Update a load balancer.
-"""
-
-# Load Balancer address pool
-
-helps['network lb address-pool'] = """
-    type: group
-    short-summary: Manage load balancer backend address pools
-"""
-
-helps['network lb address-pool create'] = """
-    type: command
-    short-summary: Create a new load balancer backend address pool.
-"""
-
-helps['network lb address-pool delete'] = """
-    type: command
-    short-summary: Delete a load balancer backend address pool.
-"""
-
-helps['network lb address-pool list'] = """
-    type: command
-    short-summary: List backend address pools in a load balancer.
-"""
-
-helps['network lb address-pool show'] = """
-    type: command
-    short-summary: Show details of a load balancer backend address pool.
-"""
-
-# Load Balancer frontend IP
-
-helps['network lb frontend-ip'] = """
-    type: group
-    short-summary: Manage load balancer front-end IP addresses
-"""
-
-helps['network lb frontend-ip create'] = """
-    type: command
-    short-summary: Create a new load balancer front-end IP address.
-"""
-
-helps['network lb frontend-ip delete'] = """
-    type: command
-    short-summary: Delete a load balancer front-end IP address.
-"""
-
-helps['network lb frontend-ip list'] = """
-    type: command
-    short-summary: List front-end IP addresses in a load balancer.
-"""
-
-helps['network lb frontend-ip show'] = """
-    type: command
-    short-summary: Show details of a load balancer front-end IP address.
-"""
-
-helps['network lb frontend-ip update'] = """
-    type: command
-    short-summary: Update a load balancer front-end IP address.
-"""
-
-# Load Balancer inbound NAT pool
-
-helps['network lb inbound-nat-pool'] = """
-    type: group
-    short-summary: Manage load balancer inbound NAT address pools
-"""
-
-helps['network lb inbound-nat-pool create'] = """
-    type: command
-    short-summary: Create a new load balancer inbound NAT address pool.
-"""
-
-helps['network lb inbound-nat-pool delete'] = """
-    type: command
-    short-summary: Delete a load balancer inbound NAT address pool.
-"""
-
-helps['network lb inbound-nat-pool list'] = """
-    type: command
-    short-summary: List inbound NAT address pools in a load balancer.
-"""
-
-helps['network lb inbound-nat-pool show'] = """
-    type: command
-    short-summary: Show details of a load balancer inbound NAT address pool.
-"""
-
-helps['network lb inbound-nat-pool update'] = """
-    type: command
-    short-summary: Update a load balancer inbound NAT address pool.
-"""
-
-# Load Balancer inbound NAT rule
-
-helps['network lb inbound-nat-rule'] = """
-    type: group
-    short-summary: Manage load balancer inbound NAT rules
-"""
-
-helps['network lb inbound-nat-rule create'] = """
-    type: command
-    short-summary: Create a new load balancer inbound NAT rule.
-"""
-
-helps['network lb inbound-nat-rule delete'] = """
-    type: command
-    short-summary: Delete a load balancer inbound NAT rule.
-"""
-
-helps['network lb inbound-nat-rule list'] = """
-    type: command
-    short-summary: List inbound NAT rules in a load balancer.
-"""
-
-helps['network lb inbound-nat-rule show'] = """
-    type: command
-    short-summary: Show details of a load balancer inbound NAT rule.
-"""
-
-helps['network lb inbound-nat-rule update'] = """
-    type: command
-    short-summary: Update a load balancer inbound NAT rule.
-"""
-
-# Load Balancer probe
-
-helps['network lb probe'] = """
-    type: group
-    short-summary: Evaluate probe information and define routing rules
-"""
-
-helps['network lb probe create'] = """
-    type: command
-    short-summary: Create a new load balancer probe.
-"""
-
-helps['network lb probe delete'] = """
-    type: command
-    short-summary: Delete a load balancer probe.
-"""
-
-helps['network lb probe list'] = """
-    type: command
-    short-summary: List probes in a load balancer.
-"""
-
-helps['network lb probe show'] = """
-    type: command
-    short-summary: Show details of a load balancer probe.
-"""
-
-helps['network lb probe update'] = """
-    type: command
-    short-summary: Update a load balancer probe.
-"""
-
-# Load Balancer rule
-
-helps['network lb rule'] = """
-    type: group
-    short-summary: Gather information, such as utilization, to be evaluated by rules
-"""
-
-helps['network lb rule create'] = """
-    type: command
-    short-summary: Create a new load balancing rule.
-"""
-
-helps['network lb rule delete'] = """
-    type: command
-    short-summary: Delete a load balancing rule.
-"""
-
-helps['network lb rule list'] = """
-    type: command
-    short-summary: List load balancing rules in a load balancer.
-"""
-
-helps['network lb rule show'] = """
-    type: command
-    short-summary: Show details of a load balancing rule.
-"""
-
-helps['network lb rule update'] = """
-    type: command
-    short-summary: Update a load balancing rule.
-"""
-
-# Local Gateway
-
-helps['network local-gateway'] = """
-    type: group
-    short-summary: Manage local gateways
-"""
-
-helps['network local-gateway create'] = """
-    type: command
-    short-summary: Create a new local VPN gateway.
-"""
-
-helps['network local-gateway delete'] = """
-    type: command
-    short-summary: Delete a local VPN gateway.
-"""
-helps['network local-gateway list'] = """
-    type: command
-    short-summary: List local VPN gateways in a resource group.
-"""
-helps['network local-gateway show'] = """
-    type: command
-    short-summary: Show details of a local VPN gateway.
-"""
-
-helps['network local-gateway update'] = """
-    type: command
-    short-summary: Update an existing local VPN gateway.
-"""
-
-# Network Security Group (NSG)
+# region Network Security Group (NSG)
 
 helps['network nsg'] = """
     type: group
@@ -1047,8 +1040,9 @@ helps['network nsg rule'] = """
     type: group
     short-summary: Manage NSG rules
 """
+#endregion
 
-# Public IP
+# region Public IP
 
 helps['network public-ip'] = """
     type: group
@@ -1079,8 +1073,9 @@ helps['network public-ip update'] = """
     type: command
     short-summary: Update an existing public IP address.
 """
+#endregion
 
-# Route Table
+# region Route Table
 
 helps['network route-table'] = """
     type: group
@@ -1090,8 +1085,9 @@ helps['network route-table route'] = """
     type: group
     short-summary: Manage route table routes
 """
+#endregion
 
-# Traffic Manager
+# region Traffic Manager
 
 helps['network traffic-manager'] = """
     type: group
@@ -1162,19 +1158,115 @@ helps['network traffic-manager endpoint update'] = """
     type: command
     short-summary: Update an existing Traffic Manager endpoint.
 """
+#endregion
 
-# Virtual Network (VNET)
+# region Virtual Network (VNET)
 
 helps['network vnet'] = """
     type: group
-    short-summary: Provision private networks
-"""
-helps['network vnet subnet'] = """
-    type: group
-    short-summary: Manage subnets
+    short-summary: Manage virtual networks.
 """
 
-# VPN Connection
+helps['network vnet check-ip-address'] = """
+    type: command
+    short-summary: Check whether a private IP address is available for use.
+"""
+
+helps['network vnet create'] = """
+    type: command
+    short-summary: Create a virtual network.
+    long-summary: You may also create a subnet at the same time by specifying a subnet name and
+        (optionally) an address prefix.
+"""
+
+helps['network vnet delete'] = """
+    type: command
+    short-summary: Delete a virtual network.
+"""
+
+helps['network vnet list'] = """
+    type: command
+    short-summary: List virtual networks within a resource group or subscription.
+"""
+
+helps['network vnet show'] = """
+    type: command
+    short-summary: Show details on a virtual network.
+"""
+
+helps['network vnet update'] = """
+    type: command
+    short-summary: Update a virtual network.
+"""
+#endregion
+
+# region VNet Subnet
+
+helps['network vnet subnet'] = """
+    type: group
+    short-summary: Manage virtual network subnets.
+"""
+
+helps['network vnet subnet create'] = """
+    type: command
+    short-summary: Create a virtual network subnet.
+"""
+
+helps['network vnet subnet delete'] = """
+    type: command
+    short-summary: Delete a virtual network subnet.
+"""
+
+helps['network vnet subnet list'] = """
+    type: command
+    short-summary: List subnets within a virtual network.
+"""
+
+helps['network vnet subnet show'] = """
+    type: command
+    short-summary: Show details on a virtual network subnet.
+"""
+
+helps['network vnet subnet update'] = """
+    type: command
+    short-summary: Update a virtual network subnet.
+"""
+#endregion
+
+# region Virtual Network (VNet) Peering
+
+helps['network vnet peering'] = """
+    type: group
+    short-summary: Manage peering connections between virtual networks.
+"""
+
+helps['network vnet peering create'] = """
+    type: command
+    short-summary: Create a virtual network peering.
+"""
+
+helps['network vnet peering delete'] = """
+    type: command
+    short-summary: Delete a virtual network peering.
+"""
+
+helps['network vnet peering list'] = """
+    type: command
+    short-summary: List peerings within a virtual network.
+"""
+
+helps['network vnet peering show'] = """
+    type: command
+    short-summary: Show details on a virtual network peering.
+"""
+
+helps['network vnet peering update'] = """
+    type: command
+    short-summary: Update a virtual network peering.
+"""
+#endregion
+
+# region VPN Connection
 
 helps['network vpn-connection'] = """
     type: group
@@ -1206,7 +1298,9 @@ helps['network vpn-connection update'] = """
     short-summary: Update a VPN connection.
 """
 
-# VPN Connection shared key
+#endregion
+
+# region VPN Connection shared key
 
 helps['network vpn-connection shared-key'] = """
     type: group
@@ -1228,7 +1322,9 @@ helps['network vpn-connection shared-key update'] = """
     short-summary: Update a VPN connection shared key.
 """
 
-# VNET Gateway
+#endregion
+
+# region VNet Gateway
 
 helps['network vnet-gateway'] = """
     type: group
@@ -1269,8 +1365,9 @@ helps['network vnet-gateway update'] = """
     type: command
     short-summary: Update a VNet gateway.
 """
+#endregion
 
-# VPN Gateway Revoke Cert
+# region VNet Gateway Revoke Cert
 
 helps['network vnet-gateway revoked-cert'] = """
     type: group
@@ -1287,8 +1384,9 @@ helps['network vnet-gateway revoked-cert delete'] = """
     short-summary: Delete a revoked VNet gateway certificate.
 """
 
-# VPN Gateway Root Cert
+#endregion
 
+# region VNet Gateway Root Cert
 helps['network vnet-gateway root-cert'] = """
     type: group
     short-summary: Manage VNet gateway root certificates
@@ -1303,3 +1401,5 @@ helps['network vnet-gateway root-cert delete'] = """
     type: command
     short-summary: Delete a VNet gateway root certificate.
 """
+
+#endregion

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -120,6 +120,7 @@ load_balancer_name_type = CliArgumentType(options_list=('--lb-name',), metavar='
 private_ip_address_type = CliArgumentType(help='Static private IP address to use.', validator=validate_private_ip_address)
 cookie_based_affinity_type = CliArgumentType(**enum_choice_list(ApplicationGatewayCookieBasedAffinity))
 http_protocol_type = CliArgumentType(**enum_choice_list(ApplicationGatewayProtocol))
+modified_record_type = CliArgumentType(options_list=('--type', '-t'), help='The type of DNS records in the record set.', **enum_choice_list([x.value for x in RecordType if x.value != 'SOA']))
 
 # ARGUMENT REGISTRATION
 
@@ -503,13 +504,12 @@ register_cli_argument('network traffic-manager endpoint create', 'target', help=
 
 # DNS
 register_cli_argument('network dns', 'location', help=argparse.SUPPRESS, default='global')
-register_cli_argument('network dns', 'record_set_name', name_arg_type, help='The name of the RecordSet, relative to the name of the zone.')
-register_cli_argument('network dns', 'relative_record_set_name', name_arg_type, help='The name of the RecordSet, relative to the name of the zone.')
+register_cli_argument('network dns', 'record_set_name', name_arg_type, help='The name of the record set, relative to the name of the zone.')
+register_cli_argument('network dns', 'relative_record_set_name', name_arg_type, help='The name of the record set, relative to the name of the zone.')
 register_cli_argument('network dns', 'zone_name', options_list=('--zone-name', '-z'), help='The name of the zone without a terminating dot.')
 register_cli_argument('network dns', 'metadata', nargs='+', help='Metadata in space-separated key=value pairs. This overwrites any existing metadata.', validator=validate_metadata)
 
-modified_record_type = [x.value for x in RecordType if x.value != 'SOA']
-register_cli_argument('network dns', 'record_type', options_list=('--type', '-t'), **enum_choice_list(modified_record_type))
+register_cli_argument('network dns', 'record_type', modified_record_type)
 register_cli_argument('network dns', 'location', help=argparse.SUPPRESS, default='global')
 
 register_cli_argument('network dns zone', 'zone_name', name_arg_type)
@@ -523,7 +523,7 @@ register_cli_argument('network dns record', 'record_set_name', options_list=('--
 register_cli_argument('network dns record txt add', 'value', nargs='+')
 register_cli_argument('network dns record txt remove', 'value', nargs='+')
 
-register_cli_argument('network dns record-set create', 'record_set_type', options_list=('--type', '-t'), help='The type of DNS records in the record set.', **enum_choice_list(modified_record_type))
+register_cli_argument('network dns record-set create', 'record_set_type', modified_record_type)
 register_cli_argument('network dns record-set create', 'ttl', help='Record set TTL (time-to-live)')
 register_cli_argument('network dns record-set create', 'if_none_match', help='Create the record set only if it does not already exist.', action='store_true')
 

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -35,7 +35,7 @@ from azure.cli.command_modules.network._validators import \
      process_vnet_gateway_create_namespace, process_vpn_connection_create_namespace,
      validate_inbound_nat_rule_id_list, validate_address_pool_id_list,
      validate_inbound_nat_rule_name_or_id, validate_address_pool_name_or_id,
-     validate_servers, load_cert_file,
+     validate_servers, load_cert_file, validate_metadata,
      validate_peering_type,
      get_public_ip_validator, get_nsg_validator, get_subnet_validator,
      get_virtual_network_validator)
@@ -503,17 +503,29 @@ register_cli_argument('network traffic-manager endpoint create', 'target', help=
 
 # DNS
 register_cli_argument('network dns', 'location', help=argparse.SUPPRESS, default='global')
-register_cli_argument('network dns zone', 'zone_name', name_arg_type)
 register_cli_argument('network dns', 'record_set_name', name_arg_type, help='The name of the RecordSet, relative to the name of the zone.')
 register_cli_argument('network dns', 'relative_record_set_name', name_arg_type, help='The name of the RecordSet, relative to the name of the zone.')
-register_cli_argument('network dns', 'zone_name', help='The name of the zone without a terminating dot.')
-register_cli_argument('network dns record-set create', 'record_set_type', options_list=('--type',), **enum_choice_list(RecordType))
-register_cli_argument('network dns record-set create', 'ttl', default=3600)
-register_cli_argument('network dns', 'record_type', options_list=('--type',), **enum_choice_list(RecordType))
-register_cli_argument('network dns record', 'record_set_name', options_list=('--record-set-name',))
-register_cli_argument('network dns record txt add', 'value', nargs='+')
-register_cli_argument('network dns record txt remove', 'value', nargs='+')
+register_cli_argument('network dns', 'zone_name', options_list=('--zone-name', '-z'), help='The name of the zone without a terminating dot.')
+register_cli_argument('network dns', 'metadata', nargs='+', help='Metadata in space-separated key=value pairs. This overwrites any existing metadata.', validator=validate_metadata)
+
+modified_record_type = [x.value for x in RecordType if x.value != 'SOA']
+register_cli_argument('network dns', 'record_type', options_list=('--type', '-t'), **enum_choice_list(modified_record_type))
+register_cli_argument('network dns', 'location', help=argparse.SUPPRESS, default='global')
+
+register_cli_argument('network dns zone', 'zone_name', name_arg_type)
+
 register_cli_argument('network dns zone import', 'file_name', help='Path to the DNS zone file to import')
 register_cli_argument('network dns zone export', 'file_name', help='Path to the DNS zone file to save')
-register_cli_argument('network dns', 'location', help=argparse.SUPPRESS, default='global')
 register_cli_argument('network dns zone update', 'if_none_match', ignore_type)
+
+register_cli_argument('network dns record', 'record_set_name', options_list=('--record-set-name',))
+
+register_cli_argument('network dns record txt add', 'value', nargs='+')
+register_cli_argument('network dns record txt remove', 'value', nargs='+')
+
+register_cli_argument('network dns record-set create', 'record_set_type', options_list=('--type', '-t'), help='The type of DNS records in the record set.', **enum_choice_list(modified_record_type))
+register_cli_argument('network dns record-set create', 'ttl', help='Record set TTL (time-to-live)')
+register_cli_argument('network dns record-set create', 'if_none_match', help='Create the record set only if it does not already exist.', action='store_true')
+
+for item in ['list', 'show']:
+    register_cli_argument('network dns record-set {}'.format(item), 'record_type', options_list=('--type', '-t'), **enum_choice_list(RecordType))

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
@@ -135,6 +135,10 @@ def validate_inbound_nat_rule_name_or_id(namespace):
         namespace.inbound_nat_rule = _generate_lb_subproperty_id(
             namespace, 'inboundNatRules', rule_name)
 
+def validate_metadata(namespace):
+    if namespace.metadata:
+        namespace.metadata = dict(x.split('=', 1) for x in namespace.metadata)
+
 def validate_peering_type(namespace):
     if namespace.peering_type and namespace.peering_type == 'MicrosoftPeering':
 

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -25,6 +25,7 @@ from azure.cli.command_modules.network.mgmt_nic.lib.operations.nic_operations im
 from azure.mgmt.trafficmanager import TrafficManagerManagementClient
 from azure.mgmt.trafficmanager.models import Endpoint
 from azure.mgmt.dns import DnsManagementClient
+from azure.mgmt.dns.operations import RecordSetsOperations
 from azure.mgmt.dns.models import (RecordSet, AaaaRecord, ARecord, CnameRecord, MxRecord,
                                    NsRecord, PtrRecord, SoaRecord, SrvRecord, TxtRecord, Zone)
 
@@ -1038,11 +1039,13 @@ def list_dns_zones(resource_group_name=None):
         return ncf.list_in_subscription()
 
 def create_dns_record_set(resource_group_name, zone_name, record_set_name, record_set_type,
-                          ttl=None):
+                          metadata=None, if_match=None, if_none_match=None, ttl=3600):
     ncf = get_mgmt_service_client(DnsManagementClient).record_sets
-    record_set = RecordSet(name=record_set_name, type=record_set_type, ttl=ttl)
+    record_set = RecordSet(name=record_set_name, type=record_set_type, ttl=ttl, metadata=metadata)
     return ncf.create_or_update(resource_group_name, zone_name, record_set_name,
-                                record_set_type, record_set)
+                                record_set_type, record_set, if_match=if_match,
+                                if_none_match='*' if if_none_match else None)
+create_dns_record_set.__doc__ = RecordSetsOperations.create_or_update.__doc__
 
 def export_zone(resource_group_name, zone_name, file_name):
     client = get_mgmt_service_client(DnsManagementClient)


### PR DESCRIPTION
Fixes #1129 (and pieces of other DNS issues).

- Updates help text
- Adds the following parameters to `dnz record-set create`: `--metadata`, `--if-match`, `--if-none-match`
- Removes record type SOA from the --type enum because that type cannot be created, only updated.
- Adds `-t` alias for `--type` and `-z` alias for `--zone-name`