### PR TITLE
Automated building and releasing of a component (with version patching)

### DIFF
--- a/scripts/automation/release/README.md
+++ b/scripts/automation/release/README.md
@@ -1,0 +1,40 @@
+Examples of use
+===============
+NOTE:
+Wheel and Twine are required.
+Use the command below to install them if not installed.
+pip install --upgrade wheel twine
+
+Show help
+---------
+```
+$ python -m automation.release.run -h
+```
+
+Build azure-cli-core
+--------------------
+```
+$ python -m automation.release.run -c azure-cli-core
+```
+
+Build azure-cli-core without patching the version number
+--------------------------------------------------------
+```
+$ python -m automation.release.run -c azure-cli-core --no-version-patch
+```
+
+Build & Publish azure-cli-core to test PyPI
+-------------------------------------------
+```
+$ export TWINE_USERNAME=<user>
+$ export TWINE_PASSWORD=<pass>
+$ python -m automation.release.run -c azure-cli-core -r https://testpypi.python.org/pypi
+```
+
+Build & Publish azure-cli-core to public PyPI
+---------------------------------------------
+```
+$ export TWINE_USERNAME=<user>
+$ export TWINE_PASSWORD=<pass>
+$ python -m automation.release.run -c azure-cli-core -r https://pypi.python.org/pypi
+```

--- a/scripts/automation/release/__init__.py
+++ b/scripts/automation/release/__init__.py
@@ -1,0 +1,6 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+"""Component/Package release automation code"""

--- a/scripts/automation/release/run.py
+++ b/scripts/automation/release/run.py
@@ -1,0 +1,69 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+# pylint: disable=line-too-long
+
+from __future__ import print_function
+
+import os
+import tempfile
+import argparse
+from subprocess import check_call
+
+from .version_patcher import VersionPatcher
+from ..utilities.path import get_all_module_paths
+
+
+def build(pkg_path, dest):
+    """
+    pkg_path - Full path to directory of the package to build
+    dest - Destination for the built package
+    """
+    check_call(['python', 'setup.py', 'sdist', '-d', dest, 'bdist_wheel', '-d', dest], cwd=pkg_path)
+
+
+def release(pkg_dir, repo):
+    """Release all packages in a directory"""
+    pkgs = [os.path.join(pkg_dir, f) for f in os.listdir(pkg_dir)]
+    for pkg in pkgs:
+        check_call(['twine', 'register', '--repository-url', repo, '--repository', repo, pkg])
+        check_call(['twine', 'upload', '--repository-url', repo, '--repository', repo, pkg])
+
+
+def run_build_release(component_name, repo, use_version_patch=True):
+    """
+    component_name - The full component name (e.g. azure-cli, azure-cli-core, azure-cli-vm, etc.)
+    """
+    for comp_name, comp_path in get_all_module_paths():
+        if comp_name == component_name:
+            pkg_dir = tempfile.mkdtemp()
+            patcher = VersionPatcher(use_version_patch, component_name, comp_path)
+            patcher.patch()
+            build(comp_path, pkg_dir)
+            patcher.unpatch()
+            print("Built '{}' to '{}'".format(comp_name, pkg_dir))
+            if repo:
+                release(pkg_dir, repo)
+            return
+    raise ValueError("No component found with name '{}'".format(component_name))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Automated build and release of a component. "\
+                        "To only build, don't specify the repo parameter. "\
+                        "The environment variables TWINE_USERNAME and TWINE_PASSWORD are required if releasing.")
+    parser.add_argument('--component', '-c', required=True,
+                        help='Component name (e.g. azure-cli, azure-cli-vm, etc.)')
+    parser.add_argument('--no-version-patch', action='store_false',
+                        help="By default, we patch the version number of the package to remove '+dev' if it exists.")
+    parser.add_argument('--repo', '-r',
+                        help='Repository URL for release (e.g. https://pypi.python.org/pypi, https://testpypi.python.org/pypi)')
+    args = parser.parse_args()
+    if args.repo:
+        assert os.environ.get('TWINE_USERNAME') and os.environ.get('TWINE_PASSWORD'), \
+            "Set TWINE_USERNAME and TWINE_PASSWORD environment variables to authentication with PyPI repository."
+    run_build_release(args.component,
+                      args.repo,
+                      args.no_version_patch)

