### PR TITLE
Fix blob type validator

### DIFF
--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
@@ -122,7 +122,8 @@ def validate_source_uri(namespace):
     namespace.copy_source = uri
 
 def validate_blob_type(namespace):
-    namespace.blob_type = 'page' if namespace.file_path.endswith('.vhd') else 'block'
+    if namespace.blob_type is None:
+        namespace.blob_type = 'page' if namespace.file_path.endswith('.vhd') else 'block'
 
 def get_content_setting_validator(settings_class, update):
     def _class_name(class_type):

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
@@ -122,7 +122,7 @@ def validate_source_uri(namespace):
     namespace.copy_source = uri
 
 def validate_blob_type(namespace):
-    if namespace.blob_type is None:
+    if not namespace.blob_type:
         namespace.blob_type = 'page' if namespace.file_path.endswith('.vhd') else 'block'
 
 def get_content_setting_validator(settings_class, update):

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_blob_scenario.yaml
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_blob_scenario.yaml
@@ -7,69 +7,69 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.2 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 storagemanagementclient/0.30.0rc6 Azure-SDK-For-Python
           AZURECLI/TEST/0.1.0b11+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [75443ff0-d2a6-11e6-bbe6-a0b3ccf7272a]
+      x-ms-client-request-id: [c75f8ec6-d397-11e6-924c-480fcf61db4b]
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_blob_scenario_test/providers/Microsoft.Storage/storageAccounts/dummystorage.listKeys?api-version=2016-01-01
   response:
