### PR TITLE
Bug fix in proxy tracing during cli login command

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_debug.py
+++ b/src/azure-cli-core/azure/cli/core/_debug.py
@@ -9,13 +9,20 @@ import azure.cli.core._logging as _logging
 logger = _logging.get_az_logger(__name__)
 
 DISABLE_VERIFY_VARIABLE_NAME = "AZURE_CLI_DISABLE_CONNECTION_VERIFICATION"
+ADAL_PYTHON_SSL_NO_VERIFY = "ADAL_PYTHON_SSL_NO_VERIFY"
 
 def allow_debug_connection(client):
     if should_disable_connection_verify():
         logger.warning("Connection verification disabled by environment variable %s",
                        DISABLE_VERIFY_VARIABLE_NAME)
+        os.environ[ADAL_PYTHON_SSL_NO_VERIFY] = '1'
         client.config.connection.verify = False
+    return client
 
 def should_disable_connection_verify():
     return bool(os.environ.get(DISABLE_VERIFY_VARIABLE_NAME))
+
+def allow_debug_adal_connection():
+    if should_disable_connection_verify():
+        os.environ[ADAL_PYTHON_SSL_NO_VERIFY] = '1'
 

--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -96,6 +96,8 @@ class Profile(object):
                                     password,
                                     is_service_principal,
                                     tenant):
+        from azure.cli.core._debug import allow_debug_adal_connection
+        allow_debug_adal_connection()
         subscriptions = []
         if interactive:
             subscriptions = self._subscription_finder.find_through_interactive_flow(
@@ -295,12 +297,13 @@ class SubscriptionFinder(object):
     '''finds all subscriptions for a user or service principal'''
     def __init__(self, auth_context_factory, adal_token_cache, arm_client_factory=None):
         from azure.mgmt.resource.subscriptions import SubscriptionClient
+        from azure.cli.core._debug import allow_debug_connection
 
         self._adal_token_cache = adal_token_cache
         self._auth_context_factory = auth_context_factory
         self.user_id = None # will figure out after log user in
         self._arm_client_factory = arm_client_factory or \
-             (lambda config: SubscriptionClient(config, base_url=CLOUD.endpoints.resource_manager)) #pylint: disable=unnecessary-lambda
+             (lambda config: allow_debug_connection(SubscriptionClient(config, base_url=CLOUD.endpoints.resource_manager))) #pylint: disable=unnecessary-lambda,line-too-long
 
     def find_from_user_account(self, username, password, resource):
         context = self._create_auth_context(_COMMON_TENANT)

--- a/src/azure-cli-core/azure/cli/core/commands/client_factory.py
+++ b/src/azure-cli-core/azure/cli/core/commands/client_factory.py
@@ -23,7 +23,7 @@ def get_subscription_service_client(client_type):
     return _get_mgmt_service_client(client_type, False)
 
 def configure_common_settings(client):
-    _debug.allow_debug_connection(client)
+    client = _debug.allow_debug_connection(client)
 
     client.config.add_user_agent(UA_AGENT)
 

--- a/src/azure-cli-core/azure/cli/core/test_utils/vcr_test_base.py
+++ b/src/azure-cli-core/azure/cli/core/test_utils/vcr_test_base.py
@@ -55,7 +55,7 @@ def _mock_get_mgmt_service_client(client_type, subscription_bound=True, subscrip
         client = client_type(cred, api_version=api_version) \
             if api_version else client_type(cred)
 
-    _debug.allow_debug_connection(client)
+    client = _debug.allow_debug_connection(client)
 
     client.config.add_user_agent("AZURECLI/TEST/{}".format(core_version))
 

--- a/src/azure-cli-core/azure/cli/core/tests/test_connection_verify.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_connection_verify.py
@@ -34,7 +34,7 @@ class Test_argparse(unittest.TestCase):
 
         clientMock = MagicMock()
         clientMock.config.connection.verify = True
-        _debug.allow_debug_connection(clientMock)
+        clientMock = _debug.allow_debug_connection(clientMock)
         self.assertFalse(clientMock.config.connection.verify)
 
 


### PR DESCRIPTION
1. Make sure tracing works during login. The bug is during login, the subscription client created doesn't respect related env var. The reason is it can't go through the common factory method, which is only usable at post login
2. I will also hide ADAL env var for proxy tracing, CLI will turn it on automatically 