### PR TITLE
Correct endpoints for USGov

### DIFF
--- a/src/azure-cli-core/azure/cli/core/cloud.py
+++ b/src/azure-cli-core/azure/cli/core/cloud.py
@@ -119,8 +119,8 @@ AZURE_CHINA_CLOUD = Cloud('AzureChinaCloud',
 
 AZURE_US_GOV_CLOUD = Cloud('AzureUSGovernment',
                            endpoints=CloudEndpoints(
-                               management='https://management.core.usgovcloudapi.net',
-                               resource_manager='https://management.usgovcloudapi.net',
+                               management='https://management.core.usgovcloudapi.net/',
+                               resource_manager='https://management.usgovcloudapi.net/',
                                sql_management='https://management.core.usgovcloudapi.net:8443/',
                                gallery='https://gallery.usgovcloudapi.net/',
                                active_directory='https://login.microsoftonline.com',


### PR DESCRIPTION
Was getting this error:

```
The access token has been obtained from wrong audience or resource
'https://management.core.usgovcloudapi.net'. It should exactly match
(including forward slash) with one of the allowed audiences
'https://management.core.usgovcloudapi.net/','https://management.usgovcloudapi.net/'.
```