-    body: {string: !!python/unicode '{"keys":[{"keyName":"key1","permissions":"Full","value":"hkE98paHEPYJFCJBrnEnm+Adc1wv5nlxl6LkJTOBHY+3vPLoD4185iesyAYTOcdPIPpsa3pJd9xX9LjLM0e/Sg=="},{"keyName":"key2","permissions":"Full","value":"DyE5cdp52v9D0fUtonb9x+5jy2vyqboNWCuFLv5gwcf8ZgitsL2LW/AlYHGIMoxOMKUuB0Kgw3sEAO9ia7CO6w=="}]}
+    body: {string: '{"keys":[{"keyName":"key1","permissions":"Full","value":"c7We2TixgweM2y/ov9B4GQhdH/z2Iyfy7uhBZDvzgfoZfNKo/SJiDOJpvUJcKx3evTXjFLaemOVU3dJFSZ0xoQ=="},{"keyName":"key2","permissions":"Full","value":"rd6iezHVQ8E6qG2kTjKHLOUSxwHgkKJ4NHpZwoZ7yFdfxZKMwkpH6JOX+RjRY73tOeJylN6LTah18IG0yBa7SQ=="}]}
 
         '}
     headers:
-      cache-control: [no-cache]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Thu, 05 Jan 2017 22:39:11 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       content-length: ['289']
-      content-type: [application/json]
-      date: ['Wed, 04 Jan 2017 17:51:44 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1193']
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:46 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:12 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/cont1?restype=container
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:51:45 GMT']
-      etag: ['"0x8D434CA5A005A32"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:46 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Date: ['Thu, 05 Jan 2017 22:39:11 GMT']
+      ETag: ['"0x8D435BBABC47413"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:12 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:46 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:13 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/cont1?restype=container
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:51:46 GMT']
-      etag: ['"0x8D434CA5A005A32"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:46 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Date: ['Thu, 05 Jan 2017 22:39:10 GMT']
+      ETag: ['"0x8D435BBABC47413"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:12 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-lease-state: [available]
       x-ms-lease-status: [unlocked]
       x-ms-version: ['2015-07-08']
@@ -78,68 +78,68 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:47 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:13 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.blob.core.windows.net/cont1?comp=acl&restype=container
+    uri: https://dummystorage.blob.core.windows.net/cont1?restype=container&comp=acl
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers\
         \ />"}
     headers:
-      content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:51:46 GMT']
-      etag: ['"0x8D434CA5A005A32"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:46 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Content-Type: [application/xml]
+      Date: ['Thu, 05 Jan 2017 22:39:13 GMT']
+      ETag: ['"0x8D435BBABC47413"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:12 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+    body: '<?xml version=''1.0'' encoding=''utf-8''?>
 
       <SignedIdentifiers />'
     headers:
       Connection: [keep-alive]
       Content-Length: ['60']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
       x-ms-blob-public-access: [blob]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:47 GMT']
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:13 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.blob.core.windows.net/cont1?comp=acl&restype=container
+    uri: https://dummystorage.blob.core.windows.net/cont1?restype=container&comp=acl
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:51:47 GMT']
-      etag: ['"0x8D434CA5A8CC4FD"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:47 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Date: ['Thu, 05 Jan 2017 22:39:13 GMT']
+      ETag: ['"0x8D435BBAC8FE22C"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:13 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:47 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:14 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.blob.core.windows.net/cont1?comp=acl&restype=container
+    uri: https://dummystorage.blob.core.windows.net/cont1?restype=container&comp=acl
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers\
         \ />"}
     headers:
-      content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:51:47 GMT']
-      etag: ['"0x8D434CA5A8CC4FD"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:47 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Content-Type: [application/xml]
+      Date: ['Thu, 05 Jan 2017 22:39:14 GMT']
+      ETag: ['"0x8D435BBAC8FE22C"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:13 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-blob-public-access: [blob]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
@@ -147,88 +147,88 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:48 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:14 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.blob.core.windows.net/cont1?comp=acl&restype=container
+    uri: https://dummystorage.blob.core.windows.net/cont1?restype=container&comp=acl
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers\
         \ />"}
     headers:
-      content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:51:48 GMT']
-      etag: ['"0x8D434CA5A8CC4FD"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:47 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Content-Type: [application/xml]
+      Date: ['Thu, 05 Jan 2017 22:39:14 GMT']
+      ETag: ['"0x8D435BBAC8FE22C"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:13 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-blob-public-access: [blob]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+    body: '<?xml version=''1.0'' encoding=''utf-8''?>
 
       <SignedIdentifiers />'
     headers:
       Connection: [keep-alive]
       Content-Length: ['60']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:48 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:14 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.blob.core.windows.net/cont1?comp=acl&restype=container
+    uri: https://dummystorage.blob.core.windows.net/cont1?restype=container&comp=acl
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:51:48 GMT']
-      etag: ['"0x8D434CA5B50E17B"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:48 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Date: ['Thu, 05 Jan 2017 22:39:14 GMT']
+      ETag: ['"0x8D435BBAD43F5AC"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:14 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:49 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:15 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.blob.core.windows.net/cont1?comp=acl&restype=container
+    uri: https://dummystorage.blob.core.windows.net/cont1?restype=container&comp=acl
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers\
         \ />"}
     headers:
-      content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:51:48 GMT']
-      etag: ['"0x8D434CA5B50E17B"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:48 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Content-Type: [application/xml]
+      Date: ['Thu, 05 Jan 2017 22:39:15 GMT']
+      ETag: ['"0x8D435BBAD43F5AC"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:14 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:49 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:15 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/cont1?restype=container
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:51:49 GMT']
-      etag: ['"0x8D434CA5B50E17B"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:48 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Date: ['Thu, 05 Jan 2017 22:39:15 GMT']
+      ETag: ['"0x8D435BBAD43F5AC"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:14 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-lease-state: [available]
       x-ms-lease-status: [unlocked]
       x-ms-version: ['2015-07-08']
@@ -237,23 +237,23 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:50 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:16 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/?comp=list
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults\
-        \ ServiceEndpoint=\"https://vcrstorage166550539831.blob.core.windows.net/\"\
-        ><Containers><Container><Name>cont1</Name><Properties><Last-Modified>Wed,\
-        \ 04 Jan 2017 17:51:48 GMT</Last-Modified><Etag>\"0x8D434CA5B50E17B\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties></Container></Containers><NextMarker\
+        \ ServiceEndpoint=\"https://vcrstorage213990324496.blob.core.windows.net/\"\
+        ><Containers><Container><Name>cont1</Name><Properties><Last-Modified>Thu,\
+        \ 05 Jan 2017 22:39:14 GMT</Last-Modified><Etag>\"0x8D435BBAD43F5AC\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties></Container></Containers><NextMarker\
         \ /></EnumerationResults>"}
     headers:
-      content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:51:49 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Content-Type: [application/xml]
+      Date: ['Thu, 05 Jan 2017 22:39:16 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
@@ -261,42 +261,42 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:50 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:16 GMT']
       x-ms-meta-foo: [bar]
       x-ms-meta-moo: [bak]
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.blob.core.windows.net/cont1?comp=metadata&restype=container
+    uri: https://dummystorage.blob.core.windows.net/cont1?restype=container&comp=metadata
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:51:50 GMT']
-      etag: ['"0x8D434CA5C96F807"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:50 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Date: ['Thu, 05 Jan 2017 22:39:16 GMT']
+      ETag: ['"0x8D435BBAE7BFFF8"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:16 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:51 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:17 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.blob.core.windows.net/cont1?comp=metadata&restype=container
+    uri: https://dummystorage.blob.core.windows.net/cont1?restype=container&comp=metadata
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:51:51 GMT']
-      etag: ['"0x8D434CA5C96F807"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:50 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Date: ['Thu, 05 Jan 2017 22:39:16 GMT']
+      ETag: ['"0x8D435BBAE7BFFF8"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:16 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-meta-foo: [bar]
       x-ms-meta-moo: [bak]
       x-ms-version: ['2015-07-08']
@@ -306,212 +306,303 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:51 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:17 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.blob.core.windows.net/cont1?comp=metadata&restype=container
+    uri: https://dummystorage.blob.core.windows.net/cont1?restype=container&comp=metadata
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:51:51 GMT']
-      etag: ['"0x8D434CA5D416B9F"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:51 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Date: ['Thu, 05 Jan 2017 22:39:18 GMT']
+      ETag: ['"0x8D435BBAF17CA84"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:17 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:52 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:18 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.blob.core.windows.net/cont1?comp=metadata&restype=container
+    uri: https://dummystorage.blob.core.windows.net/cont1?restype=container&comp=metadata
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:51:51 GMT']
-      etag: ['"0x8D434CA5D416B9F"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:51 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Date: ['Thu, 05 Jan 2017 22:39:17 GMT']
+      ETag: ['"0x8D435BBAF17CA84"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:17 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode 'This is a test file for performance of automated tests.
-      DO NOT MOVE OR DELETE!'
+    body: This is a test file for performance of automated tests. DO NOT MOVE OR DELETE!
     headers:
       Connection: [keep-alive]
       Content-Length: ['78']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
       x-ms-blob-type: [BlockBlob]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:53 GMT']
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:18 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      content-md5: [zeGiTMG1TdAobIHawzap3A==]
-      date: ['Wed, 04 Jan 2017 17:51:53 GMT']
-      etag: ['"0x8D434CA5E0E936C"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:53 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Content-MD5: [zeGiTMG1TdAobIHawzap3A==]
+      Date: ['Thu, 05 Jan 2017 22:39:18 GMT']
+      ETag: ['"0x8D435BBAFBCF2F6"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:18 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:53 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:19 GMT']
       x-ms-version: ['2015-07-08']
     method: HEAD
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      accept-ranges: [bytes]
-      content-length: ['78']
-      content-md5: [zeGiTMG1TdAobIHawzap3A==]
-      content-type: [application/octet-stream]
-      date: ['Wed, 04 Jan 2017 17:51:53 GMT']
-      etag: ['"0x8D434CA5E0E936C"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:53 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Accept-Ranges: [bytes]
+      Content-Length: ['78']
+      Content-MD5: [zeGiTMG1TdAobIHawzap3A==]
+      Content-Type: [application/octet-stream]
+      Date: ['Thu, 05 Jan 2017 22:39:18 GMT']
+      ETag: ['"0x8D435BBAFBCF2F6"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:18 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-blob-type: [BlockBlob]
       x-ms-lease-state: [available]
       x-ms-lease-status: [unlocked]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode 'This is a test file for performance of automated tests.
-      DO NOT MOVE OR DELETE!                                                                                                                                                                                                                                                                                                                                                                                                                                                  '
+    body: null
+    headers:
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-blob-content-length: ['512']
+      x-ms-blob-type: [PageBlob]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:19 GMT']
+      x-ms-version: ['2015-07-08']
+    method: PUT
+    uri: https://dummystorage.blob.core.windows.net/cont1/testpageblob
+  response:
+    body: {string: ''}
+    headers:
+      Date: ['Thu, 05 Jan 2017 22:39:21 GMT']
+      ETag: ['"0x8D435BBB051DCA4"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:19 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
+      x-ms-version: ['2015-07-08']
+    status: {code: 201, message: Created}
+- request:
+    body: 'This is a test file for performance of automated tests. DO NOT MOVE OR
+      DELETE!                                                                                                                                                                                                                                                                                                                                                                                                                                                  '
     headers:
       Connection: [keep-alive]
       Content-Length: ['512']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-blob-type: [BlockBlob]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:54 GMT']
+      If-Match: ['"0x8D435BBB051DCA4"']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:20 GMT']
+      x-ms-page-write: [update]
+      x-ms-range: [bytes=0-511]
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.blob.core.windows.net/cont1/testpageblob
+    uri: https://dummystorage.blob.core.windows.net/cont1/testpageblob?comp=page
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      content-md5: [JKbxCPFguN3PtJpiW3lCrQ==]
-      date: ['Wed, 04 Jan 2017 17:51:54 GMT']
-      etag: ['"0x8D434CA5EB690E5"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:54 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Content-MD5: [JKbxCPFguN3PtJpiW3lCrQ==]
+      Date: ['Thu, 05 Jan 2017 22:39:21 GMT']
+      ETag: ['"0x8D435BBB0597F9F"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:19 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
+      x-ms-blob-sequence-number: ['0']
       x-ms-version: ['2015-07-08']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:54 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:20 GMT']
       x-ms-version: ['2015-07-08']
     method: HEAD
     uri: https://dummystorage.blob.core.windows.net/cont1/testpageblob
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      accept-ranges: [bytes]
-      content-length: ['512']
-      content-md5: [JKbxCPFguN3PtJpiW3lCrQ==]
-      content-type: [application/octet-stream]
-      date: ['Wed, 04 Jan 2017 17:51:53 GMT']
-      etag: ['"0x8D434CA5EB690E5"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:54 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-blob-type: [BlockBlob]
+      Accept-Ranges: [bytes]
+      Content-Length: ['512']
+      Content-Type: [application/octet-stream]
+      Date: ['Thu, 05 Jan 2017 22:39:20 GMT']
+      ETag: ['"0x8D435BBB0597F9F"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:19 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-blob-sequence-number: ['0']
+      x-ms-blob-type: [PageBlob]
       x-ms-lease-state: [available]
       x-ms-lease-status: [unlocked]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode 'This is a test file for performance of automated tests.
-      DO NOT MOVE OR DELETE!'
+    body: null
     headers:
       Connection: [keep-alive]
-      Content-Length: ['78']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-blob-type: [BlockBlob]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:55 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:20 GMT']
+      x-ms-version: ['2015-07-08']
+    method: HEAD
+    uri: https://dummystorage.blob.core.windows.net/cont1/testappendblob
+  response:
+    body: {string: ''}
+    headers:
+      Date: ['Thu, 05 Jan 2017 22:39:20 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
+      x-ms-version: ['2015-07-08']
+    status: {code: 404, message: The specified blob does not exist.}
+- request:
+    body: null
+    headers:
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-blob-type: [AppendBlob]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:21 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/cont1/testappendblob
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      content-md5: [zeGiTMG1TdAobIHawzap3A==]
-      date: ['Wed, 04 Jan 2017 17:51:55 GMT']
-      etag: ['"0x8D434CA5F5DA3F9"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:55 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Date: ['Thu, 05 Jan 2017 22:39:20 GMT']
+      ETag: ['"0x8D435BBB0F56FE3"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:21 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 201, message: Created}
 - request:
-    body: !!python/unicode 'This is a test file for performance of automated tests.
-      DO NOT MOVE OR DELETE!'
+    body: This is a test file for performance of automated tests. DO NOT MOVE OR DELETE!
     headers:
       Connection: [keep-alive]
       Content-Length: ['78']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-blob-type: [BlockBlob]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:55 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:21 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.blob.core.windows.net/cont1/testappendblob
+    uri: https://dummystorage.blob.core.windows.net/cont1/testappendblob?comp=appendblock
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      content-md5: [zeGiTMG1TdAobIHawzap3A==]
-      date: ['Wed, 04 Jan 2017 17:51:55 GMT']
-      etag: ['"0x8D434CA5FB80CB0"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:56 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Content-MD5: [zeGiTMG1TdAobIHawzap3A==]
+      Date: ['Thu, 05 Jan 2017 22:39:20 GMT']
+      ETag: ['"0x8D435BBB123B700"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:21 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
+      x-ms-blob-append-offset: ['0']
+      x-ms-blob-committed-block-count: ['1']
       x-ms-version: ['2015-07-08']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:56 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:21 GMT']
       x-ms-version: ['2015-07-08']
     method: HEAD
     uri: https://dummystorage.blob.core.windows.net/cont1/testappendblob
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      accept-ranges: [bytes]
-      content-length: ['78']
-      content-md5: [zeGiTMG1TdAobIHawzap3A==]
-      content-type: [application/octet-stream]
-      date: ['Wed, 04 Jan 2017 17:51:55 GMT']
-      etag: ['"0x8D434CA5FB80CB0"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:56 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-blob-type: [BlockBlob]
+      Accept-Ranges: [bytes]
+      Content-Length: ['78']
+      Content-Type: [application/octet-stream]
+      Date: ['Thu, 05 Jan 2017 22:39:21 GMT']
+      ETag: ['"0x8D435BBB123B700"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:21 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-blob-committed-block-count: ['1']
+      x-ms-blob-type: [AppendBlob]
+      x-ms-lease-state: [available]
+      x-ms-lease-status: [unlocked]
+      x-ms-version: ['2015-07-08']
+    status: {code: 200, message: OK}
+- request:
+    body: This is a test file for performance of automated tests. DO NOT MOVE OR DELETE!
+    headers:
+      Connection: [keep-alive]
+      Content-Length: ['78']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:21 GMT']
+      x-ms-version: ['2015-07-08']
+    method: PUT
+    uri: https://dummystorage.blob.core.windows.net/cont1/testappendblob?comp=appendblock
+  response:
+    body: {string: ''}
+    headers:
+      Content-MD5: [zeGiTMG1TdAobIHawzap3A==]
+      Date: ['Thu, 05 Jan 2017 22:39:21 GMT']
+      ETag: ['"0x8D435BBB17C9AC0"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:21 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
+      x-ms-blob-append-offset: ['78']
+      x-ms-blob-committed-block-count: ['2']
+      x-ms-version: ['2015-07-08']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Connection: [keep-alive]
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:22 GMT']
+      x-ms-version: ['2015-07-08']
+    method: HEAD
+    uri: https://dummystorage.blob.core.windows.net/cont1/testappendblob
+  response:
+    body: {string: ''}
+    headers:
+      Accept-Ranges: [bytes]
+      Content-Length: ['156']
+      Content-Type: [application/octet-stream]
+      Date: ['Thu, 05 Jan 2017 22:39:21 GMT']
+      ETag: ['"0x8D435BBB17C9AC0"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:21 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-blob-committed-block-count: ['2']
+      x-ms-blob-type: [AppendBlob]
       x-ms-lease-state: [available]
       x-ms-lease-status: [unlocked]
       x-ms-version: ['2015-07-08']
@@ -521,42 +612,42 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:57 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:23 GMT']
       x-ms-meta-a: [b]
       x-ms-meta-c: [d]
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob?comp=metadata
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:51:56 GMT']
-      etag: ['"0x8D434CA60926FE5"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:57 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Date: ['Thu, 05 Jan 2017 22:39:22 GMT']
+      ETag: ['"0x8D435BBB239AF97"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:23 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:57 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:23 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob?comp=metadata
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:51:57 GMT']
-      etag: ['"0x8D434CA60926FE5"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:57 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Date: ['Thu, 05 Jan 2017 22:39:23 GMT']
+      ETag: ['"0x8D435BBB239AF97"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:23 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-meta-a: [b]
       x-ms-meta-c: [d]
       x-ms-version: ['2015-07-08']
@@ -566,94 +657,94 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:58 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:24 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob?comp=metadata
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:51:58 GMT']
-      etag: ['"0x8D434CA61401438"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:58 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Date: ['Thu, 05 Jan 2017 22:39:24 GMT']
+      ETag: ['"0x8D435BBB2D8117B"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:24 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:58 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:24 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob?comp=metadata
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:51:58 GMT']
-      etag: ['"0x8D434CA61401438"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:58 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Date: ['Thu, 05 Jan 2017 22:39:24 GMT']
+      ETag: ['"0x8D435BBB2D8117B"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:24 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:59 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:25 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.blob.core.windows.net/cont1?comp=list&restype=container
+    uri: https://dummystorage.blob.core.windows.net/cont1?restype=container&comp=list
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults\
-        \ ServiceEndpoint=\"https://vcrstorage166550539831.blob.core.windows.net/\"\
-        \ ContainerName=\"cont1\"><Blobs><Blob><Name>testappendblob</Name><Properties><Last-Modified>Wed,\
-        \ 04 Jan 2017 17:51:56 GMT</Last-Modified><Etag>0x8D434CA5FB80CB0</Etag><Content-Length>78</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding\
+        \ ServiceEndpoint=\"https://vcrstorage213990324496.blob.core.windows.net/\"\
+        \ ContainerName=\"cont1\"><Blobs><Blob><Name>testappendblob</Name><Properties><Last-Modified>Thu,\
+        \ 05 Jan 2017 22:39:21 GMT</Last-Modified><Etag>0x8D435BBB17C9AC0</Etag><Content-Length>156</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding\
+        \ /><Content-Language /><Content-MD5 /><Cache-Control /><Content-Disposition\
+        \ /><BlobType>AppendBlob</BlobType><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties></Blob><Blob><Name>testblockblob</Name><Properties><Last-Modified>Thu,\
+        \ 05 Jan 2017 22:39:24 GMT</Last-Modified><Etag>0x8D435BBB2D8117B</Etag><Content-Length>78</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding\
         \ /><Content-Language /><Content-MD5>zeGiTMG1TdAobIHawzap3A==</Content-MD5><Cache-Control\
-        \ /><Content-Disposition /><BlobType>BlockBlob</BlobType><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties></Blob><Blob><Name>testblockblob</Name><Properties><Last-Modified>Wed,\
-        \ 04 Jan 2017 17:51:58 GMT</Last-Modified><Etag>0x8D434CA61401438</Etag><Content-Length>78</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding\
-        \ /><Content-Language /><Content-MD5>zeGiTMG1TdAobIHawzap3A==</Content-MD5><Cache-Control\
-        \ /><Content-Disposition /><BlobType>BlockBlob</BlobType><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties></Blob><Blob><Name>testpageblob</Name><Properties><Last-Modified>Wed,\
-        \ 04 Jan 2017 17:51:54 GMT</Last-Modified><Etag>0x8D434CA5EB690E5</Etag><Content-Length>512</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding\
-        \ /><Content-Language /><Content-MD5>JKbxCPFguN3PtJpiW3lCrQ==</Content-MD5><Cache-Control\
-        \ /><Content-Disposition /><BlobType>BlockBlob</BlobType><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties></Blob></Blobs><NextMarker\
+        \ /><Content-Disposition /><BlobType>BlockBlob</BlobType><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties></Blob><Blob><Name>testpageblob</Name><Properties><Last-Modified>Thu,\
+        \ 05 Jan 2017 22:39:19 GMT</Last-Modified><Etag>0x8D435BBB0597F9F</Etag><Content-Length>512</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding\
+        \ /><Content-Language /><Content-MD5 /><Cache-Control /><Content-Disposition\
+        \ /><x-ms-blob-sequence-number>0</x-ms-blob-sequence-number><BlobType>PageBlob</BlobType><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties></Blob></Blobs><NextMarker\
         \ /></EnumerationResults>"}
     headers:
-      content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:51:59 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Content-Type: [application/xml]
+      Date: ['Thu, 05 Jan 2017 22:39:24 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:00 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:25 GMT']
       x-ms-version: ['2015-07-08']
     method: HEAD
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      accept-ranges: [bytes]
-      content-length: ['78']
-      content-md5: [zeGiTMG1TdAobIHawzap3A==]
-      content-type: [application/octet-stream]
-      date: ['Wed, 04 Jan 2017 17:51:59 GMT']
-      etag: ['"0x8D434CA61401438"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:58 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Accept-Ranges: [bytes]
+      Content-Length: ['78']
+      Content-MD5: [zeGiTMG1TdAobIHawzap3A==]
+      Content-Type: [application/octet-stream]
+      Date: ['Thu, 05 Jan 2017 22:39:25 GMT']
+      ETag: ['"0x8D435BBB2D8117B"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:24 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-blob-type: [BlockBlob]
       x-ms-lease-state: [available]
       x-ms-lease-status: [unlocked]
@@ -663,25 +754,25 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:00 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:26 GMT']
       x-ms-range: [bytes=0-33554431]
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob
   response:
-    body: {string: !!python/unicode 'This is a test file for performance of automated
-        tests. DO NOT MOVE OR DELETE!'}
+    body: {string: This is a test file for performance of automated tests. DO NOT
+        MOVE OR DELETE!}
     headers:
-      accept-ranges: [bytes]
-      content-length: ['78']
-      content-range: [bytes 0-77/78]
-      content-type: [application/octet-stream]
-      date: ['Wed, 04 Jan 2017 17:52:00 GMT']
-      etag: ['"0x8D434CA61401438"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:58 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Accept-Ranges: [bytes]
+      Content-Length: ['78']
+      Content-Range: [bytes 0-77/78]
+      Content-Type: [application/octet-stream]
+      Date: ['Thu, 05 Jan 2017 22:39:25 GMT']
+      ETag: ['"0x8D435BBB2D8117B"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:24 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-blob-type: [BlockBlob]
       x-ms-lease-state: [available]
       x-ms-lease-status: [unlocked]
@@ -693,9 +784,9 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       If-Modified-Since: ['Fri, 01 Apr 2016 12:00:00 GMT']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:01 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:26 GMT']
       x-ms-lease-action: [acquire]
       x-ms-lease-duration: ['60']
       x-ms-proposed-lease-id: [abcdabcd-abcd-abcd-abcd-abcdabcdabcd]
@@ -703,13 +794,13 @@ interactions:
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob?comp=lease
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:52:00 GMT']
-      etag: ['"0x8D434CA61401438"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:58 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Date: ['Thu, 05 Jan 2017 22:39:26 GMT']
+      ETag: ['"0x8D435BBB2D8117B"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:24 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-lease-id: [abcdabcd-abcd-abcd-abcd-abcdabcdabcd]
       x-ms-version: ['2015-07-08']
     status: {code: 201, message: Created}
@@ -717,23 +808,23 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:01 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:27 GMT']
       x-ms-version: ['2015-07-08']
     method: HEAD
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      accept-ranges: [bytes]
-      content-length: ['78']
-      content-md5: [zeGiTMG1TdAobIHawzap3A==]
-      content-type: [application/octet-stream]
-      date: ['Wed, 04 Jan 2017 17:52:01 GMT']
-      etag: ['"0x8D434CA61401438"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:58 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Accept-Ranges: [bytes]
+      Content-Length: ['78']
+      Content-MD5: [zeGiTMG1TdAobIHawzap3A==]
+      Content-Type: [application/octet-stream]
+      Date: ['Thu, 05 Jan 2017 22:39:27 GMT']
+      ETag: ['"0x8D435BBB2D8117B"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:24 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-blob-type: [BlockBlob]
       x-ms-lease-duration: [fixed]
       x-ms-lease-state: [leased]
@@ -745,9 +836,9 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:02 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:27 GMT']
       x-ms-lease-action: [change]
       x-ms-lease-id: [abcdabcd-abcd-abcd-abcd-abcdabcdabcd]
       x-ms-proposed-lease-id: [dcbadcba-dcba-dcba-dcba-dcbadcbadcba]
@@ -755,13 +846,13 @@ interactions:
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob?comp=lease
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:52:01 GMT']
-      etag: ['"0x8D434CA61401438"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:58 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Date: ['Thu, 05 Jan 2017 22:39:27 GMT']
+      ETag: ['"0x8D435BBB2D8117B"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:24 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-lease-id: [dcbadcba-dcba-dcba-dcba-dcbadcbadcba]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
@@ -770,22 +861,22 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:03 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:28 GMT']
       x-ms-lease-action: [renew]
       x-ms-lease-id: [dcbadcba-dcba-dcba-dcba-dcbadcbadcba]
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob?comp=lease
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:52:02 GMT']
-      etag: ['"0x8D434CA61401438"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:58 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Date: ['Thu, 05 Jan 2017 22:39:27 GMT']
+      ETag: ['"0x8D435BBB2D8117B"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:24 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-lease-id: [dcbadcba-dcba-dcba-dcba-dcbadcbadcba]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
@@ -793,23 +884,23 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:03 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:28 GMT']
       x-ms-version: ['2015-07-08']
     method: HEAD
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      accept-ranges: [bytes]
-      content-length: ['78']
-      content-md5: [zeGiTMG1TdAobIHawzap3A==]
-      content-type: [application/octet-stream]
-      date: ['Wed, 04 Jan 2017 17:52:03 GMT']
-      etag: ['"0x8D434CA61401438"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:58 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Accept-Ranges: [bytes]
+      Content-Length: ['78']
+      Content-MD5: [zeGiTMG1TdAobIHawzap3A==]
+      Content-Type: [application/octet-stream]
+      Date: ['Thu, 05 Jan 2017 22:39:27 GMT']
+      ETag: ['"0x8D435BBB2D8117B"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:24 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-blob-type: [BlockBlob]
       x-ms-lease-duration: [fixed]
       x-ms-lease-state: [leased]
@@ -821,22 +912,22 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:04 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:29 GMT']
       x-ms-lease-action: [break]
       x-ms-lease-break-period: ['30']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob?comp=lease
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:52:04 GMT']
-      etag: ['"0x8D434CA61401438"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:58 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Date: ['Thu, 05 Jan 2017 22:39:28 GMT']
+      ETag: ['"0x8D435BBB2D8117B"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:24 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-lease-time: ['30']
       x-ms-version: ['2015-07-08']
     status: {code: 202, message: Accepted}
@@ -844,23 +935,23 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:05 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:29 GMT']
       x-ms-version: ['2015-07-08']
     method: HEAD
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      accept-ranges: [bytes]
-      content-length: ['78']
-      content-md5: [zeGiTMG1TdAobIHawzap3A==]
-      content-type: [application/octet-stream]
-      date: ['Wed, 04 Jan 2017 17:52:05 GMT']
-      etag: ['"0x8D434CA61401438"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:58 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Accept-Ranges: [bytes]
+      Content-Length: ['78']
+      Content-MD5: [zeGiTMG1TdAobIHawzap3A==]
+      Content-Type: [application/octet-stream]
+      Date: ['Thu, 05 Jan 2017 22:39:29 GMT']
+      ETag: ['"0x8D435BBB2D8117B"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:24 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-blob-type: [BlockBlob]
       x-ms-lease-state: [breaking]
       x-ms-lease-status: [locked]
@@ -871,45 +962,45 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:05 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:30 GMT']
       x-ms-lease-action: [release]
       x-ms-lease-id: [dcbadcba-dcba-dcba-dcba-dcbadcbadcba]
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob?comp=lease
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:52:05 GMT']
-      etag: ['"0x8D434CA61401438"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:58 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Date: ['Thu, 05 Jan 2017 22:39:29 GMT']
+      ETag: ['"0x8D435BBB2D8117B"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:24 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:06 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:30 GMT']
       x-ms-version: ['2015-07-08']
     method: HEAD
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      accept-ranges: [bytes]
-      content-length: ['78']
-      content-md5: [zeGiTMG1TdAobIHawzap3A==]
-      content-type: [application/octet-stream]
-      date: ['Wed, 04 Jan 2017 17:52:05 GMT']
-      etag: ['"0x8D434CA61401438"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:58 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Accept-Ranges: [bytes]
+      Content-Length: ['78']
+      Content-MD5: [zeGiTMG1TdAobIHawzap3A==]
+      Content-Type: [application/octet-stream]
+      Date: ['Thu, 05 Jan 2017 22:39:29 GMT']
+      ETag: ['"0x8D435BBB2D8117B"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:24 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-blob-type: [BlockBlob]
       x-ms-lease-state: [available]
       x-ms-lease-status: [unlocked]
@@ -920,45 +1011,45 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:06 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:31 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/cont1/testappendblob?comp=snapshot
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:52:07 GMT']
-      etag: ['"0x8D434CA5FB80CB0"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:56 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
-      x-ms-snapshot: ['2017-01-04T17:52:06.9872093Z']
+      Date: ['Thu, 05 Jan 2017 22:39:30 GMT']
+      ETag: ['"0x8D435BBB17C9AC0"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:21 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
+      x-ms-snapshot: ['2017-01-05T22:39:31.2700415Z']
       x-ms-version: ['2015-07-08']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:07 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:31 GMT']
       x-ms-version: ['2015-07-08']
     method: HEAD
-    uri: https://dummystorage.blob.core.windows.net/cont1/testappendblob?snapshot=2017-01-04T17%3A52%3A06.9872093Z
+    uri: https://dummystorage.blob.core.windows.net/cont1/testappendblob?snapshot=2017-01-05T22%3A39%3A31.2700415Z
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      accept-ranges: [bytes]
-      content-length: ['78']
-      content-md5: [zeGiTMG1TdAobIHawzap3A==]
-      content-type: [application/octet-stream]
-      date: ['Wed, 04 Jan 2017 17:52:07 GMT']
-      etag: ['"0x8D434CA5FB80CB0"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:56 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-blob-type: [BlockBlob]
+      Accept-Ranges: [bytes]
+      Content-Length: ['156']
+      Content-Type: [application/octet-stream]
+      Date: ['Thu, 05 Jan 2017 22:39:30 GMT']
+      ETag: ['"0x8D435BBB17C9AC0"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:21 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-blob-committed-block-count: ['2']
+      x-ms-blob-type: [AppendBlob]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
@@ -966,36 +1057,36 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:08 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:32 GMT']
       x-ms-version: ['2015-07-08']
     method: DELETE
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:52:08 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Date: ['Thu, 05 Jan 2017 22:39:31 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 202, message: Accepted}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:08 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:32 GMT']
       x-ms-version: ['2015-07-08']
     method: HEAD
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:52:08 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Date: ['Thu, 05 Jan 2017 22:39:32 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 404, message: The specified blob does not exist.}
 - request:
@@ -1004,23 +1095,23 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       If-Modified-Since: ['Fri, 01 Apr 2016 12:00:00 GMT']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:09 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:33 GMT']
       x-ms-lease-action: [acquire]
       x-ms-lease-duration: ['60']
       x-ms-proposed-lease-id: [abcdabcd-abcd-abcd-abcd-abcdabcdabcd]
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.blob.core.windows.net/cont1?comp=lease&restype=container
+    uri: https://dummystorage.blob.core.windows.net/cont1?restype=container&comp=lease
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:52:08 GMT']
-      etag: ['"0x8D434CA5D416B9F"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:51 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Date: ['Thu, 05 Jan 2017 22:39:33 GMT']
+      ETag: ['"0x8D435BBAF17CA84"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:17 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-lease-id: [abcdabcd-abcd-abcd-abcd-abcdabcdabcd]
       x-ms-version: ['2015-07-08']
     status: {code: 201, message: Created}
@@ -1028,20 +1119,20 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:09 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:33 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/cont1?restype=container
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:52:08 GMT']
-      etag: ['"0x8D434CA5D416B9F"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:51 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Date: ['Thu, 05 Jan 2017 22:39:33 GMT']
+      ETag: ['"0x8D435BBAF17CA84"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:17 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-lease-duration: [fixed]
       x-ms-lease-state: [leased]
       x-ms-lease-status: [locked]
@@ -1052,23 +1143,23 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:10 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:34 GMT']
       x-ms-lease-action: [change]
       x-ms-lease-id: [abcdabcd-abcd-abcd-abcd-abcdabcdabcd]
       x-ms-proposed-lease-id: [dcbadcba-dcba-dcba-dcba-dcbadcbadcba]
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.blob.core.windows.net/cont1?comp=lease&restype=container
+    uri: https://dummystorage.blob.core.windows.net/cont1?restype=container&comp=lease
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:52:09 GMT']
-      etag: ['"0x8D434CA5D416B9F"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:51 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Date: ['Thu, 05 Jan 2017 22:39:34 GMT']
+      ETag: ['"0x8D435BBAF17CA84"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:17 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-lease-id: [dcbadcba-dcba-dcba-dcba-dcbadcbadcba]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
@@ -1077,22 +1168,22 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:10 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:34 GMT']
       x-ms-lease-action: [renew]
       x-ms-lease-id: [dcbadcba-dcba-dcba-dcba-dcbadcbadcba]
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.blob.core.windows.net/cont1?comp=lease&restype=container
+    uri: https://dummystorage.blob.core.windows.net/cont1?restype=container&comp=lease
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:52:10 GMT']
-      etag: ['"0x8D434CA5D416B9F"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:51 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Date: ['Thu, 05 Jan 2017 22:39:34 GMT']
+      ETag: ['"0x8D435BBAF17CA84"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:17 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-lease-id: [dcbadcba-dcba-dcba-dcba-dcbadcbadcba]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
@@ -1100,20 +1191,20 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:11 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:35 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/cont1?restype=container
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:52:10 GMT']
-      etag: ['"0x8D434CA5D416B9F"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:51 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Date: ['Thu, 05 Jan 2017 22:39:35 GMT']
+      ETag: ['"0x8D435BBAF17CA84"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:17 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-lease-duration: [fixed]
       x-ms-lease-state: [leased]
       x-ms-lease-status: [locked]
@@ -1124,22 +1215,22 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:12 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:35 GMT']
       x-ms-lease-action: [break]
       x-ms-lease-break-period: ['30']
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.blob.core.windows.net/cont1?comp=lease&restype=container
+    uri: https://dummystorage.blob.core.windows.net/cont1?restype=container&comp=lease
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:52:11 GMT']
-      etag: ['"0x8D434CA5D416B9F"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:51 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Date: ['Thu, 05 Jan 2017 22:39:34 GMT']
+      ETag: ['"0x8D435BBAF17CA84"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:17 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-lease-time: ['30']
       x-ms-version: ['2015-07-08']
     status: {code: 202, message: Accepted}
@@ -1147,20 +1238,20 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:12 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:36 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/cont1?restype=container
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:52:12 GMT']
-      etag: ['"0x8D434CA5D416B9F"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:51 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Date: ['Thu, 05 Jan 2017 22:39:36 GMT']
+      ETag: ['"0x8D435BBAF17CA84"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:17 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-lease-state: [breaking]
       x-ms-lease-status: [locked]
       x-ms-version: ['2015-07-08']
@@ -1170,42 +1261,42 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:13 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:36 GMT']
       x-ms-lease-action: [release]
       x-ms-lease-id: [dcbadcba-dcba-dcba-dcba-dcbadcbadcba]
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.blob.core.windows.net/cont1?comp=lease&restype=container
+    uri: https://dummystorage.blob.core.windows.net/cont1?restype=container&comp=lease
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:52:12 GMT']
-      etag: ['"0x8D434CA5D416B9F"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:51 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Date: ['Thu, 05 Jan 2017 22:39:36 GMT']
+      ETag: ['"0x8D435BBAF17CA84"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:17 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:13 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:37 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/cont1?restype=container
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:52:13 GMT']
-      etag: ['"0x8D434CA5D416B9F"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:51 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Date: ['Thu, 05 Jan 2017 22:39:36 GMT']
+      ETag: ['"0x8D435BBAF17CA84"']
+      Last-Modified: ['Thu, 05 Jan 2017 22:39:17 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-lease-state: [available]
       x-ms-lease-status: [unlocked]
       x-ms-version: ['2015-07-08']
@@ -1215,39 +1306,39 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:14 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:37 GMT']
       x-ms-version: ['2015-07-08']
     method: DELETE
     uri: https://dummystorage.blob.core.windows.net/cont1?restype=container
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:52:14 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      transfer-encoding: [chunked]
+      Date: ['Thu, 05 Jan 2017 22:39:37 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Transfer-Encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 202, message: Accepted}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:15 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
+      x-ms-date: ['Thu, 05 Jan 2017 22:39:38 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/cont1?restype=container
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The\
-        \ specified container does not exist.\nRequestId:4411ffa4-0001-00c0-29b3-66ecc1000000\n\
-        Time:2017-01-04T17:52:15.1449680Z</Message></Error>"}
+        \ specified container does not exist.\nRequestId:4d593734-0001-0128-0fa4-67019c000000\n\
+        Time:2017-01-05T22:39:39.1810409Z</Message></Error>"}
     headers:
-      content-length: ['225']
-      content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:52:14 GMT']
-      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      Content-Length: ['225']
+      Content-Type: [application/xml]
+      Date: ['Thu, 05 Jan 2017 22:39:38 GMT']
+      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 404, message: The specified container does not exist.}
 version: 1


### PR DESCRIPTION
The blob_type cannot be set to `append` because of this validator, such as in `az storage blob upload` command by `--type` argument.