### PR TITLE
[IoT] update IoT management SDK and add missing commands

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_help.py
+++ b/src/azure-cli-core/azure/cli/core/_help.py
@@ -186,12 +186,8 @@ def _print_groups(help_file):
         _print_items(subcommands)
 
 def _get_choices_defaults_sources_str(p):
-    # Convert each choice item to string and add double quotes if string contains white space
-    def _stringify(item):
-        item_str = str(item)
-        return '"{0}"'.format(item_str) if ' ' in item_str else item_str
-    choice_str = '  Allowed values: {0}.'.format(
-        ', '.join(sorted([_stringify(x) for x in p.choices]))) if p.choices else ''
+    choice_str = '  Allowed values: {0}.'.format(', '.join(sorted([str(x) for x in p.choices]))) \
+        if p.choices else ''
     default_str = '  Default: {0}.'.format(p.default) \
         if p.default and p.default != argparse.SUPPRESS else ''
     value_sources_str = '  Values from: {0}.'.format(', '.join(p.value_sources)) \

--- a/src/azure-cli-core/azure/cli/core/_help.py
+++ b/src/azure-cli-core/azure/cli/core/_help.py
@@ -186,8 +186,12 @@ def _print_groups(help_file):
         _print_items(subcommands)
 
 def _get_choices_defaults_sources_str(p):
-    choice_str = '  Allowed values: {0}.'.format(', '.join(sorted([str(x) for x in p.choices]))) \
-        if p.choices else ''
+    # Convert each choice item to string and add double quotes if string contains white space
+    def _stringify(item):
+        item_str = str(item)
+        return '"{0}"'.format(item_str) if ' ' in item_str else item_str
+    choice_str = '  Allowed values: {0}.'.format(
+        ', '.join(sorted([_stringify(x) for x in p.choices]))) if p.choices else ''
     default_str = '  Default: {0}.'.format(p.default) \
         if p.default and p.default != argparse.SUPPRESS else ''
     value_sources_str = '  Values from: {0}.'.format(', '.join(p.value_sources)) \

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_help.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_help.py
@@ -41,6 +41,16 @@ helps['iot hub show'] = """
     short-summary: Show non-security metadata of an IoT Hub.
 """
 
+helps['iot hub update'] = """
+    type: command
+    short-summary: Update non-security metadata of an IoT Hub.
+    examples:
+        - name: Add a new IP filter rule.
+          text: >
+            az iot hub update --name my-iot-hub --add properties.ipFilterRules filter_name=test-rule action=Accept ip_mask=127.0.0.0/31
+            az iot hub update --name my-iot-hub --add properties.ipFilterRules filter_name=test-rule action=Reject ip_mask=127.0.0.0/31
+"""
+
 helps['iot hub list'] = """
     type: command
     short-summary: List IoT Hubs in your subscription or resource group.
@@ -67,6 +77,11 @@ helps['iot hub show-connection-string'] = """
         - name: Show connection strings of all IoT Hubs in current subscription.
           text: >
             az iot hub show-connection-string
+"""
+
+helps['iot hub delete'] = """
+    type: command
+    short-summary: Delete an IoT Hub.
 """
 
 helps['iot hub consumer-group'] = """
@@ -116,6 +131,20 @@ helps['iot hub policy show'] = """
     short-summary: Get a shared access policy of an IoT Hub.
 """
 
