### PR TITLE
Fix PEP8 for azure-cli-core

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,4 +3,5 @@ max-line-length = 100
 max-complexity = 10
 ignore =
     E501,
-    F401
+    F401,
+    C901

--- a/scripts/automation/style/run.py
+++ b/scripts/automation/style/run.py
@@ -40,7 +40,7 @@ def run_pep8(modules):
         os.path.join(get_repo_root(), '.flake8'),
         ' '.join(path for _, path in modules))
 
-    return_code = call(command)
+    return_code = call(command.split())
     if return_code:
         print('Flake8 failed')
     else:

--- a/src/azure-cli-core/azure/cli/core/_config.py
+++ b/src/azure-cli-core/azure/cli/core/_config.py
@@ -10,15 +10,18 @@ GLOBAL_CONFIG_DIR = get_config_dir()
 GLOBAL_CONFIG_PATH = os.path.join(GLOBAL_CONFIG_DIR, 'config')
 ENV_VAR_PREFIX = 'AZURE_'
 
+
 def active_context():
     from azure.cli.core.context import get_active_context_name
     return get_active_context_name()
+
 
 CONTEXT_CONFIG_DIR = os.path.expanduser(os.path.join(GLOBAL_CONFIG_DIR, 'context_config'))
 ACTIVE_CONTEXT_CONFIG_PATH = os.path.join(CONTEXT_CONFIG_DIR, active_context())
 
 _UNSET = object()
-_ENV_VAR_FORMAT = ENV_VAR_PREFIX+'{section}_{option}'
+_ENV_VAR_FORMAT = ENV_VAR_PREFIX + '{section}_{option}'
+
 
 class AzConfig(object):
     _BOOLEAN_STATES = {'1': True, 'yes': True, 'true': True, 'on': True,
@@ -55,9 +58,10 @@ class AzConfig(object):
 
     def getboolean(self, section, option, fallback=_UNSET):
         val = str(self.get(section, option, fallback))
-        if val.lower() not in AzConfig._BOOLEAN_STATES: #pylint: disable=E1101
+        if val.lower() not in AzConfig._BOOLEAN_STATES:  # pylint: disable=E1101
             raise ValueError('Not a boolean: {}'.format(val))
-        return AzConfig._BOOLEAN_STATES[val.lower()] #pylint: disable=E1101
+        return AzConfig._BOOLEAN_STATES[val.lower()]  # pylint: disable=E1101
+
 
 az_config = AzConfig()
 az_config.config_parser.read([GLOBAL_CONFIG_PATH, ACTIVE_CONTEXT_CONFIG_PATH])

--- a/src/azure-cli-core/azure/cli/core/_debug.py
+++ b/src/azure-cli-core/azure/cli/core/_debug.py
@@ -4,12 +4,14 @@
 # --------------------------------------------------------------------------------------------
 
 import os
+
 import azure.cli.core._logging as _logging
 
 logger = _logging.get_az_logger(__name__)
 
 DISABLE_VERIFY_VARIABLE_NAME = "AZURE_CLI_DISABLE_CONNECTION_VERIFICATION"
 ADAL_PYTHON_SSL_NO_VERIFY = "ADAL_PYTHON_SSL_NO_VERIFY"
+
 
 def allow_debug_connection(client):
     if should_disable_connection_verify():
@@ -19,10 +21,11 @@ def allow_debug_connection(client):
         client.config.connection.verify = False
     return client
 
+
 def should_disable_connection_verify():
     return bool(os.environ.get(DISABLE_VERIFY_VARIABLE_NAME))
+
 
 def allow_debug_adal_connection():
     if should_disable_connection_verify():
         os.environ[ADAL_PYTHON_SSL_NO_VERIFY] = '1'
-

--- a/src/azure-cli-core/azure/cli/core/_environment.py
+++ b/src/azure-cli-core/azure/cli/core/_environment.py
@@ -5,6 +5,7 @@
 
 import os
 
+
 def get_config_dir():
     if os.getenv('AZURE_CONFIG_DIR'):
         return os.getenv('AZURE_CONFIG_DIR')

--- a/src/azure-cli-core/azure/cli/core/_help.py
+++ b/src/azure-cli-core/azure/cli/core/_help.py
@@ -14,6 +14,7 @@ __all__ = ['print_detailed_help', 'print_welcome_message', 'GroupHelpFile', 'Com
 
 FIRST_LINE_PREFIX = ': '
 
+
 def show_help(nouns, parser, is_group):
     delimiters = ' '.join(nouns)
     help_file = CommandHelpFile(delimiters, parser) \
@@ -28,21 +29,24 @@ def show_help(nouns, parser, is_group):
 
     print_detailed_help(help_file)
 
+
 def show_welcome(parser):
     print_welcome_message()
 
     help_file = GroupHelpFile('', parser)
     print_description_list(help_file.children)
 
+
 def print_welcome_message():
     _print_indent(r"""
-     /\                        
-    /  \    _____   _ _ __ ___ 
+     /\
+    /  \    _____   _ _ __ ___
    / /\ \  |_  / | | | \'__/ _ \
   / ____ \  / /| |_| | | |  __/
  /_/    \_\/___|\__,_|_|  \___|
 """)
     _print_indent('\nWelcome to the cool new Azure CLI!\n\nHere are the base commands:\n')
+
 
 def print_detailed_help(help_file):
     _print_header(help_file)
@@ -56,17 +60,19 @@ def print_detailed_help(help_file):
     if len(help_file.examples) > 0:
         _print_examples(help_file)
 
+
 def print_description_list(help_files):
     indent = 1
     max_name_length = max(len(f.name) for f in help_files) if help_files else 0
     for help_file in sorted(help_files, key=lambda h: h.name):
         _print_indent('{0}{1}{2}'.format(help_file.name,
                                          _get_column_indent(help_file.name, max_name_length),
-                                         FIRST_LINE_PREFIX + help_file.short_summary \
-                                             if help_file.short_summary \
-                                             else ''),
+                                         FIRST_LINE_PREFIX + help_file.short_summary
+                                         if help_file.short_summary
+                                         else ''),
                       indent,
                       _get_hanging_indent(max_name_length, indent))
+
 
 def print_arguments(help_file):
     indent = 1
@@ -85,9 +91,12 @@ def print_arguments(help_file):
     group_registry = ArgumentGroupRegistry(
         [p.group_name for p in help_file.parameters if p.group_name])
 
-    for p in sorted(help_file.parameters,
-                    key=lambda p: group_registry.get_group_priority(p.group_name)
-                    + str(not p.required) + p.name):
+    def _get_parameter_key(parameter):
+        return '{}{}{}'.format(group_registry.get_group_priority(parameter.group_name),
+                               str(not parameter.required),
+                               parameter.name)
+
+    for p in sorted(help_file.parameters, key=_get_parameter_key):
         indent = 1
         required_text = required_tag if p.required else ''
 
@@ -120,7 +129,8 @@ def print_arguments(help_file):
 
     return indent
 
-class ArgumentGroupRegistry(object): # pylint: disable=too-few-public-methods
+
+class ArgumentGroupRegistry(object):  # pylint: disable=too-few-public-methods
 
     def __init__(self, group_list):
 
@@ -129,7 +139,7 @@ class ArgumentGroupRegistry(object): # pylint: disable=too-few-public-methods
             'Resource Id Arguments': 1,
             'Generic Update Arguments': 998,
             'Global Arguments': 1000,
-            }
+        }
         priority = 2
         # any groups not already in the static dictionary should be prioritized alphabetically
         other_groups = [g for g in sorted(list(set(group_list))) if g not in self.priorities]
@@ -140,6 +150,7 @@ class ArgumentGroupRegistry(object): # pylint: disable=too-few-public-methods
     def get_group_priority(self, group_name):
         key = self.priorities.get(group_name, 0)
         return "%06d" % key
+
 
 def _print_header(help_file):
     indent = 0
@@ -158,6 +169,7 @@ def _print_header(help_file):
         _print_indent('{0}'.format(help_file.long_summary.rstrip()), indent)
     _print_indent('')
 
+
 def _print_groups(help_file):
 
     def _print_items(items):
@@ -165,7 +177,7 @@ def _print_groups(help_file):
             column_indent = _get_column_indent(c.name, max_name_length)
             summary = FIRST_LINE_PREFIX + c.short_summary if c.short_summary else ''
             summary = summary.replace('\n', ' ')
-            hanging_indent = max_name_length + indent*4 + 2
+            hanging_indent = max_name_length + indent * 4 + 2
             _print_indent(
                 '{0}{1}{2}'.format(c.name, column_indent, summary), indent, hanging_indent)
         _print_indent('')
@@ -185,6 +197,7 @@ def _print_groups(help_file):
         _print_indent('Commands:')
         _print_items(subcommands)
 
+
 def _get_choices_defaults_sources_str(p):
     choice_str = '  Allowed values: {0}.'.format(', '.join(sorted([str(x) for x in p.choices]))) \
         if p.choices else ''
@@ -193,6 +206,7 @@ def _get_choices_defaults_sources_str(p):
     value_sources_str = '  Values from: {0}.'.format(', '.join(p.value_sources)) \
         if p.value_sources else ''
     return '{0}{1}{2}'.format(choice_str, default_str, value_sources_str)
+
 
 def _print_examples(help_file):
     indent = 0
@@ -206,7 +220,9 @@ def _print_examples(help_file):
         indent = 2
         _print_indent('{0}'.format(e.text), indent)
 
-class HelpObject(object): #pylint: disable=too-few-public-methods
+
+class HelpObject(object):  # pylint: disable=too-few-public-methods
+
     def __init__(self, **kwargs):
         self._short_summary = ''
         self._long_summary = ''
@@ -228,7 +244,9 @@ class HelpObject(object): #pylint: disable=too-few-public-methods
     def long_summary(self, value):
         self._long_summary = _normalize_text(value)
 
-class HelpFile(HelpObject): #pylint: disable=too-few-public-methods,too-many-instance-attributes
+
+class HelpFile(HelpObject):  # pylint: disable=too-few-public-methods,too-many-instance-attributes
+
     def __init__(self, delimiters):
         super(HelpFile, self).__init__()
         self.delimiters = delimiters
@@ -282,7 +300,8 @@ class HelpFile(HelpObject): #pylint: disable=too-few-public-methods,too-many-ins
             self.examples = [HelpExample(d) for d in data['examples']]
 
 
-class GroupHelpFile(HelpFile): #pylint: disable=too-few-public-methods
+class GroupHelpFile(HelpFile):  # pylint: disable=too-few-public-methods
+
     def __init__(self, delimiters, parser):
         super(GroupHelpFile, self).__init__(delimiters)
         self.type = 'group'
@@ -296,14 +315,16 @@ class GroupHelpFile(HelpFile): #pylint: disable=too-few-public-methods
                 child.load(options)
                 self.children.append(child)
 
-class CommandHelpFile(HelpFile): #pylint: disable=too-few-public-methods
+
+class CommandHelpFile(HelpFile):  # pylint: disable=too-few-public-methods
+
     def __init__(self, delimiters, parser):
         super(CommandHelpFile, self).__init__(delimiters)
         self.type = 'command'
 
         self.parameters = []
 
