### PR TITLE
Mitigate the pylint error caused by setuptools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,12 +6,13 @@ jmespath
 mock==1.3.0
 nose==1.3.7
 paramiko==2.0.2
-pip
+pip==9.0.1
 pygments==2.1.3
 pylint==1.5.4
 pyOpenSSL==16.1.0
 pyyaml==3.11
 requests==2.9.1
+setuptools==30.4.0
 six==1.10.0
 tabulate==0.7.5
 vcrpy==1.10.3

--- a/scripts/dev_setup.py
+++ b/scripts/dev_setup.py
@@ -25,6 +25,9 @@ def exec_command(command):
 print('Running dev setup...')
 print('Root directory \'{}\'\n'.format(root_dir))
 
+# install general requirements
+exec_command('pip install -r requirements.txt')
+
 # command modules have dependency on azure-cli-core so install this first
 exec_command('pip install -e src/azure-cli-nspkg')
 exec_command('pip install -e src/azure-cli-core')
@@ -32,6 +35,5 @@ exec_command('python scripts/command_modules/install.py')
 
 # azure cli has dependencies on the above packages so install this one last
 exec_command('pip install -e src/azure-cli')
-exec_command('pip install -r requirements.txt')
 
 print('Finished dev setup.')


### PR DESCRIPTION
Since 12/12/2016, the CI build on python 3.5-dev began failing while running pylint. The errors are import-error. The error was caused by setuptools. The python 3.5-dev build uses the latest setuptools. A change introduced between 30.4.0 and 31.0.0 add additional `.pth` file to the installation folder under virtualenv. The files obviously confused the pylint cause `import-error` in turn. 

This change will fix the setuptools version to 30.4.0 to mitigate this issue.