### PR TITLE
[Docs] Carify Windows pip install

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,9 +26,9 @@ A list of common install issues and their resolutions are available at `install 
 Interactive install script
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-On Linux, see our `prerequisites <https://github.com/Azure/azure-cli/blob/master/doc/install_linux_prerequisites.md>`__.
-
 On Windows, install via `pip <#pip>`__.
+
+On Linux, see our `prerequisites <https://github.com/Azure/azure-cli/blob/master/doc/install_linux_prerequisites.md>`__ then install as follows:
 
 .. code-block:: console
 

--- a/README.rst
+++ b/README.rst
@@ -26,9 +26,9 @@ A list of common install issues and their resolutions are available at `install 
 Interactive install script
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Not supported on Windows. For Windows, install via `pip <#pip>`__.
-
 On Linux, see our `prerequisites <https://github.com/Azure/azure-cli/blob/master/doc/install_linux_prerequisites.md>`__.
+
+On Windows, install via `pip <#pip>`__.
 
 .. code-block:: console
 

--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,8 @@ A list of common install issues and their resolutions are available at `install 
 Interactive install script
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Not supported on Windows. For Windows, install via `pip <#pip>`__.
+
 On Linux, see our `prerequisites <https://github.com/Azure/azure-cli/blob/master/doc/install_linux_prerequisites.md>`__.
 
 .. code-block:: console
@@ -65,7 +67,7 @@ You may need to modify your PATH:
 
     **Windows**
 
-    Add ``%APPDATA%\Python\PythonXY\Scripts`` to your PATH.
+    Add ``%APPDATA%\PythonXY\Scripts`` to your PATH.
 
     Where X, Y is your Python version.
 


### PR DESCRIPTION
Closes https://github.com/Azure/azure-cli/issues/1690 - Clarify that curl install not supported on Windows.

Closes https://github.com/Azure/azure-cli/issues/1691 - Correct PATH for `pip install --user` on Windows.

refs: https://docs.python.org/2/library/site.html#site.USER_BASE
https://pip.pypa.io/en/stable/user_guide/#user-installs