-        for action in [a for a in parser._actions if a.help != argparse.SUPPRESS]: # pylint: disable=protected-access
+        for action in [a for a in parser._actions if a.help != argparse.SUPPRESS]:  # pylint: disable=protected-access
             self.parameters.append(HelpParameter(' '.join(sorted(action.option_strings)),
                                                  action.help,
                                                  required=action.required,
@@ -336,8 +357,9 @@ class CommandHelpFile(HelpFile): #pylint: disable=too-few-public-methods
         self.parameters = loaded_params
 
 
-class HelpParameter(HelpObject): #pylint: disable=too-few-public-methods, too-many-instance-attributes
-    def __init__(self, param_name, description, required, choices=None, #pylint: disable=too-many-arguments
+class HelpParameter(HelpObject):  # pylint: disable=too-few-public-methods, too-many-instance-attributes
+
+    def __init__(self, param_name, description, required, choices=None,  # pylint: disable=too-many-arguments
                  default=None, group_name=None):
         super(HelpParameter, self).__init__()
         self.name = param_name
@@ -369,16 +391,18 @@ class HelpParameter(HelpObject): #pylint: disable=too-few-public-methods, too-ma
             self.value_sources = data.get('populator-commands')
 
 
-class HelpExample(object): #pylint: disable=too-few-public-methods
+class HelpExample(object):  # pylint: disable=too-few-public-methods
+
     def __init__(self, _data):
         self.name = _data['name']
         self.text = _data['text']
 
+
 def _print_indent(s, indent=0, subsequent_spaces=-1):
-    tw = textwrap.TextWrapper(initial_indent='    '*indent,
-                              subsequent_indent=('    '*indent
+    tw = textwrap.TextWrapper(initial_indent='    ' * indent,
+                              subsequent_indent=('    ' * indent
                                                  if subsequent_spaces == -1
-                                                 else ' '*subsequent_spaces),
+                                                 else ' ' * subsequent_spaces),
                               replace_whitespace=False,
                               width=100)
     paragraphs = s.split('\n')
@@ -388,11 +412,14 @@ def _print_indent(s, indent=0, subsequent_spaces=-1):
         except UnicodeEncodeError:
             print(tw.fill(p).encode('ascii', 'ignore').decode('utf-8', 'ignore'), file=sys.stdout)
 
+
 def _get_column_indent(text, max_name_length):
-    return ' '*(max_name_length - len(text))
+    return ' ' * (max_name_length - len(text))
+
 
 def _get_hanging_indent(max_length, indent):
     return max_length + (indent * 4) + len(FIRST_LINE_PREFIX)
+
 
 def _normalize_text(s):
     if not s or len(s) < 2:
@@ -402,16 +429,19 @@ def _normalize_text(s):
     trailing_period = '' if s[-1] in '.!?' else '.'
     return initial_upper + trailing_period
 
+
 def _load_help_file_from_string(text):
     import yaml
     try:
         return yaml.load(text) if text else None
-    except Exception: #pylint: disable=broad-except
+    except Exception:  # pylint: disable=broad-except
         return text
+
 
 def _get_single_metadata(cmd_table):
     assert len(cmd_table) == 1
     return next(metadata for _, metadata in cmd_table.items())
+
 
 class HelpAuthoringException(Exception):
     pass

--- a/src/azure-cli-core/azure/cli/core/_logging.py
+++ b/src/azure-cli-core/azure/cli/core/_logging.py
@@ -49,6 +49,7 @@ CONSOLE_LOG_FORMAT = {
     }
 }
 
+
 def _determine_verbose_level(argv):
     # Get verbose level by reading the arguments.
     # Remove any consumed args.
@@ -64,13 +65,16 @@ def _determine_verbose_level(argv):
             argv.pop(i)
         else:
             i += 1
+
     # Use max verbose level if too much verbosity specified.
-    return verbose_level if verbose_level < len(CONSOLE_LOG_CONFIGS) else len(CONSOLE_LOG_CONFIGS)-1
+    return min(verbose_level, len(CONSOLE_LOG_CONFIGS) - 1)
+
 
 def _color_wrapper(color_marker):
     def wrap_msg_with_color(msg):
         return color_marker + msg + colorama.Style.RESET_ALL
     return wrap_msg_with_color
+
 
 class CustomStreamHandler(logging.StreamHandler):
     COLOR_MAP = {
@@ -108,11 +112,13 @@ class CustomStreamHandler(logging.StreamHandler):
                 pass
         return msg
 
+
 def _init_console_handlers(root_logger, az_logger, log_level_config):
     root_logger.addHandler(CustomStreamHandler(log_level_config['root'],
                                                CONSOLE_LOG_FORMAT['root']))
     az_logger.addHandler(CustomStreamHandler(log_level_config['az'],
                                              CONSOLE_LOG_FORMAT['az']))
+
 
 def _get_log_file_path():
     log_dir = LOG_DIR or DEFAULT_LOG_DIR
@@ -120,16 +126,18 @@ def _get_log_file_path():
         os.makedirs(log_dir)
     return os.path.join(log_dir, AZ_LOGFILE_NAME)
 
+
 def _init_logfile_handlers(root_logger, az_logger):
     if not ENABLE_LOG_FILE:
         return
     log_file_path = _get_log_file_path()
-    logfile_handler = RotatingFileHandler(log_file_path, maxBytes=10*1024*1024, backupCount=5)
+    logfile_handler = RotatingFileHandler(log_file_path, maxBytes=10 * 1024 * 1024, backupCount=5)
     lfmt = logging.Formatter('%(process)d : %(asctime)s : %(levelname)s : %(name)s : %(message)s')
     logfile_handler.setFormatter(lfmt)
     logfile_handler.setLevel(logging.DEBUG)
     root_logger.addHandler(logfile_handler)
     az_logger.addHandler(logfile_handler)
+
 
 def configure_logging(argv):
     verbose_level = _determine_verbose_level(argv)
@@ -148,6 +156,7 @@ def configure_logging(argv):
         return
     _init_console_handlers(root_logger, az_logger, log_level_config)
     _init_logfile_handlers(root_logger, az_logger)
+
 
 def get_az_logger(module_name=None):
     return logging.getLogger('az.' + module_name if module_name else 'az')

--- a/src/azure-cli-core/azure/cli/core/_output.py
+++ b/src/azure-cli-core/azure/cli/core/_output.py
@@ -21,27 +21,32 @@ import azure.cli.core._logging as _logging
 
 logger = _logging.get_az_logger(__name__)
 
+
 def _decode_str(output):
     if not isinstance(output, text_type):
         output = u(str(output))
     return output
 
+
 class ComplexEncoder(json.JSONEncoder):
-    def default(self, obj): #pylint: disable=method-hidden
+
+    def default(self, obj):  # pylint: disable=method-hidden
         if isinstance(obj, bytes) and not isinstance(obj, str):
             return obj.decode()
         return json.JSONEncoder.default(self, obj)
 
+
 def format_json(obj):
     result = obj.result
-    #OrderedDict.__dict__ is always '{}', to persist the data, convert to dict first.
+    # OrderedDict.__dict__ is always '{}', to persist the data, convert to dict first.
     input_dict = dict(result) if hasattr(result, '__dict__') else result
     return json.dumps(input_dict, indent=2, sort_keys=True, cls=ComplexEncoder,
                       separators=(',', ': ')) + '\n'
 
+
 def format_json_color(obj):
     from pygments import highlight, lexers, formatters
-    return highlight(format_json(obj), lexers.JsonLexer(), formatters.TerminalFormatter()) # pylint: disable=no-member
+    return highlight(format_json(obj), lexers.JsonLexer(), formatters.TerminalFormatter())  # pylint: disable=no-member
 
 
 def format_text(obj):
@@ -56,6 +61,7 @@ def format_text(obj):
     except TypeError:
         return ''
 
+
 def format_table(obj):
     result = obj.result
     try:
@@ -65,9 +71,10 @@ def format_table(obj):
         return TableOutput.dump(result_list)
     except:
         logger.debug(traceback.format_exc())
-        raise CLIError("Table output unavailable. "\
-                       "Use the --query option to specify an appropriate query. "\
+        raise CLIError("Table output unavailable. "
+                       "Use the --query option to specify an appropriate query. "
                        "Use --debug for more info.")
+
 
 def format_list(obj):
     result = obj.result
@@ -75,19 +82,22 @@ def format_list(obj):
     lo = ListOutput()
     return lo.dump(result_list)
 
+
 def format_tsv(obj):
     result = obj.result
     result_list = result if isinstance(result, list) else [result]
     return TsvOutput.dump(result_list)
 
-class CommandResultItem(object): #pylint: disable=too-few-public-methods
+
+class CommandResultItem(object):  # pylint: disable=too-few-public-methods
 
     def __init__(self, result, table_transformer=None, is_query_active=False):
         self.result = result
         self.table_transformer = table_transformer
         self.is_query_active = is_query_active
 
-class OutputProducer(object): #pylint: disable=too-few-public-methods
+
+class OutputProducer(object):  # pylint: disable=too-few-public-methods
 
     format_dict = {
         'json': format_json,
@@ -98,7 +108,7 @@ class OutputProducer(object): #pylint: disable=too-few-public-methods
         'tsv': format_tsv,
     }
 
-    def __init__(self, formatter=format_list, file=sys.stdout): #pylint: disable=redefined-builtin
+    def __init__(self, formatter=format_list, file=sys.stdout):  # pylint: disable=redefined-builtin
         self.formatter = formatter
         self.file = file
 
@@ -121,7 +131,8 @@ class OutputProducer(object): #pylint: disable=too-few-public-methods
     def get_formatter(format_type):
         return OutputProducer.format_dict.get(format_type, format_list)
 
-class TableOutput(object): #pylint: disable=too-few-public-methods
+
+class TableOutput(object):  # pylint: disable=too-few-public-methods
 
     SKIP_KEYS = ['id', 'type']
 
@@ -165,7 +176,8 @@ class TableOutput(object): #pylint: disable=too-few-public-methods
             raise ValueError('Unable to extract fields for table.')
         return table_str + '\n'
 
-class ListOutput(object): #pylint: disable=too-few-public-methods
+
+class ListOutput(object):  # pylint: disable=too-few-public-methods
 
     # Match the capital letters in a camel case string
     FORMAT_KEYS_PATTERN = re.compile('([A-Z]+(?![a-z])|[A-Z]{1}[a-z]+)')
@@ -182,9 +194,9 @@ class ListOutput(object): #pylint: disable=too-few-public-methods
         # We want dictionaries to be last so use ASCII char 126 ~ to
         # prefix dictionary and list key names.
         if isinstance(item[key], dict):
-            return '~~'+key
+            return '~~' + key
         elif isinstance(item[key], list):
-            return '~'+key
+            return '~' + key
         else:
             return key
 
@@ -217,7 +229,7 @@ class ListOutput(object): #pylint: disable=too-few-public-methods
                     # complex object
                     line = '%s :' % (self._get_formatted_key(key).ljust(key_width))
                     ListOutput._dump_line(io, line, indent)
-                    self._dump_object(io, obj[key] if obj[key] else 'None', indent+1)
+                    self._dump_object(io, obj[key] if obj[key] else 'None', indent + 1)
                 else:
                     # non-complex so write it
                     line = '%s : %s' % (self._get_formatted_key(key).ljust(key_width),
@@ -235,6 +247,7 @@ class ListOutput(object): #pylint: disable=too-few-public-methods
         result = io.getvalue()
         io.close()
         return result
+
 
 class TextOutput(object):
 
@@ -264,7 +277,8 @@ class TextOutput(object):
         io.close()
         return result
 
-class TsvOutput(object): #pylint: disable=too-few-public-methods
+
+class TsvOutput(object):  # pylint: disable=too-few-public-methods
 
     @staticmethod
     def _dump_obj(data, stream):

--- a/src/azure-cli-core/azure/cli/core/_pkg_util.py
+++ b/src/azure-cli-core/azure/cli/core/_pkg_util.py
@@ -10,11 +10,12 @@ import azure.cli.core._logging as _logging
 
 logger = _logging.get_az_logger(__name__)
 
+
 def handle_module_not_installed(module_name):
     try:
         import xmlrpclib
     except ImportError:
-        import xmlrpc.client as xmlrpclib #pylint: disable=import-error
+        import xmlrpc.client as xmlrpclib  # pylint: disable=import-error
     query = {'author': 'Microsoft Corporation', 'author_email': 'azpycli'}
     logger.debug("Checking PyPI for modules using query '%s'", query)
     client = xmlrpclib.ServerProxy('https://pypi.python.org/pypi')

--- a/src/azure-cli-core/azure/cli/core/_session.py
+++ b/src/azure-cli-core/azure/cli/core/_session.py
@@ -14,6 +14,7 @@ except ImportError:
 
 from codecs import open as codecs_open
 
+
 class Session(collections.MutableMapping):
     '''A simple dict-like class that is backed by a JSON file.
 
@@ -73,6 +74,7 @@ class Session(collections.MutableMapping):
 
     def __len__(self):
         return len(self.data)
+
 
 # ACCOUNT contains subscriptions information
 ACCOUNT = Session()

--- a/src/azure-cli-core/azure/cli/core/_util.py
+++ b/src/azure-cli-core/azure/cli/core/_util.py
@@ -17,6 +17,7 @@ COMPONENT_PREFIX = 'azure-cli-'
 
 logger = _logging.get_az_logger(__name__)
 
+
 class CLIError(Exception):
     """Base class for exceptions that occur during
     normal operation of the application.
@@ -24,8 +25,9 @@ class CLIError(Exception):
     """
     pass
 
+
 def handle_exception(ex):
-    #For error code, follow guidelines at https://docs.python.org/2/library/sys.html#sys.exit,
+    # For error code, follow guidelines at https://docs.python.org/2/library/sys.html#sys.exit,
     from msrestazure.azure_exceptions import CloudError
     if isinstance(ex, CLIError) or isinstance(ex, CloudError):
         logger.error(ex.args[0])
@@ -36,8 +38,10 @@ def handle_exception(ex):
         logger.exception(ex)
         return 1
 
+
 def normalize_newlines(str_to_normalize):
     return str_to_normalize.replace('\r\n', '\n')
+
 
 def show_version_info_exit(out_file):
     import platform
@@ -66,6 +70,7 @@ def show_version_info_exit(out_file):
     print('Python ({}) {}'.format(platform.system(), sys.version), file=out_file)
     sys.exit(0)
 
+
 def get_json_object(json_string):
     """ Loads a JSON string as an object and converts all keys to snake case """
     def _convert_to_snake_case(item):
@@ -80,9 +85,10 @@ def get_json_object(json_string):
             return item
     return _convert_to_snake_case(json.loads(json_string))
 
+
 def get_file_json(file_path, throw_on_empty=True):
     from codecs import open as codecs_open
-    #always try 'utf-8-sig' first, so that BOM in WinOS won't cause trouble.
+    # always try 'utf-8-sig' first, so that BOM in WinOS won't cause trouble.
     for encoding in ('utf-8-sig', 'utf-8', 'utf-16', 'utf-16le', 'utf-16be'):
         try:
             with codecs_open(file_path, encoding=encoding) as f:
@@ -99,7 +105,8 @@ def get_file_json(file_path, throw_on_empty=True):
 
     raise CLIError('Failed to decode file {} - unknown decoding'.format(file_path))
 
-def todict(obj): #pylint: disable=too-many-return-statements
+
+def todict(obj):  # pylint: disable=too-many-return-statements
 
     if isinstance(obj, dict):
         return {k: todict(v) for (k, v) in obj.items()}
@@ -120,9 +127,13 @@ def todict(obj): #pylint: disable=too-many-return-statements
     else:
         return obj
 
+
 KEYS_CAMELCASE_PATTERN = re.compile('(?!^)_([a-zA-Z])')
+
+
 def to_camel_case(s):
     return re.sub(KEYS_CAMELCASE_PATTERN, lambda x: x.group(1).upper(), s)
+
 
 def to_snake_case(s):
     s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', s)

--- a/src/azure-cli-core/azure/cli/core/adal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/adal_authentication.py
@@ -10,7 +10,8 @@ from msrest.authentication import Authentication
 
 from azure.cli.core._util import CLIError
 
-class AdalAuthentication(Authentication):#pylint: disable=too-few-public-methods
+
+class AdalAuthentication(Authentication):  # pylint: disable=too-few-public-methods
 
     def __init__(self, token_retriever):
         self._token_retriever = token_retriever
@@ -21,9 +22,10 @@ class AdalAuthentication(Authentication):#pylint: disable=too-few-public-methods
         try:
             scheme, token = self._token_retriever()
         except adal.AdalError as err:
-            #pylint: disable=no-member
-            if (hasattr(err, 'error_response') and ('error_description' in err.error_response)
-                    and ('AADSTS70008:' in err.error_response['error_description'])):
+            # pylint: disable=no-member
+            if (hasattr(err, 'error_response') and
+                    ('error_description' in err.error_response) and
+                    ('AADSTS70008:' in err.error_response['error_description'])):
                 raise CLIError("Credentials have expired due to inactivity. Please run 'az login'")
 
             raise CLIError(err)

--- a/src/azure-cli-core/azure/cli/core/application.py
+++ b/src/azure-cli-core/azure/cli/core/application.py
@@ -22,21 +22,24 @@ logger = _logging.get_az_logger(__name__)
 
 ARGCOMPLETE_ENV_NAME = '_ARGCOMPLETE'
 
-class Configuration(object): # pylint: disable=too-few-public-methods
+
+class Configuration(object):  # pylint: disable=too-few-public-methods
     """The configuration object tracks session specific data such
     as output formats, available commands etc.
     """
+
     def __init__(self, argv):
         self.argv = argv or sys.argv[1:]
         self.output_format = None
 
-    def get_command_table(self): # pylint: disable=no-self-use
+    def get_command_table(self):  # pylint: disable=no-self-use
         import azure.cli.core.commands as commands
         return commands.get_command_table()
 
-    def load_params(self, command): # pylint: disable=no-self-use
+    def load_params(self, command):  # pylint: disable=no-self-use
         import azure.cli.core.commands as commands
         commands.load_params(command)
+
 
 class Application(object):
 
@@ -53,11 +56,11 @@ class Application(object):
         self.session = {
             'headers': {
                 'x-ms-client-request-id': str(uuid.uuid1())
-                },
+            },
             'command': 'unknown',
             'completer_active': ARGCOMPLETE_ENV_NAME in os.environ,
             'query_active': False
-            }
+        }
 
         # Register presence of and handlers for global parameters
         self.register(self.GLOBAL_PARSER_CREATED, Application._register_builtin_arguments)
@@ -77,7 +80,7 @@ class Application(object):
     def initialize(self, configuration):
         self.configuration = configuration
 
-    def execute(self, unexpanded_argv): # pylint: disable=too-many-statements
+    def execute(self, unexpanded_argv):  # pylint: disable=too-many-statements
         argv = Application._expand_file_prefixed_files(unexpanded_argv)
         command_table = self.configuration.get_command_table()
         self.raise_event(self.COMMAND_TABLE_LOADED, command_table=command_table)
@@ -123,7 +126,7 @@ class Application(object):
                 _validate_arguments(expanded_arg)
             except CLIError:
                 raise
-            except: # pylint: disable=bare-except
+            except:  # pylint: disable=bare-except
                 err = sys.exc_info()[1]
                 getattr(expanded_arg, '_parser', self.parser).validation_error(str(err))
 
@@ -151,15 +154,14 @@ class Application(object):
         self.raise_event(self.TRANSFORM_RESULT, event_data=event_data)
         self.raise_event(self.FILTER_RESULT, event_data=event_data)
         return CommandResultItem(event_data['result'],
-                                 table_transformer=
-                                 command_table[args.command].table_transformer,
+                                 table_transformer=command_table[args.command].table_transformer,
                                  is_query_active=self.session['query_active'])
 
     def raise_event(self, name, **kwargs):
         '''Raise the event `name`.
         '''
         logger.info("Application event '%s' with event data %s", name, kwargs)
-        for func in list(self._event_handlers[name]): # Make copy in case handler modifies the list
+        for func in list(self._event_handlers[name]):  # Make copy in case handler modifies the list
             func(**kwargs)
 
     def register(self, name, handler):
@@ -196,22 +198,22 @@ class Application(object):
                                   type=str.lower)
         # The arguments for verbosity don't get parsed by argparse but we add it here for help.
         global_group.add_argument('--verbose', dest='_log_verbosity_verbose', action='store_true',
-                                  help='Increase logging verbosity. Use --debug for full debug logs.') #pylint: disable=line-too-long
+                                  help='Increase logging verbosity. Use --debug for full debug logs.')  # pylint: disable=line-too-long
         global_group.add_argument('--debug', dest='_log_verbosity_debug', action='store_true',
                                   help='Increase logging verbosity to show all debug logs.')
 
     @staticmethod
     def _maybe_load_file(arg):
         ix = arg.find('@')
-        if ix == -1: # no @ found
+        if ix == -1:  # no @ found
             return arg
 
         poss_file = arg[ix + 1:]
-        if not poss_file: # if nothing after @ then it can't be a file
+        if not poss_file:  # if nothing after @ then it can't be a file
             return arg
         elif ix == 0:
             return Application._load_file(poss_file)
-        else: # if @ not at the start it can't be a file
+        else:  # if @ not at the start it can't be a file
             return arg
 
     @staticmethod
@@ -244,8 +246,9 @@ class Application(object):
 
     def _handle_builtin_arguments(self, **kwargs):
         args = kwargs['args']
-        self.configuration.output_format = args._output_format #pylint: disable=protected-access
+        self.configuration.output_format = args._output_format  # pylint: disable=protected-access
         del args._output_format
+
 
 def _validate_arguments(args, **_):
     for validator in getattr(args, '_validators', []):
@@ -255,6 +258,7 @@ def _validate_arguments(args, **_):
     except AttributeError:
         pass
 
+
 def _explode_list_args(args):
     '''Iterate through each attribute member of args and create a copy with
     the IterateValues 'flattened' to only contain a single value
@@ -262,7 +266,7 @@ def _explode_list_args(args):
     Ex.
         { a1:'x', a2:IterateValue(['y', 'z']) } => [{ a1:'x', a2:'y'),{ a1:'x', a2:'z'}]
     '''
-    list_args = {argname:argvalue for argname, argvalue in vars(args).items()
+    list_args = {argname: argvalue for argname, argvalue in vars(args).items()
                  if isinstance(argvalue, IterateValue)}
     if not list_args:
         yield args
@@ -278,7 +282,7 @@ def _explode_list_args(args):
             yield new_ns
 
 
-class IterateAction(argparse.Action): # pylint: disable=too-few-public-methods
+class IterateAction(argparse.Action):  # pylint: disable=too-few-public-methods
     '''Action used to collect argument values in an IterateValue list
     The application will loop through each value in the IterateValue
     and execeute the associated handler for each
@@ -296,6 +300,7 @@ class IterateValue(list):
     Typical use is to allow multiple ID parameter to a show command etc.
     '''
     pass
+
 
 APPLICATION = Application()
 

--- a/src/azure-cli-core/azure/cli/core/cloud.py
+++ b/src/azure-cli-core/azure/cli/core/cloud.py
@@ -10,31 +10,40 @@ from azure.cli.core._config import GLOBAL_CONFIG_DIR
 
 CUSTOM_CLOUD_CONFIG_FILE = os.path.join(GLOBAL_CONFIG_DIR, 'clouds.config')
 
+
 class CloudNotRegisteredException(Exception):
     def __init__(self, cloud_name):
         super(CloudNotRegisteredException, self).__init__(cloud_name)
         self.cloud_name = cloud_name
+
     def __str__(self):
         return "The cloud '{}' is not registered.".format(self.cloud_name)
+
 
 class CloudAlreadyRegisteredException(Exception):
     def __init__(self, cloud_name):
         super(CloudAlreadyRegisteredException, self).__init__(cloud_name)
         self.cloud_name = cloud_name
+
     def __str__(self):
         return "The cloud '{}' is already registered.".format(self.cloud_name)
+
 
 class CannotUnregisterCloudException(Exception):
     pass
 
+
 class CloudEndpointNotSetException(Exception):
     pass
+
 
 class CloudSuffixNotSetException(Exception):
     pass
 
-class CloudEndpoints(object): #pylint: disable=too-few-public-methods
-    def __init__(self, #pylint: disable=too-many-arguments
+
+class CloudEndpoints(object):  # pylint: disable=too-few-public-methods
+
+    def __init__(self,  # pylint: disable=too-many-arguments
                  management=None,
                  resource_manager=None,
                  sql_management=None,
@@ -54,11 +63,14 @@ class CloudEndpoints(object): #pylint: disable=too-few-public-methods
     def __getattribute__(self, name):
         val = object.__getattribute__(self, name)
         if val is None:
-            raise CloudEndpointNotSetException("The endpoint '{}' for this cloud is not set but is used".format(name)) #pylint: disable=line-too-long
+            raise CloudEndpointNotSetException("The endpoint '{}' for this cloud "
+                                               "is not set but is used".format(name))
         return val
 
-class CloudSuffixes(object): #pylint: disable=too-few-public-methods
-    def __init__(self, #pylint: disable=too-many-arguments
+
+class CloudSuffixes(object):  # pylint: disable=too-few-public-methods
+
+    def __init__(self,  # pylint: disable=too-many-arguments
                  storage_endpoint=None,
                  keyvault_dns=None,
                  sql_server_hostname=None,
@@ -69,15 +81,17 @@ class CloudSuffixes(object): #pylint: disable=too-few-public-methods
         self.keyvault_dns = keyvault_dns
         self.sql_server_hostname = sql_server_hostname
         self.azure_datalake_store_file_system_endpoint = azure_datalake_store_file_system_endpoint
-        self.azure_datalake_analytics_catalog_and_job_endpoint = azure_datalake_analytics_catalog_and_job_endpoint #pylint: disable=line-too-long
+        self.azure_datalake_analytics_catalog_and_job_endpoint = azure_datalake_analytics_catalog_and_job_endpoint  # pylint: disable=line-too-long
 
     def __getattribute__(self, name):
         val = object.__getattribute__(self, name)
         if val is None:
-            raise CloudSuffixNotSetException("The suffix '{}' for this cloud is not set but is used".format(name)) #pylint: disable=line-too-long
+            raise CloudSuffixNotSetException("The suffix '{}' for this cloud "
+                                             "is not set but is used".format(name))
         return val
 
-class Cloud(object): # pylint: disable=too-few-public-methods
+
+class Cloud(object):  # pylint: disable=too-few-public-methods
     """ Represents an Azure Cloud instance """
 
     def __init__(self, name, endpoints=None, suffixes=None):
@@ -85,71 +99,75 @@ class Cloud(object): # pylint: disable=too-few-public-methods
         self.endpoints = endpoints or CloudEndpoints()
         self.suffixes = suffixes or CloudSuffixes()
 
-AZURE_PUBLIC_CLOUD = Cloud('AzureCloud',
-                           endpoints=CloudEndpoints(
-                               management='https://management.core.windows.net/',
-                               resource_manager='https://management.azure.com/',
-                               sql_management='https://management.core.windows.net:8443/',
-                               gallery='https://gallery.azure.com/',
-                               active_directory='https://login.microsoftonline.com',
-                               active_directory_resource_id='https://management.core.windows.net/',
-                               active_directory_graph_resource_id='https://graph.windows.net/'),
-                           suffixes=CloudSuffixes(
-                               storage_endpoint='core.windows.net',
-                               keyvault_dns='.vault.azure.net',
-                               sql_server_hostname='.database.windows.net',
-                               azure_datalake_store_file_system_endpoint='azuredatalakestore.net',
-                               azure_datalake_analytics_catalog_and_job_endpoint='azuredatalakeanalytics.net') #pylint: disable=line-too-long
-                          )
 
-AZURE_CHINA_CLOUD = Cloud('AzureChinaCloud',
-                          endpoints=CloudEndpoints(
-                              management='https://management.core.chinacloudapi.cn/',
-                              resource_manager='https://management.chinacloudapi.cn',
-                              sql_management='https://management.core.chinacloudapi.cn:8443/',
-                              gallery='https://gallery.chinacloudapi.cn/',
-                              active_directory='https://login.chinacloudapi.cn',
-                              active_directory_resource_id='https://management.core.chinacloudapi.cn/', #pylint: disable=line-too-long
-                              active_directory_graph_resource_id='https://graph.chinacloudapi.cn/'),
-                          suffixes=CloudSuffixes(
-                              storage_endpoint='core.chinacloudapi.cn',
-                              keyvault_dns='.vault.azure.cn',
-                              sql_server_hostname='.database.chinacloudapi.cn')
-                         )
+AZURE_PUBLIC_CLOUD = Cloud(
+    'AzureCloud',
+    endpoints=CloudEndpoints(
+        management='https://management.core.windows.net/',
+        resource_manager='https://management.azure.com/',
+        sql_management='https://management.core.windows.net:8443/',
+        gallery='https://gallery.azure.com/',
+        active_directory='https://login.microsoftonline.com',
+        active_directory_resource_id='https://management.core.windows.net/',
+        active_directory_graph_resource_id='https://graph.windows.net/'),
+    suffixes=CloudSuffixes(
+        storage_endpoint='core.windows.net',
+        keyvault_dns='.vault.azure.net',
+        sql_server_hostname='.database.windows.net',
+        azure_datalake_store_file_system_endpoint='azuredatalakestore.net',
+        azure_datalake_analytics_catalog_and_job_endpoint='azuredatalakeanalytics.net'))
 
-AZURE_US_GOV_CLOUD = Cloud('AzureUSGovernment',
-                           endpoints=CloudEndpoints(
-                               management='https://management.core.usgovcloudapi.net/',
-                               resource_manager='https://management.usgovcloudapi.net/',
-                               sql_management='https://management.core.usgovcloudapi.net:8443/',
-                               gallery='https://gallery.usgovcloudapi.net/',
-                               active_directory='https://login.microsoftonline.com',
-                               active_directory_resource_id='https://management.core.usgovcloudapi.net/', #pylint: disable=line-too-long
-                               active_directory_graph_resource_id='https://graph.windows.net/'),
-                           suffixes=CloudSuffixes(
-                               storage_endpoint='core.usgovcloudapi.net',
-                               keyvault_dns='.vault.usgovcloudapi.net',
-                               sql_server_hostname='.database.usgovcloudapi.net')
-                          )
+AZURE_CHINA_CLOUD = Cloud(
+    'AzureChinaCloud',
+    endpoints=CloudEndpoints(
+        management='https://management.core.chinacloudapi.cn/',
+        resource_manager='https://management.chinacloudapi.cn',
+        sql_management='https://management.core.chinacloudapi.cn:8443/',
+        gallery='https://gallery.chinacloudapi.cn/',
+        active_directory='https://login.chinacloudapi.cn',
+        active_directory_resource_id='https://management.core.chinacloudapi.cn/',
+        active_directory_graph_resource_id='https://graph.chinacloudapi.cn/'),
+    suffixes=CloudSuffixes(
+        storage_endpoint='core.chinacloudapi.cn',
+        keyvault_dns='.vault.azure.cn',
+        sql_server_hostname='.database.chinacloudapi.cn'))
 
-AZURE_GERMAN_CLOUD = Cloud('AzureGermanCloud',
-                           endpoints=CloudEndpoints(
-                               management='https://management.core.cloudapi.de/',
-                               resource_manager='https://management.microsoftazure.de',
-                               sql_management='https://management.core.cloudapi.de:8443/',
-                               gallery='https://gallery.cloudapi.de/',
-                               active_directory='https://login.microsoftonline.de',
-                               active_directory_resource_id='https://management.core.cloudapi.de/',
-                               active_directory_graph_resource_id='https://graph.cloudapi.de/'),
-                           suffixes=CloudSuffixes(
-                               storage_endpoint='core.cloudapi.de',
-                               keyvault_dns='.vault.microsoftazure.de',
-                               sql_server_hostname='.database.cloudapi.de')
-                          )
+AZURE_US_GOV_CLOUD = Cloud(
+    'AzureUSGovernment',
+    endpoints=CloudEndpoints(
+        management='https://management.core.usgovcloudapi.net/',
+        resource_manager='https://management.usgovcloudapi.net/',
+        sql_management='https://management.core.usgovcloudapi.net:8443/',
+        gallery='https://gallery.usgovcloudapi.net/',
+        active_directory='https://login.microsoftonline.com',
+        active_directory_resource_id='https://management.core.usgovcloudapi.net/',
+        active_directory_graph_resource_id='https://graph.windows.net/'),
+    suffixes=CloudSuffixes(
+        storage_endpoint='core.usgovcloudapi.net',
+        keyvault_dns='.vault.usgovcloudapi.net',
+        sql_server_hostname='.database.usgovcloudapi.net'))
+
+AZURE_GERMAN_CLOUD = Cloud(
+    'AzureGermanCloud',
+    endpoints=CloudEndpoints(
+        management='https://management.core.cloudapi.de/',
+        resource_manager='https://management.microsoftazure.de',
+        sql_management='https://management.core.cloudapi.de:8443/',
+        gallery='https://gallery.cloudapi.de/',
+        active_directory='https://login.microsoftonline.de',
+        active_directory_resource_id='https://management.core.cloudapi.de/',
+        active_directory_graph_resource_id='https://graph.cloudapi.de/'),
+    suffixes=CloudSuffixes(
+        storage_endpoint='core.cloudapi.de',
+        keyvault_dns='.vault.microsoftazure.de',
+        sql_server_hostname='.database.cloudapi.de'))
 
 KNOWN_CLOUDS = [AZURE_PUBLIC_CLOUD, AZURE_CHINA_CLOUD, AZURE_US_GOV_CLOUD, AZURE_GERMAN_CLOUD]
 
-_get_cloud = lambda cloud_name: next((x for x in get_clouds() if x.name == cloud_name), None)
+
+def _get_cloud(cloud_name):
+    return next((x for x in get_clouds() if x.name == cloud_name), None)
+
 
 def get_custom_clouds():
     clouds = []
@@ -165,16 +183,19 @@ def get_custom_clouds():
         clouds.append(c)
     return clouds
 
+
 def get_clouds():
     clouds = KNOWN_CLOUDS[:]
     clouds.extend(get_custom_clouds())
     return clouds
+
 
 def get_cloud(cloud_name):
     cloud = _get_cloud(cloud_name)
     if not cloud:
         raise CloudNotRegisteredException(cloud_name)
     return cloud
+
 
 def add_cloud(cloud):
     if _get_cloud(cloud.name):
@@ -196,21 +217,25 @@ def add_cloud(cloud):
     with open(CUSTOM_CLOUD_CONFIG_FILE, 'w') as configfile:
         config.write(configfile)
 
+
 def remove_cloud(cloud_name):
     from azure.cli.core.context import get_contexts
     if not _get_cloud(cloud_name):
         raise CloudNotRegisteredException(cloud_name)
     is_known_cloud = next((x for x in KNOWN_CLOUDS if x.name == cloud_name), None)
     if is_known_cloud:
-        raise CannotUnregisterCloudException("The cloud '{}' cannot be unregistered as it's not a custom cloud.".format(cloud_name)) #pylint: disable=line-too-long
-    contexts_using_cloud = [context for context in get_contexts() if context.get('cloud', None) == cloud_name] #pylint: disable=line-too-long
+        raise CannotUnregisterCloudException("The cloud '{}' cannot be unregistered "
+                                             "as it's not a custom cloud.".format(cloud_name))
+    contexts_using_cloud = [context for context in get_contexts() if context.get(
+        'cloud', None) == cloud_name]  # pylint: disable=line-too-long
     if contexts_using_cloud:
         context_names = [context['name'] for context in contexts_using_cloud]
         many_contexts = len(context_names) > 1
-        raise CannotUnregisterCloudException("The cloud '{0}' is in use by the following context{1} '{2}'.".format( #pylint: disable=line-too-long
-            cloud_name,
-            's' if many_contexts else '',
-            ', '.join(context_names)))
+        raise CannotUnregisterCloudException(
+            "The cloud '{0}' is in use by the following context{1} '{2}'.".format(
+                cloud_name,
+                's' if many_contexts else '',
+                ', '.join(context_names)))
     config = configparser.SafeConfigParser()
     config.read(CUSTOM_CLOUD_CONFIG_FILE)
     config.remove_section(cloud_name)

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -25,6 +25,7 @@ regex = re.compile('/subscriptions/(?P<subscription>[^/]*)/resourceGroups/(?P<re
                    '(/(?P<child_type>[^/]*)/(?P<child_name>[^/]*))?'
                    '(/(?P<grandchild_type>[^/]*)/(?P<grandchild_name>[^/]*))?')
 
+
 def resource_id(**kwargs):
     '''Create a valid resource id string from the given parts
     The method accepts the following keyword arguments:
@@ -49,6 +50,7 @@ def resource_id(**kwargs):
         pass
     return rid
 
+
 def parse_resource_id(rid):
     '''Build a dictionary with the following key/value pairs (if found)
 
@@ -68,7 +70,8 @@ def parse_resource_id(rid):
     else:
         result = dict(name=rid)
 
-    return {key:value for key, value in result.items() if value is not None}
+    return {key: value for key, value in result.items() if value is not None}
+
 
 def is_valid_resource_id(rid, exception_type=None):
     is_valid = False
@@ -80,6 +83,7 @@ def is_valid_resource_id(rid, exception_type=None):
         raise exception_type()
     return is_valid
 
+
 class ResourceId(str):
 
     def __new__(cls, val):
@@ -87,7 +91,8 @@ class ResourceId(str):
             raise ValueError()
         return str.__new__(cls, val)
 
-def resource_exists(resource_group, name, namespace, type, **_): # pylint: disable=redefined-builtin
+
+def resource_exists(resource_group, name, namespace, type, **_):  # pylint: disable=redefined-builtin
     '''Checks if the given resource exists.
     '''
     from azure.mgmt.resource.resources import ResourceManagementClient
@@ -98,10 +103,11 @@ def resource_exists(resource_group, name, namespace, type, **_): # pylint: disab
     existing = len(list(client.list(filter=odata_filter))) == 1
     return existing
 
+
 def add_id_parameters(command_table):
 
     def split_action(arguments):
-        class SplitAction(argparse.Action): #pylint: disable=too-few-public-methods
+        class SplitAction(argparse.Action):  # pylint: disable=too-few-public-methods
 
             def __call__(self, parser, namespace, values, option_string=None):
                 ''' The SplitAction will take the given ID parameter and spread the parsed
@@ -120,7 +126,7 @@ def add_id_parameters(command_table):
                                 existing_values.append(parts[arg.id_part])
                             elif isinstance(existing_values, str):
                                 logger.warning(
-                                    "Property '%s=%s' being overriden by value '%s' from IDs parameter.", # pylint: disable=line-too-long
+                                    "Property '%s=%s' being overriden by value '%s' from IDs parameter.",  # pylint: disable=line-too-long
                                     arg.name, existing_values, parts[arg.id_part]
                                 )
                                 existing_values = IterateValue()
@@ -132,7 +138,7 @@ def add_id_parameters(command_table):
         return SplitAction
 
     def command_loaded_handler(command):
-        if not 'name' in [arg.id_part for arg in command.arguments.values() if arg.id_part]:
+        if 'name' not in [arg.id_part for arg in command.arguments.values() if arg.id_part]:
             # Only commands with a resource name are candidates for an id parameter
             return
         if command.name.split()[-1] == 'create':
@@ -177,6 +183,7 @@ def add_id_parameters(command_table):
     for command in command_table.values():
         command_loaded_handler(command)
 
+
 APPLICATION.register(APPLICATION.COMMAND_TABLE_PARAMS_LOADED, add_id_parameters)
 
 APPLICATION.register(APPLICATION.COMMAND_TABLE_LOADED, add_id_parameters)
@@ -185,43 +192,55 @@ add_usage = '--add property.listProperty <key=value, string or JSON string>'
 set_usage = '--set property1.property2=<value>'
 remove_usage = '--remove property.list <indexToRemove> OR --remove propertyToRemove'
 
+
 def _get_child(parent, collection_name, item_name, collection_key):
     items = getattr(parent, collection_name)
-    result = next((x for x in items if getattr(x, collection_key, '').lower() == item_name.lower()), None) # pylint: disable=line-too-long
+    result = next((x for x in items if getattr(x, collection_key, '').lower() ==
+                   item_name.lower()), None)
     if not result:
         raise CLIError("Property '{}' does not exist for key '{}'.".format(
             item_name, collection_key))
     else:
         return result
 
-def cli_generic_update_command(module_name, name, getter_op, setter_op, factory=None, setter_arg_name='parameters', # pylint: disable=too-many-arguments, line-too-long
-                               table_transformer=None, child_collection_prop_name=None,
-                               child_collection_key='name', child_arg_name='item_name',
-                               custom_function_op=None, no_wait_param=None, transform=None):
+
+# pylint: disable=too-many-arguments
+def cli_generic_update_command(module_name, name, getter_op, setter_op, factory=None,
+                               setter_arg_name='parameters', table_transformer=None,
+                               child_collection_prop_name=None, child_collection_key='name',
+                               child_arg_name='item_name', custom_function_op=None,
+                               no_wait_param=None, transform=None):
     if not isinstance(getter_op, string_types):
         raise ValueError("Getter operation must be a string. Got '{}'".format(getter_op))
     if not isinstance(setter_op, string_types):
         raise ValueError("Setter operation must be a string. Got '{}'".format(setter_op))
     if custom_function_op and not isinstance(custom_function_op, string_types):
-        raise ValueError("Custom function operation must be a string. Got '{}'".format(custom_function_op)) #pylint: disable=line-too-long
+        raise ValueError("Custom function operation must be a string. Got '{}'".format(
+            custom_function_op))
 
-    get_arguments_loader = lambda: dict(extract_args_from_signature(get_op_handler(getter_op)))
-    set_arguments_loader = lambda: dict(extract_args_from_signature(get_op_handler(setter_op),
-                                                                    no_wait_param=no_wait_param)) #pylint: disable=line-too-long
-    function_arguments_loader = lambda: dict(extract_args_from_signature(get_op_handler(custom_function_op))) if custom_function_op else {} #pylint: disable=line-too-long
+    def get_arguments_loader():
+        return dict(extract_args_from_signature(get_op_handler(getter_op)))
+
+    def set_arguments_loader():
+        return dict(extract_args_from_signature(get_op_handler(setter_op),
+                                                no_wait_param=no_wait_param))
+
+    def function_arguments_loader():
+        return dict(extract_args_from_signature(get_op_handler(custom_function_op))) \
+            if custom_function_op else {}
 
     def arguments_loader():
         arguments = {}
         arguments.update(set_arguments_loader())
         arguments.update(get_arguments_loader())
         arguments.update(function_arguments_loader())
-        arguments.pop('instance', None) # inherited from custom_function(instance, ...)
+        arguments.pop('instance', None)  # inherited from custom_function(instance, ...)
         arguments.pop('parent', None)
-        arguments.pop('expand', None) # possibly inherited from the getter
+        arguments.pop('expand', None)  # possibly inherited from the getter
         arguments.pop(setter_arg_name, None)
         return arguments
 
-    def handler(args):#pylint: disable=too-many-branches,too-many-statements
+    def handler(args):  # pylint: disable=too-many-branches,too-many-statements
         from msrestazure.azure_operation import AzureOperationPoller
 
         ordered_arguments = args.pop('ordered_arguments') if 'ordered_arguments' in args else []
@@ -259,7 +278,7 @@ def cli_generic_update_command(module_name, name, getter_op, setter_op, factory=
         setterargs = set_arguments_loader()
         for k in args.copy().keys():
             if k in get_arguments_loader() or k in setterargs \
-                or k in ('properties_to_add', 'properties_to_remove', 'properties_to_set'):
+                    or k in ('properties_to_add', 'properties_to_remove', 'properties_to_set'):
                 args.pop(k)
         for key, val in args.items():
             ordered_arguments.append((key, val))
@@ -310,7 +329,8 @@ def cli_generic_update_command(module_name, name, getter_op, setter_op, factory=
 
         return result
 
-    class OrderedArgsAction(argparse.Action): #pylint:disable=too-few-public-methods
+    class OrderedArgsAction(argparse.Action):  # pylint:disable=too-few-public-methods
+
         def __call__(self, parser, namespace, values, option_string=None):
             if not getattr(namespace, 'ordered_arguments', None):
                 setattr(namespace, 'ordered_arguments', [])
@@ -334,11 +354,14 @@ def cli_generic_update_command(module_name, name, getter_op, setter_op, factory=
     main_command_table[name] = cmd
     main_command_module_map[name] = module_name
 
+
 def cli_generic_wait_command(module_name, name, getter_op, factory=None):
 
     if not isinstance(getter_op, string_types):
         raise ValueError("Getter operation must be a string. Got '{}'".format(type(getter_op)))
-    get_arguments_loader = lambda: dict(extract_args_from_signature(get_op_handler(getter_op)))
+
+    def get_arguments_loader():
+        return dict(extract_args_from_signature(get_op_handler(getter_op)))
 
     def arguments_loader():
         arguments = {}
@@ -348,7 +371,7 @@ def cli_generic_wait_command(module_name, name, getter_op, factory=None):
     def get_provisioning_state(instance):
         provisioning_state = getattr(instance, 'provisioning_state', None)
         if not provisioning_state:
-            #some SDK, like resource-group, has 'provisioning_state' under 'properties'
+            # some SDK, like resource-group, has 'provisioning_state' under 'properties'
             properties = getattr(instance, 'properties', None)
             if properties:
                 provisioning_state = getattr(properties, 'provisioning_state', None)
@@ -376,7 +399,8 @@ def cli_generic_wait_command(module_name, name, getter_op, factory=None):
         custom_condition = args.pop('custom')
         if not any([wait_for_created, wait_for_updated, wait_for_deleted,
                     wait_for_exists, custom_condition]):
-            raise CLIError("incorrect usage: --created | --updated | --deleted | --exists | --custom JMESPATH")#pylint: disable=line-too-long
+            raise CLIError(
+                "incorrect usage: --created | --updated | --deleted | --exists | --custom JMESPATH")  # pylint: disable=line-too-long
 
         for _ in range(0, timeout, interval):
             try:
@@ -384,7 +408,7 @@ def cli_generic_wait_command(module_name, name, getter_op, factory=None):
                 if wait_for_exists:
                     return
                 provisioning_state = get_provisioning_state(instance)
-                #until we have any needs to wait for 'Failed', let us bail out on this
+                # until we have any needs to wait for 'Failed', let us bail out on this
                 if provisioning_state == 'Failed':
                     raise CLIError('The operation failed')
                 if wait_for_created or wait_for_updated:
@@ -426,6 +450,7 @@ def cli_generic_wait_command(module_name, name, getter_op, factory=None):
     main_command_table[name] = cmd
     main_command_module_map[name] = module_name
 
+
 def verify_property(instance, condition):
     from jmespath import compile as compile_jmespath
     result = todict(instance)
@@ -433,13 +458,16 @@ def verify_property(instance, condition):
     value = jmes_query.search(result)
     return value
 
+
 index_or_filter_regex = re.compile(r'\[(.*)\]')
+
+
 def set_properties(instance, expression):
     key, value = expression.rsplit('=', 1)
 
     try:
         value = json.loads(value)
-    except: #pylint:disable=bare-except
+    except:  # pylint:disable=bare-except
         pass
 
     # name should be the raw casing as it could refer to a property OR a dictionary key
@@ -472,6 +500,7 @@ def set_properties(instance, expression):
         raise CLIError('index {} doesn\'t exist on {}'.format(index_value, name))
     except (AttributeError, KeyError):
         show_options(instance, name, key.split('.'))
+
 
 def add_properties(instance, argument_values):
     # The first argument indicates the path to the collection to add to.
@@ -511,6 +540,7 @@ def add_properties(instance, argument_values):
     if dict_entry:
         list_to_add_to.append(dict_entry)
 
+
 def remove_properties(instance, argument_values):
     # The first argument indicates the path to the collection to add to.
     argument_values = argument_values if isinstance(argument_values, list) else [argument_values]
@@ -539,6 +569,7 @@ def remove_properties(instance, argument_values):
             raise CLIError('index {} doesn\'t exist on {}'
                            .format(list_index, list_attribute_path[-1]))
 
+
 def show_options(instance, part, path):
     options = instance.__dict__ if hasattr(instance, '__dict__') else instance
     parent = '.'.join(path[:-1]).replace('.[', '[')
@@ -554,13 +585,17 @@ def show_options(instance, part, path):
         error_message = "{} '{}' does not support further indexing.".format(error_message, parent)
     raise CLIError(error_message)
 
+
 snake_regex_1 = re.compile('(.)([A-Z][a-z]+)')
 snake_regex_2 = re.compile('([a-z0-9])([A-Z])')
+
+
 def make_snake_case(s):
     if isinstance(s, str):
         s1 = re.sub(snake_regex_1, r'\1_\2', s)
         return re.sub(snake_regex_2, r'\1_\2', s1).lower()
     return s
+
 
 def make_camel_case(s):
     if isinstance(s, str):
@@ -568,7 +603,10 @@ def make_camel_case(s):
         return parts[0].lower() + ''.join(p.capitalize() for p in parts[1:])
     return s
 
+
 internal_path_regex = re.compile(r'(\[.*?\])|([^.]+)')
+
+
 def _get_internal_path(path):
     # to handle indexing in the same way as other dot qualifiers,
     # we split paths like foo[0][1] into foo.[0].[1]
@@ -581,12 +619,14 @@ def _get_internal_path(path):
         final_paths.append(segment)
     return final_paths
 
+
 def _get_name_path(path):
     pathlist = _get_internal_path(path)
     return pathlist.pop(), pathlist
 
+
 def _update_instance(instance, part, path):
-    try: # pylint: disable=too-many-nested-blocks
+    try:  # pylint: disable=too-many-nested-blocks
         index = index_or_filter_regex.match(part)
         if index:
             # indexing on anything but a list is not allowed
@@ -627,8 +667,8 @@ def _update_instance(instance, part, path):
         show_options(instance, part, path)
     return instance
 
+
 def _find_property(instance, path):
     for part in path:
         instance = _update_instance(instance, part, path)
     return instance
-

--- a/src/azure-cli-core/azure/cli/core/commands/client_factory.py
+++ b/src/azure-cli-core/azure/cli/core/commands/client_factory.py
@@ -14,13 +14,16 @@ logger = _logging.get_az_logger(__name__)
 
 UA_AGENT = "AZURECLI/{}".format(core_version)
 
+
 def get_mgmt_service_client(client_type, subscription_id=None, api_version=None):
     client, _ = _get_mgmt_service_client(client_type, subscription_id=subscription_id,
                                          api_version=api_version)
     return client
 
+
 def get_subscription_service_client(client_type):
     return _get_mgmt_service_client(client_type, False)
+
 
 def configure_common_settings(client):
     client = _debug.allow_debug_connection(client)
@@ -31,13 +34,14 @@ def configure_common_settings(client):
         # We are working with the autorest team to expose the add_header
         # functionality of the generated client to avoid having to access
         # private members
-        client._client.add_header(header, value) #pylint: disable=protected-access
+        client._client.add_header(header, value)  # pylint: disable=protected-access
 
     command_name_suffix = ';completer-request' if APPLICATION.session['completer_active'] else ''
-    client._client.add_header('CommandName', #pylint: disable=protected-access
+    client._client.add_header('CommandName',  # pylint: disable=protected-access
                               "{}{}".format(APPLICATION.session['command'], command_name_suffix))
     client.config.generate_client_request_id = \
         'x-ms-client-request-id' not in APPLICATION.session['headers']
+
 
 def _get_mgmt_service_client(client_type, subscription_bound=True, subscription_id=None,
                              api_version=None):
@@ -56,7 +60,8 @@ def _get_mgmt_service_client(client_type, subscription_bound=True, subscription_
 
     return (client, subscription_id)
 
-def get_data_service_client(service_type, account_name, account_key, connection_string=None, #pylint: disable=too-many-arguments
+
+def get_data_service_client(service_type, account_name, account_key, connection_string=None,  # pylint: disable=too-many-arguments
                             sas_token=None, endpoint_suffix=None):
     logger.info('Getting data service client service_type=%s', service_type.__name__)
     try:
@@ -73,10 +78,12 @@ def get_data_service_client(service_type, account_name, account_key, connection_
     client.request_callback = _add_headers
     return client
 
+
 def get_subscription_id():
     profile = Profile()
     _, subscription_id, _ = profile.get_login_credentials()
     return subscription_id
+
 
 def _add_headers(request):
     request.headers['User-Agent'] = ' '.join((request.headers['User-Agent'], UA_AGENT))

--- a/src/azure-cli-core/azure/cli/core/commands/parameters.py
+++ b/src/azure-cli-core/azure/cli/core/commands/parameters.py
@@ -12,21 +12,26 @@ from azure.cli.core.commands.validators import validate_tag, validate_tags
 from azure.cli.core._util import CLIError
 from azure.cli.core.commands.validators import generate_deployment_name
 
+
 def get_subscription_locations():
     from azure.cli.core.commands.client_factory import get_subscription_service_client
     from azure.mgmt.resource.subscriptions import SubscriptionClient
     subscription_client, subscription_id = get_subscription_service_client(SubscriptionClient)
     return list(subscription_client.subscriptions.list_locations(subscription_id))
 
-def get_location_completion_list(prefix, **kwargs):#pylint: disable=unused-argument
+
+def get_location_completion_list(prefix, **kwargs):  # pylint: disable=unused-argument
     result = get_subscription_locations()
     return [l.name for l in result]
+
 
 def location_name_type(name):
     if ' ' in name:
         # if display name is provided, attempt to convert to short form name
-        name = next((l.name for l in get_subscription_locations() if l.display_name.lower() == name.lower()), name)
+        name = next((l.name for l in get_subscription_locations()
+                     if l.display_name.lower() == name.lower()), name)
     return name
+
 
 def get_one_of_subscription_locations():
     result = get_subscription_locations()
@@ -35,15 +40,18 @@ def get_one_of_subscription_locations():
     else:
         raise CLIError('Current subscription does not have valid location list')
 
+
 def get_resource_groups():
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
     from azure.mgmt.resource.resources import ResourceManagementClient
     rcf = get_mgmt_service_client(ResourceManagementClient)
     return list(rcf.resource_groups.list())
 
-def get_resource_group_completion_list(prefix, **kwargs):#pylint: disable=unused-argument
+
+def get_resource_group_completion_list(prefix, **kwargs):  # pylint: disable=unused-argument
     result = get_resource_groups()
     return [l.name for l in result]
+
 
 def get_resources_in_resource_group(resource_group_name, resource_type=None):
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
@@ -52,6 +60,7 @@ def get_resources_in_resource_group(resource_group_name, resource_type=None):
     filter_str = "resourceType eq '{}'".format(resource_type) if resource_type else None
     return list(rcf.resource_groups.list_resources(resource_group_name, filter=filter_str))
 
+
 def get_resources_in_subscription(resource_type=None):
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
     from azure.mgmt.resource.resources import ResourceManagementClient
@@ -59,8 +68,9 @@ def get_resources_in_subscription(resource_type=None):
     filter_str = "resourceType eq '{}'".format(resource_type) if resource_type else None
     return list(rcf.resources.list(filter=filter_str))
 
+
 def get_resource_name_completion_list(resource_type=None):
-    def completer(prefix, action, parsed_args, **kwargs):#pylint: disable=unused-argument
+    def completer(prefix, action, parsed_args, **kwargs):  # pylint: disable=unused-argument
         if getattr(parsed_args, 'resource_group_name', None):
             rg = parsed_args.resource_group_name
             return [r.name for r in get_resources_in_resource_group(rg, resource_type=resource_type)]
@@ -68,14 +78,18 @@ def get_resource_name_completion_list(resource_type=None):
             return [r.name for r in get_resources_in_subscription(resource_type=resource_type)]
     return completer
 
+
 def get_generic_completion_list(generic_list):
-    def completer(prefix, action, parsed_args, **kwargs): # pylint: disable=unused-argument
+    def completer(prefix, action, parsed_args, **kwargs):  # pylint: disable=unused-argument
         return generic_list
     return completer
 
-class CaseInsenstiveList(list): # pylint: disable=too-few-public-methods
+
+class CaseInsenstiveList(list):  # pylint: disable=too-few-public-methods
+
     def __contains__(self, other):
         return next((True for x in self if other.lower() == x.lower()), False)
+
 
 def enum_choice_list(data):
     """ Creates the argparse choices and type kwargs for a supplied enum type or list of strings. """
@@ -84,6 +98,7 @@ def enum_choice_list(data):
         choices = [x.value for x in data]
     except AttributeError:
         choices = data
+
     def _type(value):
         return next((x for x in choices if x.lower() == value.lower()), value) if value else value
     params = {
@@ -92,12 +107,15 @@ def enum_choice_list(data):
     }
     return params
 
-class IgnoreAction(argparse.Action): # pylint: disable=too-few-public-methods
+
+class IgnoreAction(argparse.Action):  # pylint: disable=too-few-public-methods
+
     def __call__(self, parser, namespace, values, option_string=None):
         raise argparse.ArgumentError(None, 'unrecognized argument: {} {}'.format(
             option_string, values or ''))
 
-# GLOBAL ARGUMENT DEFINTIONS
+
+# GLOBAL ARGUMENT DEFINITIONS
 
 ignore_type = CliArgumentType(
     help=argparse.SUPPRESS,

--- a/src/azure-cli-core/azure/cli/core/commands/template_create.py
+++ b/src/azure-cli-core/azure/cli/core/commands/template_create.py
@@ -17,7 +17,8 @@ from azure.cli.core.commands.arm import (
     resource_exists,
     make_camel_case)
 
-def register_folded_cli_argument(scope, base_name, resource_type, parent_name=None, # pylint: disable=too-many-arguments
+
+def register_folded_cli_argument(scope, base_name, resource_type, parent_name=None,  # pylint: disable=too-many-arguments
                                  parent_option_flag=None, parent_type=None, type_field=None,
                                  existing_id_flag_value='existingId', new_flag_value='new',
                                  none_flag_value='none', default_value_flag='new',
@@ -62,7 +63,8 @@ def register_folded_cli_argument(scope, base_name, resource_type, parent_name=No
     register_cli_argument(scope, base_name, validator=validator, help=help_text, **kwargs)
     register_cli_argument(scope, type_field_name, help=argparse.SUPPRESS, default=None)
 
-def _name_id_fold(base_name, resource_type, type_field, #pylint: disable=too-many-arguments
+
+def _name_id_fold(base_name, resource_type, type_field,  # pylint: disable=too-many-arguments
                   existing_id_flag_value, new_flag_value, none_flag_value,
                   parent_name=None, parent_option_flag=None, parent_type=None, base_required=True):
     def handle_folding(namespace):
@@ -125,6 +127,8 @@ def _name_id_fold(base_name, resource_type, type_field, #pylint: disable=too-man
 # NEW STYLE
 
 # pylint: disable=line-too-long
+
+
 def get_folded_parameter_help_string(
         display_name, allow_none=False, allow_new=False, default_none=False,
         other_required_option=None):
@@ -139,18 +143,22 @@ def get_folded_parameter_help_string(
     elif not allow_new and allow_none and not default_none:
         help_text = 'Name or ID of an existing {}, or {} for none.'.format(display_name, quotes)
     elif allow_new and not allow_none and not default_none:
-        help_text = 'Name or ID of the {}. Will create resource if it does not exist.'.format(display_name)
+        help_text = 'Name or ID of the {}. Will create resource if it does not exist.'.format(
+            display_name)
     elif allow_new and allow_none and not default_none:
-        help_text = 'Name or ID of the {}, or {} for none. Uses existing resource if available or will create a new resource with defaults if omitted.'.format(display_name, quotes)
+        help_text = 'Name or ID of the {}, or {} for none. Uses existing resource if available or will create a new resource with defaults if omitted.'.format(
+            display_name, quotes)
     elif not allow_new and allow_none and default_none:
         help_text = 'Name or ID of an existing {}, or none by default.'.format(display_name)
     elif allow_new and allow_none and default_none:
-        help_text = 'Name or ID of a {}. Uses existing resource or creates new if specified, or none if omitted.'.format(display_name)
+        help_text = 'Name or ID of a {}. Uses existing resource or creates new if specified, or none if omitted.'.format(
+            display_name)
 
     # add parent name option string (if applicable)
     if other_required_option:
         help_text = '{} If name specified, also specify {}'.format(help_text, other_required_option)
     return help_text
+
 
 def _validate_name_or_id(
         resource_group_name, property_value, property_type, parent_value, parent_type):
@@ -179,7 +187,8 @@ def _validate_name_or_id(
         value_supplied_was_id = False
     return (resource_id_parts, value_supplied_was_id)
 
-def get_folded_parameter_validator( # pylint: disable=too-many-arguments
+
+def get_folded_parameter_validator(  # pylint: disable=too-many-arguments
         property_name, property_type, property_option,
         parent_name=None, parent_type=None, parent_option=None,
         allow_none=False, allow_new=False, default_none=False):
@@ -210,7 +219,7 @@ def get_folded_parameter_validator( # pylint: disable=too-many-arguments
                 logger = _logging.get_az_logger(__name__)
                 logger.warning('Ignoring: %s %s', parent_option, parent_val)
                 setattr(namespace, parent_name, None)
-            return # SUCCESS
+            return  # SUCCESS
 
         # Create a resource ID we can check for existence.
         (resource_id_parts, value_was_id) = _validate_name_or_id(
@@ -225,7 +234,7 @@ def get_folded_parameter_validator( # pylint: disable=too-many-arguments
                     logger = _logging.get_az_logger(__name__)
                     logger.warning('Ignoring: %s %s', parent_option, parent_val)
                 setattr(namespace, parent_name, None)
-            return # SUCCESS
+            return  # SUCCESS
 
         # if a parent name was required but not specified, raise a usage error
         if has_parent and not value_was_id and not parent_val and not allow_new:

--- a/src/azure-cli-core/azure/cli/core/commands/validators.py
+++ b/src/azure-cli-core/azure/cli/core/commands/validators.py
@@ -7,6 +7,7 @@ import argparse
 import time
 import random
 
+
 def validate_tags(ns):
     ''' Extracts multiple space-separated tags in key[=value] format '''
     if isinstance(ns.tags, list):
@@ -14,6 +15,7 @@ def validate_tags(ns):
         for item in ns.tags:
             tags_dict.update(validate_tag(item))
         ns.tags = tags_dict
+
 
 def validate_tag(string):
     ''' Extracts a single tag in key[=value] format '''
@@ -23,6 +25,7 @@ def validate_tag(string):
         result = {comps[0]: comps[1]} if len(comps) > 1 else {string: ''}
     return result
 
+
 def validate_key_value_pairs(string):
     ''' Validates key-value pairs in the following format: a=b;c=d '''
     result = None
@@ -31,14 +34,19 @@ def validate_key_value_pairs(string):
         result = dict(x.split('=', 1) for x in kv_list)
     return result
 
+
 def generate_deployment_name(namespace):
     if not namespace.deployment_name:
         namespace.deployment_name = \
             'azurecli{}{}'.format(str(time.time()), str(random.randint(1, 100000)))
 
+
 SPECIFIED_SENTINEL = '__SET__'
-class MarkSpecifiedAction(argparse.Action): # pylint: disable=too-few-public-methods
+
+
+class MarkSpecifiedAction(argparse.Action):  # pylint: disable=too-few-public-methods
     """ Use this to identify when a parameter is explicitly set by the user (as opposed to a
     default). You must remove the __SET__ sentinel substring in a follow-up validator."""
+
     def __call__(self, parser, args, values, option_string=None):
         setattr(args, self.dest, '{}{}'.format(SPECIFIED_SENTINEL, values))

--- a/src/azure-cli-core/azure/cli/core/context.py
+++ b/src/azure-cli-core/azure/cli/core/context.py
@@ -8,36 +8,59 @@ from six.moves import configparser
 
 from azure.cli.core._config import (CONTEXT_CONFIG_DIR, GLOBAL_CONFIG_DIR)
 
+
 class ContextNotFoundException(Exception):
+
     def __init__(self, context_name):
         super(ContextNotFoundException, self).__init__(context_name)
         self.context_name = context_name
+
     def __str__(self):
         return "The context '{}' does not exist.".format(self.context_name)
 
+
 class ContextExistsException(Exception):
+
     def __init__(self, context_name):
         super(ContextExistsException, self).__init__(context_name)
         self.context_name = context_name
+
     def __str__(self):
         return "The context '{}' already exists.".format(self.context_name)
 
+
 class CannotDeleteActiveContextException(Exception):
+
     def __str__(self):
         return "You cannot delete the current active context"
 
+
 class CannotDeleteDefaultContextException(Exception):
+
     def __str__(self):
         return "You cannot delete the default context."
+
 
 ACTIVE_CONTEXT_FILE = os.path.join(GLOBAL_CONFIG_DIR, 'active_context')
 ACTIVE_CONTEXT_ENV_VAR_NAME = 'AZURE_CONTEXT'
 DEFAULT_CONTEXT_NAME = 'default'
 
-get_active_context = lambda: get_context(get_active_context_name())
-context_exists = lambda n: any([x for x in get_context_names() if x == n])
-get_context_file_path = lambda n: os.path.join(CONTEXT_CONFIG_DIR, n)
-get_contexts = lambda: [get_context(context_name) for context_name in get_context_names()]
+
+def get_active_context():
+    return get_context(get_active_context_name())
+
+
+def context_exists(n):
+    return any([x for x in get_context_names() if x == n])
+
+
+def get_context_file_path(n):
+    return os.path.join(CONTEXT_CONFIG_DIR, n)
+
+
+def get_contexts():
+    return [get_context(context_name) for context_name in get_context_names()]
+
 
 def _set_active_subscription(context):
     ''' Set the active subscription used by Profile '''
@@ -59,6 +82,7 @@ def _set_active_subscription(context):
     if subscription_to_use:
         profile.set_active_subscription(subscription_to_use)
 
+
 def get_active_context_name():
     active_context_env_var = os.environ.get(ACTIVE_CONTEXT_ENV_VAR_NAME, None)
     if active_context_env_var:
@@ -69,6 +93,7 @@ def get_active_context_name():
     except (OSError, IOError):
         return DEFAULT_CONTEXT_NAME
 
+
 def set_active_context(context_name, skip_set_active_subsciption=False):
     if not context_exists(context_name):
         raise ContextNotFoundException(context_name)
@@ -77,10 +102,11 @@ def set_active_context(context_name, skip_set_active_subsciption=False):
     if not skip_set_active_subsciption:
         _set_active_subscription(get_active_context())
 
+
 def get_context_names():
     if os.path.isdir(CONTEXT_CONFIG_DIR):
-        contexts = [f for f in os.listdir(CONTEXT_CONFIG_DIR) \
-               if os.path.isfile(os.path.join(CONTEXT_CONFIG_DIR, f))]
+        contexts = [f for f in os.listdir(CONTEXT_CONFIG_DIR)
+                    if os.path.isfile(os.path.join(CONTEXT_CONFIG_DIR, f))]
         if contexts:
             return contexts
     # No contexts yet. Let's create the default one now.
@@ -90,6 +116,7 @@ def get_context_names():
     create_context(DEFAULT_CONTEXT_NAME, AZURE_PUBLIC_CLOUD.name, skip_exists_check=True)
     set_active_context(DEFAULT_CONTEXT_NAME, skip_set_active_subsciption=True)
     return [DEFAULT_CONTEXT_NAME]
+
 
 def get_context(context_name):
     if not context_exists(context_name):
@@ -108,6 +135,7 @@ def get_context(context_name):
         pass
     return context
 
+
 def delete_context(context_name):
     if not context_exists(context_name):
         raise ContextNotFoundException(context_name)
@@ -116,6 +144,7 @@ def delete_context(context_name):
     if context_name == get_active_context_name():
         raise CannotDeleteActiveContextException()
     os.remove(get_context_file_path(context_name))
+
 
 def create_context(context_name, cloud_name, skip_exists_check=False):
     from azure.cli.core.cloud import get_cloud
@@ -134,6 +163,7 @@ def create_context(context_name, cloud_name, skip_exists_check=False):
         os.makedirs(CONTEXT_CONFIG_DIR)
     with open(context_file_path, 'w') as configfile:
         context_config.write(configfile)
+
 
 def modify_context(context_name, cloud_name=None, default_subscription=None):
     from azure.cli.core.cloud import get_cloud

--- a/src/azure-cli-core/azure/cli/core/extensions/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/extensions/__init__.py
@@ -6,6 +6,7 @@
 from azure.cli.core.extensions.query import register as register_query
 from azure.cli.core.extensions.transform import register as register_transform
 
+
 def register_extensions(application):
     register_query(application)
     register_transform(application)

--- a/src/azure-cli-core/azure/cli/core/extensions/experimental.py
+++ b/src/azure-cli-core/azure/cli/core/extensions/experimental.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+
 def register(event_dispatcher):
     def _enable_experimental_handlers(_, event_data):
         """The user can opt in to experimental event handlers by
@@ -36,7 +37,7 @@ def register(event_dispatcher):
             except TypeError:
                 pass
 
-    def generate_skeleton(_, event_data): #pylint: disable=unused-variable
+    def generate_skeleton(_, event_data):  # pylint: disable=unused-variable
         try:
             def switcheroo(_, event_data):
                 """We replace the handler for the command
@@ -59,9 +60,9 @@ def register(event_dispatcher):
         try:
             args = event_data['args']
             skeleton_index = args.index('--use-skeleton')
-            skeleton_value = args[skeleton_index + 1] # pylint: disable=unused-variable
+            skeleton_value = args[skeleton_index + 1]  # pylint: disable=unused-variable
 
-            def overlay_arguments(_, event_data): # pylint: disable=unused-argument
+            def overlay_arguments(_, event_data):  # pylint: disable=unused-argument
                 # TODO: overlay the arguments with the data in the skeleton file
                 # passed to us...
                 pass

--- a/src/azure-cli-core/azure/cli/core/extensions/query.py
+++ b/src/azure-cli-core/azure/cli/core/extensions/query.py
@@ -5,6 +5,7 @@
 
 import collections
 
+
 def jmespath_type(raw_query):
     '''Compile the query with JMESPath and return the compiled result.
        JMESPath raises exceptions which subclass from ValueError.
@@ -18,20 +19,22 @@ def jmespath_type(raw_query):
         # Raise a ValueError which argparse can handle
         raise ValueError
 
+
 def _register_global_parameter(global_group):
     # Argparse uses __name__ of the function used for 'type' when generating error message.
     # We set __name__ for our function here.
     jmespath_type.__name__ = 'query'
     # Let the program know that we are adding a parameter --query
     global_group.add_argument('--query', dest='_jmespath_query', metavar='JMESPATH',
-                              help='JMESPath query string. See http://jmespath.org/ for more'\
+                              help='JMESPath query string. See http://jmespath.org/ for more'
                                    ' information and examples.',
                               type=jmespath_type)
+
 
 def register(application):
     def handle_query_parameter(**kwargs):
         args = kwargs['args']
-        query_expression = args._jmespath_query # pylint: disable=protected-access
+        query_expression = args._jmespath_query  # pylint: disable=protected-access
         del args._jmespath_query
         if query_expression:
             def filter_output(**kwargs):
@@ -44,4 +47,3 @@ def register(application):
 
     application.register(application.GLOBAL_PARSER_CREATED, _register_global_parameter)
     application.register(application.COMMAND_PARSER_PARSED, handle_query_parameter)
-

--- a/src/azure-cli-core/azure/cli/core/extensions/transform.py
+++ b/src/azure-cli-core/azure/cli/core/extensions/transform.py
@@ -5,8 +5,10 @@
 
 import re
 
+
 def register(application):
     application.register(application.TRANSFORM_RESULT, _resource_group_transform)
+
 
 def _parse_id(strid):
     parsed = {}
@@ -17,6 +19,7 @@ def _parse_id(strid):
     parsed['resource-group'] = parts[4]
     parsed['name'] = parts[8]
     return parsed
+
 
 def _add_resource_group(obj):
     if isinstance(obj, list):
@@ -32,6 +35,6 @@ def _add_resource_group(obj):
         for item_key in obj:
             _add_resource_group(obj[item_key])
 
+
 def _resource_group_transform(**kwargs):
     _add_resource_group(kwargs['event_data']['result'])
-

--- a/src/azure-cli-core/azure/cli/core/help_files.py
+++ b/src/azure-cli-core/azure/cli/core/help_files.py
@@ -7,6 +7,7 @@
 # modules should add entries to helps in the form: "group command": "YAML help"
 helps = {}
 
+
 def _load_help_file(delimiters):
     import yaml
     if delimiters in helps:

--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -11,32 +11,41 @@ import azure.cli.core._help as _help
 from azure.cli.core._util import CLIError
 from azure.cli.core._pkg_util import handle_module_not_installed
 
+
 class IncorrectUsageError(CLIError):
     '''Raised when a command is incorrectly used and the usage should be
     displayed to the user.
     '''
     pass
 
-class CaseInsensitiveChoicesCompleter(argcomplete.completers.ChoicesCompleter): #pylint: disable=too-few-public-methods
+
+class CaseInsensitiveChoicesCompleter(argcomplete.completers.ChoicesCompleter):  # pylint: disable=too-few-public-methods
+
     def __call__(self, prefix, **kwargs):
         return (c for c in self.choices if c.lower().startswith(prefix.lower()))
+
 
 # Override the choices completer with one that is case insensitive
 argcomplete.completers.ChoicesCompleter = CaseInsensitiveChoicesCompleter
 
+
 class EmptyDefaultCompletionFinder(argcomplete.CompletionFinder):
+
     def __init__(self, *args, **kwargs):
         super(EmptyDefaultCompletionFinder, self).__init__(*args, default_completer=lambda _: (),
                                                            **kwargs)
+
 
 def enable_autocomplete(parser):
     argcomplete.autocomplete = EmptyDefaultCompletionFinder()
     argcomplete.autocomplete(parser, validator=lambda c, p: c.lower().startswith(p.lower()))
 
+
 class AzCliCommandParser(argparse.ArgumentParser):
     """ArgumentParser implementation specialized for the
     Azure CLI utility.
     """
+
     def __init__(self, **kwargs):
         self.subparsers = {}
         self.parents = kwargs.get('parents', [])
@@ -121,7 +130,7 @@ class AzCliCommandParser(argparse.ArgumentParser):
                 self.subparsers[tuple(path[0:length])] = parent_subparser
         return parent_subparser
 
-    def _handle_command_package_error(self, err_msg): #pylint: disable=no-self-use
+    def _handle_command_package_error(self, err_msg):  # pylint: disable=no-self-use
         if err_msg and err_msg.startswith('argument _command_package: invalid choice:'):
             import re
             try:

--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -3,17 +3,17 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import getpass
 import datetime
-import subprocess
-import json
-import os
-import sys
-import platform
-import locale
+import getpass
 import hashlib
-import traceback
+import json
+import locale
+import os
+import platform
 import re
+import subprocess
+import sys
+import traceback
 from functools import wraps
 
 __all__ = ['set_application', 'log_telemetry', 'flush_telemetry']
@@ -356,6 +356,7 @@ if _user_agrees_to_telemetry():
     telemetry_service = _TelemetryService()
 else:
     telemetry_service = None
+
 
 if __name__ == '__main__':
     if _user_agrees_to_telemetry():

--- a/src/azure-cli-core/azure/cli/core/tests/test_add_resourcegroup_transform.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_add_resourcegroup_transform.py
@@ -7,6 +7,7 @@ import unittest
 from six import StringIO
 from azure.cli.core.extensions.transform import _parse_id, _add_resource_group
 
+
 class TestResourceGroupTransform(unittest.TestCase):
 
     @classmethod
@@ -23,17 +24,17 @@ class TestResourceGroupTransform(unittest.TestCase):
     def tearDown(self):
         self.io.close()
 
-    CORRECT_ID = "/subscriptions/00000000-0000-0000-0000-0000000000000/resourceGroups/REsourceGROUPname/providers/Microsoft.Compute/virtualMachines/vMName" # pylint: disable=line-too-long
-    NON_RG_ID = "/subscriptions/00000000-0000-0000-0000-0000000000000/somethingElse/REsourceGROUPname/providers/Microsoft.Compute/virtualMachines/vMName" # pylint: disable=line-too-long
+    CORRECT_ID = "/subscriptions/00000000-0000-0000-0000-0000000000000/resourceGroups/REsourceGROUPname/providers/Microsoft.Compute/virtualMachines/vMName"  # pylint: disable=line-too-long
+    NON_RG_ID = "/subscriptions/00000000-0000-0000-0000-0000000000000/somethingElse/REsourceGROUPname/providers/Microsoft.Compute/virtualMachines/vMName"  # pylint: disable=line-too-long
     BOGUS_ID = "|completely-bogus-id|"
-    DICT_ID = {'value': "/subscriptions/00000000-0000-0000-0000-0000000000000/resourceGroups/REsourceGROUPname/providers/Microsoft.Compute/virtualMachines/vMName"} # pylint: disable=line-too-long
+    DICT_ID = {'value': "/subscriptions/00000000-0000-0000-0000-0000000000000/resourceGroups/REsourceGROUPname/providers/Microsoft.Compute/virtualMachines/vMName"}  # pylint: disable=line-too-long
 
     def test_split_correct_id(self):
         result = _parse_id(TestResourceGroupTransform.CORRECT_ID)
         self.assertDictEqual(result, {
             'resource-group': 'REsourceGROUPname',
             'name': 'vMName'
-            })
+        })
 
     def test_split_non_resourcegroup_id(self):
         with self.assertRaises(KeyError):
@@ -51,37 +52,37 @@ class TestResourceGroupTransform(unittest.TestCase):
         instance = {
             'id': TestResourceGroupTransform.CORRECT_ID,
             'name': 'A name'
-            }
+        }
         _add_resource_group(instance)
         self.assertDictEqual(instance, {
             'id': TestResourceGroupTransform.CORRECT_ID,
             'resourceGroup': 'REsourceGROUPname',
             'name': 'A name'
-            })
+        })
 
     def test_dont_add_invalid_resourcegroup_id(self):
         instance = {
             'id': TestResourceGroupTransform.BOGUS_ID,
             'name': 'A name'
-            }
+        }
         _add_resource_group(instance)
         self.assertDictEqual(instance, {
             'id': TestResourceGroupTransform.BOGUS_ID,
             'name': 'A name'
-            })
+        })
 
     def test_dont_stomp_on_existing_resourcegroup_id(self):
         instance = {
             'id': TestResourceGroupTransform.CORRECT_ID,
             'resourceGroup': 'SomethingElse',
             'name': 'A name'
-            }
+        }
         _add_resource_group(instance)
         self.assertDictEqual(instance, {
             'id': TestResourceGroupTransform.CORRECT_ID,
             'resourceGroup': 'SomethingElse',
             'name': 'A name'
-            })
+        })
 
 
 if __name__ == '__main__':

--- a/src/azure-cli-core/azure/cli/core/tests/test_application.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_application.py
@@ -14,6 +14,7 @@ from azure.cli.core.application import Application, Configuration, IterateAction
 from azure.cli.core.commands import CliCommand
 from azure.cli.core._util import CLIError
 
+
 class TestApplication(unittest.TestCase):
 
     @classmethod
@@ -36,7 +37,7 @@ class TestApplication(unittest.TestCase):
         def handler(**kwargs):
             kwargs['args'][0] = True
 
-        def other_handler(**kwargs): # pylint: disable=unused-variable
+        def other_handler(**kwargs):  # pylint: disable=unused-variable
             self.assertEqual(kwargs['args'], 'secret sauce')
 
         config = Configuration([])
@@ -58,8 +59,6 @@ class TestApplication(unittest.TestCase):
         self.assertTrue(handler_called[0], "Handler didn't get called")
 
         app.raise_event('other_handler_called', args='secret sauce')
-
-
 
     def test_list_value_parameter(self):
         hellos = []
@@ -104,12 +103,13 @@ class TestApplication(unittest.TestCase):
 
         for test_case in cases:
             try:
-                args = Application._expand_file_prefixed_files(test_case[0]) #pylint: disable=protected-access
+                args = Application._expand_file_prefixed_files(test_case[0])  # pylint: disable=protected-access
                 self.assertEqual(args, test_case[1], 'Failed for: {}'.format(test_case[0]))
             except CLIError as ex:
                 self.fail('Unexpected error for {} ({}): {}'.format(test_case[0], args, ex))
 
         os.remove(f.name)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/azure-cli-core/azure/cli/core/tests/test_cloud.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_cloud.py
@@ -7,8 +7,6 @@ import tempfile
 import unittest
 import mock
 
-#pylint: disable=line-too-long
-
 from azure.cli.core.cloud import (Cloud,
                                   CloudEndpoints,
                                   CloudSuffixes,
@@ -17,6 +15,7 @@ from azure.cli.core.cloud import (Cloud,
                                   remove_cloud,
                                   CloudEndpointNotSetException)
 from azure.cli.core._profile import Profile
+
 
 class TestCloud(unittest.TestCase):
 
@@ -31,8 +30,11 @@ class TestCloud(unittest.TestCase):
         endpoints = CloudEndpoints(management='http://management.contoso.com')
         suffixes = CloudSuffixes(storage_endpoint='core.contoso.com')
         c = Cloud('MyOwnCloud', endpoints=endpoints, suffixes=suffixes)
-        expected_config_file_result = "[MyOwnCloud]\nendpoint_management = http://management.contoso.com\nsuffix_storage_endpoint = core.contoso.com\n\n"
-        with mock.patch('azure.cli.core.cloud.CUSTOM_CLOUD_CONFIG_FILE', tempfile.mkstemp()[1]) as config_file:
+        expected_config_file_result = '[MyOwnCloud]\nendpoint_management = ' \
+                                      'http://management.contoso.com\nsuffix_storage_endpoint = ' \
+                                      'core.contoso.com\n\n'
+        with mock.patch('azure.cli.core.cloud.CUSTOM_CLOUD_CONFIG_FILE', tempfile.mkstemp()[1]) as\
+                config_file:
             with mock.patch('azure.cli.core.cloud.get_custom_clouds', lambda: []):
                 add_cloud(c)
                 with open(config_file, 'r') as cf:
@@ -41,11 +43,13 @@ class TestCloud(unittest.TestCase):
             self.assertEqual(len(custom_clouds), 1)
             self.assertEqual(custom_clouds[0].name, c.name)
             self.assertEqual(custom_clouds[0].endpoints.management, c.endpoints.management)
-            self.assertEqual(custom_clouds[0].suffixes.storage_endpoint, c.suffixes.storage_endpoint)
+            self.assertEqual(custom_clouds[0].suffixes.storage_endpoint,
+                             c.suffixes.storage_endpoint)
             with mock.patch('azure.cli.core.cloud._get_cloud', lambda _: c):
                 remove_cloud(c.name)
             custom_clouds = get_custom_clouds()
             self.assertEqual(len(custom_clouds), 0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/azure-cli-core/azure/cli/core/tests/test_command_registration.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_command_registration.py
@@ -16,7 +16,9 @@ from azure.cli.core.commands import (
     register_cli_argument,
     register_extra_cli_argument)
 
+
 class Test_command_registration(unittest.TestCase):
+
     @classmethod
     def setUpClass(cls):
         # Ensure initialization has occurred correctly
@@ -28,7 +30,7 @@ class Test_command_registration(unittest.TestCase):
         logging.shutdown()
 
     @staticmethod
-    def sample_vm_get(resource_group_name, vm_name, opt_param=None, expand=None, custom_headers={}, # pylint: disable=dangerous-default-value, too-many-arguments
+    def sample_vm_get(resource_group_name, vm_name, opt_param=None, expand=None, custom_headers={},  # pylint: disable=dangerous-default-value, too-many-arguments
                       raw=False, **operation_config):
         """
         The operation to get a virtual machine.
@@ -94,7 +96,7 @@ class Test_command_registration(unittest.TestCase):
                                        required=True,
                                        help='The name of the virtual machine.'),
             'opt_param': CliArgumentType(required=False,
-                                         help='Used to verify reflection correctly identifies optional params.'), # pylint: disable=line-too-long
+                                         help='Used to verify reflection correctly identifies optional params.'),  # pylint: disable=line-too-long
             'expand': CliArgumentType(required=False,
                                       help='The expand expression to apply on the operation.')
         }
@@ -173,7 +175,7 @@ class Test_command_registration(unittest.TestCase):
         command_table.clear()
 
     def test_command_build_argument_help_text(self):
-        def sample_sdk_method_with_weird_docstring(param_a, param_b, param_c): # pylint: disable=unused-argument
+        def sample_sdk_method_with_weird_docstring(param_a, param_b, param_c):  # pylint: disable=unused-argument
             """
             An operation with nothing good.
 
@@ -187,8 +189,10 @@ class Test_command_registration(unittest.TestCase):
             nothing2.
             """
         command_table.clear()
-        setattr(sys.modules[__name__], sample_sdk_method_with_weird_docstring.__name__, sample_sdk_method_with_weird_docstring) #pylint: disable=line-too-long
-        cli_command(None, 'test command foo', '{}#{}'.format(__name__, sample_sdk_method_with_weird_docstring.__name__), None) #pylint: disable=line-too-long
+        setattr(sys.modules[__name__], sample_sdk_method_with_weird_docstring.__name__,
+                sample_sdk_method_with_weird_docstring)  # pylint: disable=line-too-long
+        cli_command(None, 'test command foo', '{}#{}'.format(
+            __name__, sample_sdk_method_with_weird_docstring.__name__), None)  # pylint: disable=line-too-long
 
         command_table['test command foo'].load_arguments()
         _update_command_definitions(command_table)
@@ -229,7 +233,7 @@ class Test_command_registration(unittest.TestCase):
         self.assertIsNone(arg.settings['validator'])
 
     def test_override_using_register_cli_argument(self):
-        def sample_sdk_method(param_a): # pylint: disable=unused-argument
+        def sample_sdk_method(param_a):  # pylint: disable=unused-argument
             pass
 
         def test_validator_completer():
@@ -277,6 +281,7 @@ class Test_command_registration(unittest.TestCase):
                                      help=CliArgumentType.REMOVE)
         self.assertFalse('required' in cmd_arg.options)
         self.assertFalse('help' in cmd_arg.options)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/azure-cli-core/azure/cli/core/tests/test_config.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_config.py
@@ -9,6 +9,7 @@ import mock
 from six.moves import configparser
 from azure.cli.core._config import AzConfig
 
+
 class TestAzConfig(unittest.TestCase):
 
     def setUp(self):
@@ -116,6 +117,7 @@ class TestAzConfig(unittest.TestCase):
         self.az_config.config_parser.set(section, option, value)
         with self.assertRaises(ValueError):
             self.az_config.getboolean(section, option)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/azure-cli-core/azure/cli/core/tests/test_connection_verify.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_connection_verify.py
@@ -15,6 +15,7 @@ import azure.cli.core._debug as _debug
 
 
 class Test_argparse(unittest.TestCase):
+
     @classmethod
     def setUpClass(cls):
         # Ensure initialization has occurred correctly

--- a/src/azure-cli-core/azure/cli/core/tests/test_context.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_context.py
@@ -8,7 +8,7 @@ import os
 # Determine the correct patch target for open
 try:
     # python 3
-    import builtins #pylint: disable=unused-import
+    import builtins  # pylint: disable=unused-import
     OPEN_PATCH_TARGET = 'builtins.open'
 except ImportError:
     OPEN_PATCH_TARGET = '__builtin__.open'
@@ -17,11 +17,12 @@ import unittest
 import mock
 
 # Need to import config before we can import context
-import azure.cli.core._config #pylint: disable=unused-import
+import azure.cli.core._config  # pylint: disable=unused-import
 
 from azure.cli.core.context import (get_active_context_name,
                                     set_active_context,
                                     ContextNotFoundException)
+
 
 class TestContext(unittest.TestCase):
 
@@ -48,6 +49,7 @@ class TestContext(unittest.TestCase):
         # We haven't created the context yet so it doesn't exist
         with self.assertRaises(ContextNotFoundException):
             set_active_context(context_name, skip_set_active_subsciption=True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/azure-cli-core/azure/cli/core/tests/test_extensions_query.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_extensions_query.py
@@ -7,6 +7,7 @@ import unittest
 
 from azure.cli.core.extensions.query import jmespath_type
 
+
 class TestQuery(unittest.TestCase):
     '''Tests for the values that can be passed to the --query parameter.
     These tests ensure that we are handling invalid queries correctly and raising appropriate errors
@@ -14,12 +15,12 @@ class TestQuery(unittest.TestCase):
     (We are not testing JMESPath itself here.)
     '''
 
-    def test_query_valid_1(self): # pylint: disable=no-self-use
+    def test_query_valid_1(self):  # pylint: disable=no-self-use
         query = 'length(@)'
         # Should not raise any exception as it is valid
         jmespath_type(query)
 
-    def test_query_valid_2(self): # pylint: disable=no-self-use
+    def test_query_valid_2(self):  # pylint: disable=no-self-use
         query = "[?storageProfile.osDisk.osType=='Linux'].[resourceGroup,name]"
         # Should not raise any exception as it is valid
         jmespath_type(query)
@@ -53,6 +54,7 @@ class TestQuery(unittest.TestCase):
         query = "length([?contains('id', 'Publishers'])"
         with self.assertRaises(ValueError):
             jmespath_type(query)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/azure-cli-core/azure/cli/core/tests/test_generic_update.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_generic_update.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-#pylint:disable=unused-import,invalid-sequence-index,unsubscriptable-object,line-too-long,too-few-public-methods
+# pylint:disable=unused-import,invalid-sequence-index,unsubscriptable-object,line-too-long,too-few-public-methods
 
 import logging
 import unittest
@@ -14,21 +14,29 @@ from azure.cli.core.commands import CliArgumentType, register_cli_argument
 from azure.cli.core.commands.arm import cli_generic_update_command
 from azure.cli.core._util import CLIError
 
+
 class ListTestObject(object):
+
     def __init__(self, val):
         self.list_value = list(val)
 
+
 class DictTestObject(object):
+
     def __init__(self, val):
         self.dict_value = dict(val)
 
+
 class ObjectTestObject(object):
+
     def __init__(self, str_val, int_val, bool_val):
         self.my_string = str(str_val)
         self.my_int = int(int_val)
         self.my_bool = bool(bool_val)
 
+
 class TestObject(object):
+
     def __init__(self):
         self.my_prop = 'my_value'
         self.my_list = [
@@ -51,18 +59,20 @@ class TestObject(object):
             ObjectTestObject('1.2.3.4', 100, False),
         ]
 
+
 class GenericUpdateTest(unittest.TestCase):
+
     @classmethod
     def setUpClass(cls):
         logging.getLogger().setLevel(logging.ERROR)
 
-    def test_generic_update(self): # pylint: disable=too-many-statements
+    def test_generic_update(self):  # pylint: disable=too-many-statements
         my_obj = TestObject()
 
         def my_get():
             return my_obj
 
-        def my_set(**kwargs): #pylint:disable=unused-argument
+        def my_set(**kwargs):  # pylint:disable=unused-argument
             return my_obj
 
         config = Configuration([])
@@ -70,7 +80,8 @@ class GenericUpdateTest(unittest.TestCase):
 
         setattr(sys.modules[__name__], my_get.__name__, my_get)
         setattr(sys.modules[__name__], my_set.__name__, my_set)
-        cli_generic_update_command(None, 'update-obj', '{}#{}'.format(__name__, my_get.__name__), '{}#{}'.format(__name__, my_set.__name__))
+        cli_generic_update_command(None, 'update-obj', '{}#{}'.format(__name__,
+                                                                      my_get.__name__), '{}#{}'.format(__name__, my_set.__name__))
 
         # Test simplest ways of setting properties
         app.execute('update-obj --set myProp=newValue'.split())
@@ -86,20 +97,28 @@ class GenericUpdateTest(unittest.TestCase):
         self.assertEqual(my_obj.my_list[0], 'newValB', 'set simple list element')
 
         app.execute('update-obj --set myDict.myCamelKey=success'.split())
-        self.assertEqual(my_obj.my_dict['myCamelKey'], 'success', 'set simple dict element with camel case key')
+        self.assertEqual(my_obj.my_dict['myCamelKey'], 'success',
+                         'set simple dict element with camel case key')
 
         app.execute('update-obj --set myDict.my_snake_key=success'.split())
-        self.assertEqual(my_obj.my_dict['my_snake_key'], 'success', 'set simple dict element with snake case key')
+        self.assertEqual(my_obj.my_dict['my_snake_key'], 'success',
+                         'set simple dict element with snake case key')
 
         # Test the different ways of indexing into a list of objects or dictionaries by filter
         app.execute('update-obj --set myListOfCamelDicts[myKey=value_2].myKey=new_value'.split())
-        self.assertEqual(my_obj.my_list_of_camel_dicts[1]['myKey'], 'new_value', 'index into list of dictionaries by camel-case key')
+        self.assertEqual(my_obj.my_list_of_camel_dicts[1]['myKey'],
+                         'new_value',
+                         'index into list of dictionaries by camel-case key')
 
         app.execute('update-obj --set myListOfSnakeDicts[my_key=value2].my_key=new_value'.split())
-        self.assertEqual(my_obj.my_list_of_snake_dicts[1]['my_key'], 'new_value', 'index into list of dictionaries by snake-case key')
+        self.assertEqual(my_obj.my_list_of_snake_dicts[1]['my_key'],
+                         'new_value',
+                         'index into list of dictionaries by snake-case key')
 
         app.execute('update-obj --set myListOfObjects[myString=1.2.3.4].myString=new_value'.split())
-        self.assertEqual(my_obj.my_list_of_objects[1].my_string, 'new_value', 'index into list of objects by key')
+        self.assertEqual(my_obj.my_list_of_objects[1].my_string,
+                         'new_value',
+                         'index into list of objects by key')
 
         # Test setting on elements nested within lists
         app.execute('update-obj --set myList[1][1]=newValue'.split())
@@ -115,9 +134,12 @@ class GenericUpdateTest(unittest.TestCase):
         app.execute('update-obj --set myProp={} myProp.foo=bar'.split())
         self.assertEqual(my_obj.my_prop['foo'], 'bar', 'replace scalar with dict')
 
-        app.execute('update-obj --set myProp=[] --add myProp key1=value1 --set myProp[0].key2=value2'.split())
-        self.assertEqual(my_obj.my_prop[0]['key1'], 'value1', 'replace scalar with new list and add a dict entry')
-        self.assertEqual(my_obj.my_prop[0]['key2'], 'value2', 'add a second value to the new dict entry')
+        app.execute(
+            'update-obj --set myProp=[] --add myProp key1=value1 --set myProp[0].key2=value2'.split())
+        self.assertEqual(my_obj.my_prop[0]['key1'], 'value1',
+                         'replace scalar with new list and add a dict entry')
+        self.assertEqual(my_obj.my_prop[0]['key2'], 'value2',
+                         'add a second value to the new dict entry')
 
         app.execute('update-obj --remove myProp --add myProp str1 str2 --remove myProp 0'.split())
         self.assertEqual(len(my_obj.my_prop), 1, 'nullify property, add two and remove one')
@@ -125,14 +147,18 @@ class GenericUpdateTest(unittest.TestCase):
 
         # Test various --add to lists
         app.execute('update-obj --set myList=[]'.split())
-        app.execute(shlex.split('update-obj --add myList key1=value1 key2=value2 foo "string in quotes" [] {} foo=bar'))
+        app.execute(shlex.split(
+            'update-obj --add myList key1=value1 key2=value2 foo "string in quotes" [] {} foo=bar'))
         self.assertEqual(my_obj.my_list[0]['key1'], 'value1', 'add a value to a dictionary')
-        self.assertEqual(my_obj.my_list[0]['key2'], 'value2', 'add a second value to the dictionary')
+        self.assertEqual(my_obj.my_list[0]['key2'], 'value2',
+                         'add a second value to the dictionary')
         self.assertEqual(my_obj.my_list[1], 'foo', 'add scalar value to list')
-        self.assertEqual(my_obj.my_list[2], 'string in quotes', 'add scalar value with quotes to list')
+        self.assertEqual(my_obj.my_list[2], 'string in quotes',
+                         'add scalar value with quotes to list')
         self.assertEqual(my_obj.my_list[3], [], 'add list to a list')
         self.assertEqual(my_obj.my_list[4], {}, 'add dict to a list')
-        self.assertEqual(my_obj.my_list[-1]['foo'], 'bar', 'add second dict and verify when dict is at the end')
+        self.assertEqual(my_obj.my_list[-1]['foo'], 'bar',
+                         'add second dict and verify when dict is at the end')
 
         # Test --remove
         self.assertEqual(len(my_obj.my_list), 6, 'pre-verify length of list')
@@ -144,13 +170,13 @@ class GenericUpdateTest(unittest.TestCase):
         app.execute('update-obj --remove myList[0].key1'.split())
         self.assertEqual('key1' not in my_obj.my_list[0], True, 'verify dict entry can be removed')
 
-    def test_generic_update_errors(self): #pylint: disable=no-self-use
+    def test_generic_update_errors(self):  # pylint: disable=no-self-use
         my_obj = TestObject()
 
-        def my_get(a1, a2): #pylint: disable=unused-argument
+        def my_get(a1, a2):  # pylint: disable=unused-argument
             return my_obj
 
-        def my_set(**kwargs): #pylint:disable=unused-argument
+        def my_set(**kwargs):  # pylint:disable=unused-argument
             return my_obj
 
         config = Configuration([])
@@ -158,14 +184,16 @@ class GenericUpdateTest(unittest.TestCase):
 
         setattr(sys.modules[__name__], my_get.__name__, my_get)
         setattr(sys.modules[__name__], my_set.__name__, my_set)
-        cli_generic_update_command(None, 'gencommand', '{}#{}'.format(__name__, my_get.__name__), '{}#{}'.format(__name__, my_set.__name__))
+        cli_generic_update_command(None, 'gencommand', '{}#{}'.format(
+            __name__, my_get.__name__), '{}#{}'.format(__name__, my_set.__name__))
 
         def _execute_with_error(command, error, message):
             try:
                 app.execute(command.split())
             except CLIError as err:
-                if not error in str(err):
-                    raise AssertionError('{}\nExpected: {}\nActual: {}'.format(message, error, str(err)))
+                if error not in str(err):
+                    raise AssertionError(
+                        '{}\nExpected: {}\nActual: {}'.format(message, error, str(err)))
             else:
                 raise AssertionError('exception not thrown')
 
@@ -261,7 +289,8 @@ class GenericUpdateTest(unittest.TestCase):
     #                                                                 metavar='NAME', id_part='name'))
     #     setattr(sys.modules[__name__], my_get.__name__, my_get)
     #     setattr(sys.modules[__name__], my_set.__name__, my_set)
-    #     cli_generic_update_command(None, 'gencommand', '{}#{}'.format(__name__, my_get.__name__), '{}#{}'.format(__name__, my_set.__name__))
+    # cli_generic_update_command(None, 'gencommand', '{}#{}'.format(__name__,
+    # my_get.__name__), '{}#{}'.format(__name__, my_set.__name__))
 
     #     config = Configuration([])
     #     APPLICATION.initialize(config)
@@ -276,21 +305,20 @@ class GenericUpdateTest(unittest.TestCase):
     #     if not sys.version_info < (2, 7, 10):
     #         self.assertEqual(my_objs[1]['prop'], 'newval', 'second object updated')
 
-
     def test_generic_update_empty_nodes(self):
         my_obj = {
             'prop': None,
             'list': [],
             'dict': {
                 'dict2': None
-                },
+            },
             'dict3': {}
-            }
+        }
 
         def my_get():
             return my_obj
 
-        def my_set(**kwargs): #pylint:disable=unused-argument
+        def my_set(**kwargs):  # pylint:disable=unused-argument
             return my_obj
 
         config = Configuration([])
@@ -298,14 +326,15 @@ class GenericUpdateTest(unittest.TestCase):
 
         setattr(sys.modules[__name__], my_get.__name__, my_get)
         setattr(sys.modules[__name__], my_set.__name__, my_set)
-        cli_generic_update_command(None, 'gencommand', '{}#{}'.format(__name__, my_get.__name__), '{}#{}'.format(__name__, my_set.__name__))
+        cli_generic_update_command(None, 'gencommand', '{}#{}'.format(
+            __name__, my_get.__name__), '{}#{}'.format(__name__, my_set.__name__))
 
         # add to prop
         app.execute('gencommand --add prop a=b'.split())
         self.assertEqual(my_obj['prop'][0]['a'], 'b', 'verify object added to null list')
         self.assertEqual(len(my_obj['prop'][0]), 1, 'verify only one object added to null list')
 
-        #add to list
+        # add to list
         app.execute('gencommand --add list c=d'.split())
         self.assertEqual(my_obj['list'][0]['c'], 'd', 'verify object added to empty list')
         self.assertEqual(len(my_obj['list']), 1, 'verify only one object added to empty list')
@@ -316,10 +345,11 @@ class GenericUpdateTest(unittest.TestCase):
         self.assertEqual(len(my_obj['dict']['dict2']), 1,
                          'verify only one object added to null dict')
 
-        #set dict3
+        # set dict3
         app.execute('gencommand --set dict3.g=h'.split())
         self.assertEqual(my_obj['dict3']['g'], 'h', 'verify object added to empty dict')
         self.assertEqual(len(my_obj['dict3']), 1, 'verify only one object added to empty dict')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/azure-cli-core/azure/cli/core/tests/test_help.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_help.py
@@ -4,23 +4,26 @@
 # --------------------------------------------------------------------------------------------
 
 from __future__ import print_function
+
+import logging
 import sys
 import unittest
-import logging
 import mock
 from six import StringIO
 
+import azure.cli.core._help as _help
+import azure.cli.core.help_files
+from azure.cli.core._help import ArgumentGroupRegistry
 from azure.cli.core.application import Application, Configuration
 from azure.cli.core.commands import \
     (CliCommand, cli_command, _update_command_definitions, command_table)
-import azure.cli.core.help_files
-import azure.cli.core._help as _help
-from azure.cli.core._help import ArgumentGroupRegistry
 
 io = {}
+
+
 def redirect_io(func):
     def wrapper(self):
-        global io # pylint: disable=global-statement
+        global io  # pylint: disable=global-statement
         old_stdout = sys.stdout
         old_stderr = sys.stderr
         sys.stdout = sys.stderr = io = StringIO()
@@ -28,7 +31,9 @@ def redirect_io(func):
         io.close()
         sys.stdout = old_stdout
         sys.stderr = old_stderr
+
     return wrapper
+
 
 class HelpArgumentGroupRegistryTest(unittest.TestCase):
     def test_help_argument_group_registry(self):
@@ -49,12 +54,13 @@ class HelpArgumentGroupRegistryTest(unittest.TestCase):
         self.assertEqual(group_registry.get_group_priority('Generic Update Arguments'), '000998')
         self.assertEqual(group_registry.get_group_priority('Global Arguments'), '001000')
 
+
 class HelpObjectTest(unittest.TestCase):
     def test_short_summary_no_fullstop(self):
         obj = _help.HelpObject()
         original_summary = 'This summary has no fullstop'
         obj.short_summary = original_summary
-        self.assertEqual(obj.short_summary, original_summary+'.')
+        self.assertEqual(obj.short_summary, original_summary + '.')
 
     def test_short_summary_fullstop(self):
         obj = _help.HelpObject()
@@ -68,11 +74,11 @@ class HelpObjectTest(unittest.TestCase):
         obj.short_summary = original_summary
         self.assertEqual(obj.short_summary, original_summary)
 
+
 class HelpTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # Ensure initialization has occurred correctly
-        import azure.cli.main # pylint: disable=redefined-outer-name
         logging.basicConfig(level=logging.DEBUG)
 
     @classmethod
@@ -151,7 +157,8 @@ class HelpTest(unittest.TestCase):
 
         with self.assertRaises(SystemExit):
             app.execute('n1 -h'.split())
-        self.assertEqual(True, io.getvalue().startswith('\nCommand\n    az n1\n        Long description.')) # pylint: disable=line-too-long
+        self.assertEqual(True, io.getvalue().startswith(
+            '\nCommand\n    az n1\n        Long description.'))  # pylint: disable=line-too-long
 
     @redirect_io
     def test_help_long_description_from_docstring(self):
@@ -173,7 +180,8 @@ class HelpTest(unittest.TestCase):
 
         with self.assertRaises(SystemExit):
             app.execute('test -h'.split())
-        self.assertEqual(True, io.getvalue().startswith('\nCommand\n    az test: Short Description.\n        Long description with line break.')) # pylint: disable=line-too-long
+        self.assertEqual(True, io.getvalue().startswith(
+            '\nCommand\n    az test: Short Description.\n        Long description with line break.'))  # pylint: disable=line-too-long
 
     @redirect_io
     def test_help_long_description_and_short_description(self):
@@ -192,7 +200,8 @@ class HelpTest(unittest.TestCase):
 
         with self.assertRaises(SystemExit):
             app.execute('n1 -h'.split())
-        self.assertEqual(True, io.getvalue().startswith('\nCommand\n    az n1: Short description.\n        Long description.')) # pylint: disable=line-too-long
+        self.assertEqual(True, io.getvalue().startswith(
+            '\nCommand\n    az n1: Short description.\n        Long description.'))  # pylint: disable=line-too-long
 
     @redirect_io
     def test_help_docstring_description_overrides_short_description(self):
@@ -235,12 +244,14 @@ class HelpTest(unittest.TestCase):
         with self.assertRaises(SystemExit):
             app.execute('n1 -h'.split())
 
-        self.assertEqual(True, io.getvalue().startswith('\nCommand\n    az n1\n        Line1\n        line2.')) # pylint: disable=line-too-long
+        self.assertEqual(True, io.getvalue().startswith(
+            '\nCommand\n    az n1\n        Line1\n        line2.'))  # pylint: disable=line-too-long
 
     @redirect_io
     @mock.patch('azure.cli.core.application.Application.register', return_value=None)
     def test_help_params_documentations(self, _):
         app = Application(Configuration([]))
+
         def test_handler():
             pass
 
@@ -249,13 +260,13 @@ class HelpTest(unittest.TestCase):
         command.add_argument('foobar2', '--foobar2', '-fb2', required=True)
         command.add_argument('foobar3', '--foobar3', '-fb3', required=False, help='the foobar3')
         command.help = """
-            parameters: 
+            parameters:
                 - name: --foobar -fb
                   type: string
                   required: false
                   short-summary: one line partial sentence
                   long-summary: text, markdown, etc.
-                  populator-commands: 
+                  populator-commands:
                     - az vm list
                     - default
                 - name: --foobar2 -fb2
@@ -292,6 +303,7 @@ Global Arguments
     @mock.patch('azure.cli.core.application.Application.register', return_value=None)
     def test_help_full_documentations(self, _):
         app = Application(Configuration([]))
+
         def test_handler():
             pass
 
@@ -303,13 +315,13 @@ Global Arguments
                 long-summary: |
                     this module.... kjsdflkj... klsfkj paragraph1
                     this module.... kjsdflkj... klsfkj paragraph2
-                parameters: 
+                parameters:
                     - name: --foobar -fb
                       type: string
                       required: false
                       short-summary: one line partial sentence
                       long-summary: text, markdown, etc.
-                      populator-commands: 
+                      populator-commands:
                         - az vm list
                         - default
                     - name: --foobar2 -fb2
@@ -354,6 +366,7 @@ Examples
     @mock.patch('azure.cli.core.application.Application.register', return_value=None)
     def test_help_with_param_specified(self, _):
         app = Application(Configuration([]))
+
         def test_handler():
             pass
 
@@ -386,8 +399,10 @@ Global Arguments
     @redirect_io
     def test_help_group_children(self):
         app = Application(Configuration([]))
+
         def test_handler():
             pass
+
         def test_handler2():
             pass
 
@@ -413,7 +428,8 @@ Global Arguments
     @redirect_io
     def test_help_extra_missing_params(self):
         app = Application(Configuration([]))
-        def test_handler(foobar2, foobar=None): # pylint: disable=unused-argument
+
+        def test_handler(foobar2, foobar=None):  # pylint: disable=unused-argument
             pass
 
         command = CliCommand('n1', test_handler)
@@ -443,14 +459,15 @@ Global Arguments
             with self.assertRaises(SystemExit):
                 app.execute('n1 -fb a --foobar2 value --foobar3 extra'.split())
 
-            self.assertTrue('required' in io.getvalue()
-                            and '--foobar/-fb' not in io.getvalue()
-                            and '--foobar2/-fb2' in io.getvalue()
-                            and 'unrecognized arguments: --foobar3 extra' in io.getvalue())
+            self.assertTrue('required' in io.getvalue() and
+                            '--foobar/-fb' not in io.getvalue() and
+                            '--foobar2/-fb2' in io.getvalue() and
+                            'unrecognized arguments: --foobar3 extra' in io.getvalue())
 
     @redirect_io
     def test_help_group_help(self):
         app = Application(Configuration([]))
+
         def test_handler():
             pass
 
@@ -473,13 +490,13 @@ Global Arguments
             long-summary: |
                 this module.... kjsdflkj... klsfkj paragraph1
                 this module.... kjsdflkj... klsfkj paragraph2
-            parameters: 
+            parameters:
                 - name: --foobar -fb
                   type: string
                   required: false
                   short-summary: one line partial sentence
                   long-summary: text, markdown, etc.
-                  populator-commands: 
+                  populator-commands:
                     - az vm list
                     - default
                 - name: --foobar2 -fb2
@@ -489,7 +506,7 @@ Global Arguments
                   long-summary: paragraph(s)
             examples:
                 - name: foo example
-                  text: example details        
+                  text: example details
         """
         cmd_table = {'test_group1 test_group2 n1': command}
 
@@ -524,11 +541,15 @@ Examples
         def register_globals(global_group):
             global_group.add_argument('--query2', dest='_jmespath_query', metavar='JMESPATH',
                                       help='JMESPath query string. See http://jmespath.org/ '
-                                      'for more information and examples.')
+                                           'for more information and examples.')
 
         mock_register_extensions.return_value = None
-        mock_register_extensions.side_effect = lambda app: \
-            app._event_handlers[app.GLOBAL_PARSER_CREATED].append(register_globals) # pylint: disable=protected-access
+
+        def _register_global_parser(appl):
+            # noqa pylint: disable=protected-access
+            appl._event_handlers[appl.GLOBAL_PARSER_CREATED].append(register_globals)
+
+        mock_register_extensions.side_effect = _register_global_parser
 
         def test_handler():
             pass
@@ -595,7 +616,8 @@ Global Arguments
 
             extras = [k for k in azure.cli.core.help_files.helps.keys() if k not in parser_dict]
             self.assertTrue(len(extras) == 0,
-                            'Found help files that don\'t map to a command: '+ str(extras))
+                            'Found help files that don\'t map to a command: ' + str(extras))
+
 
 def _store_parsers(parser, d):
     for s in parser.subparsers.values():
@@ -605,11 +627,15 @@ def _store_parsers(parser, d):
                 d[_get_parser_name(c)] = c
                 _store_parsers(c, d)
 
+
 def _is_group(parser):
     return getattr(parser, 'choices', None) is not None
 
+
 def _get_parser_name(parser):
-    return (parser._prog_prefix if hasattr(parser, '_prog_prefix') else parser.prog)[len('az '):] #pylint:disable=protected-access
+    # pylint:disable=protected-access
+    return (parser._prog_prefix if hasattr(parser, '_prog_prefix') else parser.prog)[len('az '):]
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/azure-cli-core/azure/cli/core/tests/test_logging.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_logging.py
@@ -6,6 +6,7 @@
 import unittest
 import azure.cli.core._logging as _logging
 
+
 class TestLogging(unittest.TestCase):
 
     # When running verbose level tests, we check that argv is empty
@@ -13,28 +14,28 @@ class TestLogging(unittest.TestCase):
 
     def test_determine_verbose_level_default(self):
         argv = []
-        actual_level = _logging._determine_verbose_level(argv) # pylint: disable=protected-access
+        actual_level = _logging._determine_verbose_level(argv)  # pylint: disable=protected-access
         expected_level = 0
         self.assertEqual(actual_level, expected_level)
         self.assertFalse(argv)
 
     def test_determine_verbose_level_verbose(self):
         argv = ['--verbose']
-        actual_level = _logging._determine_verbose_level(argv) # pylint: disable=protected-access
+        actual_level = _logging._determine_verbose_level(argv)  # pylint: disable=protected-access
         expected_level = 1
         self.assertEqual(actual_level, expected_level)
         self.assertFalse(argv)
 
     def test_determine_verbose_level_debug(self):
         argv = ['--debug']
-        actual_level = _logging._determine_verbose_level(argv) # pylint: disable=protected-access
+        actual_level = _logging._determine_verbose_level(argv)  # pylint: disable=protected-access
         expected_level = 2
         self.assertEqual(actual_level, expected_level)
         self.assertFalse(argv)
 
     def test_determine_verbose_level_v_v_v_default(self):
         argv = ['--verbose', '--debug']
-        actual_level = _logging._determine_verbose_level(argv) # pylint: disable=protected-access
+        actual_level = _logging._determine_verbose_level(argv)  # pylint: disable=protected-access
         expected_level = 2
         self.assertEqual(actual_level, expected_level)
         # We still consumed the arguments
@@ -42,7 +43,7 @@ class TestLogging(unittest.TestCase):
 
     def test_determine_verbose_level_other_args_verbose(self):
         argv = ['account', '--verbose']
-        actual_level = _logging._determine_verbose_level(argv) # pylint: disable=protected-access
+        actual_level = _logging._determine_verbose_level(argv)  # pylint: disable=protected-access
         expected_level = 1
         self.assertEqual(actual_level, expected_level)
         # We consumed 1 argument
@@ -50,7 +51,7 @@ class TestLogging(unittest.TestCase):
 
     def test_determine_verbose_level_other_args_debug(self):
         argv = ['account', '--debug']
-        actual_level = _logging._determine_verbose_level(argv) # pylint: disable=protected-access
+        actual_level = _logging._determine_verbose_level(argv)  # pylint: disable=protected-access
         expected_level = 2
         self.assertEqual(actual_level, expected_level)
         # We consumed 1 argument
@@ -63,6 +64,7 @@ class TestLogging(unittest.TestCase):
     def test_get_az_logger_module(self):
         az_module_logger = _logging.get_az_logger('azure.cli.module')
         self.assertEqual(az_module_logger.name, 'az.azure.cli.module')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/azure-cli-core/azure/cli/core/tests/test_output.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_output.py
@@ -4,14 +4,15 @@
 # --------------------------------------------------------------------------------------------
 
 from __future__ import print_function
- # pylint: disable=protected-access, bad-continuation, too-many-public-methods, trailing-whitespace
+# pylint: disable=protected-access, bad-continuation, too-many-public-methods, trailing-whitespace
 import unittest
 from collections import OrderedDict
 from six import StringIO
 
 from azure.cli.core._output import (OutputProducer, format_json, format_table, format_list,
-                               format_tsv, ListOutput, CommandResultItem)
+                                    format_tsv, ListOutput, CommandResultItem)
 import azure.cli.core._util as util
+
 
 class TestOutput(unittest.TestCase):
 
@@ -36,12 +37,12 @@ class TestOutput(unittest.TestCase):
         output_producer = OutputProducer(formatter=format_json, file=self.io)
         output_producer.out(CommandResultItem({'active': True, 'id': '0b1f6472'}))
         self.assertEqual(util.normalize_newlines(self.io.getvalue()), util.normalize_newlines(
-"""{
+            """{
   "active": true,
   "id": "0b1f6472"
 }
 """))
-   
+
     def test_out_json_from_ordered_dict(self):
         """
         The JSON output when the input is OrderedDict should be serialized to JSON
@@ -49,7 +50,7 @@ class TestOutput(unittest.TestCase):
         output_producer = OutputProducer(formatter=format_json, file=self.io)
         output_producer.out(CommandResultItem(OrderedDict({'active': True, 'id': '0b1f6472'})))
         self.assertEqual(util.normalize_newlines(self.io.getvalue()), util.normalize_newlines(
-"""{
+            """{
   "active": true,
   "id": "0b1f6472"
 }
@@ -59,7 +60,7 @@ class TestOutput(unittest.TestCase):
         output_producer = OutputProducer(formatter=format_json, file=self.io)
         output_producer.out(CommandResultItem({'active': True, 'contents': b'0b1f6472'}))
         self.assertEqual(util.normalize_newlines(self.io.getvalue()), util.normalize_newlines(
-"""{
+            """{
   "active": true,
   "contents": "0b1f6472"
 }
@@ -69,7 +70,7 @@ class TestOutput(unittest.TestCase):
         output_producer = OutputProducer(formatter=format_json, file=self.io)
         output_producer.out(CommandResultItem({'active': True, 'contents': b''}))
         self.assertEqual(util.normalize_newlines(self.io.getvalue()), util.normalize_newlines(
-"""{
+            """{
   "active": true,
   "contents": ""
 }
@@ -90,7 +91,7 @@ class TestOutput(unittest.TestCase):
         obj['val'] = '0b1f6472'
         output_producer.out(CommandResultItem(obj))
         self.assertEqual(util.normalize_newlines(self.io.getvalue()), util.normalize_newlines(
-"""  Active  Val
+            """  Active  Val
 --------  --------
        1  0b1f6472
 """))
@@ -100,7 +101,7 @@ class TestOutput(unittest.TestCase):
         obj = [['a', 'b'], ['c', 'd']]
         output_producer.out(CommandResultItem(obj))
         self.assertEqual(util.normalize_newlines(self.io.getvalue()), util.normalize_newlines(
-"""Column1    Column2
+            """Column1    Column2
 ---------  ---------
 a          b
 c          d
@@ -115,7 +116,7 @@ c          d
         result_item = CommandResultItem(obj)
         output_producer.out(result_item)
         self.assertEqual(util.normalize_newlines(self.io.getvalue()), util.normalize_newlines(
-"""Name    Val
+            """Name    Val
 ------  --------------
 qwerty  0b1f6472qwerty
 """))
@@ -126,7 +127,7 @@ qwerty  0b1f6472qwerty
         output_producer = OutputProducer(formatter=format_list, file=self.io)
         output_producer.out(CommandResultItem({'active': True, 'id': '0b1f6472'}))
         self.assertEqual(util.normalize_newlines(self.io.getvalue()), util.normalize_newlines(
-"""Active : True
+            """Active : True
 Id     : 0b1f6472
 
 
@@ -136,7 +137,7 @@ Id     : 0b1f6472
         output_producer = OutputProducer(formatter=format_list, file=self.io)
         output_producer.out(CommandResultItem({'active': True, 'TESTStuff': 'blah'}))
         self.assertEqual(util.normalize_newlines(self.io.getvalue()), util.normalize_newlines(
-"""Test Stuff : blah
+            """Test Stuff : blah
 Active     : True
 
 
@@ -146,7 +147,7 @@ Active     : True
         output_producer = OutputProducer(formatter=format_list, file=self.io)
         output_producer.out(CommandResultItem({'active': None, 'id': '0b1f6472'}))
         self.assertEqual(util.normalize_newlines(self.io.getvalue()), util.normalize_newlines(
-"""Active : None
+            """Active : None
 Id     : 0b1f6472
 
 
@@ -156,7 +157,7 @@ Id     : 0b1f6472
         output_producer = OutputProducer(formatter=format_list, file=self.io)
         output_producer.out(CommandResultItem({'active': None, 'id': '0b1f6472', 'hosts': []}))
         self.assertEqual(util.normalize_newlines(self.io.getvalue()), util.normalize_newlines(
-"""Active : None
+            """Active : None
 Id     : 0b1f6472
 Hosts  :
    None
@@ -167,11 +168,11 @@ Hosts  :
     def test_out_list_valid_array_complex(self):
         output_producer = OutputProducer(formatter=format_list, file=self.io)
         output_producer.out(CommandResultItem([
-                             {'active': True, 'id': '783yesdf'},
-                             {'active': False, 'id': '3hjnme32'},
-                             {'active': False, 'id': '23hiujbs'}]))
+            {'active': True, 'id': '783yesdf'},
+            {'active': False, 'id': '3hjnme32'},
+            {'active': False, 'id': '23hiujbs'}]))
         self.assertEqual(util.normalize_newlines(self.io.getvalue()), util.normalize_newlines(
-"""Active : True
+            """Active : True
 Id     : 783yesdf
 
 Active : False
@@ -187,7 +188,7 @@ Id     : 23hiujbs
         output_producer = OutputProducer(formatter=format_list, file=self.io)
         output_producer.out(CommandResultItem(['location', 'id', 'host', 'server']))
         self.assertEqual(util.normalize_newlines(self.io.getvalue()), util.normalize_newlines(
-"""location
+            """location
 
 id
 
@@ -201,9 +202,9 @@ server
     def test_out_list_valid_complex_array(self):
         output_producer = OutputProducer(formatter=format_list, file=self.io)
         output_producer.out(CommandResultItem({'active': True, 'id': '0b1f6472',
-                                        'myarray': ['1', '2', '3', '4']}))
+                                               'myarray': ['1', '2', '3', '4']}))
         self.assertEqual(util.normalize_newlines(self.io.getvalue()), util.normalize_newlines(
-"""Active  : True
+            """Active  : True
 Id      : 0b1f6472
 Myarray :
    1
@@ -270,6 +271,7 @@ Myarray :
         obj2['B'] = 4
         result = format_tsv(CommandResultItem([obj1, obj2]))
         self.assertEqual(result, '1\t2\n3\t4\n')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/azure-cli-core/azure/cli/core/tests/test_parser.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_parser.py
@@ -9,6 +9,7 @@ from azure.cli.core.parser import AzCliCommandParser
 from azure.cli.core.commands import CliCommand
 from azure.cli.core.commands.parameters import enum_choice_list
 
+
 class TestParser(unittest.TestCase):
 
     def setUp(self):
@@ -41,7 +42,7 @@ class TestParser(unittest.TestCase):
         self.assertTrue(AzCliCommandParser.error.called)
 
     def test_required_parameter(self):
-        def test_handler(args): # pylint: disable=unused-argument
+        def test_handler(args):  # pylint: disable=unused-argument
             pass
 
         command = CliCommand('test command', test_handler)
@@ -79,7 +80,7 @@ class TestParser(unittest.TestCase):
     def test_case_insensitive_enum_choices(self):
         from enum import Enum
 
-        class TestEnum(Enum): # pylint: disable=too-few-public-methods
+        class TestEnum(Enum):  # pylint: disable=too-few-public-methods
 
             opt1 = "ALL_CAPS"
             opt2 = "camelCase"
@@ -104,7 +105,8 @@ class TestParser(unittest.TestCase):
         args = parser.parse_args('test command --opt sNake_CASE'.split())
         self.assertEqual(args.opt, 'snake_case')
 
-class VerifyError(object): # pylint: disable=too-few-public-methods
+
+class VerifyError(object):  # pylint: disable=too-few-public-methods
 
     def __init__(self, test, substr=None):
         self.test = test
@@ -115,6 +117,7 @@ class VerifyError(object): # pylint: disable=too-few-public-methods
         if self.substr:
             self.test.assertTrue(message.find(self.substr) >= 0)
         self.called = True
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -12,7 +12,8 @@ from azure.mgmt.resource.subscriptions.models import (SubscriptionState, Subscri
 from azure.cli.core._profile import Profile, CredsCache, SubscriptionFinder, CLOUD
 from azure.cli.core._util import CLIError
 
-class Test_Profile(unittest.TestCase): #pylint: disable=too-many-public-methods
+
+class Test_Profile(unittest.TestCase):  # pylint: disable=too-many-public-methods
 
     @classmethod
     def setUpClass(cls):
@@ -59,22 +60,21 @@ class Test_Profile(unittest.TestCase): #pylint: disable=too-many-public-methods
             'name': self.display_name1,
             'state': self.state1.value,
             'user': {
-                'name':self.user1,
-                'type':'user'
-                },
+                'name': self.user1,
+                'type': 'user'
+            },
             'isDefault': False,
             'tenantId': self.tenant_id
-            }
+        }
         self.assertEqual(expected, consolidated[0])
-        #verify serialization works
+        # verify serialization works
         self.assertIsNotNone(json.dumps(consolidated[0]))
-
 
     def test_update_add_two_different_subscriptions(self):
         storage_mock = {'subscriptions': None}
         profile = Profile(storage_mock)
 
-        #add the first and verify
+        # add the first and verify
         consolidated = Profile._normalize_properties(self.user1,
                                                      [self.subscription1],
                                                      False)
@@ -90,12 +90,12 @@ class Test_Profile(unittest.TestCase): #pylint: disable=too-many-public-methods
             'user': {
                 'name': self.user1,
                 'type': 'user'
-                },
+            },
             'isDefault': True,
             'tenantId': self.tenant_id
-            })
+        })
 
-        #add the second and verify
+        # add the second and verify
         consolidated = Profile._normalize_properties(self.user2,
                                                      [self.subscription2],
                                                      False)
@@ -111,12 +111,12 @@ class Test_Profile(unittest.TestCase): #pylint: disable=too-many-public-methods
             'user': {
                 'name': self.user2,
                 'type': 'user'
-                },
+            },
             'isDefault': True,
             'tenantId': self.tenant_id
-            })
+        })
 
-        #verify the old one stays, but no longer active
+        # verify the old one stays, but no longer active
         self.assertEqual(storage_mock['subscriptions'][0]['name'],
                          subscription1['name'])
         self.assertFalse(storage_mock['subscriptions'][0]['isDefault'])
@@ -125,7 +125,7 @@ class Test_Profile(unittest.TestCase): #pylint: disable=too-many-public-methods
         storage_mock = {'subscriptions': None}
         profile = Profile(storage_mock)
 
-        #add one twice and verify we will have one but with new token
+        # add one twice and verify we will have one but with new token
         consolidated = Profile._normalize_properties(self.user1,
                                                      [self.subscription1],
                                                      False)
@@ -193,7 +193,7 @@ class Test_Profile(unittest.TestCase): #pylint: disable=too-many-public-methods
         profile._set_subscriptions(consolidated)
         sub_id = self.id1.split('/')[-1]
 
-        #testing dump of existing logged in account
+        # testing dump of existing logged in account
         extended_info = profile.get_expanded_subscription_info()
         self.assertEqual(self.user1, extended_info['userName'])
         self.assertEqual(sub_id, extended_info['subscriptionId'])
@@ -201,7 +201,7 @@ class Test_Profile(unittest.TestCase): #pylint: disable=too-many-public-methods
         self.assertEqual('https://login.microsoftonline.com',
                          extended_info['endpoints'].active_directory)
 
-        #testing dump of service principal by 'create-for-rbac'
+        # testing dump of service principal by 'create-for-rbac'
         extended_info = profile.get_expanded_subscription_info(name='great-sp',
                                                                password='verySecret-')
         self.assertEqual(sub_id, extended_info['subscriptionId'])
@@ -225,19 +225,18 @@ class Test_Profile(unittest.TestCase): #pylint: disable=too-many-public-methods
         profile._management_resource_uri = 'https://management.core.windows.net/'
         profile._subscription_finder = finder
         profile.find_subscriptions_on_login(False, '1234', 'my-secret', True, self.tenant_id)
-        #action
+        # action
         extended_info = profile.get_expanded_subscription_info()
-        #assert
+        # assert
         self.assertEqual(self.id1.split('/')[-1], extended_info['subscriptionId'])
         self.assertEqual(self.display_name1, extended_info['subscriptionName'])
         self.assertEqual('1234', extended_info['client'])
         self.assertEqual('https://login.microsoftonline.com',
                          extended_info['endpoints'].active_directory)
 
-
     @mock.patch('azure.cli.core._profile._load_tokens_from_file', autospec=True)
     def test_get_current_account_user(self, mock_read_cred_file):
-        #setup
+        # setup
         mock_read_cred_file.return_value = [Test_Profile.token_entry1]
 
         storage_mock = {'subscriptions': None}
@@ -246,10 +245,10 @@ class Test_Profile(unittest.TestCase): #pylint: disable=too-many-public-methods
                                                      [self.subscription1],
                                                      False)
         profile._set_subscriptions(consolidated)
-        #action
+        # action
         user = profile.get_current_account_user()
 
-        #verify
+        # verify
         self.assertEqual(user, self.user1)
 
     @mock.patch('azure.cli.core._profile._load_tokens_from_file', return_value=None)
@@ -269,7 +268,7 @@ class Test_Profile(unittest.TestCase): #pylint: disable=too-many-public-methods
             "_authority": "https://login.microsoftonline.com/common",
             "_clientId": "04b07795-8ddb-461a-bbee-02f9e1bf7b46",
             "userId": self.user1
-            })
+        })
         self.assertEqual(len(matched), 1)
         self.assertEqual(matched[0]['accessToken'], self.raw_token1)
 
@@ -279,20 +278,20 @@ class Test_Profile(unittest.TestCase): #pylint: disable=too-many-public-methods
         some_token_type = 'Bearer'
         mock_read_cred_file.return_value = [Test_Profile.token_entry1]
         mock_get_token.return_value = (some_token_type, Test_Profile.raw_token1)
-        #setup
+        # setup
         storage_mock = {'subscriptions': None}
         profile = Profile(storage_mock)
         consolidated = Profile._normalize_properties(self.user1,
                                                      [self.subscription1],
                                                      False)
         profile._set_subscriptions(consolidated)
-        #action
+        # action
         cred, subscription_id, _ = profile.get_login_credentials()
 
-        #verify
+        # verify
         self.assertEqual(subscription_id, '1')
 
-        #verify the cred._tokenRetriever is a working lambda
+        # verify the cred._tokenRetriever is a working lambda
         token_type, token = cred._token_retriever()
         self.assertEqual(token, self.raw_token1)
         self.assertEqual(some_token_type, token_type)
@@ -307,17 +306,17 @@ class Test_Profile(unittest.TestCase): #pylint: disable=too-many-public-methods
         some_token_type = 'Bearer'
         mock_read_cred_file.return_value = [Test_Profile.token_entry1]
         mock_get_token.return_value = (some_token_type, Test_Profile.raw_token1)
-        #setup
+        # setup
         storage_mock = {'subscriptions': None}
         profile = Profile(storage_mock)
         consolidated = Profile._normalize_properties(self.user1, [self.subscription1],
                                                      False)
         profile._set_subscriptions(consolidated)
-        #action
+        # action
         cred, _, tenant_id = profile.get_login_credentials(
             resource=CLOUD.endpoints.active_directory_graph_resource_id)
         _, _ = cred._token_retriever()
-        #verify
+        # verify
         mock_get_token.assert_called_once_with(mock.ANY, self.user1, self.tenant_id,
                                                'https://graph.windows.net/')
         self.assertEqual(tenant_id, self.tenant_id)
@@ -325,7 +324,7 @@ class Test_Profile(unittest.TestCase): #pylint: disable=too-many-public-methods
     @mock.patch('azure.cli.core._profile._load_tokens_from_file', autospec=True)
     @mock.patch('azure.cli.core._profile.CredsCache.persist_cached_creds', autospec=True)
     def test_logout(self, mock_persist_creds, mock_read_cred_file):
-        #setup
+        # setup
         mock_read_cred_file.return_value = [Test_Profile.token_entry1]
 
         storage_mock = {'subscriptions': None}
@@ -335,17 +334,17 @@ class Test_Profile(unittest.TestCase): #pylint: disable=too-many-public-methods
                                                      False)
         profile._set_subscriptions(consolidated)
         self.assertEqual(1, len(storage_mock['subscriptions']))
-        #action
+        # action
         profile.logout(self.user1)
 
-        #verify
+        # verify
         self.assertEqual(0, len(storage_mock['subscriptions']))
         self.assertEqual(mock_read_cred_file.call_count, 1)
         self.assertEqual(mock_persist_creds.call_count, 1)
 
     @mock.patch('azure.cli.core._profile._delete_file', autospec=True)
     def test_logout_all(self, mock_delete_cred_file):
-        #setup
+        # setup
         storage_mock = {'subscriptions': None}
         profile = Profile(storage_mock)
         consolidated = Profile._normalize_properties(self.user1,
@@ -357,10 +356,10 @@ class Test_Profile(unittest.TestCase): #pylint: disable=too-many-public-methods
         profile._set_subscriptions(consolidated + consolidated2)
 
         self.assertEqual(2, len(storage_mock['subscriptions']))
-        #action
+        # action
         profile.logout_all()
 
-        #verify
+        # verify
         self.assertEqual([], storage_mock['subscriptions'])
         self.assertEqual(mock_delete_cred_file.call_count, 1)
 
@@ -375,10 +374,10 @@ class Test_Profile(unittest.TestCase): #pylint: disable=too-many-public-methods
                                     None,
                                     lambda _: mock_arm_client)
         mgmt_resource = 'https://management.core.windows.net/'
-        #action
+        # action
         subs = finder.find_from_user_account(self.user1, 'bar', mgmt_resource)
 
-        #assert
+        # assert
         self.assertEqual([self.subscription1], subs)
         mock_auth_context.acquire_token_with_username_password.assert_called_once_with(
             mgmt_resource, self.user1, 'bar', mock.ANY)
@@ -387,7 +386,7 @@ class Test_Profile(unittest.TestCase): #pylint: disable=too-many-public-methods
 
     @mock.patch('adal.AuthenticationContext', autospec=True)
     def test_find_subscriptions_through_interactive_flow(self, mock_auth_context):
-        test_nonsense_code = {'message':'magic code for you'}
+        test_nonsense_code = {'message': 'magic code for you'}
         mock_auth_context.acquire_user_code.return_value = test_nonsense_code
         mock_auth_context.acquire_token_with_device_code.return_value = self.token_entry1
         mock_arm_client = mock.MagicMock()
@@ -397,10 +396,10 @@ class Test_Profile(unittest.TestCase): #pylint: disable=too-many-public-methods
                                     None,
                                     lambda _: mock_arm_client)
         mgmt_resource = 'https://management.core.windows.net/'
-        #action
+        # action
         subs = finder.find_through_interactive_flow(mgmt_resource)
 
-        #assert
+        # assert
         self.assertEqual([self.subscription1], subs)
         mock_auth_context.acquire_user_code.assert_called_once_with(
             mgmt_resource, mock.ANY)
@@ -418,11 +417,11 @@ class Test_Profile(unittest.TestCase): #pylint: disable=too-many-public-methods
                                     None,
                                     lambda _: mock_arm_client)
         mgmt_resource = 'https://management.core.windows.net/'
-        #action
+        # action
         subs = finder.find_from_service_principal_id('my app', 'my secret',
                                                      self.tenant_id, mgmt_resource)
 
-        #assert
+        # assert
         self.assertEqual([self.subscription1], subs)
         mock_arm_client.tenants.list.assert_not_called()
         mock_auth_context.acquire_token.assert_not_called()
@@ -438,10 +437,10 @@ class Test_Profile(unittest.TestCase): #pylint: disable=too-many-public-methods
         }
         mock_read_file.return_value = [self.token_entry1, test_sp]
 
-        #action
+        # action
         creds_cache = CredsCache()
 
-        #assert
+        # assert
         token_entries = [entry for _, entry in creds_cache.adal_token_cache.read_items()]
         self.assertEqual(token_entries, [self.token_entry1])
         self.assertEqual(creds_cache._service_principal_creds, [test_sp])
@@ -464,13 +463,13 @@ class Test_Profile(unittest.TestCase): #pylint: disable=too-many-public-methods
         mock_read_file.return_value = [self.token_entry1, test_sp]
         creds_cache = CredsCache()
 
-        #action
+        # action
         creds_cache.save_service_principal_cred(
             test_sp2['servicePrincipalId'],
             test_sp2['accessToken'],
             test_sp2['servicePrincipalTenant'])
 
-        #assert
+        # assert
         token_entries = [entry for _, entry in creds_cache.adal_token_cache.read_items()]
         self.assertEqual(token_entries, [self.token_entry1])
         self.assertEqual(creds_cache._service_principal_creds, [test_sp, test_sp2])
@@ -489,17 +488,17 @@ class Test_Profile(unittest.TestCase): #pylint: disable=too-many-public-methods
         mock_read_file.return_value = [self.token_entry1, test_sp]
         creds_cache = CredsCache()
 
-        #action #1, logout a user
+        # action #1, logout a user
         creds_cache.remove_cached_creds(self.user1)
 
-        #assert #1
+        # assert #1
         token_entries = [entry for _, entry in creds_cache.adal_token_cache.read_items()]
         self.assertEqual(token_entries, [])
 
-        #action #2 logout a service principal
+        # action #2 logout a service principal
         creds_cache.remove_cached_creds('myapp')
 
-        #assert #2
+        # assert #2
         self.assertEqual(creds_cache._service_principal_creds, [])
 
         mock_open_for_write.assert_called_with(mock.ANY, 'w+')
@@ -509,16 +508,18 @@ class Test_Profile(unittest.TestCase): #pylint: disable=too-many-public-methods
     @mock.patch('os.fdopen', autospec=True)
     @mock.patch('os.open', autospec=True)
     @mock.patch('adal.AuthenticationContext', autospec=True)
-    def test_credscache_new_token_added_by_adal(self, mock_adal_auth_context, _, mock_open_for_write, mock_read_file): # pylint: disable=line-too-long
+    def test_credscache_new_token_added_by_adal(self, mock_adal_auth_context, _, mock_open_for_write, mock_read_file):  # pylint: disable=line-too-long
         token_entry2 = {
             "accessToken": "new token",
             "tokenType": "Bearer",
             "userId": self.user1
         }
-        def acquire_token_side_effect(*args): # pylint: disable=unused-argument
+
+        def acquire_token_side_effect(*args):  # pylint: disable=unused-argument
             creds_cache.adal_token_cache.has_state_changed = True
             return token_entry2
-        def get_auth_context(authority, **kwargs): # pylint: disable=unused-argument
+
+        def get_auth_context(authority, **kwargs):  # pylint: disable=unused-argument
             mock_adal_auth_context.cache = kwargs['cache']
             return mock_adal_auth_context
 
@@ -527,7 +528,7 @@ class Test_Profile(unittest.TestCase): #pylint: disable=too-many-public-methods
         mock_read_file.return_value = [self.token_entry1]
         creds_cache = CredsCache(auth_ctx_factory=get_auth_context)
 
-        #action
+        # action
         mgmt_resource = 'https://management.core.windows.net/'
         token_type, token = creds_cache.retrieve_token_for_user(self.user1, self.tenant_id,
                                                                 mgmt_resource)
@@ -536,21 +537,27 @@ class Test_Profile(unittest.TestCase): #pylint: disable=too-many-public-methods
             self.user1,
             mock.ANY)
 
-        #assert
+        # assert
         mock_open_for_write.assert_called_with(mock.ANY, 'w+')
         self.assertEqual(token, 'new token')
         self.assertEqual(token_type, token_entry2['tokenType'])
 
-class FileHandleStub(object): # pylint: disable=too-few-public-methods
+
+class FileHandleStub(object):  # pylint: disable=too-few-public-methods
+
     def write(self, content):
         pass
+
     def __enter__(self):
         return self
+
     def __exit__(self, _2, _3, _4):
         pass
 
-class SubscriptionStub(Subscription): # pylint: disable=too-few-public-methods
-    def __init__(self, id, display_name, state, tenant_id): # pylint: disable=redefined-builtin,
+
+class SubscriptionStub(Subscription):  # pylint: disable=too-few-public-methods
+
+    def __init__(self, id, display_name, state, tenant_id):  # pylint: disable=redefined-builtin,
         policies = SubscriptionPolicies()
         policies.spending_limit = spendingLimit.current_period_off
         policies.quota_id = 'some quota'
@@ -560,9 +567,12 @@ class SubscriptionStub(Subscription): # pylint: disable=too-few-public-methods
         self.state = state
         self.tenant_id = tenant_id
 
-class TenantStub(object): # pylint: disable=too-few-public-methods
+
+class TenantStub(object):  # pylint: disable=too-few-public-methods
+
     def __init__(self, tenant_id):
         self.tenant_id = tenant_id
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/azure-cli-core/azure/cli/core/tests/test_resource_id.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_resource_id.py
@@ -8,6 +8,7 @@ import unittest
 from six import StringIO
 from azure.cli.core.commands.arm import parse_resource_id, resource_id, is_valid_resource_id
 
+
 class TestApplication(unittest.TestCase):
 
     def setUp(self):
@@ -22,7 +23,8 @@ class TestApplication(unittest.TestCase):
         namespace = 'Microsoft.Network'
         rtype = 'loadBalancers'
         sub = '00000000-0000-0000-0000-000000000000'
-        result = resource_id(resource_group=rg, name=lb, namespace=namespace, type=rtype, subscription=sub)
+        result = resource_id(resource_group=rg, name=lb, namespace=namespace,
+                             type=rtype, subscription=sub)
         expected = '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbrg/providers/Microsoft.Network/loadBalancers/mylb'
         self.assertTrue(is_valid_resource_id(expected))
         self.assertTrue(is_valid_resource_id(result))
@@ -36,7 +38,8 @@ class TestApplication(unittest.TestCase):
         bep = 'mybep'
         bep_type = 'backendAddressPools'
         sub = '00000000-0000-0000-0000-000000000000'
-        result = resource_id(name=lb, resource_group=rg, namespace=namespace, type=rtype, subscription=sub, child_type=bep_type, child_name=bep)
+        result = resource_id(name=lb, resource_group=rg, namespace=namespace,
+                             type=rtype, subscription=sub, child_type=bep_type, child_name=bep)
         expected = '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbrg/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mybep'
         self.assertTrue(is_valid_resource_id(expected))
         self.assertTrue(is_valid_resource_id(result))
@@ -52,7 +55,8 @@ class TestApplication(unittest.TestCase):
         grandchild = 'grandchild'
         gc_type = 'grandchildType'
         sub = '00000000-0000-0000-0000-000000000000'
-        result = resource_id(name=lb, resource_group=rg, namespace=namespace, type=rtype, subscription=sub, child_type=bep_type, child_name=bep, grandchild_name=grandchild, grandchild_type=gc_type)
+        result = resource_id(name=lb, resource_group=rg, namespace=namespace, type=rtype, subscription=sub,
+                             child_type=bep_type, child_name=bep, grandchild_name=grandchild, grandchild_type=gc_type)
         expected = '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbrg/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mybep/grandchildType/grandchild'
         self.assertTrue(is_valid_resource_id(expected))
         self.assertTrue(is_valid_resource_id(result))
@@ -62,6 +66,7 @@ class TestApplication(unittest.TestCase):
         rid = '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/lbrg/providers/Microsoft.Network/loadBalancers/mylb/backendAddressPools/mybep/grandchildType/grandchild'
         result = resource_id(**parse_resource_id(rid))
         self.assertEqual(result, rid)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/azure-cli-core/azure/cli/core/tests/test_util.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_util.py
@@ -10,6 +10,7 @@ import tempfile
 
 from azure.cli.core._util import get_file_json, todict, to_snake_case
 
+
 class TestUtils(unittest.TestCase):
 
     def test_application_todict_none(self):
@@ -54,19 +55,19 @@ class TestUtils(unittest.TestCase):
     def test_load_json_from_file(self):
         _, pathname = tempfile.mkstemp()
 
-        #test good case
+        # test good case
         with open(pathname, 'w') as good_file:
             good_file.write('{"key1":"value1", "key2":"value2"}')
         result = get_file_json(pathname)
         self.assertEqual('value2', result['key2'])
 
-        #test error case
+        # test error case
         with open(pathname, 'w') as bad_file:
             try:
                 bad_file.write('{"key1":"value1" "key2":"value2"}')
                 get_file_json(pathname)
                 self.fail('expect throw on reading from badly formatted file')
-            except Exception as ex: #pylint: disable=broad-except
+            except Exception as ex:  # pylint: disable=broad-except
                 self.assertTrue(str(ex).find(
                     'contains error: Expecting value: line 1 column 1 (char 0)'))
 
@@ -87,6 +88,7 @@ class TestUtils(unittest.TestCase):
         expected = 'this_is_snake_cased'
         actual = to_snake_case(the_input)
         self.assertEqual(expected, actual)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/azure-cli-core/azure/cli/core/tests/test_validators.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_validators.py
@@ -7,10 +7,11 @@ import argparse
 import unittest
 from six import StringIO
 
-from azure.cli.core.commands.validators import * # pylint: disable=wildcard-import, unused-wildcard-import
+from azure.cli.core.commands.validators import (validate_key_value_pairs, validate_tag,
+                                                validate_tags)
 
-class Test_storage_validators(unittest.TestCase):
 
+class TestStorageValidators(unittest.TestCase):
     def setUp(self):
         self.io = StringIO()
 
@@ -20,20 +21,20 @@ class Test_storage_validators(unittest.TestCase):
     def test_key_value_pairs_valid(self):
         the_input = 'a=b;c=d'
         actual = validate_key_value_pairs(the_input)
-        expected = {'a':'b', 'c':'d'}
+        expected = {'a': 'b', 'c': 'd'}
         self.assertEqual(actual, expected)
 
     def test_key_value_pairs_invalid(self):
         the_input = 'a=b;c=d;e'
         actual = validate_key_value_pairs(the_input)
-        expected = {'a':'b', 'c':'d'}
+        expected = {'a': 'b', 'c': 'd'}
         self.assertEqual(actual, expected)
 
     def test_tags_valid(self):
         the_input = argparse.Namespace()
         the_input.tags = ['a=b', 'c=d', 'e']
         validate_tags(the_input)
-        expected = {'a':'b', 'c':'d', 'e':''}
+        expected = {'a': 'b', 'c': 'd', 'e': ''}
         self.assertEqual(the_input.tags, expected)
 
     def test_tags_invalid(self):
@@ -43,9 +44,10 @@ class Test_storage_validators(unittest.TestCase):
         self.assertEqual(the_input.tags, {})
 
     def test_tag(self):
-        self.assertEqual(validate_tag('test'), {'test':''})
-        self.assertEqual(validate_tag('a=b'), {'a':'b'})
-        self.assertEqual(validate_tag('a=b;c=d'), {'a':'b;c=d'})
+        self.assertEqual(validate_tag('test'), {'test': ''})
+        self.assertEqual(validate_tag('a=b'), {'a': 'b'})
+        self.assertEqual(validate_tag('a=b;c=d'), {'a': 'b;c=d'})
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/azure-cli-core/azure/cli/core/tests/test_vcr_security.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_vcr_security.py
@@ -7,6 +7,7 @@
 import os
 import unittest
 
+
 class Test_vcr_security(unittest.TestCase):
 
     @classmethod
@@ -38,10 +39,11 @@ class Test_vcr_security(unittest.TestCase):
                         lower_line = line.lower()
                         if 'grant_type=refresh_token' in lower_line or \
                             '/oauth2/token' in lower_line or \
-                            'authorization:' in lower_line:
+                                'authorization:' in lower_line:
                             insecure_cassettes.append(name)
                             break
-        self.assertFalse(insecure_cassettes, 'The following cassettes contain tokens: {}'.format(insecure_cassettes))
+        self.assertFalse(insecure_cassettes,
+                         'The following cassettes contain tokens: {}'.format(insecure_cassettes))
 
     def test_deployment_name_scrub(self):
         from azure.cli.core.test_utils.vcr_test_base import _scrub_deployment_name as scrub_deployment_name
@@ -51,8 +53,10 @@ class Test_vcr_security(unittest.TestCase):
         uri1 = scrub_deployment_name(uri1)
         uri2 = scrub_deployment_name(uri2)
 
-        self.assertEqual(uri1, 'https://www.contoso.com/deployments/mock-deployment?api-version=2015-11-01')
+        self.assertEqual(
+            uri1, 'https://www.contoso.com/deployments/mock-deployment?api-version=2015-11-01')
         self.assertEqual(uri2, 'https://www.contoso.com/deployments/mock-deployment/more')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -19,7 +19,8 @@ try:
 except OSError:
     pass
 else:
-    import re, sys
+    import re
+    import sys
     m = re.search(r'__version__\s*=\s*[\'"](.+?)[\'"]', content)
     if not m:
         print('Could not find __version__ in azure/cli/core/__init__.py')


### PR DESCRIPTION
Most the changes are trivial, including adding whitespace, blank lines and break long lines. There are a few non-trivial changes, which I commented to help you spot. The non-trivial changes includes converting lambda to function as well as adding some intermediate variables to shorten lines.

Most changes were made by autopep8, and the other 15% are manual updates.