### PR TITLE
Correcting unittest location in docs

### DIFF
--- a/doc/configuring_your_machine.md
+++ b/doc/configuring_your_machine.md
@@ -103,7 +103,7 @@ The repo has a launch.json file that will launch the version of Python that is f
 
   To test the core of the CLI:
   ```BatchFile
-  python -m unittest discover -s src/azure/cli/tests
+  python -m unittest discover -s src/azure-cli/azure/cli/tests
   ```
  
   To test the command modules:


### PR DESCRIPTION
From
`python -m unittest discover -s src/azure/cli/tests` to 
`python -m unittest discover -s src/azure-cli/azure/cli/tests`