### PR TITLE
Change the automation code

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ adal==0.4.3
 applicationinsights==0.10.0
 argcomplete==1.3.0
 colorama==0.3.7
-coverage==4.2
 jmespath
 mock==1.3.0
 nose==1.3.7

--- a/scripts/automation/style/pep8.py
+++ b/scripts/automation/style/pep8.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 
-def fix_pip8(directory):
+def fix_p2p8(directory):
     import autopep8
     import multiprocessing
 
@@ -26,4 +26,4 @@ if __name__ == '__main__':
         print('usage: python automation.style.pep8 <directory>')
         sys.exit(1)
 
-    fix_pip8(sys.argv[1])
+    fix_p2p8(sys.argv[1])

--- a/scripts/automation/style/pep8.py
+++ b/scripts/automation/style/pep8.py
@@ -1,0 +1,29 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+
+def fix_pip8(directory):
+    import autopep8
+    import multiprocessing
+
+    autopep8.fix_multiple_files([directory],
+                                options=autopep8._get_options(
+                                {
+                                    'jobs': multiprocessing.cpu_count(),
+                                    'verbose': True,
+                                    'recursive': True,
+                                    'in_place': True,
+                                    'max_line_length': 100
+                                }, False))
+
+
+if __name__ == '__main__':
+    import sys
+
+    if len(sys.argv) < 2:
+        print('usage: python automation.style.pep8 <directory>')
+        sys.exit(1)
+
+    fix_pip8(sys.argv[1])

--- a/scripts/dev_setup.py
+++ b/scripts/dev_setup.py
@@ -13,6 +13,7 @@ from subprocess import check_call, CalledProcessError
 
 root_dir = os.path.abspath(os.path.join(os.path.abspath(__file__), '..', '..'))
 
+
 def exec_command(command):
     try:
         print('Executing: ' + command)
@@ -27,6 +28,9 @@ print('Root directory \'{}\'\n'.format(root_dir))
 
 # install general requirements
 exec_command('pip install -r requirements.txt')
+
+# install automation package
+exec_command('pip install -e ./scripts')
 
 # command modules have dependency on azure-cli-core so install this first
 exec_command('pip install -e src/azure-cli-nspkg')

--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -5,5 +5,4 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-export PYTHONPATH=${PYTHONPATH}:$(cd $(dirname $0); pwd)
 python -m automation.coverage.run

--- a/scripts/run_pylint.sh
+++ b/scripts/run_pylint.sh
@@ -5,5 +5,4 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-export PYTHONPATH=${PYTHONPATH}:$(cd $(dirname $0); pwd)
 python -m automation.style.run

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -5,5 +5,4 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-export PYTHONPATH=${PYTHONPATH}:$(cd $(dirname $0); pwd)
 python -m automation.tests.run

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from setuptools import setup
+
+VERSION = "0.1.0"
+
+CLASSIFIERS = [
+    'Development Status :: 4 - Beta',
+    'Intended Audience :: Developers',
+    'Intended Audience :: System Administrators',
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 2',
+    'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
+    'License :: OSI Approved :: MIT License',
+]
+
+DEPENDENCIES = [
+    'autopep8==1.2.4',
+    'coverage==4.2',
+    'pycodestyle==2.2.0'
+]
+
+setup(
+    name='automation',
+    version=VERSION,
+    description='Microsoft Azure Command-Line Tools - Automation Utility',
+    long_description='',
+    license='MIT',
+    author='Microsoft Corporation',
+    author_email='azpycli@microsoft.com',
+    url='https://github.com/Azure/azure-cli',
+    namespace_packages=[
+    ],
+    packages=[
+        'automation',
+        'automation.style',
+        'automation.tests',
+        'automation.setup',
+        'automation.coverage'
+    ],
+    install_requires=DEPENDENCIES
+)


### PR DESCRIPTION
1. Install automation code as a development package. The outcome is that the automation code can be invoked without add ./scripts folder to the PYTHONPATH.
2. Add PEP8 scripts to fix PEP8 automatically