### PR TITLE
Expanding ElasticPool while creating elastic-pool

### DIFF
--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/params.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/params.py
@@ -23,3 +23,8 @@ with ParametersContext(command='sql db create') as c:
     from azure.mgmt.sql.models.database import Database
 
     c.expand('parameters', Database, group_name='Creating')
+
+with ParametersContext(command='sql elastic-pools create') as c:
+    from azure.mgmt.sql.models.elastic_pool import ElasticPool
+
+    c.expand('parameters', ElasticPool, group_name='Creating')


### PR DESCRIPTION
Fix for #1769 

Output after the fix

```
(env) vishrut@visshamac azure-cli (sql-db-test) $ az sql elastic-pools create -h

Command
    az sql elastic-pools create: Creates a new Azure SQL elastic pool or updates an existing Azure
    SQL elastic pool.

Arguments
    --elastic-pool-name [Required]: The name of the Azure SQL Elastic Pool to be operated on
                                    (Updated or created).
    --resource-group -g [Required]: Name of resource group.
    --server-name       [Required]: The name of the Azure SQL server.

Creating Arguments
    --location -l       [Required]: Location.
    --database-dtu-max            : The maximum DTU any one SQL Azure Database can consume.
    --database-dtu-min            : The minimum DTU all SQL Azure Databases are guaranteed.
    --dtu                         : The total shared DTU for the SQL Azure Database Elastic Pool.
    --edition                     : The edition of the Azure SQL Elastic Pool.
    --storage-mb                  : Gets storage limit for the SQL Azure Database Elastic Pool in
                                    MB.
    --tags                        : Resource tags.

Global Arguments
    --debug                       : Increase logging verbosity to show all debug logs.
    --help -h                     : Show this help message and exit.
    --output -o                   : Output format.  Allowed values: json, jsonc, list, table, tsv.
                                    Default: json.
    --query                       : JMESPath query string. See http://jmespath.org/ for more
                                    information and examples.
    --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
```

@troydai / @derekbekoe / @tjprescott Please have a look when you get a chance. Thanks