### PR TITLE
Fix PEP8 for azure-cli

### DIFF
--- a/src/azure-cli/azure/cli/__main__.py
+++ b/src/azure-cli/azure/cli/__main__.py
@@ -15,7 +15,7 @@ try:
     try:
         if user_agrees_to_telemetry():
             init_telemetry()
-    except Exception: #pylint: disable=broad-except
+    except Exception:  # pylint: disable=broad-except
         pass
 
     args = sys.argv[1:]
@@ -35,5 +35,5 @@ finally:
     try:
         if user_agrees_to_telemetry():
             telemetry_flush()
-    except Exception: #pylint: disable=broad-except
+    except Exception:  # pylint: disable=broad-except
         pass

--- a/src/azure-cli/azure/cli/main.py
+++ b/src/azure-cli/azure/cli/main.py
@@ -14,7 +14,8 @@ from azure.cli.core._environment import get_config_dir
 
 logger = _logging.get_az_logger(__name__)
 
-def main(args, file=sys.stdout): #pylint: disable=redefined-builtin
+
+def main(args, file=sys.stdout):  # pylint: disable=redefined-builtin
     _logging.configure_logging(args)
 
     if len(args) > 0 and args[0] == '--version':
@@ -38,9 +39,8 @@ def main(args, file=sys.stdout): #pylint: disable=redefined-builtin
             from azure.cli.core._output import OutputProducer
             formatter = OutputProducer.get_formatter(APPLICATION.configuration.output_format)
             OutputProducer(formatter=formatter, file=file).out(cmd_result)
-    except Exception as ex: # pylint: disable=broad-except
+    except Exception as ex:  # pylint: disable=broad-except
         from azure.cli.core.telemetry import log_telemetry
         log_telemetry('Error', log_type='trace')
         error_code = handle_exception(ex)
         return error_code
-

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -19,7 +19,8 @@ try:
 except OSError:
     pass
 else:
-    import re, sys
+    import re
+    import sys
     m = re.search(r'__version__\s*=\s*[\'"](.+?)[\'"]', content)
     if not m:
         print('Could not find __version__ in azure/cli/__init__.py')


### PR DESCRIPTION
Log:
```
[file:.\src\azure-cli\setup.py]
[file:.\src\azure-cli\azure\cli\__init__.py]
[file:.\src\azure-cli\azure\cli\__main__.py]
--->  Applying global fix for E265
--->  Applying global fix for W602
[file:.\src\azure-cli\azure\__init__.py]
--->  Applying global fix for E265
--->  Applying global fix for E265
--->  Applying global fix for W602
--->  0 issue(s) to fix {}
--->  Applying global fix for W602
--->  4 issue(s) to fix {'E261': {18, 38}, 'E262': {18, 38}}
--->  1 issue(s) to fix {'E401': {22}}
[file:.\src\azure-cli\azure\cli\main.py]
[file:.\src\azure-cli\azure\cli\tests\__init__.py]
--->  0 issue(s) to fix {}
--->  Applying global fix for E265
--->  Applying global fix for W602
--->  0 issue(s) to fix {}
--->  0 issue(s) to fix {}
--->  Applying global fix for E265
--->  Applying global fix for W602
--->  Applying global fix for E265
--->  Applying global fix for W602
--->  0 issue(s) to fix {}
--->  5 issue(s) to fix {'E302': {17}, 'E261': {17, 41}, 'E262': {17}, 'W391': {46}}
--->  1 issue(s) to fix {'E302': {17}}
--->  0 issue(s) to fix {}
```