### PR TITLE
Release management - Check for changes made to a component since a git commit or tag

### DIFF
--- a/scripts/automation/release/README.md
+++ b/scripts/automation/release/README.md
@@ -38,3 +38,19 @@ $ export TWINE_USERNAME=<user>
 $ export TWINE_PASSWORD=<pass>
 $ python -m automation.release.run -c azure-cli-core -r https://pypi.python.org/pypi
 ```
+
+
+Examples of checking for component changes since git tag
+========================================================
+
+List changes for all components since all-v0.1.0b11
+---------------------------------------------------
+```
+$ python -m automation.release.check -s all-v0.1.0b11
+```
+
+List changes for azure-cli-core since all-v0.1.0b11
+---------------------------------------------------
+```
+$ python -m automation.release.check -c azure-cli-core -s all-v0.1.0b11
+```

--- a/scripts/automation/release/check.py
+++ b/scripts/automation/release/check.py
@@ -1,0 +1,43 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+#pylint: disable=line-too-long
+from __future__ import print_function
+
+import argparse
+from subprocess import check_call
+
+from ..utilities.path import get_repo_root, get_all_module_paths
+
+def check_component_revisions(component_name, r_start, r_end):
+    for comp_name, comp_path in get_all_module_paths():
+        if comp_name == component_name:
+            revision_range = "{}..{}".format(r_start, r_end)
+            check_call(["git", "log", "--pretty=format:'%C(yellow)%h %Cred%ad %Cblue%an%Cgreen%d %Creset%s'", revision_range, "--", comp_path], cwd=get_repo_root())
+            return
+    raise ValueError("No component found with name '{}'".format(component_name))
+
+def check_all_component_revisions(r_start, r_end):
+    for comp_name, _ in get_all_module_paths():
+        print('<<< {} >>>'.format(comp_name))
+        check_component_revisions(comp_name, r_start, r_end)
+        print()
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Check for changes made to a component since a git commit or tag. Empty response means no changes.")
+    parser.add_argument('--component', '-c',
+                        help='Component name (e.g. azure-cli, azure-cli-vm, etc.). If not specified, all component changes are shown.')
+    parser.add_argument('--git-revision-start', '-s', required=True,
+                        help="Git tag (or commit) to use as the start of the revision range. (e.g. release-azure-cli-vm-0.1.0)")
+    parser.add_argument('--git-revision-end', '-e', default='HEAD',
+                        help='Git tag (or commit) to use as the end of the revision range.')
+    args = parser.parse_args()
+    if args.component:
+        check_component_revisions(args.component,
+                                  args.git_revision_start,
+                                  args.git_revision_end)
+    else:
+        check_all_component_revisions(args.git_revision_start,
+                                      args.git_revision_end)


### PR DESCRIPTION
Examples:
```
$ python -m scripts.automation.release.check -h
usage: check.py [-h] [--component COMPONENT] --git-revision-start
                GIT_REVISION_START [--git-revision-end GIT_REVISION_END]

Check for changes made to a component since a git commit or tag. Empty
response means no changes.

optional arguments:
  -h, --help            show this help message and exit
  --component COMPONENT, -c COMPONENT
                        Component name (e.g. azure-cli, azure-cli-vm, etc.).
                        If not specified, all component changes are shown.
  --git-revision-start GIT_REVISION_START, -s GIT_REVISION_START
                        Git tag (or commit) to use as the start of the
                        revision range. (e.g. release-azure-cli-vm-0.1.0)
  --git-revision-end GIT_REVISION_END, -e GIT_REVISION_END
                        Git tag (or commit) to use as the end of the revision
                        range.
```


```
$ python -m scripts.automation.release.check -c azure-cli-core -s all-v0.1.0b11
'a12be38 Thu Jan 5 10:59:01 2017 -0800 Troy Dai Update regex of parsing sdk function argument comments (#1650)'
'6206ea6 Thu Jan 5 09:38:49 2017 -0800 Travis Prescott Fix issue 1644. (#1647)'
'0e2f45e Wed Jan 4 16:17:14 2017 -0800 Travis Prescott [Network] Application Gateway Commands and Fixes (#1606)'
```