### PR TITLE
Database is a sub-group instead of command for az sql elastic-pools 

### DIFF
--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/commands.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/commands.py
@@ -76,7 +76,7 @@ with ServiceGroup(__name__, get_sql_elasticpools_operations, elasticpools_ops) a
         c.command('list', 'list_by_server')
         c.generic_update_command('update', 'get', 'create_or_update')
 
-    with s.group('sql elastic-pools database') as c:
+    with s.group('sql elastic-pools db') as c:
         c.command('list', 'list_databases')
         c.command('show', 'get_database')
         c.command('show-activity', 'list_database_activity')

--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/help.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/help.py
@@ -87,7 +87,7 @@ helps['sql elastic-pools update'] = """
             type: command
             short-summary: Update a database elastic pool
             """
-helps['sql elastic-pools database'] = """
+helps['sql elastic-pools db'] = """
             type: group
             short-summary: Command to manage databases activities in database elastic pools
             """

--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/help.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/help.py
@@ -88,6 +88,6 @@ helps['sql elastic-pools update'] = """
             short-summary: Update a database elastic pool
             """
 helps['sql elastic-pools database'] = """
-            type: command
+            type: group
             short-summary: Command to manage databases activities in database elastic pools
             """


### PR DESCRIPTION
Fix for #1777 

```
(env) vishrut@mac azure-cli (fix-elastic-pools-database-help) $ az sql elastic-pools database -h

Group
    az sql elastic-pools database: Command to manage databases activities in database elastic pools.

Commands:
    list         : Returns information about an Azure SQL database inside of an Azure SQL elastic
                   pool.
    show         : Gets information about an Azure SQL database inside of an Azure SQL elastic pool.
    show-activity: Returns information about activity on Azure SQL databases inside of an Azure SQL
                   elastic pool.

(env) vishrut@mac azure-cli (fix-elastic-pools-database-help) $ az sql elastic-pools database show -h

Command
    az sql elastic-pools database show: Gets information about an Azure SQL database inside of an
    Azure SQL elastic pool.

Arguments
    --database-name     [Required]: The name of the Azure SQL database to be retrieved.
    --elastic-pool-name [Required]: The name of the Azure SQL Elastic Pool to be retrieved.
    --resource-group -g [Required]: Name of resource group.
    --server-name       [Required]: The name of the Azure SQL server.

Global Arguments
    --debug                       : Increase logging verbosity to show all debug logs.
    --help -h                     : Show this help message and exit.
    --output -o                   : Output format.  Allowed values: json, jsonc, list, table, tsv.
                                    Default: json.
    --query                       : JMESPath query string. See http://jmespath.org/ for more
                                    information and examples.
    --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
```

@troydai / @derekbekoe / @tjprescott Please have a look when you get a chance. Thanks