### PR TITLE
Azure CLI GitHub bot for Release PRs

### DIFF
--- a/scripts/github_bot/HISTORY.rst
+++ b/scripts/github_bot/HISTORY.rst
@@ -1,0 +1,9 @@
+.. :changelog:
+
+Release History
+===============
+
+0.1.0 (2017-01-13)
+++++++++++++++++++
+
+* First release.

--- a/scripts/github_bot/README.md
+++ b/scripts/github_bot/README.md
@@ -13,14 +13,17 @@ Run locally with `export FLASK_APP=app.py; flask run -h '0.0.0.0'`
 How to Build
 ------------
 ```
-$ sudo docker build --no-cache -t azure-cli-bot-api:1 .
+$ sudo docker build --no-cache -t azuresdk/azure-cli-bot:0.1.0 .
 ```
 
 How to Run with Docker
 ----------------------
 The following environment variables are required for the server to run:
 
+`REPO_NAME` - The name of the GitHub repo (e.g. azure/azure-cli)
 `GITHUB_SECRET_TOKEN` - The Secret that is configured in GitHub Webhook settings.  
+`GITHUB_USER` - User id of the bot that will post comments and create releases.  
+`GITHUB_USER_TOKEN` - Access token for this user.  
 `ALLOWED_USERS` - Space separated list of GitHub usernames that can create releases.  
 `PYPI_REPO` - URL to PyPI (e.g. https://testpypi.python.org/pypi or https://pypi.python.org/pypi).  
 `TWINE_USERNAME` - Username to authenticate with PyPI.  
@@ -29,9 +32,10 @@ The following environment variables are required for the server to run:
 For example:
 
 ```
-$ sudo docker run -d -e "GITHUB_SECRET_TOKEN=<secret>" -e "ALLOWED_USERS=blue red yellow" \
+$ sudo docker run -d -e "REPO_NAME=azure/azure-cli" -e "GITHUB_SECRET_TOKEN=<secret>" -e "GITHUB_USER=user1" \
+-e "GITHUB_USER_TOKEN=<guid>" -e "ALLOWED_USERS=user1 user2 user3" \
 -e "PYPI_REPO=https://testpypi.python.org/pypi" -e "TWINE_USERNAME=<user>" -e "TWINE_PASSWORD=<pass>" \
--p 5000:5000 azure-cli-bot-api:1
+-p 80:80 azuresdk/azure-cli-bot:0.1.0
 ```
 
 
@@ -56,15 +60,22 @@ Deploy on Azure Linux Web App (with Docker container)
 -----------------------------------------------------
 The docker image should be available on a Docker registry.
 
+```
+$ sudo docker push azuresdk/azure-cli-bot:0.1.0
+```
+
+
 For example:
 
 ```
 $ az appservice plan create -g <RG> -n <PLAN-NAME> --sku s1 --is-linux
-$ az appservice web create -g <RG> -n <WEBAPP-NAME> --plan <PLAN-NAME>
+$ az appservice web create -g <RG> --plan <PLAN-NAME> -n <WEBAPP-NAME>
 $ az appservice web config container update -g <RG> -n <WEBAPP-NAME> \
---docker-custom-image-name <DOCKER-IMAGE-NAME> \
---settings 'GITHUB_SECRET_TOKEN=<secret>' 'ALLOWED_USERS=blue red yellow' \
-PYPI_REPO=https://testpypi.python.org/pypi TWINE_USERNAME=<user> TWINE_PASSWORD=<pass>
+--docker-custom-image-name <DOCKER-IMAGE-NAME>
+$ az appservice web config appsettings update -g <RG> -n <WEBAPP-NAME> \
+--settings 'REPO_NAME=azure/azure-cli' 'GITHUB_SECRET_TOKEN=<secret>' 'GITHUB_USER=user1' 'GITHUB_USER_TOKEN=<guid>' \
+'ALLOWED_USERS=user1 user2 user3' 'PYPI_REPO=https://testpypi.python.org/pypi' \
+'TWINE_USERNAME=<user>' 'TWINE_PASSWORD=<pass>'
 $ az appservice web browse -g <RG> -n <WEBAPP-NAME>
 ```
 

--- a/scripts/github_bot/README.md
+++ b/scripts/github_bot/README.md
@@ -29,6 +29,10 @@ The following environment variables are required for the server to run:
 `TWINE_USERNAME` - Username to authenticate with PyPI.  
 `TWINE_PASSWORD` - Password to authenticate with PyPI.
 
+The `GITHUB_USER` should have the following GitHub OAuth scopes:  
+- repo_deployment (to create GitHub releases)
+- public_repo (to post comments on the repo)
+
 For example:
 
 ```

--- a/scripts/github_bot/api/Dockerfile
+++ b/scripts/github_bot/api/Dockerfile
@@ -3,13 +3,15 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-FROM python:3.5
+FROM python:3.5.2-alpine
 
-RUN pip install gunicorn Flask
-RUN pip install wheel twine
+RUN apk update && apk upgrade && \
+    apk add --no-cache bash git openssh
+
+RUN pip install --upgrade pip gunicorn Flask wheel twine requests
 
 ADD app.py /
 
 ENV FLASK_APP app.py
 
-CMD gunicorn --log-level DEBUG -w 10 -b 0.0.0.0:5000 app:app
+CMD gunicorn --log-level DEBUG -w 10 -b 0.0.0.0:80 app:app

--- a/scripts/github_bot/api/app.py
+++ b/scripts/github_bot/api/app.py
@@ -9,12 +9,12 @@ import os
 import hmac
 import tempfile
 import shutil
+import requests
 from hashlib import sha1
 from flask import Flask, jsonify, request, Response
 from subprocess import check_call, CalledProcessError
 
-VERSION = '0.1.0'
-REPO_NAME = 'azure/azure-cli'
+VERSION = '0.0.7'
 
 # GitHub API constants
 GITHUB_UA_PREFIX = 'GitHub-Hookshot/'
@@ -23,16 +23,41 @@ GITHUB_EVENT_NAME_PR = 'pull_request'
 GITHUB_ALLOWED_EVENTS = [GITHUB_EVENT_NAME_PING, GITHUB_EVENT_NAME_PR]
 
 # Environment variables
+ENV_REPO_NAME = os.environ.get('REPO_NAME')
 ENV_GITHUB_SECRET_TOKEN = os.environ.get('GITHUB_SECRET_TOKEN')
+ENV_GITHUB_API_USER = os.environ.get('GITHUB_USER')
+ENV_GITHUB_API_USER_TOKEN = os.environ.get('GITHUB_USER_TOKEN')
 ENV_ALLOWED_USERS = os.environ.get('ALLOWED_USERS')
 ENV_PYPI_REPO = os.environ.get('PYPI_REPO')
 # although not used directly here, twine env vars are needed for releasing
 ENV_PYPI_USERNAME = os.environ.get('TWINE_USERNAME')
 ENV_PYPI_PASSWORD = os.environ.get('TWINE_PASSWORD')
 
-assert (ENV_GITHUB_SECRET_TOKEN and ENV_ALLOWED_USERS and ENV_PYPI_REPO and ENV_PYPI_USERNAME and ENV_PYPI_PASSWORD),\
+assert (ENV_REPO_NAME and ENV_GITHUB_SECRET_TOKEN and ENV_ALLOWED_USERS and ENV_PYPI_REPO and ENV_PYPI_USERNAME and ENV_PYPI_PASSWORD and ENV_GITHUB_API_USER and ENV_GITHUB_API_USER_TOKEN),\
         "Not all required environment variables have been set. "\
-        "Set GITHUB_SECRET_TOKEN, ALLOWED_USERS, PYPI_REPO, TWINE_USERNAME, TWINE_PASSWORD"
+        "Set ENV_REPO_NAME, GITHUB_SECRET_TOKEN, GITHUB_USER, GITHUB_USER_TOKEN, ALLOWED_USERS, PYPI_REPO, TWINE_USERNAME, TWINE_PASSWORD"
+
+GITHUB_API_AUTH = (ENV_GITHUB_API_USER, ENV_GITHUB_API_USER_TOKEN)
+GITHUB_API_HEADERS = {'Accept': 'application/vnd.github.v3+json', 'user-agent': 'azure-cli-bot/{}'.format(VERSION)}
+
+RELEASE_LABEL = 'Release'
+
+OPENED_RELEASE_PR_COMMENT = """
+Reviewers, please verify the following for this PR:
+
+- [ ] The PR title has format `Release <component-name> <version>`.
+- [ ] `setup.py` has been modified with the same version as in the PR title.
+- [ ] `HISTORY.rst` has been modified with appropriate release notes.
+- [ ] If releasing azure-cli or azure-cli-core, `__version__` defined in `__init__.py` should also be modified to match.
+"""
+
+GITHUB_RELEASE_BODY_TMPL = """
+The module has been published to PyPI.
+
+View HISTORY.rst of the module for a changelog.
+
+{}
+"""
 
 def _verify_parse_request(req):
     headers = req.headers
@@ -50,7 +75,7 @@ def _verify_parse_request(req):
     assert gh_event in GITHUB_ALLOWED_EVENTS, "Webhook does not support event '{}'".format(gh_event)
     # Verify the repository
     event_repo = payload['repository']['full_name']
-    assert event_repo == REPO_NAME, "Not listening for events from repo '{}'".format(event_repo)
+    assert event_repo == ENV_REPO_NAME, "Not listening for events from repo '{}'".format(event_repo)
     # Verify the sender (user who performed/triggered the event)
     event_sender = payload['sender']['login']
     assert event_sender in ENV_ALLOWED_USERS.split(), "Not listening for events from sender '{}'".format(event_sender)
@@ -68,27 +93,65 @@ def _parse_pr_title(title):
 
 def create_release(component_name):
     working_dir = tempfile.mkdtemp()
-    check_call(['git', 'clone', 'https://github.com/{}'.format(REPO_NAME), working_dir])
+    check_call(['git', 'clone', 'https://github.com/{}'.format(ENV_REPO_NAME), working_dir])
+    check_call(['pip', 'install', '-e', 'scripts'], cwd=working_dir)
     check_call(['python', '-m', 'scripts.automation.release.run', '-c', component_name,
                 '-r', ENV_PYPI_REPO], cwd=working_dir)
     shutil.rmtree(working_dir, ignore_errors=True)
+
+def apply_release_label(issue_url):
+    payload = [RELEASE_LABEL]
+    r = requests.post('{}/labels'.format(issue_url), json=payload, auth=GITHUB_API_AUTH, headers=GITHUB_API_HEADERS)
+    return True if r.status_code in [200, 201] else False
+
+def comment_on_pr(comments_url, comment_body):
+    payload = {'body': comment_body}
+    r = requests.post(comments_url, json=payload, auth=GITHUB_API_AUTH, headers=GITHUB_API_HEADERS)
+    return True if r.status_code == 201 else False
+
+def create_github_release(component_name, component_version, released_pypi_url):
+    tag_name = '{}-{}'.format(component_name, component_version)
+    release_name = "{} {}".format(component_name, component_version)
+    payload = {'tag_name': tag_name, "target_commitish": "master", "name": release_name, "body": GITHUB_RELEASE_BODY_TMPL.format(released_pypi_url), "prerelease": True}
+    r = requests.post('https://api.github.com/repos/{}/releases'.format(ENV_REPO_NAME), json=payload, auth=GITHUB_API_AUTH, headers=GITHUB_API_HEADERS)
+    return True if r.status_code == 201 else False
 
 def _handle_pr_event(payload):
     pr_action = payload['action']
     pr = payload['pull_request']
     pr_merged = pr_action == 'closed' and pr['merged']
-    if not pr_merged:
-        return jsonify(msg="Ignoring event. PR not merged.")
     try:
         component_name, component_version = _parse_pr_title(pr['title'])
-        try:
-            create_release(component_name)
-            released_pypi_url = '{}/{}'.format(ENV_PYPI_REPO, component_name)
-            return jsonify(msg="Release of '{}' with version '{}' successful. View at {}".format(component_name, component_version, released_pypi_url))
-        except CalledProcessError as e:
-            print("Release of '{}' with version '{}' failed:".format(component_name, component_version))
-            print(e)
-            return jsonify(msg="Release of '{}' with version '{}' failed. View server logs for more info.".format(component_name, component_version)), 500
+        issue_url = pr['_links']['issue']['href']
+        comment_url = pr['_links']['comments']['href']
+        if pr_action == 'opened':
+            apply_release_label(issue_url)
+            comment_created = comment_on_pr(comment_url, OPENED_RELEASE_PR_COMMENT)
+            if comment_created:
+                return jsonify(msg="Commented on PR with release PR checklist.")
+            else:
+                return jsonify(msg="Attempted to comment on PR but API request did not succeed.")
+        elif not pr_merged:
+            return jsonify(msg="Ignoring event. PR not merged.")
+        else:
+            # Merged PR
+            try:
+                create_release(component_name)
+                released_pypi_url = '{}/{}/{}'.format(ENV_PYPI_REPO, component_name, component_version)
+                msg = "Release of '{}' with version '{}' successful. View at {}.".format(component_name, component_version, released_pypi_url)
+                comment_on_pr(comment_url, msg)
+                success = create_github_release(component_name, component_version, released_pypi_url)
+                if success:
+                    comment_on_pr(comment_url, 'GitHub release created. https://github.com/{}/releases.'.format(ENV_REPO_NAME))
+                else:
+                    comment_on_pr(comment_url, 'GitHub release creation unsuccessful. Please create a release at https://github.com/{}/releases.'.format(ENV_REPO_NAME))
+                return jsonify(msg=msg)
+            except CalledProcessError as e:
+                err_msg = "Release of '{}' with version '{}' unsuccessful. Admins, please release manually.".format(component_name, component_version)
+                comment_on_pr(comment_url, err_msg)
+                print(err_msg)
+                print(e)
+                return jsonify(msg="Release of '{}' with version '{}' failed. View server logs for more info.".format(component_name, component_version)), 500
     except (AssertionError, ValueError):
         return jsonify(msg="Ignoring merged PR as not a Release PR. Expecting title to have format 'Release <component-name> <version>'")
     return jsonify(error='Unable to handle PR event.'), 500


### PR DESCRIPTION
- In Dockerfile, upgrade pip
- Add fix for calling the automation script after a recent change to how automation works
- Run on port 80
- Use alpine docker image as base
- Bot comment on opened Release PR with checklist
- Bot comment if release successful or not
- Bot apply release label automatically
- Bot create a GitHub release
- Add HISTORY.rst for github bot changelog