### PR TITLE
Fix pip seg fault on 'az component update'

### DIFF
--- a/src/command_modules/azure-cli-component/azure/cli/command_modules/component/custom.py
+++ b/src/command_modules/azure-cli-component/azure/cli/command_modules/component/custom.py
@@ -101,7 +101,7 @@ def _installed_in_user():
 
 def _install_or_update(package_list, link, private, pre):
     import pip
-    options = ['--isolated', '--disable-pip-version-check', '--upgrade', '--ignore-installed']
+    options = ['--isolated', '--disable-pip-version-check', '--upgrade']
     if pre:
         options.append('--pre')
     if _installed_in_user():


### PR DESCRIPTION
Closes https://github.com/Azure/azure-cli/issues/1578

The pip —ignore-installed flag would sometimes cause a seg fault.
Removing it prevents the seg fault.
It isn’t required now anyway.