--- a/scripts/automation/release/version_patcher.py
+++ b/scripts/automation/release/version_patcher.py
@@ -1,0 +1,84 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+#pylint: disable=line-too-long
+
+import os
+import sys
+import fileinput
+
+
+class VersionPatcher(object):
+    """Manages patching the version of a package to remove '+dev' from the version."""
+
+    def __init__(self, use_version_patch, component_name, component_path):
+        self.use_version_patch = use_version_patch
+        self.component_name = component_name
+        self.component_path = component_path
+        self.setup_py = os.path.join(component_path, 'setup.py')
+        self.backup_setup_py_version = None
+        # These two modules also have version defined in the __init__.py file
+        # These versions have to be kept in sync.
+        if self.component_name == 'azure-cli':
+            self.init_py_path = os.path.join(self.component_path, 'azure', 'cli', '__init__.py')
+        elif self.component_name == 'azure-cli-core':
+            self.init_py_path = os.path.join(self.component_path, 'azure', 'cli', 'core', '__init__.py')
+        else:
+            self.init_py_path = None
+        self.backup_init_version = None
+
+
+    def _patch_setup_py(self):
+        for _, line in enumerate(fileinput.input(self.setup_py, inplace=1)):
+            if line.startswith('VERSION'):
+                self.backup_setup_py_version = line
+                # apply version patch
+                sys.stdout.write(line.replace('+dev', ''))
+            else:
+                sys.stdout.write(line)
+
+
+    def _unpatch_setup_py(self):
+        for _, line in enumerate(fileinput.input(self.setup_py, inplace=1)):
+            if line.startswith('VERSION'):
+                # restore original version
+                sys.stdout.write(self.backup_setup_py_version)
+            else:
+                sys.stdout.write(line)
+
+
+    def _patch_init_py(self):
+        for _, line in enumerate(fileinput.input(self.init_py_path, inplace=1)):
+            if line.startswith('__version__'):
+                self.backup_init_version = line
+                # apply init version patch
+                sys.stdout.write(line.replace('+dev', ''))
+            else:
+                sys.stdout.write(line)
+
+
+    def _unpatch_init_py(self):
+        for _, line in enumerate(fileinput.input(self.init_py_path, inplace=1)):
+            if line.startswith('__version__'):
+                # restore original init version
+                sys.stdout.write(self.backup_init_version)
+            else:
+                sys.stdout.write(line)
+
+
+    def patch(self):
+        if not self.use_version_patch:
+            return
+        self._patch_setup_py()
+        if self.init_py_path:
+            self._patch_init_py()
+
+
+    def unpatch(self):
+        if not self.use_version_patch:
+            return
+        self._unpatch_setup_py()
+        if self.init_py_path:
+            self._unpatch_init_py()

--- a/scripts/automation/utilities/path.py
+++ b/scripts/automation/utilities/path.py
@@ -16,11 +16,16 @@ def get_repo_root():
     return current_dir
 
 
-def get_command_modules_paths():
-    """List all the command modules and returns those have tests folder"""
+def get_all_module_paths():
+    """List all core and command modules"""
+    return list(get_core_modules_paths()) + get_command_modules_paths(include_prefix=True)
+
+def get_command_modules_paths(include_prefix=False):
+    """List all the command modules"""
     root = os.path.join(get_repo_root(), 'src', 'command_modules')
 
-    modules_paths = ((name[len(COMMAND_MODULE_PREFIX):], os.path.join(root, name))
+    modules_paths = ((name if include_prefix else name[len(COMMAND_MODULE_PREFIX):],
+                      os.path.join(root, name))
                      for name in os.listdir(root) if name.startswith(COMMAND_MODULE_PREFIX))
 
     return list(modules_paths)


### PR DESCRIPTION
NOTE: These **are not** `az` CLI commands. This is a separate, simple interface for automating building and packaging of components.

Examples of use
---------------

Show help
```
$ python -m automation.release.run -h
usage: run.py [-h] --component COMPONENT [--no-version-patch] [--repo REPO]
              [--repo-username REPO_USERNAME] [--repo-password REPO_PASSWORD]

Automated build and release of a component. To only build, don't specify the
repo parameters.

optional arguments:
  -h, --help            show this help message and exit
  --component COMPONENT, -c COMPONENT
                        Component name (e.g. azure-cli, azure-cli-vm, etc.)
  --no-version-patch    By default, we patch the version number of the package
                        to remove '+dev' if it exists.
  --repo REPO, -r REPO  Repository URL for release (e.g.
                        https://pypi.python.org/pypi,
                        https://testpypi.python.org/pypi)
  --repo-username REPO_USERNAME, -u REPO_USERNAME
                        The username to authenticate to the repository as
  --repo-password REPO_PASSWORD, -p REPO_PASSWORD
                        The password to authenticate to the repository with
```

Build azure-cli-core
`$ python -m automation.release.run -c azure-cli-core`

Build azure-cli-core without patching the version number (i.e. dev build)
`$ python -m automation.release.run -c azure-cli-core --no-version-patch`

Build & Publish azure-cli-core to test PyPI
`$ python -m automation.release.run -c azure-cli-core -r https://testpypi.python.org/pypi -u <user> -p <pass>`

Build & Publish azure-cli-core to public PyPI
`$ python -m automation.release.run -c azure-cli-core -r https://pypi.python.org/pypi -u <user> -p <pass>`