+helps['iot hub policy create'] = """
+    type: command
+    short-summary: Create a new shared access policy in an IoT Hub.
+    examples:
+        - name: Create a new shared access policy
+          text: >
+            az iot hub policy create --hub-name my-iot-hub --name new-policy --permissions "RegistryWrite, ServiceConnect, DeviceConnect"
+"""
+
+helps['iot hub policy delete'] = """
+    type: command
+    short-summary: Delete a shared access policy from an IoT Hub.
+"""
+
 helps['iot hub list-skus'] = """
     type: command
     short-summary: List all valid pricing tiers.
@@ -149,11 +178,6 @@ helps['iot hub show-quota-metrics'] = """
 helps['iot hub show-stats'] = """
     type: command
     short-summary: Show stats of an IoT Hub.
-"""
-
-helps['iot device'] = """
-    type: group
-    short-summary: Manage devices attached to an IoT Hub.
 """
 
 helps['iot device create'] = """
@@ -265,4 +289,16 @@ helps['iot device message reject'] = """
 helps['iot device message abandon'] = """
     type: command
     short-summary: Abandon a cloud-to-device message.
+"""
+
+helps['iot device export'] = """
+    type: command
+    short-summary: Exports all the device identities in the IoT hub identity registry to an Azure Storage blob container.
+    long-summary: For more information, see https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities.
+"""
+
+helps['iot device import'] = """
+    type: command
+    short-summary: Import, update, or delete device identities in the IoT hub identity registry from a blob.
+    long-summary: For more information, see https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-identity-registry#import-and-export-device-identities.
 """

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_help.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_help.py
@@ -137,7 +137,7 @@ helps['iot hub policy create'] = """
     examples:
         - name: Create a new shared access policy
           text: >
-            az iot hub policy create --hub-name my-iot-hub --name new-policy --permissions "RegistryWrite, ServiceConnect, DeviceConnect"
+            az iot hub policy create --hub-name my-iot-hub --name new-policy --permissions RegistryWrite ServiceConnect DeviceConnect
 """
 
 helps['iot hub policy delete'] = """

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_params.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_params.py
@@ -7,7 +7,7 @@
 from azure.cli.core.commands.parameters import \
     location_type, enum_choice_list, get_resource_name_completion_list, CliArgumentType
 from azure.cli.core.commands import register_cli_argument
-from azure.mgmt.iothub.models.iot_hub_client_enums import IotHubSku
+from azure.mgmt.iothub.models.iot_hub_client_enums import IotHubSku, AccessRights
 from ._factory import iot_hub_service_factory
 from .custom import iot_device_list, KeyType
 
@@ -37,6 +37,8 @@ register_cli_argument('iot hub consumer-group', 'event_hub_name', id_part='child
 # Arguments for 'iot hub policy' group
 register_cli_argument('iot hub policy', 'policy_name', options_list=('--name', '-n'), id_part='child_name',
                       help='Shared access policy name.')
+register_cli_argument('iot hub policy', 'permissions', help='Permissions of shared access policy.',
+                      **enum_choice_list(AccessRights))
 
 # Arguments for 'iot hub job' group
 register_cli_argument('iot hub job', 'job_id', id_part='child_name', help='Job Id.')
@@ -103,3 +105,18 @@ register_cli_argument('iot device message send', 'user_id', help='Device-to-clou
 register_cli_argument('iot device message receive', 'lock_timeout', type=int,
                       help='In case a message returned to this call, this specifies the amount of time in seconds, '
                            'the message will be invisible to other receive calls.')
+
+# Arguments for 'iot device export'
+register_cli_argument('iot device export', 'blob_container_uri',
+                      help='Blob Shared Access Signature URI with write access to a blob container.'
+                           'This is used to output the status of the job and the results.')
+register_cli_argument('iot device export', 'include_keys', action='store_true',
+                      help='If set, keys are exported normally. Otherwise, keys are set to null in export output.')
+
+# Arguments for 'iot device import'
+register_cli_argument('iot device import', 'input_blob_container_uri',
+                      help='Blob Shared Access Signature URI with read access to a blob container.'
+                           'This blob contains the operations to be performed on the identity registry ')
+register_cli_argument('iot device import', 'output_blob_container_uri',
+                      help='Blob Shared Access Signature URI with write access to a blob container.'
+                           'This is used to output the status of the job and the results.')

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_params.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_params.py
@@ -7,9 +7,10 @@
 from azure.cli.core.commands.parameters import \
     location_type, enum_choice_list, get_resource_name_completion_list, CliArgumentType
 from azure.cli.core.commands import register_cli_argument
-from azure.mgmt.iothub.models.iot_hub_client_enums import IotHubSku, AccessRights
+from azure.mgmt.iothub.models.iot_hub_client_enums import IotHubSku
 from ._factory import iot_hub_service_factory
-from .custom import iot_device_list, KeyType
+from .custom import iot_device_list, KeyType, SimpleAccessRights
+from ._validators import validate_policy_permissions
 
 
 def get_device_id_completion_list(prefix, action, parsed_args, **kwargs):  # pylint: disable=unused-argument
@@ -37,8 +38,11 @@ register_cli_argument('iot hub consumer-group', 'event_hub_name', id_part='child
 # Arguments for 'iot hub policy' group
 register_cli_argument('iot hub policy', 'policy_name', options_list=('--name', '-n'), id_part='child_name',
                       help='Shared access policy name.')
-register_cli_argument('iot hub policy', 'permissions', help='Permissions of shared access policy.',
-                      **enum_choice_list(AccessRights))
+
+permission_values = ', '.join([x.value for x in SimpleAccessRights])
+register_cli_argument('iot hub policy', 'permissions', nargs='*', validator=validate_policy_permissions, type=str.lower,
+                      help='Permissions of shared access policy. Use space separated list for multiple permissions.'
+                           'Possible values: {}'.format(permission_values))
 
 # Arguments for 'iot hub job' group
 register_cli_argument('iot hub job', 'job_id', id_part='child_name', help='Job Id.')

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_validators.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/_validators.py
@@ -1,0 +1,17 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from argparse import ArgumentError
+from .custom import SimpleAccessRights
+
+
+def validate_policy_permissions(ns):
+    if ns.permissions is None or ns.permissions == []:
+        raise ArgumentError(None, 'the following arguments are required: --permissions')
+
+    allowed = [x.value.lower() for x in SimpleAccessRights]
+    for p in ns.permissions:
+        if p not in allowed:
+            raise ValueError('Unrecognized permission "{}"'.format(p))

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/commands.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/commands.py
@@ -4,17 +4,20 @@
 # --------------------------------------------------------------------------------------------
 # pylint: disable=line-too-long
 
-from azure.cli.core.commands import cli_command, LongRunningOperation
+from azure.cli.core.commands import cli_command
 from azure.cli.core.commands.arm import cli_generic_update_command
 from ._factory import iot_hub_service_factory as factory
+from .custom import PolicyUpdateResultTransform, HubDeleteResultTransform
 
 custom_path = 'azure.cli.command_modules.iot.custom#{0}'
 
 # iot hub commands
-cli_command(__name__, 'iot hub create', custom_path.format('iot_hub_create'), factory, transform=LongRunningOperation('creating IoT Hub...', '', 10000.0))
+cli_command(__name__, 'iot hub create', custom_path.format('iot_hub_create'), factory)
 cli_command(__name__, 'iot hub list', custom_path.format('iot_hub_list'), factory)
 cli_command(__name__, 'iot hub show-connection-string', custom_path.format('iot_hub_show_connection_string'), factory)
 cli_command(__name__, 'iot hub show', custom_path.format('iot_hub_get'), factory)
+cli_generic_update_command(__name__, 'iot hub update', custom_path.format('iot_hub_get'), custom_path.format('iot_hub_update'), factory)
+cli_command(__name__, 'iot hub delete', custom_path.format('iot_hub_delete'), factory, transform=HubDeleteResultTransform())
 cli_command(__name__, 'iot hub list-skus', custom_path.format('iot_hub_sku_list'), factory)
 cli_command(__name__, 'iot hub consumer-group create', custom_path.format('iot_hub_consumer_group_create'), factory)
 cli_command(__name__, 'iot hub consumer-group list', custom_path.format('iot_hub_consumer_group_list'), factory)
@@ -22,6 +25,8 @@ cli_command(__name__, 'iot hub consumer-group show', custom_path.format('iot_hub
 cli_command(__name__, 'iot hub consumer-group delete', custom_path.format('iot_hub_consumer_group_delete'), factory)
 cli_command(__name__, 'iot hub policy list', custom_path.format('iot_hub_policy_list'), factory)
 cli_command(__name__, 'iot hub policy show', custom_path.format('iot_hub_policy_get'), factory)
+cli_command(__name__, 'iot hub policy create', custom_path.format('iot_hub_policy_create'), factory, transform=PolicyUpdateResultTransform())
+cli_command(__name__, 'iot hub policy delete', custom_path.format('iot_hub_policy_delete'), factory, transform=PolicyUpdateResultTransform())
 cli_command(__name__, 'iot hub job list', custom_path.format('iot_hub_job_list'), factory)
 cli_command(__name__, 'iot hub job show', custom_path.format('iot_hub_job_get'), factory)
 cli_command(__name__, 'iot hub job cancel', custom_path.format('iot_hub_job_cancel'), factory)
@@ -40,3 +45,5 @@ cli_command(__name__, 'iot device message receive', custom_path.format('iot_devi
 cli_command(__name__, 'iot device message complete', custom_path.format('iot_device_complete_message'), factory)
 cli_command(__name__, 'iot device message reject', custom_path.format('iot_device_reject_message'), factory)
 cli_command(__name__, 'iot device message abandon', custom_path.format('iot_device_abandon_message'), factory)
+cli_command(__name__, 'iot device export', custom_path.format('iot_device_export'), factory)
+cli_command(__name__, 'iot device import', custom_path.format('iot_device_import'), factory)

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/tests/recordings/test_iot_hub.yaml
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/tests/recordings/test_iot_hub.yaml
@@ -7,10 +7,10 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['28']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [31e72068-c22f-11e6-b140-a0b3ccf7272a]
+      x-ms-client-request-id: [9ff3162c-cb35-11e6-bc69-40a8f04ffd53]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/checkNameAvailability?api-version=2016-02-03
   response:
@@ -18,7 +18,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 18:57:43 GMT']
+      Date: ['Mon, 26 Dec 2016 06:36:26 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -26,7 +26,7 @@ interactions:
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       content-length: ['56']
-      x-ms-ratelimit-remaining-subscription-writes: ['1188']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -35,11 +35,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 resourcemanagementclient/0.30.2 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          resourcemanagementclient/0.30.2 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [32388eba-c22f-11e6-af54-a0b3ccf7272a]
+      x-ms-client-request-id: [a0ea8746-cb35-11e6-a6d8-40a8f04ffd53]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/iot-hub-test-rg?api-version=2016-09-01
   response:
@@ -47,7 +46,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 18:57:44 GMT']
+      Date: ['Mon, 26 Dec 2016 06:36:27 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
@@ -55,27 +54,28 @@ interactions:
       content-length: ['220']
     status: {code: 200, message: OK}
 - request:
-    body: '{"location": "westus", "sku": {"capacity": 1, "name": "S1"}}'
+    body: '{"location": "westus", "sku": {"name": "S1", "capacity": 1}, "resourcegroup":
+      "iot-hub-test-rg", "subscriptionid": "ba8e3a3d-29a9-48dd-972c-cdcc47ecf584"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['60']
+      Content-Length: ['160']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [3246b2de-c22f-11e6-adc5-a0b3ccf7272a]
+      x-ms-client-request-id: [a1225470-cb35-11e6-a1eb-40a8f04ffd53]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test?api-version=2016-02-03
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","properties":{"state":"Activating","provisioningState":"Accepted","enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","properties":{"state":"Activating","provisioningState":"Accepted","enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}'}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NjZhNWIyOGMtMThiNC00YWIwLTgyNWItZDA5MTVkNWRiMTQ2?api-version=2016-02-03&asyncinfo']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/ba8e3a3d-29a9-48dd-972c-cdcc47ecf584/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NzBhYzhlZmUtNDQ5OC00ZjJiLTk4MTYtZmJiMDkwNWYxYTBm?api-version=2016-02-03&asyncinfo']
       Cache-Control: [no-cache]
       Content-Length: ['689']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 18:57:45 GMT']
+      Date: ['Mon, 26 Dec 2016 06:36:31 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -89,18 +89,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [3246b2de-c22f-11e6-adc5-a0b3ccf7272a]
+      x-ms-client-request-id: [a1225470-cb35-11e6-a1eb-40a8f04ffd53]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NjZhNWIyOGMtMThiNC00YWIwLTgyNWItZDA5MTVkNWRiMTQ2?api-version=2016-02-03&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NzBhYzhlZmUtNDQ5OC00ZjJiLTk4MTYtZmJiMDkwNWYxYTBm?api-version=2016-02-03&asyncinfo
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 18:58:15 GMT']
+      Date: ['Mon, 26 Dec 2016 06:37:03 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -116,18 +116,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [3246b2de-c22f-11e6-adc5-a0b3ccf7272a]
+      x-ms-client-request-id: [a1225470-cb35-11e6-a1eb-40a8f04ffd53]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NjZhNWIyOGMtMThiNC00YWIwLTgyNWItZDA5MTVkNWRiMTQ2?api-version=2016-02-03&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NzBhYzhlZmUtNDQ5OC00ZjJiLTk4MTYtZmJiMDkwNWYxYTBm?api-version=2016-02-03&asyncinfo
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 18:58:45 GMT']
+      Date: ['Mon, 26 Dec 2016 06:37:35 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -143,18 +143,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [3246b2de-c22f-11e6-adc5-a0b3ccf7272a]
+      x-ms-client-request-id: [a1225470-cb35-11e6-a1eb-40a8f04ffd53]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NjZhNWIyOGMtMThiNC00YWIwLTgyNWItZDA5MTVkNWRiMTQ2?api-version=2016-02-03&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NzBhYzhlZmUtNDQ5OC00ZjJiLTk4MTYtZmJiMDkwNWYxYTBm?api-version=2016-02-03&asyncinfo
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 18:59:16 GMT']
+      Date: ['Mon, 26 Dec 2016 06:38:06 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -170,18 +170,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [3246b2de-c22f-11e6-adc5-a0b3ccf7272a]
+      x-ms-client-request-id: [a1225470-cb35-11e6-a1eb-40a8f04ffd53]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NjZhNWIyOGMtMThiNC00YWIwLTgyNWItZDA5MTVkNWRiMTQ2?api-version=2016-02-03&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NzBhYzhlZmUtNDQ5OC00ZjJiLTk4MTYtZmJiMDkwNWYxYTBm?api-version=2016-02-03&asyncinfo
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 18:59:47 GMT']
+      Date: ['Mon, 26 Dec 2016 06:38:38 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -197,18 +197,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [3246b2de-c22f-11e6-adc5-a0b3ccf7272a]
+      x-ms-client-request-id: [a1225470-cb35-11e6-a1eb-40a8f04ffd53]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NjZhNWIyOGMtMThiNC00YWIwLTgyNWItZDA5MTVkNWRiMTQ2?api-version=2016-02-03&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NzBhYzhlZmUtNDQ5OC00ZjJiLTk4MTYtZmJiMDkwNWYxYTBm?api-version=2016-02-03&asyncinfo
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:00:17 GMT']
+      Date: ['Mon, 26 Dec 2016 06:39:09 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -224,18 +224,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [3246b2de-c22f-11e6-adc5-a0b3ccf7272a]
+      x-ms-client-request-id: [a1225470-cb35-11e6-a1eb-40a8f04ffd53]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NjZhNWIyOGMtMThiNC00YWIwLTgyNWItZDA5MTVkNWRiMTQ2?api-version=2016-02-03&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NzBhYzhlZmUtNDQ5OC00ZjJiLTk4MTYtZmJiMDkwNWYxYTBm?api-version=2016-02-03&asyncinfo
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:00:48 GMT']
+      Date: ['Mon, 26 Dec 2016 06:39:40 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -251,18 +251,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [3246b2de-c22f-11e6-adc5-a0b3ccf7272a]
+      x-ms-client-request-id: [a1225470-cb35-11e6-a1eb-40a8f04ffd53]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NjZhNWIyOGMtMThiNC00YWIwLTgyNWItZDA5MTVkNWRiMTQ2?api-version=2016-02-03&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NzBhYzhlZmUtNDQ5OC00ZjJiLTk4MTYtZmJiMDkwNWYxYTBm?api-version=2016-02-03&asyncinfo
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:01:18 GMT']
+      Date: ['Mon, 26 Dec 2016 06:40:12 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -278,18 +278,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [3246b2de-c22f-11e6-adc5-a0b3ccf7272a]
+      x-ms-client-request-id: [a1225470-cb35-11e6-a1eb-40a8f04ffd53]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NjZhNWIyOGMtMThiNC00YWIwLTgyNWItZDA5MTVkNWRiMTQ2?api-version=2016-02-03&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NzBhYzhlZmUtNDQ5OC00ZjJiLTk4MTYtZmJiMDkwNWYxYTBm?api-version=2016-02-03&asyncinfo
   response:
     body: {string: '{"status":"Running"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:01:48 GMT']
+      Date: ['Mon, 26 Dec 2016 06:40:44 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -305,45 +305,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [3246b2de-c22f-11e6-adc5-a0b3ccf7272a]
+      x-ms-client-request-id: [a1225470-cb35-11e6-a1eb-40a8f04ffd53]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NjZhNWIyOGMtMThiNC00YWIwLTgyNWItZDA5MTVkNWRiMTQ2?api-version=2016-02-03&asyncinfo
-  response:
-    body: {string: '{"status":"Running"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:02:19 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['20']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [3246b2de-c22f-11e6-adc5-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NjZhNWIyOGMtMThiNC00YWIwLTgyNWItZDA5MTVkNWRiMTQ2?api-version=2016-02-03&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NzBhYzhlZmUtNDQ5OC00ZjJiLTk4MTYtZmJiMDkwNWYxYTBm?api-version=2016-02-03&asyncinfo
   response:
     body: {string: '{"status":"Succeeded"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:02:49 GMT']
+      Date: ['Mon, 26 Dec 2016 06:41:15 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -359,18 +332,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [3246b2de-c22f-11e6-adc5-a0b3ccf7272a]
+      x-ms-client-request-id: [a1225470-cb35-11e6-a1eb-40a8f04ffd53]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test?api-version=2016-02-03
   response:
-    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9jQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:02:50 GMT']
+      Date: ['Mon, 26 Dec 2016 06:41:16 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -386,18 +359,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [eb4bacf6-c22f-11e6-ab3e-a0b3ccf7272a]
+      x-ms-client-request-id: [4e7ff802-cb36-11e6-8787-40a8f04ffd53]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9jQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:02:54 GMT']
+      Date: ['Mon, 26 Dec 2016 06:41:18 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -414,19 +387,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ebc962ae-c22f-11e6-a52a-a0b3ccf7272a]
+      x-ms-client-request-id: [4ef41c80-cb36-11e6-9e40-40a8f04ffd53]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
   response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"AwGPYGUGVXBuq+DH/J988CZxvAJCSlpdQY495cxt7ls=","secondaryKey":"XB2vej9wvuT9oF+to+u+EiNQYsUfv2z7Bug76PeboNs=","rights":"RegistryWrite,
+    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
         ServiceConnect, DeviceConnect"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:02:56 GMT']
+      Date: ['Mon, 26 Dec 2016 06:41:20 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -443,18 +416,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ecdb930c-c22f-11e6-8c6b-a0b3ccf7272a]
+      x-ms-client-request-id: [501b976e-cb36-11e6-b9a3-40a8f04ffd53]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9jQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:02:57 GMT']
+      Date: ['Mon, 26 Dec 2016 06:41:22 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -471,19 +444,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ed693af8-c22f-11e6-89c7-a0b3ccf7272a]
+      x-ms-client-request-id: [51283a30-cb36-11e6-855d-40a8f04ffd53]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
   response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"AwGPYGUGVXBuq+DH/J988CZxvAJCSlpdQY495cxt7ls=","secondaryKey":"XB2vej9wvuT9oF+to+u+EiNQYsUfv2z7Bug76PeboNs=","rights":"RegistryWrite,
+    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
         ServiceConnect, DeviceConnect"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:02:58 GMT']
+      Date: ['Mon, 26 Dec 2016 06:41:24 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -491,7 +464,7 @@ interactions:
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       content-length: ['203']
-      x-ms-ratelimit-remaining-subscription-writes: ['1194']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -500,18 +473,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ee13d754-c22f-11e6-b4c6-a0b3ccf7272a]
+      x-ms-client-request-id: [526ec5c8-cb36-11e6-9c76-40a8f04ffd53]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9jQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:02:59 GMT']
+      Date: ['Mon, 26 Dec 2016 06:41:26 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -527,45 +500,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [eec0d6c2-c22f-11e6-a90f-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:00 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1885']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [ef485214-c22f-11e6-87b3-a0b3ccf7272a]
+      x-ms-client-request-id: [536c6878-cb36-11e6-93f2-40a8f04ffd53]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9jQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:00 GMT']
+      Date: ['Mon, 26 Dec 2016 06:41:27 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -575,201 +521,48 @@ interactions:
       content-length: ['1885']
     status: {code: 200, message: OK}
 - request:
-    body: null
+    body: '{"location": "westus", "tags": {}, "subscriptionid": "ba8e3a3d-29a9-48dd-972c-cdcc47ecf584",
+      "etag": "AAAAAACS9jQ=", "sku": {"name": "S1", "capacity": 1}, "properties":
+      {"eventHubEndpoints": {"operationsMonitoringEvents": {"partitionCount": 4, "retentionTimeInDays":
+      1}, "events": {"partitionCount": 4, "retentionTimeInDays": 1}}, "enableFileUploadNotifications":
+      false, "operationsMonitoringProperties": {"events": {"C2DCommands": "None",
+      "Connections": "None", "FileUploadOperations": "None", "None": "None", "Routes":
+      "None", "DeviceTelemetry": "Error, Information", "DeviceIdentityOperations":
+      "None"}}, "features": "None", "messagingEndpoints": {"fileNotifications": {"ttlAsIso8601":
+      "PT1H", "maxDeliveryCount": 10, "lockDurationAsIso8601": "PT1M"}}, "cloudToDevice":
+      {"feedback": {"ttlAsIso8601": "PT1H", "maxDeliveryCount": 10, "lockDurationAsIso8601":
+      "PT1M"}, "maxDeliveryCount": 10, "defaultTtlAsIso8601": "PT1H"}, "ipFilterRules":
+      [], "storageEndpoints": {"$default": {"connectionString": "", "sasTtlAsIso8601":
+      "PT1H", "containerName": ""}}}, "resourcegroup": "iot-hub-test-rg"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
+      Content-Length: ['1096']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      IF-MATCH: [AAAAAACS9jQ=]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ef99aa3e-c22f-11e6-8dfd-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/skus?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"resourceType":"Microsoft.Devices/IotHubs","sku":{"name":"S1","tier":"Standard"},"capacity":{"minimum":1,"maximum":200,"default":1,"scaleType":"Manual"}},{"resourceType":"Microsoft.Devices/IotHubs","sku":{"name":"S2","tier":"Standard"},"capacity":{"minimum":1,"maximum":200,"default":1,"scaleType":"Manual"}},{"resourceType":"Microsoft.Devices/IotHubs","sku":{"name":"S3","tier":"Standard"},"capacity":{"minimum":1,"maximum":10,"default":1,"scaleType":"Manual"}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:02 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['475']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [f05567fa-c22f-11e6-b235-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:03 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1885']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [f0f029a2-c22f-11e6-a116-a0b3ccf7272a]
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/listkeys?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"keyName":"iothubowner","primaryKey":"AwGPYGUGVXBuq+DH/J988CZxvAJCSlpdQY495cxt7ls=","secondaryKey":"XB2vej9wvuT9oF+to+u+EiNQYsUfv2z7Bug76PeboNs=","rights":"RegistryWrite,
-        ServiceConnect, DeviceConnect"},{"keyName":"service","primaryKey":"xBd6gVv3DTOWK0Dl27qgoZJClBMf8jvR9ZMxq4Ivrj0=","secondaryKey":"5KXHC92EpDBz6iu6ecsX4wdlYKycCU+kQhxMa4WbQqk=","rights":"ServiceConnect"},{"keyName":"device","primaryKey":"85uRe8ichQ51NJ9qB+PblEBydh6oklj23c3HeL78118=","secondaryKey":"V4CRSZTlqkb0uIaJakDr1fnLbMHYh+oBbKC76oYWsj8=","rights":"DeviceConnect"},{"keyName":"registryRead","primaryKey":"1dim8PEc/RUEgYU1fpYBMWCXO2HCKWEsZlLerb945Hk=","secondaryKey":"l3TY+x2nw6xz93k2Q3DWXhkgmvEeBomsQjvLdhnKlwQ=","rights":"RegistryRead"},{"keyName":"registryReadWrite","primaryKey":"oHVfbYWsWvAonX5ib0y59pDKbgEBPx1HB+CZA6hcaW4=","secondaryKey":"YeOlVDCBuNVAhvPxtUlgC3Qf+qboZc5Cpx5UvRSebtA=","rights":"RegistryWrite"}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:04 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['905']
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [f18b293a-c22f-11e6-a779-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:04 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1885']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [f1d7db10-c22f-11e6-8d5b-a0b3ccf7272a]
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/service/listkeys?api-version=2016-02-03
-  response:
-    body: {string: '{"keyName":"service","primaryKey":"xBd6gVv3DTOWK0Dl27qgoZJClBMf8jvR9ZMxq4Ivrj0=","secondaryKey":"5KXHC92EpDBz6iu6ecsX4wdlYKycCU+kQhxMa4WbQqk=","rights":"ServiceConnect"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:05 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['169']
-      x-ms-ratelimit-remaining-subscription-writes: ['1189']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [f26f6926-c22f-11e6-9df5-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:06 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1885']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [f2cdacb8-c22f-11e6-8264-a0b3ccf7272a]
+      x-ms-client-request-id: [53e0d7fa-cb36-11e6-bcd3-40a8f04ffd53]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/eventHubEndpoints/events/ConsumerGroups/cg1?api-version=2016-02-03
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test?api-version=2016-02-03
   response:
-    body: {string: '{"tags":null,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"cg1"}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9jQ=","properties":{"provisioningState":"Accepted","authorizationPolicies":[{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"},{"keyName":"service","primaryKey":"7ulILAzXRPyeS+OTSAkM8EWLf66O/oCcvEFooU9GbbU=","secondaryKey":"DNg7fhkn/HtcFxoxzVxHLDHUQelYRPOOGwuLEWMxs8o=","rights":"ServiceConnect"},{"keyName":"device","primaryKey":"uoTOfrON68Y9LwTzitwcISGKWulqnZ+dUn7mEDkp4bQ=","secondaryKey":"WA2pycNQN649qgKMpkTyXH1lnOiF7qTdOxmacjjfQ5Q=","rights":"DeviceConnect"},{"keyName":"registryRead","primaryKey":"tj72HGGEEXPr5upM3Peqa6G2F5RzLwvzy2/yyuVGnSA=","secondaryKey":"9RmE73JjXzjuVl4XuDHkubgQ8vRjfKjHZ7dCbVWYzMI=","rights":"RegistryRead"},{"keyName":"registryReadWrite","primaryKey":"mWL0RMD7tOa8yc/+1pPeojmo9db4YXi7vcdG5zvbImo=","secondaryKey":"hsgOVzCVQD6aCS+TsQjY+tqyfZOaB2rboQZhf81dAYQ=","rights":"RegistryWrite"}],"ipFilterRules":[],"eventHubEndpoints":{"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4},"events":{"retentionTimeInDays":1,"partitionCount":4}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}'}
     headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/ba8e3a3d-29a9-48dd-972c-cdcc47ecf584/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/MjNhZTgyOGUtZjhmOS00NDcwLWI5OTYtNzdhMzI1MzUyMWQz?api-version=2016-02-03&asyncinfo']
       Cache-Control: [no-cache]
+      Content-Length: ['2443']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:08 GMT']
+      Date: ['Mon, 26 Dec 2016 06:41:30 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['175']
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: OK}
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['4998']
+    status: {code: 201, message: Created}
 - request:
     body: null
     headers:
@@ -777,206 +570,19 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      IF-MATCH: [AAAAAACS9jQ=]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f4762a52-c22f-11e6-bf3f-a0b3ccf7272a]
+      x-ms-client-request-id: [53e0d7fa-cb36-11e6-bcd3-40a8f04ffd53]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/MjNhZTgyOGUtZjhmOS00NDcwLWI5OTYtNzdhMzI1MzUyMWQz?api-version=2016-02-03&asyncinfo
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: '{"status":"Succeeded"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:10 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1885']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [f4f75eee-c22f-11e6-8b38-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/eventHubEndpoints/events/ConsumerGroups/cg1?api-version=2016-02-03
-  response:
-    body: {string: '{"tags":null,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"cg1"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:13 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['175']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [f7535c00-c22f-11e6-800f-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:14 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1885']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [f79e1994-c22f-11e6-afd4-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/eventHubEndpoints/events/ConsumerGroups?api-version=2016-02-03
-  response:
-    body: {string: '{"value":["$Default","cg1"]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:15 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['28']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [f8115242-c22f-11e6-8ab4-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:15 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1885']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [f860efca-c22f-11e6-8d25-a0b3ccf7272a]
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/eventHubEndpoints/events/ConsumerGroups/cg1?api-version=2016-02-03
-  response:
-    body: {string: ''}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['0']
-      Date: ['Wed, 14 Dec 2016 19:03:17 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1188']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [f8ebe83a-c22f-11e6-b1cb-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:17 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1885']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [f93652a4-c22f-11e6-856d-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/eventHubEndpoints/events/ConsumerGroups?api-version=2016-02-03
-  response:
-    body: {string: '{"value":["$Default"]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:18 GMT']
+      Date: ['Mon, 26 Dec 2016 06:42:01 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -992,25 +598,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      IF-MATCH: [AAAAAACS9jQ=]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f9a9b36c-c22f-11e6-b7c3-a0b3ccf7272a]
+      x-ms-client-request-id: [53e0d7fa-cb36-11e6-bcd3-40a8f04ffd53]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9p0=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:19 GMT']
+      Date: ['Mon, 26 Dec 2016 06:42:02 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['1885']
+      content-length: ['1887']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1019,10 +627,969 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f9f25cf8-c22f-11e6-bbfd-a0b3ccf7272a]
+      x-ms-client-request-id: [694120a8-cb36-11e6-b0b3-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9p0=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:42:04 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1899']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [6a0edfd0-cb36-11e6-8977-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9p0=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:42:05 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1899']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [6ae872c8-cb36-11e6-a23d-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9p0=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:42:06 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1899']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [6b5b37d4-cb36-11e6-8a4b-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/skus?api-version=2016-02-03
+  response:
+    body: {string: '{"value":[{"resourceType":"Microsoft.Devices/IotHubs","sku":{"name":"S1","tier":"Standard"},"capacity":{"minimum":1,"maximum":200,"default":1,"scaleType":"Manual"}},{"resourceType":"Microsoft.Devices/IotHubs","sku":{"name":"S2","tier":"Standard"},"capacity":{"minimum":1,"maximum":200,"default":1,"scaleType":"Manual"}},{"resourceType":"Microsoft.Devices/IotHubs","sku":{"name":"S3","tier":"Standard"},"capacity":{"minimum":1,"maximum":10,"default":1,"scaleType":"Manual"}}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:42:07 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['475']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [6c2c7010-cb36-11e6-b9cc-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9p0=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:42:08 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1899']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [6ca0f95e-cb36-11e6-b71f-40a8f04ffd53]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/listkeys?api-version=2016-02-03
+  response:
+    body: {string: '{"value":[{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"},{"keyName":"service","primaryKey":"7ulILAzXRPyeS+OTSAkM8EWLf66O/oCcvEFooU9GbbU=","secondaryKey":"DNg7fhkn/HtcFxoxzVxHLDHUQelYRPOOGwuLEWMxs8o=","rights":"ServiceConnect"},{"keyName":"device","primaryKey":"uoTOfrON68Y9LwTzitwcISGKWulqnZ+dUn7mEDkp4bQ=","secondaryKey":"WA2pycNQN649qgKMpkTyXH1lnOiF7qTdOxmacjjfQ5Q=","rights":"DeviceConnect"},{"keyName":"registryRead","primaryKey":"tj72HGGEEXPr5upM3Peqa6G2F5RzLwvzy2/yyuVGnSA=","secondaryKey":"9RmE73JjXzjuVl4XuDHkubgQ8vRjfKjHZ7dCbVWYzMI=","rights":"RegistryRead"},{"keyName":"registryReadWrite","primaryKey":"mWL0RMD7tOa8yc/+1pPeojmo9db4YXi7vcdG5zvbImo=","secondaryKey":"hsgOVzCVQD6aCS+TsQjY+tqyfZOaB2rboQZhf81dAYQ=","rights":"RegistryWrite"}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:42:09 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['905']
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"location": "westus", "tags": {}, "subscriptionid": "ba8e3a3d-29a9-48dd-972c-cdcc47ecf584",
+      "etag": "AAAAAACS9p0=", "sku": {"name": "S1", "capacity": 1}, "properties":
+      {"authorizationPolicies": [{"rights": "RegistryWrite, ServiceConnect, DeviceConnect",
+      "keyName": "iothubowner", "primaryKey": "B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=",
+      "secondaryKey": "90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI="}, {"rights":
+      "ServiceConnect", "keyName": "service", "primaryKey": "7ulILAzXRPyeS+OTSAkM8EWLf66O/oCcvEFooU9GbbU=",
+      "secondaryKey": "DNg7fhkn/HtcFxoxzVxHLDHUQelYRPOOGwuLEWMxs8o="}, {"rights":
+      "DeviceConnect", "keyName": "device", "primaryKey": "uoTOfrON68Y9LwTzitwcISGKWulqnZ+dUn7mEDkp4bQ=",
+      "secondaryKey": "WA2pycNQN649qgKMpkTyXH1lnOiF7qTdOxmacjjfQ5Q="}, {"rights":
+      "RegistryRead", "keyName": "registryRead", "primaryKey": "tj72HGGEEXPr5upM3Peqa6G2F5RzLwvzy2/yyuVGnSA=",
+      "secondaryKey": "9RmE73JjXzjuVl4XuDHkubgQ8vRjfKjHZ7dCbVWYzMI="}, {"rights":
+      "RegistryWrite", "keyName": "registryReadWrite", "primaryKey": "mWL0RMD7tOa8yc/+1pPeojmo9db4YXi7vcdG5zvbImo=",
+      "secondaryKey": "hsgOVzCVQD6aCS+TsQjY+tqyfZOaB2rboQZhf81dAYQ="}, {"rights":
+      "RegistryWrite, ServiceConnect, DeviceConnect", "keyName": "test_policy"}],
+      "enableFileUploadNotifications": false, "operationsMonitoringProperties": {"events":
+      {"C2DCommands": "None", "Connections": "None", "FileUploadOperations": "None",
+      "None": "None", "Routes": "None", "DeviceTelemetry": "Error, Information", "DeviceIdentityOperations":
+      "None"}}, "features": "None", "eventHubEndpoints": {"operationsMonitoringEvents":
+      {"partitionCount": 4, "retentionTimeInDays": 1}, "events": {"partitionCount":
+      4, "retentionTimeInDays": 1}}, "cloudToDevice": {"feedback": {"ttlAsIso8601":
+      "PT1H", "maxDeliveryCount": 10, "lockDurationAsIso8601": "PT1M"}, "maxDeliveryCount":
+      10, "defaultTtlAsIso8601": "PT1H"}, "messagingEndpoints": {"fileNotifications":
+      {"ttlAsIso8601": "PT1H", "maxDeliveryCount": 10, "lockDurationAsIso8601": "PT1M"}},
+      "ipFilterRules": [], "storageEndpoints": {"$default": {"connectionString": "",
+      "sasTtlAsIso8601": "PT1H", "containerName": ""}}}, "resourcegroup": "iot-hub-test-rg"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2143']
+      Content-Type: [application/json; charset=utf-8]
+      IF-MATCH: [AAAAAACS9p0=]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [6cffe9e2-cb36-11e6-8151-40a8f04ffd53]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test?api-version=2016-02-03
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9p0=","properties":{"provisioningState":"Accepted","authorizationPolicies":[{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"},{"keyName":"service","primaryKey":"7ulILAzXRPyeS+OTSAkM8EWLf66O/oCcvEFooU9GbbU=","secondaryKey":"DNg7fhkn/HtcFxoxzVxHLDHUQelYRPOOGwuLEWMxs8o=","rights":"ServiceConnect"},{"keyName":"device","primaryKey":"uoTOfrON68Y9LwTzitwcISGKWulqnZ+dUn7mEDkp4bQ=","secondaryKey":"WA2pycNQN649qgKMpkTyXH1lnOiF7qTdOxmacjjfQ5Q=","rights":"DeviceConnect"},{"keyName":"registryRead","primaryKey":"tj72HGGEEXPr5upM3Peqa6G2F5RzLwvzy2/yyuVGnSA=","secondaryKey":"9RmE73JjXzjuVl4XuDHkubgQ8vRjfKjHZ7dCbVWYzMI=","rights":"RegistryRead"},{"keyName":"registryReadWrite","primaryKey":"mWL0RMD7tOa8yc/+1pPeojmo9db4YXi7vcdG5zvbImo=","secondaryKey":"hsgOVzCVQD6aCS+TsQjY+tqyfZOaB2rboQZhf81dAYQ=","rights":"RegistryWrite"},{"keyName":"test_policy","primaryKey":"xKF4tBe+Y1iMQX/rgShSVur6zEwEwIIDQkn248Vu76s=","secondaryKey":"KMA17dUu4/cVY24FAWqLQM/OgTtJa60xfarppZXWSug=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"}],"ipFilterRules":[],"eventHubEndpoints":{"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4},"events":{"retentionTimeInDays":1,"partitionCount":4}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}'}
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/ba8e3a3d-29a9-48dd-972c-cdcc47ecf584/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NWZiZjcxNzQtZThjMS00ZTNlLTliZmUtNjA4YWY3YTRiYzMz?api-version=2016-02-03&asyncinfo']
+      Cache-Control: [no-cache]
+      Content-Length: ['2647']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:42:13 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['4999']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      IF-MATCH: [AAAAAACS9p0=]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [6cffe9e2-cb36-11e6-8151-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NWZiZjcxNzQtZThjMS00ZTNlLTliZmUtNjA4YWY3YTRiYzMz?api-version=2016-02-03&asyncinfo
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:42:43 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      IF-MATCH: [AAAAAACS9p0=]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [6cffe9e2-cb36-11e6-8151-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/NWZiZjcxNzQtZThjMS00ZTNlLTliZmUtNjA4YWY3YTRiYzMz?api-version=2016-02-03&asyncinfo
+  response:
+    body: {string: '{"status":"Succeeded"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:43:15 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['22']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      IF-MATCH: [AAAAAACS9p0=]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [6cffe9e2-cb36-11e6-8151-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test?api-version=2016-02-03
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9sM=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:43:16 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1887']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9645cfa2-cb36-11e6-819f-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9sM=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:43:20 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1899']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [972e443e-cb36-11e6-9a9a-40a8f04ffd53]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/listkeys?api-version=2016-02-03
+  response:
+    body: {string: '{"value":[{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"},{"keyName":"service","primaryKey":"7ulILAzXRPyeS+OTSAkM8EWLf66O/oCcvEFooU9GbbU=","secondaryKey":"DNg7fhkn/HtcFxoxzVxHLDHUQelYRPOOGwuLEWMxs8o=","rights":"ServiceConnect"},{"keyName":"device","primaryKey":"uoTOfrON68Y9LwTzitwcISGKWulqnZ+dUn7mEDkp4bQ=","secondaryKey":"WA2pycNQN649qgKMpkTyXH1lnOiF7qTdOxmacjjfQ5Q=","rights":"DeviceConnect"},{"keyName":"registryRead","primaryKey":"tj72HGGEEXPr5upM3Peqa6G2F5RzLwvzy2/yyuVGnSA=","secondaryKey":"9RmE73JjXzjuVl4XuDHkubgQ8vRjfKjHZ7dCbVWYzMI=","rights":"RegistryRead"},{"keyName":"registryReadWrite","primaryKey":"mWL0RMD7tOa8yc/+1pPeojmo9db4YXi7vcdG5zvbImo=","secondaryKey":"hsgOVzCVQD6aCS+TsQjY+tqyfZOaB2rboQZhf81dAYQ=","rights":"RegistryWrite"},{"keyName":"test_policy","primaryKey":"xKF4tBe+Y1iMQX/rgShSVur6zEwEwIIDQkn248Vu76s=","secondaryKey":"KMA17dUu4/cVY24FAWqLQM/OgTtJa60xfarppZXWSug=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:43:21 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1109']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9867b4f8-cb36-11e6-bffc-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9sM=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:43:22 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1899']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [98f83b9c-cb36-11e6-a211-40a8f04ffd53]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/test_policy/listkeys?api-version=2016-02-03
+  response:
+    body: {string: '{"keyName":"test_policy","primaryKey":"xKF4tBe+Y1iMQX/rgShSVur6zEwEwIIDQkn248Vu76s=","secondaryKey":"KMA17dUu4/cVY24FAWqLQM/OgTtJa60xfarppZXWSug=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:43:24 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['203']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9a39f888-cb36-11e6-9072-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9sM=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:43:26 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1899']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9b23c99e-cb36-11e6-a5f2-40a8f04ffd53]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/listkeys?api-version=2016-02-03
+  response:
+    body: {string: '{"value":[{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"},{"keyName":"service","primaryKey":"7ulILAzXRPyeS+OTSAkM8EWLf66O/oCcvEFooU9GbbU=","secondaryKey":"DNg7fhkn/HtcFxoxzVxHLDHUQelYRPOOGwuLEWMxs8o=","rights":"ServiceConnect"},{"keyName":"device","primaryKey":"uoTOfrON68Y9LwTzitwcISGKWulqnZ+dUn7mEDkp4bQ=","secondaryKey":"WA2pycNQN649qgKMpkTyXH1lnOiF7qTdOxmacjjfQ5Q=","rights":"DeviceConnect"},{"keyName":"registryRead","primaryKey":"tj72HGGEEXPr5upM3Peqa6G2F5RzLwvzy2/yyuVGnSA=","secondaryKey":"9RmE73JjXzjuVl4XuDHkubgQ8vRjfKjHZ7dCbVWYzMI=","rights":"RegistryRead"},{"keyName":"registryReadWrite","primaryKey":"mWL0RMD7tOa8yc/+1pPeojmo9db4YXi7vcdG5zvbImo=","secondaryKey":"hsgOVzCVQD6aCS+TsQjY+tqyfZOaB2rboQZhf81dAYQ=","rights":"RegistryWrite"},{"keyName":"test_policy","primaryKey":"xKF4tBe+Y1iMQX/rgShSVur6zEwEwIIDQkn248Vu76s=","secondaryKey":"KMA17dUu4/cVY24FAWqLQM/OgTtJa60xfarppZXWSug=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:43:28 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1109']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"location": "westus", "tags": {}, "subscriptionid": "ba8e3a3d-29a9-48dd-972c-cdcc47ecf584",
+      "etag": "AAAAAACS9sM=", "sku": {"name": "S1", "capacity": 1}, "properties":
+      {"authorizationPolicies": [{"rights": "RegistryWrite, ServiceConnect, DeviceConnect",
+      "keyName": "iothubowner", "primaryKey": "B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=",
+      "secondaryKey": "90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI="}, {"rights":
+      "ServiceConnect", "keyName": "service", "primaryKey": "7ulILAzXRPyeS+OTSAkM8EWLf66O/oCcvEFooU9GbbU=",
+      "secondaryKey": "DNg7fhkn/HtcFxoxzVxHLDHUQelYRPOOGwuLEWMxs8o="}, {"rights":
+      "DeviceConnect", "keyName": "device", "primaryKey": "uoTOfrON68Y9LwTzitwcISGKWulqnZ+dUn7mEDkp4bQ=",
+      "secondaryKey": "WA2pycNQN649qgKMpkTyXH1lnOiF7qTdOxmacjjfQ5Q="}, {"rights":
+      "RegistryRead", "keyName": "registryRead", "primaryKey": "tj72HGGEEXPr5upM3Peqa6G2F5RzLwvzy2/yyuVGnSA=",
+      "secondaryKey": "9RmE73JjXzjuVl4XuDHkubgQ8vRjfKjHZ7dCbVWYzMI="}, {"rights":
+      "RegistryWrite", "keyName": "registryReadWrite", "primaryKey": "mWL0RMD7tOa8yc/+1pPeojmo9db4YXi7vcdG5zvbImo=",
+      "secondaryKey": "hsgOVzCVQD6aCS+TsQjY+tqyfZOaB2rboQZhf81dAYQ="}], "enableFileUploadNotifications":
+      false, "operationsMonitoringProperties": {"events": {"C2DCommands": "None",
+      "Connections": "None", "FileUploadOperations": "None", "None": "None", "Routes":
+      "None", "DeviceTelemetry": "Error, Information", "DeviceIdentityOperations":
+      "None"}}, "features": "None", "eventHubEndpoints": {"operationsMonitoringEvents":
+      {"partitionCount": 4, "retentionTimeInDays": 1}, "events": {"partitionCount":
+      4, "retentionTimeInDays": 1}}, "cloudToDevice": {"feedback": {"ttlAsIso8601":
+      "PT1H", "maxDeliveryCount": 10, "lockDurationAsIso8601": "PT1M"}, "maxDeliveryCount":
+      10, "defaultTtlAsIso8601": "PT1H"}, "messagingEndpoints": {"fileNotifications":
+      {"ttlAsIso8601": "PT1H", "maxDeliveryCount": 10, "lockDurationAsIso8601": "PT1M"}},
+      "ipFilterRules": [], "storageEndpoints": {"$default": {"connectionString": "",
+      "sasTtlAsIso8601": "PT1H", "containerName": ""}}}, "resourcegroup": "iot-hub-test-rg"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2057']
+      Content-Type: [application/json; charset=utf-8]
+      IF-MATCH: [AAAAAACS9sM=]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9be85576-cb36-11e6-beeb-40a8f04ffd53]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test?api-version=2016-02-03
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9sM=","properties":{"provisioningState":"Accepted","authorizationPolicies":[{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"},{"keyName":"service","primaryKey":"7ulILAzXRPyeS+OTSAkM8EWLf66O/oCcvEFooU9GbbU=","secondaryKey":"DNg7fhkn/HtcFxoxzVxHLDHUQelYRPOOGwuLEWMxs8o=","rights":"ServiceConnect"},{"keyName":"device","primaryKey":"uoTOfrON68Y9LwTzitwcISGKWulqnZ+dUn7mEDkp4bQ=","secondaryKey":"WA2pycNQN649qgKMpkTyXH1lnOiF7qTdOxmacjjfQ5Q=","rights":"DeviceConnect"},{"keyName":"registryRead","primaryKey":"tj72HGGEEXPr5upM3Peqa6G2F5RzLwvzy2/yyuVGnSA=","secondaryKey":"9RmE73JjXzjuVl4XuDHkubgQ8vRjfKjHZ7dCbVWYzMI=","rights":"RegistryRead"},{"keyName":"registryReadWrite","primaryKey":"mWL0RMD7tOa8yc/+1pPeojmo9db4YXi7vcdG5zvbImo=","secondaryKey":"hsgOVzCVQD6aCS+TsQjY+tqyfZOaB2rboQZhf81dAYQ=","rights":"RegistryWrite"}],"ipFilterRules":[],"eventHubEndpoints":{"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4},"events":{"retentionTimeInDays":1,"partitionCount":4}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}'}
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/ba8e3a3d-29a9-48dd-972c-cdcc47ecf584/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/MjU3NTNmNTktNDg5Mi00ZTcwLTk1YmItNGE3ZWY3Y2NkZTYy?api-version=2016-02-03&asyncinfo']
+      Cache-Control: [no-cache]
+      Content-Length: ['2443']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:43:31 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['4998']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      IF-MATCH: [AAAAAACS9sM=]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9be85576-cb36-11e6-beeb-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/MjU3NTNmNTktNDg5Mi00ZTcwLTk1YmItNGE3ZWY3Y2NkZTYy?api-version=2016-02-03&asyncinfo
+  response:
+    body: {string: '{"status":"Succeeded"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:44:03 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['22']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      IF-MATCH: [AAAAAACS9sM=]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9be85576-cb36-11e6-beeb-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test?api-version=2016-02-03
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:44:04 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1887']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b28749c0-cb36-11e6-8bd7-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:44:07 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1899']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b392ae5c-cb36-11e6-990b-40a8f04ffd53]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/listkeys?api-version=2016-02-03
+  response:
+    body: {string: '{"value":[{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"},{"keyName":"service","primaryKey":"7ulILAzXRPyeS+OTSAkM8EWLf66O/oCcvEFooU9GbbU=","secondaryKey":"DNg7fhkn/HtcFxoxzVxHLDHUQelYRPOOGwuLEWMxs8o=","rights":"ServiceConnect"},{"keyName":"device","primaryKey":"uoTOfrON68Y9LwTzitwcISGKWulqnZ+dUn7mEDkp4bQ=","secondaryKey":"WA2pycNQN649qgKMpkTyXH1lnOiF7qTdOxmacjjfQ5Q=","rights":"DeviceConnect"},{"keyName":"registryRead","primaryKey":"tj72HGGEEXPr5upM3Peqa6G2F5RzLwvzy2/yyuVGnSA=","secondaryKey":"9RmE73JjXzjuVl4XuDHkubgQ8vRjfKjHZ7dCbVWYzMI=","rights":"RegistryRead"},{"keyName":"registryReadWrite","primaryKey":"mWL0RMD7tOa8yc/+1pPeojmo9db4YXi7vcdG5zvbImo=","secondaryKey":"hsgOVzCVQD6aCS+TsQjY+tqyfZOaB2rboQZhf81dAYQ=","rights":"RegistryWrite"}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:44:09 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['905']
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b52a97ac-cb36-11e6-9269-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:44:11 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1899']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b60a1e7e-cb36-11e6-9d83-40a8f04ffd53]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/eventHubEndpoints/events/ConsumerGroups/cg1?api-version=2016-02-03
+  response:
+    body: {string: '{"tags":null,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"cg1"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:44:17 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['175']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b9f3140a-cb36-11e6-b8d8-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:44:20 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1899']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [baedee82-cb36-11e6-a36e-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/eventHubEndpoints/events/ConsumerGroups/cg1?api-version=2016-02-03
+  response:
+    body: {string: '{"tags":null,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"cg1"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:44:21 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['175']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bc300f2c-cb36-11e6-bdee-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:44:23 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1899']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bd0b30dc-cb36-11e6-9ef1-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/eventHubEndpoints/events/ConsumerGroups?api-version=2016-02-03
+  response:
+    body: {string: '{"value":["$Default","cg1"]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:44:24 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['28']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bdde9a7e-cb36-11e6-8ba4-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:44:26 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1899']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [beb83da8-cb36-11e6-96f3-40a8f04ffd53]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/eventHubEndpoints/events/ConsumerGroups/cg1?api-version=2016-02-03
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Mon, 26 Dec 2016 06:44:28 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [c026283e-cb36-11e6-a4e4-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:44:29 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1899']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [c097b370-cb36-11e6-88cc-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/eventHubEndpoints/events/ConsumerGroups?api-version=2016-02-03
+  response:
+    body: {string: '{"value":["$Default"]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:44:29 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['22']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [c14f4fa4-cb36-11e6-ae8d-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:44:30 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1899']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [c1bf4d3e-cb36-11e6-834a-40a8f04ffd53]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/jobs?api-version=2016-02-03
   response:
@@ -1030,7 +1597,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:18 GMT']
+      Date: ['Mon, 26 Dec 2016 06:44:31 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -1046,25 +1613,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [fa767698-c22f-11e6-8476-a0b3ccf7272a]
+      x-ms-client-request-id: [c288beae-cb36-11e6-97b3-40a8f04ffd53]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:20 GMT']
+      Date: ['Mon, 26 Dec 2016 06:44:34 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['1885']
+      content-length: ['1899']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1073,22 +1641,22 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [fac15094-c22f-11e6-96b4-a0b3ccf7272a]
+      x-ms-client-request-id: [c3919b2e-cb36-11e6-b955-40a8f04ffd53]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/jobs/fake-job?api-version=2016-02-03
   response:
     body: {string: '{"Code":"JobNotFound","HttpStatusCode":"NotFound","Message":"Job
         not found with ID ''fake-job''. If you contact a support representative please
-        include this correlation identifier: 0ae82fe3-9dde-4b58-abbd-658a39c18d05,
-        timestamp: 2016-12-14 19:03:21Z, errorcode: IH404011."}'}
+        include this correlation identifier: 1cd77bf7-e618-4198-abfc-d677e3daeb31,
+        timestamp: 2016-12-26 06:44:36Z, errorcode: IH404011."}'}
     headers:
       Cache-Control: [no-cache]
       Content-Length: ['272']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:20 GMT']
+      Date: ['Mon, 26 Dec 2016 06:44:35 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -1101,25 +1669,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [fb467b6e-c22f-11e6-9945-a0b3ccf7272a]
+      x-ms-client-request-id: [c46e1c14-cb36-11e6-9aa8-40a8f04ffd53]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:21 GMT']
+      Date: ['Mon, 26 Dec 2016 06:44:36 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['1885']
+      content-length: ['1899']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1129,101 +1698,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [fb904a9a-c22f-11e6-a6c3-a0b3ccf7272a]
+      x-ms-client-request-id: [c4e1db54-cb36-11e6-80dc-40a8f04ffd53]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
   response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"AwGPYGUGVXBuq+DH/J988CZxvAJCSlpdQY495cxt7ls=","secondaryKey":"XB2vej9wvuT9oF+to+u+EiNQYsUfv2z7Bug76PeboNs=","rights":"RegistryWrite,
+    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
         ServiceConnect, DeviceConnect"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:22 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['203']
-      x-ms-ratelimit-remaining-subscription-writes: ['1187']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [SharedAccessSignature sr=iot-hub-for-test.azure-devices.net%252fdevices%252f&sig=8r0Q2jwxyj%2Be6TvwkNxowx%2FfwRuab3gwCYYCcks3sis%3D&se=1481745802&skn=iothubowner]
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [fbcc3418-c22f-11e6-85e3-a0b3ccf7272a]
-    method: DELETE
-    uri: https://iot-hub-for-test.azure-devices.net/jobs/fake-job?api-version=2016-11-14
-  response:
-    body: {string: '{"Message":"ErrorCode:JobNotFound;NotFound","ExceptionMessage":"Tracking
-        ID:0026fac997a34009bdff25d8796bab9c-G:8-TimeStamp:12/14/2016 19:03:24"}'}
-    headers:
-      Content-Length: ['144']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:23 GMT']
-      Server: [Microsoft-HTTPAPI/2.0]
-      iothub-errorcode: [JobNotFound]
-    status: {code: 404, message: Not Found}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [fc4ffa00-c22f-11e6-977e-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:23 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1885']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [fc9a7d78-c22f-11e6-86ff-a0b3ccf7272a]
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
-  response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"AwGPYGUGVXBuq+DH/J988CZxvAJCSlpdQY495cxt7ls=","secondaryKey":"XB2vej9wvuT9oF+to+u+EiNQYsUfv2z7Bug76PeboNs=","rights":"RegistryWrite,
-        ServiceConnect, DeviceConnect"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:23 GMT']
+      Date: ['Mon, 26 Dec 2016 06:44:37 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -1234,29 +1721,30 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 200, message: OK}
 - request:
-    body: '{"deviceId": "test-device-1"}'
+    body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [SharedAccessSignature sr=iot-hub-for-test.azure-devices.net%252fdevices%252ftest-device-1&sig=fZF81g0AvdLJpn3pFA0AvMBm3kNoW2xjtBgZUV4dRUw%3D&se=1481745804&skn=iothubowner]
+      Authorization: [SharedAccessSignature se=1482738277&sr=iot-hub-for-test.azure-devices.net%252fdevices%252f&sig=eX4ElZbgFuLZjbM%2FiSI2ZED3VayiImaQrcrCZ7imDGI%3D&skn=iothubowner]
       Connection: [keep-alive]
-      Content-Length: ['29']
+      Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [fcd5fbf0-c22f-11e6-bab7-a0b3ccf7272a]
-    method: PUT
-    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1?api-version=2016-11-14
+      x-ms-client-request-id: [c546845c-cb36-11e6-b222-40a8f04ffd53]
+    method: DELETE
+    uri: https://iot-hub-for-test.azure-devices.net/jobs/fake-job?api-version=2016-11-14
   response:
-    body: {string: '{"deviceId":"test-device-1","generationId":"636173390041974273","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"0hd6y9+fiT18ILMz/kIst4ALFzGGPKvJv9Hm5JaDAp4=","secondaryKey":"xDwqnBlsfdqvRL2NDxaEk/okPORoLBxJOM1G3GWfuV8="},"x509Thumbprint":{"primaryThumbprint":null,"secondaryThumbprint":null}}}'}
+    body: {string: '{"Message":"ErrorCode:JobNotFound;NotFound","ExceptionMessage":"Tracking
+        ID:4620d5f90d8345e0a1fe257830757c02-G:9-TimeStamp:12/26/2016 06:44:39"}'}
     headers:
-      Content-Length: ['543']
+      Content-Length: ['144']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:25 GMT']
-      ETag: ['"MA=="']
+      Date: ['Mon, 26 Dec 2016 06:44:39 GMT']
       Server: [Microsoft-HTTPAPI/2.0]
-    status: {code: 200, message: OK}
+      iothub-errorcode: [JobNotFound]
+    status: {code: 404, message: Not Found}
 - request:
     body: null
     headers:
@@ -1264,25 +1752,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [fd517538-c22f-11e6-b455-a0b3ccf7272a]
+      x-ms-client-request-id: [c66d8cfa-cb36-11e6-b265-40a8f04ffd53]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:25 GMT']
+      Date: ['Mon, 26 Dec 2016 06:44:40 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['1885']
+      content-length: ['1899']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1292,19 +1781,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [fd9c94c2-c22f-11e6-9a92-a0b3ccf7272a]
+      x-ms-client-request-id: [c6e07346-cb36-11e6-9c4f-40a8f04ffd53]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
   response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"AwGPYGUGVXBuq+DH/J988CZxvAJCSlpdQY495cxt7ls=","secondaryKey":"XB2vej9wvuT9oF+to+u+EiNQYsUfv2z7Bug76PeboNs=","rights":"RegistryWrite,
+    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
         ServiceConnect, DeviceConnect"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:25 GMT']
+      Date: ['Mon, 26 Dec 2016 06:44:40 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -1315,27 +1804,26 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
-    body: '{"deviceId": "test-device-2", "authentication": {"x509Thumbprint": {"primaryThumbprint":
-      "A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C", "secondaryThumbprint": "14963E8F3BA5B3984110B3C1CA8E8B8988599087"}}}'
+    body: '{"deviceId": "test-device-1"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [SharedAccessSignature sr=iot-hub-for-test.azure-devices.net%252fdevices%252ftest-device-2&sig=eBGWGc8f5wHSqCoqgV0oXj83gSfgbaG069KokAOgsKE%3D&se=1481745805&skn=iothubowner]
+      Authorization: [SharedAccessSignature se=1482738281&sr=iot-hub-for-test.azure-devices.net%252fdevices%252ftest-device-1&sig=QJiwgLwinK2rm7abTZyDJetgqUUMAVV%2Fjz4RtOuUFeY%3D&skn=iothubowner]
       Connection: [keep-alive]
-      Content-Length: ['201']
+      Content-Length: ['29']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [fdd63390-c22f-11e6-a468-a0b3ccf7272a]
+      x-ms-client-request-id: [c742d598-cb36-11e6-990f-40a8f04ffd53]
     method: PUT
-    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-2?api-version=2016-11-14
+    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1?api-version=2016-11-14
   response:
-    body: {string: '{"deviceId":"test-device-2","generationId":"636173390069287098","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":null,"secondaryKey":null},"x509Thumbprint":{"primaryThumbprint":"A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C","secondaryThumbprint":"14963E8F3BA5B3984110B3C1CA8E8B8988599087"}}}'}
+    body: {string: '{"deviceId":"test-device-1","generationId":"636183314810983457","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"tcYQ1dzGzaqdBiIWPdtr/EYhCK3aqcBXGaJOIv451s0=","secondaryKey":"Gnv9o2tcLQ+I08oX0uUsnoWuExt8azR969USelXKgjs="},"x509Thumbprint":{"primaryThumbprint":null,"secondaryThumbprint":null}}}'}
     headers:
-      Content-Length: ['535']
+      Content-Length: ['543']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:27 GMT']
+      Date: ['Mon, 26 Dec 2016 06:44:43 GMT']
       ETag: ['"MA=="']
       Server: [Microsoft-HTTPAPI/2.0]
     status: {code: 200, message: OK}
@@ -1346,25 +1834,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [fe7924b4-c22f-11e6-ab80-a0b3ccf7272a]
+      x-ms-client-request-id: [c884abd4-cb36-11e6-844f-40a8f04ffd53]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:26 GMT']
+      Date: ['Mon, 26 Dec 2016 06:44:43 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['1885']
+      content-length: ['1899']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1374,19 +1863,265 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [fec16cfe-c22f-11e6-ab96-a0b3ccf7272a]
+      x-ms-client-request-id: [c8f95ad8-cb36-11e6-876d-40a8f04ffd53]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
   response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"AwGPYGUGVXBuq+DH/J988CZxvAJCSlpdQY495cxt7ls=","secondaryKey":"XB2vej9wvuT9oF+to+u+EiNQYsUfv2z7Bug76PeboNs=","rights":"RegistryWrite,
+    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
         ServiceConnect, DeviceConnect"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:27 GMT']
+      Date: ['Mon, 26 Dec 2016 06:44:44 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['203']
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"authentication": {"x509Thumbprint": {"secondaryThumbprint": "14963E8F3BA5B3984110B3C1CA8E8B8988599087",
+      "primaryThumbprint": "A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C"}}, "deviceId":
+      "test-device-2"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [SharedAccessSignature se=1482738284&sr=iot-hub-for-test.azure-devices.net%252fdevices%252ftest-device-2&sig=QG%2FN4MciNh1Cecwgp0gWvdXL6u5H4DM7NckH40XtafY%3D&skn=iothubowner]
+      Connection: [keep-alive]
+      Content-Length: ['201']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [c95d9fde-cb36-11e6-a8b4-40a8f04ffd53]
+    method: PUT
+    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-2?api-version=2016-11-14
+  response:
+    body: {string: '{"deviceId":"test-device-2","generationId":"636183314847877850","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":null,"secondaryKey":null},"x509Thumbprint":{"primaryThumbprint":"A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C","secondaryThumbprint":"14963E8F3BA5B3984110B3C1CA8E8B8988599087"}}}'}
+    headers:
+      Content-Length: ['535']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:44:44 GMT']
+      ETag: ['"MA=="']
+      Server: [Microsoft-HTTPAPI/2.0]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [ca7bc712-cb36-11e6-97bc-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:44:47 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1899']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [caeded1e-cb36-11e6-b800-40a8f04ffd53]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
+  response:
+    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:44:47 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['203']
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [SharedAccessSignature se=1482738288&sr=iot-hub-for-test.azure-devices.net%252fdevices%252ftest-device-1&sig=iyCyg1aUQ0ZjAUxwcnAWguVTny0n9FOTbFvWicxxBdk%3D&skn=iothubowner]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [cb4dad3e-cb36-11e6-a367-40a8f04ffd53]
+    method: GET
+    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1?api-version=2016-11-14
+  response:
+    body: {string: '{"deviceId":"test-device-1","generationId":"636183314810983457","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"tcYQ1dzGzaqdBiIWPdtr/EYhCK3aqcBXGaJOIv451s0=","secondaryKey":"Gnv9o2tcLQ+I08oX0uUsnoWuExt8azR969USelXKgjs="},"x509Thumbprint":{"primaryThumbprint":null,"secondaryThumbprint":null}}}'}
+    headers:
+      Content-Length: ['543']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:44:50 GMT']
+      ETag: ['"MA=="']
+      Server: [Microsoft-HTTPAPI/2.0]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [cc51e07e-cb36-11e6-a780-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:44:49 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1899']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [ccc2eb0c-cb36-11e6-a6ed-40a8f04ffd53]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
+  response:
+    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:44:50 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['203']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [SharedAccessSignature se=1482738291&sr=iot-hub-for-test.azure-devices.net%252fdevices%252ftest-device-2&sig=ncBAsocn7qdbxfKWfFZ%2Fmy4igYbZ08RZ6%2BTJIUiyLSI%3D&skn=iothubowner]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [cd22d780-cb36-11e6-a08a-40a8f04ffd53]
+    method: GET
+    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-2?api-version=2016-11-14
+  response:
+    body: {string: '{"deviceId":"test-device-2","generationId":"636183314847877850","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":null,"secondaryKey":null},"x509Thumbprint":{"primaryThumbprint":"A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C","secondaryThumbprint":"14963E8F3BA5B3984110B3C1CA8E8B8988599087"}}}'}
+    headers:
+      Content-Length: ['535']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:44:50 GMT']
+      ETag: ['"MA=="']
+      Server: [Microsoft-HTTPAPI/2.0]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [ce28abe2-cb36-11e6-9e1d-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:44:52 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1899']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [ce996f14-cb36-11e6-834f-40a8f04ffd53]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
+  response:
+    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:44:53 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -1401,181 +2136,21 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [SharedAccessSignature sr=iot-hub-for-test.azure-devices.net%252fdevices%252ftest-device-1&sig=17BrT4HMHNqTGyuIigqklGVc6eT1LTUlADZQyZgQgAM%3D&se=1481745807&skn=iothubowner]
+      Authorization: [SharedAccessSignature se=1482738294&sr=iot-hub-for-test.azure-devices.net%252fdevices%252f&sig=5N6j1iTUvgnIQlGnMvV0kVh3DrHww1RYOxFOiyZmOQk%3D&skn=iothubowner]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [ff0ac0be-c22f-11e6-a314-a0b3ccf7272a]
-    method: GET
-    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1?api-version=2016-11-14
-  response:
-    body: {string: '{"deviceId":"test-device-1","generationId":"636173390041974273","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"0hd6y9+fiT18ILMz/kIst4ALFzGGPKvJv9Hm5JaDAp4=","secondaryKey":"xDwqnBlsfdqvRL2NDxaEk/okPORoLBxJOM1G3GWfuV8="},"x509Thumbprint":{"primaryThumbprint":null,"secondaryThumbprint":null}}}'}
-    headers:
-      Content-Length: ['543']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:28 GMT']
-      ETag: ['"MA=="']
-      Server: [Microsoft-HTTPAPI/2.0]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [ff6b4074-c22f-11e6-b7cd-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:28 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1885']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [ffb6122c-c22f-11e6-9f06-a0b3ccf7272a]
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
-  response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"AwGPYGUGVXBuq+DH/J988CZxvAJCSlpdQY495cxt7ls=","secondaryKey":"XB2vej9wvuT9oF+to+u+EiNQYsUfv2z7Bug76PeboNs=","rights":"RegistryWrite,
-        ServiceConnect, DeviceConnect"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:29 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['203']
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [SharedAccessSignature sr=iot-hub-for-test.azure-devices.net%252fdevices%252ftest-device-2&sig=Ehm1zuLtt7kxaMMaT68gEDCRz2GRfEzaXEsRpciZ1oM%3D&se=1481745809&skn=iothubowner]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [fff62ede-c22f-11e6-92e7-a0b3ccf7272a]
-    method: GET
-    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-2?api-version=2016-11-14
-  response:
-    body: {string: '{"deviceId":"test-device-2","generationId":"636173390069287098","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":null,"secondaryKey":null},"x509Thumbprint":{"primaryThumbprint":"A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C","secondaryThumbprint":"14963E8F3BA5B3984110B3C1CA8E8B8988599087"}}}'}
-    headers:
-      Content-Length: ['535']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:33 GMT']
-      ETag: ['"MA=="']
-      Server: [Microsoft-HTTPAPI/2.0]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [02034b28-c230-11e6-982a-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:33 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1885']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [024dbf02-c230-11e6-ad7e-a0b3ccf7272a]
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
-  response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"AwGPYGUGVXBuq+DH/J988CZxvAJCSlpdQY495cxt7ls=","secondaryKey":"XB2vej9wvuT9oF+to+u+EiNQYsUfv2z7Bug76PeboNs=","rights":"RegistryWrite,
-        ServiceConnect, DeviceConnect"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:33 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['203']
-      x-ms-ratelimit-remaining-subscription-writes: ['1193']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [SharedAccessSignature sr=iot-hub-for-test.azure-devices.net%252fdevices%252f&sig=MX7velistbLQz7L0omZxH8m%2F5QvtgmGdr6zsMggOMmk%3D&se=1481745813&skn=iothubowner]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [02a1254c-c230-11e6-94dd-a0b3ccf7272a]
+      x-ms-client-request-id: [cefa46f4-cb36-11e6-a9d8-40a8f04ffd53]
     method: GET
     uri: https://iot-hub-for-test.azure-devices.net/devices?api-version=2016-11-14&top=20
   response:
-    body: {string: '[{"deviceId":"test-device-2","generationId":"636173390069287098","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":null,"secondaryKey":null},"x509Thumbprint":{"primaryThumbprint":"A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C","secondaryThumbprint":"14963E8F3BA5B3984110B3C1CA8E8B8988599087"}}},{"deviceId":"test-device-1","generationId":"636173390041974273","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"0hd6y9+fiT18ILMz/kIst4ALFzGGPKvJv9Hm5JaDAp4=","secondaryKey":"xDwqnBlsfdqvRL2NDxaEk/okPORoLBxJOM1G3GWfuV8="},"x509Thumbprint":{"primaryThumbprint":null,"secondaryThumbprint":null}}}]'}
+    body: {string: '[{"deviceId":"test-device-2","generationId":"636183314847877850","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":null,"secondaryKey":null},"x509Thumbprint":{"primaryThumbprint":"A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C","secondaryThumbprint":"14963E8F3BA5B3984110B3C1CA8E8B8988599087"}}},{"deviceId":"test-device-1","generationId":"636183314810983457","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"tcYQ1dzGzaqdBiIWPdtr/EYhCK3aqcBXGaJOIv451s0=","secondaryKey":"Gnv9o2tcLQ+I08oX0uUsnoWuExt8azR969USelXKgjs="},"x509Thumbprint":{"primaryThumbprint":null,"secondaryThumbprint":null}}}]'}
     headers:
       Content-Length: ['1081']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:34 GMT']
+      Date: ['Mon, 26 Dec 2016 06:44:55 GMT']
       Server: [Microsoft-HTTPAPI/2.0]
     status: {code: 200, message: OK}
 - request:
@@ -1586,19 +2161,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [02d26958-c230-11e6-a28a-a0b3ccf7272a]
+      x-ms-client-request-id: [cf9b9330-cb36-11e6-ba54-40a8f04ffd53]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
   response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"AwGPYGUGVXBuq+DH/J988CZxvAJCSlpdQY495cxt7ls=","secondaryKey":"XB2vej9wvuT9oF+to+u+EiNQYsUfv2z7Bug76PeboNs=","rights":"RegistryWrite,
+    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
         ServiceConnect, DeviceConnect"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:34 GMT']
+      Date: ['Mon, 26 Dec 2016 06:44:55 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -1606,28 +2181,28 @@ interactions:
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       content-length: ['203']
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [SharedAccessSignature sr=iot-hub-for-test.azure-devices.net%252fdevices%252ftest-device-2&sig=LjAV880pAo0%2FCxSPo%2BDQjAiAFIRYZC9KjN%2F1pCdePuc%3D&se=1481745814&skn=iothubowner]
+      Authorization: [SharedAccessSignature se=1482738295&sr=iot-hub-for-test.azure-devices.net%252fdevices%252ftest-device-2&sig=jo6FuPy5SXHOYgH3Ou3fetlgvWEzNgqckIgMkGsms6Y%3D&skn=iothubowner]
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [0311e808-c230-11e6-aaeb-a0b3ccf7272a]
+      x-ms-client-request-id: [cffb58fa-cb36-11e6-b249-40a8f04ffd53]
     method: GET
     uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-2?api-version=2016-11-14
   response:
-    body: {string: '{"deviceId":"test-device-2","generationId":"636173390069287098","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":null,"secondaryKey":null},"x509Thumbprint":{"primaryThumbprint":"A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C","secondaryThumbprint":"14963E8F3BA5B3984110B3C1CA8E8B8988599087"}}}'}
+    body: {string: '{"deviceId":"test-device-2","generationId":"636183314847877850","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":null,"secondaryKey":null},"x509Thumbprint":{"primaryThumbprint":"A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C","secondaryThumbprint":"14963E8F3BA5B3984110B3C1CA8E8B8988599087"}}}'}
     headers:
       Content-Length: ['535']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:35 GMT']
+      Date: ['Mon, 26 Dec 2016 06:45:01 GMT']
       ETag: ['"MA=="']
       Server: [Microsoft-HTTPAPI/2.0]
     status: {code: 200, message: OK}
@@ -1639,583 +2214,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0329a3c2-c230-11e6-80ba-a0b3ccf7272a]
+      x-ms-client-request-id: [d27b4980-cb36-11e6-9eef-40a8f04ffd53]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
   response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"AwGPYGUGVXBuq+DH/J988CZxvAJCSlpdQY495cxt7ls=","secondaryKey":"XB2vej9wvuT9oF+to+u+EiNQYsUfv2z7Bug76PeboNs=","rights":"RegistryWrite,
+    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
         ServiceConnect, DeviceConnect"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:35 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['203']
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [SharedAccessSignature sr=iot-hub-for-test.azure-devices.net%252fdevices%252ftest-device-1&sig=NGfXANy8neAKs6jS1KhpHEjCFaeOmcyJ4aremmNfe9Y%3D&se=1481745815&skn=iothubowner]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [03683688-c230-11e6-adce-a0b3ccf7272a]
-    method: GET
-    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1?api-version=2016-11-14
-  response:
-    body: {string: '{"deviceId":"test-device-1","generationId":"636173390041974273","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"0hd6y9+fiT18ILMz/kIst4ALFzGGPKvJv9Hm5JaDAp4=","secondaryKey":"xDwqnBlsfdqvRL2NDxaEk/okPORoLBxJOM1G3GWfuV8="},"x509Thumbprint":{"primaryThumbprint":null,"secondaryThumbprint":null}}}'}
-    headers:
-      Content-Length: ['543']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:36 GMT']
-      ETag: ['"MA=="']
-      Server: [Microsoft-HTTPAPI/2.0]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [03cd654c-c230-11e6-902b-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:35 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1885']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [041d8e0a-c230-11e6-8daa-a0b3ccf7272a]
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
-  response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"AwGPYGUGVXBuq+DH/J988CZxvAJCSlpdQY495cxt7ls=","secondaryKey":"XB2vej9wvuT9oF+to+u+EiNQYsUfv2z7Bug76PeboNs=","rights":"RegistryWrite,
-        ServiceConnect, DeviceConnect"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:36 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['203']
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [SharedAccessSignature sr=iot-hub-for-test.azure-devices.net%252fdevices%252ftest-device-1&sig=tQVXXoopYdGJh4ixg2yWSncM8xgsvy9a6ET%2FA8%2BgNIU%3D&se=1481745816&skn=iothubowner]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [0456edac-c230-11e6-bee4-a0b3ccf7272a]
-    method: GET
-    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1?api-version=2016-11-14
-  response:
-    body: {string: '{"deviceId":"test-device-1","generationId":"636173390041974273","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"0hd6y9+fiT18ILMz/kIst4ALFzGGPKvJv9Hm5JaDAp4=","secondaryKey":"xDwqnBlsfdqvRL2NDxaEk/okPORoLBxJOM1G3GWfuV8="},"x509Thumbprint":{"primaryThumbprint":null,"secondaryThumbprint":null}}}'}
-    headers:
-      Content-Length: ['543']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:37 GMT']
-      ETag: ['"MA=="']
-      Server: [Microsoft-HTTPAPI/2.0]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [04c286f6-c230-11e6-9c9f-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:37 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1885']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [050c962e-c230-11e6-9fe1-a0b3ccf7272a]
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
-  response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"AwGPYGUGVXBuq+DH/J988CZxvAJCSlpdQY495cxt7ls=","secondaryKey":"XB2vej9wvuT9oF+to+u+EiNQYsUfv2z7Bug76PeboNs=","rights":"RegistryWrite,
-        ServiceConnect, DeviceConnect"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:38 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['203']
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [SharedAccessSignature sr=iot-hub-for-test.azure-devices.net%252fdevices%252ftest-device-2&sig=XGH4bPTkoMxH2eYzQYCCxLLTukpQ0Mcymz9hHaCmkkk%3D&se=1481745818&skn=iothubowner]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [054aca9c-c230-11e6-be95-a0b3ccf7272a]
-    method: GET
-    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-2?api-version=2016-11-14
-  response:
-    body: {string: '{"deviceId":"test-device-2","generationId":"636173390069287098","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":null,"secondaryKey":null},"x509Thumbprint":{"primaryThumbprint":"A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C","secondaryThumbprint":"14963E8F3BA5B3984110B3C1CA8E8B8988599087"}}}'}
-    headers:
-      Content-Length: ['535']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:40 GMT']
-      ETag: ['"MA=="']
-      Server: [Microsoft-HTTPAPI/2.0]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [061e0f3e-c230-11e6-9f28-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:39 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1885']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [066ab7f6-c230-11e6-a9c0-a0b3ccf7272a]
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
-  response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"AwGPYGUGVXBuq+DH/J988CZxvAJCSlpdQY495cxt7ls=","secondaryKey":"XB2vej9wvuT9oF+to+u+EiNQYsUfv2z7Bug76PeboNs=","rights":"RegistryWrite,
-        ServiceConnect, DeviceConnect"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:40 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['203']
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"deviceId": "test-device-2", "etag": "MA==", "statusUpdatedTime": "0001-01-01T00:00:00.000Z",
-      "lastActivityTime": "0001-01-01T00:00:00.000Z", "connectionState": "Disconnected",
-      "connectionStateUpdatedTime": "0001-01-01T00:00:00.000Z", "statusReason": "TestReason",
-      "status": "enabled", "authentication": {"x509Thumbprint": {"primaryThumbprint":
-      "A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C", "secondaryThumbprint": "14963E8F3BA5B3984110B3C1CA8E8B8988599087"},
-      "symmetricKey": {}}, "cloudToDeviceMessageCount": 0}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [SharedAccessSignature sr=iot-hub-for-test.azure-devices.net%252fdevices%252ftest-device-2&sig=EVi0debuIcJEc52DrgULcCATo9Ha7w5wa%2B1SCLo1AA0%3D&se=1481745820&skn=iothubowner]
-      Connection: [keep-alive]
-      Content-Length: ['510']
-      Content-Type: [application/json; charset=utf-8]
-      If-Match: ['*']
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [06a64576-c230-11e6-8f2c-a0b3ccf7272a]
-    method: PUT
-    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-2?api-version=2016-11-14
-  response:
-    body: {string: '{"deviceId":"test-device-2","generationId":"636173390069287098","etag":"MQ==","connectionState":"Disconnected","status":"enabled","statusReason":"TestReason","connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":null,"secondaryKey":null},"x509Thumbprint":{"primaryThumbprint":"A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C","secondaryThumbprint":"14963E8F3BA5B3984110B3C1CA8E8B8988599087"}}}'}
-    headers:
-      Content-Length: ['543']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:40 GMT']
-      ETag: ['"MQ=="']
-      Server: [Microsoft-HTTPAPI/2.0]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [0703d89c-c230-11e6-be6c-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:40 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1885']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [0753fdc6-c230-11e6-9f9d-a0b3ccf7272a]
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
-  response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"AwGPYGUGVXBuq+DH/J988CZxvAJCSlpdQY495cxt7ls=","secondaryKey":"XB2vej9wvuT9oF+to+u+EiNQYsUfv2z7Bug76PeboNs=","rights":"RegistryWrite,
-        ServiceConnect, DeviceConnect"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:42 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['203']
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [SharedAccessSignature sr=iot-hub-for-test.azure-devices.net%252fdevices%252f&sig=n9C6YwNoRqx5pOZpqh2GrIuth5ImN1aeJXXPti57Kaw%3D&se=1481745822&skn=iothubowner]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [07a03822-c230-11e6-9d22-a0b3ccf7272a]
-    method: GET
-    uri: https://iot-hub-for-test.azure-devices.net/devices?api-version=2016-11-14&top=20
-  response:
-    body: {string: '[{"deviceId":"test-device-2","generationId":"636173390069287098","etag":"MQ==","connectionState":"Disconnected","status":"enabled","statusReason":"TestReason","connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":null,"secondaryKey":null},"x509Thumbprint":{"primaryThumbprint":"A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C","secondaryThumbprint":"14963E8F3BA5B3984110B3C1CA8E8B8988599087"}}},{"deviceId":"test-device-1","generationId":"636173390041974273","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"0hd6y9+fiT18ILMz/kIst4ALFzGGPKvJv9Hm5JaDAp4=","secondaryKey":"xDwqnBlsfdqvRL2NDxaEk/okPORoLBxJOM1G3GWfuV8="},"x509Thumbprint":{"primaryThumbprint":null,"secondaryThumbprint":null}}}]'}
-    headers:
-      Content-Length: ['1089']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:42 GMT']
-      Server: [Microsoft-HTTPAPI/2.0]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [07f06d50-c230-11e6-8c8b-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:42 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1885']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [0841cf28-c230-11e6-9761-a0b3ccf7272a]
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
-  response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"AwGPYGUGVXBuq+DH/J988CZxvAJCSlpdQY495cxt7ls=","secondaryKey":"XB2vej9wvuT9oF+to+u+EiNQYsUfv2z7Bug76PeboNs=","rights":"RegistryWrite,
-        ServiceConnect, DeviceConnect"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:43 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['203']
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
-    status: {code: 200, message: OK}
-- request:
-    body: '"Ping from Azure CLI"'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [SharedAccessSignature sr=iot-hub-for-test.azure-devices.net%252fdevices%252ftest-device-1&sig=6nuv8fADXoNyuuPFKOp2QOawS7X5iczTESfv1WR%2Fuqo%3D&se=1481745823&skn=iothubowner]
-      Connection: [keep-alive]
-      Content-Length: ['21']
-      Content-Type: [application/octet-stream]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [087f3164-c230-11e6-b9b5-a0b3ccf7272a]
-    method: POST
-    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1/messages/events?api-version=2016-11-14
-  response:
-    body: {string: ''}
-    headers:
-      Content-Length: ['0']
-      Date: ['Wed, 14 Dec 2016 19:03:43 GMT']
-      Server: [Microsoft-HTTPAPI/2.0]
-    status: {code: 204, message: No Content}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [08f34366-c230-11e6-9cf1-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:44 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1885']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [0945736c-c230-11e6-b784-a0b3ccf7272a]
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
-  response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"AwGPYGUGVXBuq+DH/J988CZxvAJCSlpdQY495cxt7ls=","secondaryKey":"XB2vej9wvuT9oF+to+u+EiNQYsUfv2z7Bug76PeboNs=","rights":"RegistryWrite,
-        ServiceConnect, DeviceConnect"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:45 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['203']
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Authorization: [SharedAccessSignature sr=iot-hub-for-test.azure-devices.net%252fdevices%252ftest-device-1&sig=wCdkB85CVG7IHIVTBXdUKq2hlwQ%2Ft8eIZU5rn6nCFWM%3D&se=1481745825&skn=iothubowner]
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      IotHub-MessageLockTimeout: ['60']
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
-      accept-language: [en-US]
-      x-ms-client-request-id: [0987bfb6-c230-11e6-bdb1-a0b3ccf7272a]
-    method: GET
-    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1/messages/devicebound?api-version=2016-11-14
-  response:
-    body: {string: ''}
-    headers:
-      Content-Length: ['0']
-      Date: ['Wed, 14 Dec 2016 19:03:47 GMT']
-      Server: [Microsoft-HTTPAPI/2.0]
-    status: {code: 204, message: No Content}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [09d28cfa-c230-11e6-918b-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
-  response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:46 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      content-length: ['1885']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [0a1f6f3a-c230-11e6-8e7e-a0b3ccf7272a]
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
-  response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"AwGPYGUGVXBuq+DH/J988CZxvAJCSlpdQY495cxt7ls=","secondaryKey":"XB2vej9wvuT9oF+to+u+EiNQYsUfv2z7Bug76PeboNs=","rights":"RegistryWrite,
-        ServiceConnect, DeviceConnect"}'}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:46 GMT']
+      Date: ['Mon, 26 Dec 2016 06:44:59 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -2230,23 +2241,594 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [SharedAccessSignature sr=iot-hub-for-test.azure-devices.net%252fdevices%252ftest-device-1&sig=eV5QFBRBKNvysUqoyeBYRq%2FEv2KBh5oafFQkJrSpRjk%3D&se=1481745826&skn=iothubowner]
+      Authorization: [SharedAccessSignature se=1482738300&sr=iot-hub-for-test.azure-devices.net%252fdevices%252ftest-device-1&sig=Zad59qwjaU7qc0d7HCiHvXKWICnNyFHtf1gzIbZzeIA%3D&skn=iothubowner]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [d2db48e6-cb36-11e6-983b-40a8f04ffd53]
+    method: GET
+    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1?api-version=2016-11-14
+  response:
+    body: {string: '{"deviceId":"test-device-1","generationId":"636183314810983457","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"tcYQ1dzGzaqdBiIWPdtr/EYhCK3aqcBXGaJOIv451s0=","secondaryKey":"Gnv9o2tcLQ+I08oX0uUsnoWuExt8azR969USelXKgjs="},"x509Thumbprint":{"primaryThumbprint":null,"secondaryThumbprint":null}}}'}
+    headers:
+      Content-Length: ['543']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:45:00 GMT']
+      ETag: ['"MA=="']
+      Server: [Microsoft-HTTPAPI/2.0]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [d3da4612-cb36-11e6-bdc6-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:45:02 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1899']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0a58e788-c230-11e6-a614-a0b3ccf7272a]
+      x-ms-client-request-id: [d44b8b66-cb36-11e6-ac81-40a8f04ffd53]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
+  response:
+    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:45:03 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['203']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [SharedAccessSignature se=1482738303&sr=iot-hub-for-test.azure-devices.net%252fdevices%252ftest-device-1&sig=wFhFu4IOD4bW9QKHOnzCIlpygx%2F9AumOEhvuu0KFYzo%3D&skn=iothubowner]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [d4ac1076-cb36-11e6-8c32-40a8f04ffd53]
+    method: GET
+    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1?api-version=2016-11-14
+  response:
+    body: {string: '{"deviceId":"test-device-1","generationId":"636183314810983457","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"tcYQ1dzGzaqdBiIWPdtr/EYhCK3aqcBXGaJOIv451s0=","secondaryKey":"Gnv9o2tcLQ+I08oX0uUsnoWuExt8azR969USelXKgjs="},"x509Thumbprint":{"primaryThumbprint":null,"secondaryThumbprint":null}}}'}
+    headers:
+      Content-Length: ['543']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:45:06 GMT']
+      ETag: ['"MA=="']
+      Server: [Microsoft-HTTPAPI/2.0]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [d59f688a-cb36-11e6-8ac8-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:45:06 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1899']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [d613c512-cb36-11e6-964b-40a8f04ffd53]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
+  response:
+    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:45:06 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['203']
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [SharedAccessSignature se=1482738306&sr=iot-hub-for-test.azure-devices.net%252fdevices%252ftest-device-2&sig=5l5UA1G8Petl1GL7s1uJe54Gsum0tWk5zw0R0SX7TRk%3D&skn=iothubowner]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [d6745e5a-cb36-11e6-9bfc-40a8f04ffd53]
+    method: GET
+    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-2?api-version=2016-11-14
+  response:
+    body: {string: '{"deviceId":"test-device-2","generationId":"636183314847877850","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":null,"secondaryKey":null},"x509Thumbprint":{"primaryThumbprint":"A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C","secondaryThumbprint":"14963E8F3BA5B3984110B3C1CA8E8B8988599087"}}}'}
+    headers:
+      Content-Length: ['535']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:45:06 GMT']
+      ETag: ['"MA=="']
+      Server: [Microsoft-HTTPAPI/2.0]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [d7164968-cb36-11e6-9488-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:45:07 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1899']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [d78969dc-cb36-11e6-a886-40a8f04ffd53]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
+  response:
+    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:45:08 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['203']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"lastActivityTime": "0001-01-01T00:00:00.000Z", "connectionState": "Disconnected",
+      "status": "enabled", "etag": "MA==", "authentication": {"symmetricKey": {},
+      "x509Thumbprint": {"secondaryThumbprint": "14963E8F3BA5B3984110B3C1CA8E8B8988599087",
+      "primaryThumbprint": "A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C"}}, "connectionStateUpdatedTime":
+      "0001-01-01T00:00:00.000Z", "cloudToDeviceMessageCount": 0, "statusUpdatedTime":
+      "0001-01-01T00:00:00.000Z", "statusReason": "TestReason", "deviceId": "test-device-2"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [SharedAccessSignature se=1482738309&sr=iot-hub-for-test.azure-devices.net%252fdevices%252ftest-device-2&sig=Y4fYcs5Q3Mr%2FCQVU8Njue648atmSohLnWeA8BCYdy80%3D&skn=iothubowner]
+      Connection: [keep-alive]
+      Content-Length: ['510']
+      Content-Type: [application/json; charset=utf-8]
+      If-Match: ['*']
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [d7e98fa6-cb36-11e6-9da6-40a8f04ffd53]
+    method: PUT
+    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-2?api-version=2016-11-14
+  response:
+    body: {string: '{"deviceId":"test-device-2","generationId":"636183314847877850","etag":"MQ==","connectionState":"Disconnected","status":"enabled","statusReason":"TestReason","connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":null,"secondaryKey":null},"x509Thumbprint":{"primaryThumbprint":"A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C","secondaryThumbprint":"14963E8F3BA5B3984110B3C1CA8E8B8988599087"}}}'}
+    headers:
+      Content-Length: ['543']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:45:10 GMT']
+      ETag: ['"MQ=="']
+      Server: [Microsoft-HTTPAPI/2.0]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [d8e92f86-cb36-11e6-b9d4-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:45:11 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1899']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [d959e29e-cb36-11e6-a203-40a8f04ffd53]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
+  response:
+    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:45:11 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['203']
+      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [SharedAccessSignature se=1482738312&sr=iot-hub-for-test.azure-devices.net%252fdevices%252f&sig=qUMeRry59fZWbQbOG914WmAEiqCZl3o62s2OlIbXmXg%3D&skn=iothubowner]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [d9ba19d0-cb36-11e6-832d-40a8f04ffd53]
+    method: GET
+    uri: https://iot-hub-for-test.azure-devices.net/devices?api-version=2016-11-14&top=20
+  response:
+    body: {string: '[{"deviceId":"test-device-2","generationId":"636183314847877850","etag":"MQ==","connectionState":"Disconnected","status":"enabled","statusReason":"TestReason","connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":null,"secondaryKey":null},"x509Thumbprint":{"primaryThumbprint":"A361EA6A7119A8B0B7BBFFA2EAFDAD1F9D5BED8C","secondaryThumbprint":"14963E8F3BA5B3984110B3C1CA8E8B8988599087"}}},{"deviceId":"test-device-1","generationId":"636183314810983457","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"tcYQ1dzGzaqdBiIWPdtr/EYhCK3aqcBXGaJOIv451s0=","secondaryKey":"Gnv9o2tcLQ+I08oX0uUsnoWuExt8azR969USelXKgjs="},"x509Thumbprint":{"primaryThumbprint":null,"secondaryThumbprint":null}}}]'}
+    headers:
+      Content-Length: ['1089']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:45:11 GMT']
+      Server: [Microsoft-HTTPAPI/2.0]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [daac874c-cb36-11e6-9a8d-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:45:14 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1899']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [db1ec890-cb36-11e6-b4a2-40a8f04ffd53]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
+  response:
+    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:45:14 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['203']
+      x-ms-ratelimit-remaining-subscription-writes: ['1194']
+    status: {code: 200, message: OK}
+- request:
+    body: '"Ping from Azure CLI"'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [SharedAccessSignature se=1482738315&sr=iot-hub-for-test.azure-devices.net%252fdevices%252ftest-device-1&sig=%2FCyo7PkZQANiVk7Zt%2F63dIwZDBgSpWU3XB11dQCEIks%3D&skn=iothubowner]
+      Connection: [keep-alive]
+      Content-Length: ['21']
+      Content-Type: [application/octet-stream]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [db7e6164-cb36-11e6-8b3b-40a8f04ffd53]
+    method: POST
+    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1/messages/events?api-version=2016-11-14
+  response:
+    body: {string: ''}
+    headers:
+      Content-Length: ['0']
+      Date: ['Mon, 26 Dec 2016 06:45:18 GMT']
+      Server: [Microsoft-HTTPAPI/2.0]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dc9f53b8-cb36-11e6-9610-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:45:16 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1899']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd108c1a-cb36-11e6-bf7f-40a8f04ffd53]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
+  response:
+    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:45:17 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['203']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [SharedAccessSignature se=1482738318&sr=iot-hub-for-test.azure-devices.net%252fdevices%252ftest-device-1&sig=42cOSspxuelMnrlobrEUgTtyTJ6COWTkxFNCQ2DnhUA%3D&skn=iothubowner]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      IotHub-MessageLockTimeout: ['60']
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [dd71310a-cb36-11e6-975d-40a8f04ffd53]
+    method: GET
+    uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1/messages/devicebound?api-version=2016-11-14
+  response:
+    body: {string: ''}
+    headers:
+      Content-Length: ['0']
+      Date: ['Mon, 26 Dec 2016 06:45:17 GMT']
+      Server: [Microsoft-HTTPAPI/2.0]
+    status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [de6fb742-cb36-11e6-90ab-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:45:21 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1899']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [df605d00-cb36-11e6-ab85-40a8f04ffd53]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
+  response:
+    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
+        ServiceConnect, DeviceConnect"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:45:22 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['203']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [SharedAccessSignature se=1482738323&sr=iot-hub-for-test.azure-devices.net%252fdevices%252ftest-device-1&sig=no7wDoyLbKscIVWYKd6Lu0mZujFHyoQE5wCXKG0I5sw%3D&skn=iothubowner]
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e03713f6-cb36-11e6-b59b-40a8f04ffd53]
     method: DELETE
     uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1/messages/devicebound/00000000-0000-0000-0000-000000000000?api-version=2016-11-14
   response:
-    body: {string: '{"Message":"{\"errorCode\":412002,\"trackingId\":\"1c91d929d8594edca7771c94374feb1d-G:2-TimeStamp:12/14/2016
-        19:03:47\",\"message\":\"PreconditionFailed\",\"timestampUtc\":\"2016-12-14T19:03:47.2667457Z\"}","ExceptionMessage":""}'}
+    body: {string: '{"Message":"{\"errorCode\":412002,\"trackingId\":\"9e761689f9a14c5dba683db29f11e001-G:0-TimeStamp:12/26/2016
+        06:45:25\",\"message\":\"PreconditionFailed\",\"timestampUtc\":\"2016-12-26T06:45:25.0059132Z\"}","ExceptionMessage":""}'}
     headers:
       Content-Length: ['229']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:47 GMT']
+      Date: ['Mon, 26 Dec 2016 06:45:24 GMT']
       Server: [Microsoft-HTTPAPI/2.0]
       iothub-errorcode: [DeviceMessageLockLost]
     status: {code: 412, message: Precondition Failed}
@@ -2257,25 +2839,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0ab3403a-c230-11e6-b4dd-a0b3ccf7272a]
+      x-ms-client-request-id: [e1363bd0-cb36-11e6-80f9-40a8f04ffd53]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:46 GMT']
+      Date: ['Mon, 26 Dec 2016 06:45:25 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['1885']
+      content-length: ['1899']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2285,19 +2868,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0affd9a8-c230-11e6-953e-a0b3ccf7272a]
+      x-ms-client-request-id: [e1c958ae-cb36-11e6-842e-40a8f04ffd53]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
   response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"AwGPYGUGVXBuq+DH/J988CZxvAJCSlpdQY495cxt7ls=","secondaryKey":"XB2vej9wvuT9oF+to+u+EiNQYsUfv2z7Bug76PeboNs=","rights":"RegistryWrite,
+    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
         ServiceConnect, DeviceConnect"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:48 GMT']
+      Date: ['Mon, 26 Dec 2016 06:45:26 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -2305,30 +2888,30 @@ interactions:
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       content-length: ['203']
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [SharedAccessSignature sr=iot-hub-for-test.azure-devices.net%252fdevices%252ftest-device-1&sig=fApl3l7Q4y82R6IWLgMbIwPfVGAJumUuw0TpZ%2FcxEUU%3D&se=1481745828&skn=iothubowner]
+      Authorization: [SharedAccessSignature se=1482738327&sr=iot-hub-for-test.azure-devices.net%252fdevices%252ftest-device-1&sig=8g6xGLg6iN18JfXJOyOKnoL7mViCC%2F0W824GXG42mH8%3D&skn=iothubowner]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [0b422ae2-c230-11e6-abfa-a0b3ccf7272a]
+      x-ms-client-request-id: [e2a63d8c-cb36-11e6-ad81-40a8f04ffd53]
     method: DELETE
     uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1/messages/devicebound/00000000-0000-0000-0000-000000000000?api-version=2016-11-14&reject=
   response:
-    body: {string: '{"Message":"{\"errorCode\":412002,\"trackingId\":\"c95dabad70994438b17e1fc2081799c6-G:0-TimeStamp:12/14/2016
-        19:03:49\",\"message\":\"PreconditionFailed\",\"timestampUtc\":\"2016-12-14T19:03:49.057427Z\"}","ExceptionMessage":""}'}
+    body: {string: '{"Message":"{\"errorCode\":412002,\"trackingId\":\"6133673abe134adb8c41668061603d8a-G:7-TimeStamp:12/26/2016
+        06:45:26\",\"message\":\"PreconditionFailed\",\"timestampUtc\":\"2016-12-26T06:45:26.6951274Z\"}","ExceptionMessage":""}'}
     headers:
-      Content-Length: ['228']
+      Content-Length: ['229']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:49 GMT']
+      Date: ['Mon, 26 Dec 2016 06:45:26 GMT']
       Server: [Microsoft-HTTPAPI/2.0]
       iothub-errorcode: [DeviceMessageLockLost]
     status: {code: 412, message: Precondition Failed}
@@ -2339,25 +2922,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0b91d024-c230-11e6-9708-a0b3ccf7272a]
+      x-ms-client-request-id: [e3a881f4-cb36-11e6-99af-40a8f04ffd53]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:48 GMT']
+      Date: ['Mon, 26 Dec 2016 06:45:28 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['1885']
+      content-length: ['1899']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2367,19 +2951,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0becdde8-c230-11e6-939a-a0b3ccf7272a]
+      x-ms-client-request-id: [e43abbca-cb36-11e6-b49b-40a8f04ffd53]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
   response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"AwGPYGUGVXBuq+DH/J988CZxvAJCSlpdQY495cxt7ls=","secondaryKey":"XB2vej9wvuT9oF+to+u+EiNQYsUfv2z7Bug76PeboNs=","rights":"RegistryWrite,
+    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
         ServiceConnect, DeviceConnect"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:49 GMT']
+      Date: ['Mon, 26 Dec 2016 06:45:29 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -2387,30 +2971,30 @@ interactions:
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       content-length: ['203']
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+      x-ms-ratelimit-remaining-subscription-writes: ['1193']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [SharedAccessSignature sr=iot-hub-for-test.azure-devices.net%252fdevices%252ftest-device-1&sig=vnT1fitASQCHwT9v0%2BHjEflKY50hAiDkY9YxITSv1PQ%3D&se=1481745829&skn=iothubowner]
+      Authorization: [SharedAccessSignature se=1482738330&sr=iot-hub-for-test.azure-devices.net%252fdevices%252ftest-device-1&sig=gSDxILTV2HTszd8i9BlSCpnVMVcaDpoJ3jUCQ33MGy0%3D&skn=iothubowner]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [0c298414-c230-11e6-84c8-a0b3ccf7272a]
+      x-ms-client-request-id: [e49a6a5c-cb36-11e6-9bf4-40a8f04ffd53]
     method: POST
     uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1/messages/devicebound/00000000-0000-0000-0000-000000000000/abandon?api-version=2016-11-14
   response:
-    body: {string: '{"Message":"{\"errorCode\":412002,\"trackingId\":\"ad2bfbf221e14955a55287cc38e65645-G:9-TimeStamp:12/14/2016
-        19:03:50\",\"message\":\"PreconditionFailed\",\"timestampUtc\":\"2016-12-14T19:03:50.4601658Z\"}","ExceptionMessage":""}'}
+    body: {string: '{"Message":"{\"errorCode\":412002,\"trackingId\":\"5e4b6095b0d44c209b9b166ad89142f6-G:4-TimeStamp:12/26/2016
+        06:45:32\",\"message\":\"PreconditionFailed\",\"timestampUtc\":\"2016-12-26T06:45:32.9772581Z\"}","ExceptionMessage":""}'}
     headers:
       Content-Length: ['229']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:50 GMT']
+      Date: ['Mon, 26 Dec 2016 06:45:32 GMT']
       Server: [Microsoft-HTTPAPI/2.0]
       iothub-errorcode: [DeviceMessageLockLost]
     status: {code: 412, message: Precondition Failed}
@@ -2421,25 +3005,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0c82f1c8-c230-11e6-8d32-a0b3ccf7272a]
+      x-ms-client-request-id: [e5ab6c36-cb36-11e6-b977-40a8f04ffd53]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:50 GMT']
+      Date: ['Mon, 26 Dec 2016 06:45:32 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['1885']
+      content-length: ['1899']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2448,18 +3033,18 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0cca5bd4-c230-11e6-af2b-a0b3ccf7272a]
+      x-ms-client-request-id: [e621cf34-cb36-11e6-8862-40a8f04ffd53]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/quotaMetrics?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"Name":"TotalMessages","CurrentValue":0,"MaxValue":400000},{"Name":"TotalDeviceCount","CurrentValue":0,"MaxValue":500000}]}'}
+    body: {string: '{"value":[{"Name":"TotalMessages","CurrentValue":0,"MaxValue":400000},{"Name":"TotalDeviceCount","CurrentValue":2,"MaxValue":500000}]}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:51 GMT']
+      Date: ['Mon, 26 Dec 2016 06:45:33 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -2475,25 +3060,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0d49e098-c230-11e6-91a9-a0b3ccf7272a]
+      x-ms-client-request-id: [e70a83da-cb36-11e6-b121-40a8f04ffd53]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:51 GMT']
+      Date: ['Mon, 26 Dec 2016 06:45:34 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['1885']
+      content-length: ['1899']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2502,10 +3088,10 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0d944c30-c230-11e6-8a27-a0b3ccf7272a]
+      x-ms-client-request-id: [e785204a-cb36-11e6-9ae1-40a8f04ffd53]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubStats?api-version=2016-02-03
   response:
@@ -2513,7 +3099,7 @@ interactions:
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:52 GMT']
+      Date: ['Mon, 26 Dec 2016 06:45:35 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -2529,25 +3115,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0e18e03e-c230-11e6-8543-a0b3ccf7272a]
+      x-ms-client-request-id: [e84a61f6-cb36-11e6-9b7a-40a8f04ffd53]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:52 GMT']
+      Date: ['Mon, 26 Dec 2016 06:45:37 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['1885']
+      content-length: ['1899']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2557,19 +3144,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0e64e9e6-c230-11e6-9d33-a0b3ccf7272a]
+      x-ms-client-request-id: [e8bd5f5e-cb36-11e6-bd20-40a8f04ffd53]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
   response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"AwGPYGUGVXBuq+DH/J988CZxvAJCSlpdQY495cxt7ls=","secondaryKey":"XB2vej9wvuT9oF+to+u+EiNQYsUfv2z7Bug76PeboNs=","rights":"RegistryWrite,
+    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
         ServiceConnect, DeviceConnect"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:53 GMT']
+      Date: ['Mon, 26 Dec 2016 06:45:38 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -2584,22 +3171,22 @@ interactions:
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [SharedAccessSignature sr=iot-hub-for-test.azure-devices.net%252fdevices%252ftest-device-1&sig=YRoGiFOwskqlX7D2qKGPNVzESGDTwX0c%2F3ksw1wJsnQ%3D&se=1481745834&skn=iothubowner]
+      Authorization: [SharedAccessSignature se=1482738338&sr=iot-hub-for-test.azure-devices.net%252fdevices%252ftest-device-1&sig=W1STDTcM6Sa7xgMMhZA5FESYwrx0kqSqRwAxH0kZmU0%3D&skn=iothubowner]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
       If-Match: ['*']
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [0ea3fbde-c230-11e6-b201-a0b3ccf7272a]
+      x-ms-client-request-id: [e98f5c46-cb36-11e6-abd0-40a8f04ffd53]
     method: DELETE
     uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-1?api-version=2016-11-14
   response:
     body: {string: ''}
     headers:
       Content-Length: ['0']
-      Date: ['Wed, 14 Dec 2016 19:03:53 GMT']
+      Date: ['Mon, 26 Dec 2016 06:45:39 GMT']
       Server: [Microsoft-HTTPAPI/2.0]
     status: {code: 204, message: No Content}
 - request:
@@ -2609,25 +3196,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0f0dc55e-c230-11e6-9bdc-a0b3ccf7272a]
+      x-ms-client-request-id: [eabf0c08-cb36-11e6-a9b7-40a8f04ffd53]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
   response:
-    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"0b1f6471-1bf0-4dda-aec3-cb9272f09590","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACOTxQ=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-95766-0737a85d58.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"None":"None","Connections":"None","DeviceTelemetry":"None","C2DCommands":"None","DeviceIdentityOperations":"None","FileUploadOperations":"None","Routes":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:54 GMT']
+      Date: ['Mon, 26 Dec 2016 06:45:41 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
-      content-length: ['1885']
+      content-length: ['1899']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2637,19 +3225,19 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubclient/0.1.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0f5a97cc-c230-11e6-b02e-a0b3ccf7272a]
+      x-ms-client-request-id: [eb329648-cb36-11e6-9527-40a8f04ffd53]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/IotHubKeys/iothubowner/listkeys?api-version=2016-02-03
   response:
-    body: {string: '{"keyName":"iothubowner","primaryKey":"AwGPYGUGVXBuq+DH/J988CZxvAJCSlpdQY495cxt7ls=","secondaryKey":"XB2vej9wvuT9oF+to+u+EiNQYsUfv2z7Bug76PeboNs=","rights":"RegistryWrite,
+    body: {string: '{"keyName":"iothubowner","primaryKey":"B5mssSTdqdqm4Hgah0IupXyyi9n/Ii9tPbW6bCjSU9g=","secondaryKey":"90UQ3Gzp+A+8uHn8rBo34BZHeE8Gx0wRbpYBigfWkAI=","rights":"RegistryWrite,
         ServiceConnect, DeviceConnect"}'}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 14 Dec 2016 19:03:54 GMT']
+      Date: ['Mon, 26 Dec 2016 06:45:41 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0]
@@ -2657,29 +3245,140 @@ interactions:
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       content-length: ['203']
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1194']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
-      Authorization: [SharedAccessSignature sr=iot-hub-for-test.azure-devices.net%252fdevices%252ftest-device-2&sig=eB1w94uzpfBdKyEyZ6dcU27iytjwosf%2F4TGT1Rm1Uvc%3D&se=1481745835&skn=iothubowner]
+      Authorization: [SharedAccessSignature se=1482738342&sr=iot-hub-for-test.azure-devices.net%252fdevices%252ftest-device-2&sig=kE3lQoBvwUAdb8pcX%2BAp7apKBUneZ0OGTAnWiaAvYdg%3D&skn=iothubowner]
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
       If-Match: ['*']
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.11.1 msrest/0.4.4
-          msrest_azure/0.4.6 iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubdeviceclient/2016-11-14 Azure-SDK-For-Python]
       accept-language: [en-US]
-      x-ms-client-request-id: [0f97117a-c230-11e6-87b7-a0b3ccf7272a]
+      x-ms-client-request-id: [eb972e66-cb36-11e6-9a84-40a8f04ffd53]
     method: DELETE
     uri: https://iot-hub-for-test.azure-devices.net/devices/test-device-2?api-version=2016-11-14
   response:
     body: {string: ''}
     headers:
       Content-Length: ['0']
-      Date: ['Wed, 14 Dec 2016 19:03:56 GMT']
+      Date: ['Mon, 26 Dec 2016 06:45:44 GMT']
       Server: [Microsoft-HTTPAPI/2.0]
     status: {code: 204, message: No Content}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [ec9fc2b0-cb36-11e6-80c9-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/IotHubs?api-version=2016-02-03
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test","name":"iot-hub-for-test","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"ba8e3a3d-29a9-48dd-972c-cdcc47ecf584","resourcegroup":"iot-hub-test-rg","etag":"AAAAAACS9vk=","properties":{"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-test.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-test-operationmonitoring","endpoint":"sb://iothub-ns-iot-hub-fo-99363-c0649ec849.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT1M","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"operationsMonitoringProperties":{"events":{"C2DCommands":"None","Connections":"None","FileUploadOperations":"None","None":"None","Routes":"None","DeviceTelemetry":"Error,
+        Information","DeviceIdentityOperations":"None"}},"features":"None","generationNumber":0},"sku":{"name":"S1","tier":"Standard","capacity":1}}]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:45:43 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1899']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [ed0fdb0a-cb36-11e6-88da-40a8f04ffd53]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test?api-version=2016-02-03
+  response:
+    body: {string: 'null'}
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/ba8e3a3d-29a9-48dd-972c-cdcc47ecf584/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/OGVkMDZjODUtZTBkZi00MGIyLTg3OTEtZDM1NjlmZTRmYjdi?api-version=2016-02-03&asyncinfo']
+      Cache-Control: [no-cache]
+      Content-Length: ['4']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:45:46 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/ba8e3a3d-29a9-48dd-972c-cdcc47ecf584/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/OGVkMDZjODUtZTBkZi00MGIyLTg3OTEtZDM1NjlmZTRmYjdi?api-version=2016-02-03']
+      Pragma: [no-cache]
+      Retry-After: ['15']
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [ed0fdb0a-cb36-11e6-88da-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/OGVkMDZjODUtZTBkZi00MGIyLTg3OTEtZDM1NjlmZTRmYjdi?api-version=2016-02-03&asyncinfo
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:46:02 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
+          iothubclient/0.2.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b11+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [ed0fdb0a-cb36-11e6-88da-40a8f04ffd53]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iot-hub-test-rg/providers/Microsoft.Devices/IotHubs/iot-hub-for-test/operationResults/OGVkMDZjODUtZTBkZi00MGIyLTg3OTEtZDM1NjlmZTRmYjdi?api-version=2016-02-03&asyncinfo
+  response:
+    body: {string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Devices/IotHubs/iot-hub-for-test''
+        under resource group ''iot-hub-test-rg'' was not found."}}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Length: ['167']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 26 Dec 2016 06:46:33 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-failure-cause: [gateway]
+    status: {code: 404, message: Not Found}
 version: 1

--- a/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/tests/test_iot_commands.py
+++ b/src/command_modules/azure-cli-iot/azure/cli/command_modules/iot/tests/test_iot_commands.py
@@ -84,8 +84,8 @@ class IoTHubTest(ResourceGroupVCRTestBase):
 
         # Test 'az iot hub policy create'
         policy_name = 'test_policy'
-        permissions = 'RegistryWrite, ServiceConnect, DeviceConnect'
-        self.cmd('iot hub policy create --hub-name {0} -n {1} --permissions "{2}"'.format(hub, policy_name, permissions),
+        permissions = 'RegistryWrite ServiceConnect DeviceConnect'
+        self.cmd('iot hub policy create --hub-name {0} -n {1} --permissions {2}'.format(hub, policy_name, permissions),
                  checks=NoneCheck())
 
         # Test 'az iot hub policy list'
@@ -96,7 +96,7 @@ class IoTHubTest(ResourceGroupVCRTestBase):
         # Test 'az iot hub policy show'
         self.cmd('iot hub policy show --hub-name {0} -n {1}'.format(hub, policy_name), checks=[
             JMESPathCheck('keyName', policy_name),
-            JMESPathCheck('rights', permissions)
+            JMESPathCheck('rights', 'RegistryWrite, ServiceConnect, DeviceConnect')
         ])
 
         # Test 'az iot hub policy delete'

--- a/src/command_modules/azure-cli-iot/requirements.txt
+++ b/src/command_modules/azure-cli-iot/requirements.txt
@@ -1,2 +1,2 @@
-azure-mgmt-iothub==0.1.0
+azure-mgmt-iothub==0.2.1
 pyOpenSSL

--- a/src/command_modules/azure-cli-iot/setup.py
+++ b/src/command_modules/azure-cli-iot/setup.py
@@ -26,7 +26,7 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
-    'azure-mgmt-iothub==0.1.0',
+    'azure-mgmt-iothub==0.2.1',
     'pyOpenSSL',
     'azure-cli-core',
 ]


### PR DESCRIPTION
1. Upgrade IoT management SDK to latest version 0.2.1
2. Add new commands to 'iot hub' and 'iot device' group

Help messages of new commands:
```bash
>az iot hub update -h

Command
    az iot hub update: Update non-security metadata of an IoT Hub.

Arguments

Resource Id Arguments
    --ids              : One or more resource IDs. If provided, no other 'Resource Id' arguments
                         should be specified.
    --name -n          : IoT Hub name.
    --resource-group -g: Name of resource group.

Generic Update Arguments
    --add              : Add an object to a list of objects by specifying a path and key value
                         pairs.  Example: --add property.listProperty <key=value, string or JSON
                         string>.
    --remove           : Remove a property or an element from a list.  Example: --remove
                         property.list <indexToRemove> OR --remove propertyToRemove.
    --set              : Update an object by specifying a property path and value to set.  Example:
                         --set property1.property2=<value>.

Examples
    Add a new IP filter rule.
        az iot hub update --name my-iot-hub --add properties.ipFilterRules filter_name=test-rule
        action=Accept ip_mask=127.0.0.0/31 az iot hub update --name my-iot-hub --add
        properties.ipFilterRules filter_name=test-rule action=Reject ip_mask=127.0.0.0/31


>az iot hub delete -h

Command
    az iot hub delete: Delete an IoT Hub.

Arguments

Resource Id Arguments
    --ids              : One or more resource IDs. If provided, no other 'Resource Id' arguments
                         should be specified.
    --name -n          : IoT Hub name.
    --resource-group -g: Name of resource group.


>az iot hub policy create -h

Command
    az iot hub policy create: Create a new shared access policy in an IoT Hub.

Arguments
    --hub-name    [Required]: IoT Hub name.
    --name -n     [Required]: Shared access policy name.
    --permissions [Required]: Permissions of shared access policy. Use space separated list for
                              multiple permissions.Possible values: RegistryRead, RegistryWrite,
                              ServiceConnect, DeviceConnect.
    --resource-group -g     : Name of resource group.

Examples
    Create a new shared access policy
        az iot hub policy create --hub-name my-iot-hub --name new-policy --permissions
        RegistryWrite ServiceConnect DeviceConnect


>az iot hub policy delete -h

Command
    az iot hub policy delete: Delete a shared access policy from an IoT Hub.

Arguments

Resource Id Arguments
    --hub-name         : IoT Hub name.
    --ids              : One or more resource IDs. If provided, no other 'Resource Id' arguments
                         should be specified.
    --name -n          : Shared access policy name.
    --resource-group -g: Name of resource group.


>az iot device export -h

Command
    az iot device export: Exports all the device identities in the IoT hub identity registry to an
    Azure Storage blob container.
        For more information, see https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-
        identity-registry#import-and-export-device-identities.

Arguments
    --blob-container-uri [Required]: Blob Shared Access Signature URI with write access to a blob
                                     container.This is used to output the status of the job and the
                                     results.
    --hub-name           [Required]: IoT Hub name.
    --include-keys                 : If set, keys are exported normally. Otherwise, keys are set to
                                     null in export output.
    --resource-group -g            : Name of resource group.


>az iot device import -h

Command
    az iot device import: Import, update, or delete device identities in the IoT hub identity
    registry from a blob.
        For more information, see https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-
        identity-registry#import-and-export-device-identities.

Arguments
    --hub-name                  [Required]: IoT Hub name.
    --input-blob-container-uri  [Required]: Blob Shared Access Signature URI with read access to a
                                            blob container.This blob contains the operations to be
                                            performed on the identity registry.
    --output-blob-container-uri [Required]: Blob Shared Access Signature URI with write access to a
                                            blob container.This is used to output the status of the
                                            job and the results.
    --resource-group -g                   : Name of resource group.
```