### PR TITLE
[Sql] More elastic-pools + command name correction

### DIFF
--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/commands.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/commands.py
@@ -92,6 +92,6 @@ with ServiceGroup(__name__, get_sql_recommended_elastic_pools_operations,
         c.command('show-metrics', 'list_metrics')
         c.command('list', 'list')
 
-    with s.group('sql elastic-pools recommended database') as c:
+    with s.group('sql elastic-pools recommended db') as c:
         c.command('show', 'get_databases')
         c.command('list', 'list_databases')

--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/help.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/help.py
@@ -93,7 +93,7 @@ helps['sql elastic-pools db'] = """
             """
 helps['sql elastic-pools recommended'] = """
             type: group
-            short-summary: Commands to see information about an Azure SQL Recommended Elastic Pools
+            short-summary: Commands to see information about an Azure SQL Recommended Elastic Pool
             """
 helps['sql elastic-pools recommended db'] = """
             type: group

--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/help.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/help.py
@@ -91,3 +91,11 @@ helps['sql elastic-pools db'] = """
             type: group
             short-summary: Command to manage databases activities in database elastic pools
             """
+helps['sql elastic-pools recommended'] = """
+            type: group
+            short-summary: Commands to see information about an Azure SQL Recommended Elastic Pools
+            """
+helps['sql elastic-pools recommended db'] = """
+            type: group
+            short-summary: Commands to see information about an Azure SQL database inside of Recommended Elastic Pool
+            """

--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/tests/recordings/test_sql_elastic_pools_mgmt.yaml
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/tests/recordings/test_sql_elastic_pools_mgmt.yaml
@@ -1,17 +1,17 @@
 interactions:
 - request:
-    body: '{"properties": {"administratorLoginPassword": "SecretPassword123", "administratorLogin":
-      "admin123"}, "location": "westus"}'
+    body: '{"location": "westus", "properties": {"administratorLoginPassword": "SecretPassword123",
+      "administratorLogin": "admin123"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['123']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14986-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.2 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 sqlmanagementclient/0.2.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [bf156d94-dd39-11e6-b9db-605718c241fa]
+      x-ms-client-request-id: [9f073fec-dde1-11e6-ba03-f45c89b0bb23]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06?api-version=2014-04-01
   response:
@@ -22,12 +22,12 @@ interactions:
       Content-Length: ['500']
       Content-Type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Wed, 18 Jan 2017 04:52:17 GMT']
+      Date: ['Thu, 19 Jan 2017 00:53:33 GMT']
       Preference-Applied: [return-content]
       Server: [Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-Content-Type-Options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: '{"location": "westus"}'
@@ -37,27 +37,27 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['22']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14986-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.2 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 sqlmanagementclient/0.2.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d5194208-dd39-11e6-9093-605718c241fa]
+      x-ms-client-request-id: [b44a6a80-dde1-11e6-863e-f45c89b0bb23]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/elasticPools/cliautomationpool01?api-version=2014-04-01
   response:
-    body: {string: '{"operation":"CREATE","startTime":"\/Date(1484715157781+0000)\/"}'}
+    body: {string: '{"operation":"CREATE","startTime":"\/Date(1484787228950+0000)\/"}'}
     headers:
       Cache-Control: ['no-store, no-cache']
       Content-Length: ['65']
       Content-Type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Wed, 18 Jan 2017 04:52:38 GMT']
-      Location: ['https://management.azure.com/subscriptions/88271ab0-9af4-442c-abb0-901d9fa06ca8/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/elasticPools/cliautomationpool01/operationResults/509daecb-7a7f-4090-b066-0d2eeb7fb4b3?api-version=2014-04-01-Preview']
+      Date: ['Thu, 19 Jan 2017 00:53:47 GMT']
+      Location: ['https://management.azure.com/subscriptions/88271ab0-9af4-442c-abb0-901d9fa06ca8/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/elasticPools/cliautomationpool01/operationResults/388a98be-0c5e-4bc5-a1cd-bad246ba7f09?api-version=2014-04-01-Preview']
       Preference-Applied: [return-content]
       Retry-After: ['30']
       Server: [Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-Content-Type-Options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -66,21 +66,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14986-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.2 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 sqlmanagementclient/0.2.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d5194208-dd39-11e6-9093-605718c241fa]
+      x-ms-client-request-id: [b44a6a80-dde1-11e6-863e-f45c89b0bb23]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/elasticPools/cliautomationpool01/operationResults/509daecb-7a7f-4090-b066-0d2eeb7fb4b3?api-version=2014-04-01-Preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/elasticPools/cliautomationpool01/operationResults/388a98be-0c5e-4bc5-a1cd-bad246ba7f09?api-version=2014-04-01-Preview
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/elasticPools/cliautomationpool01","name":"cliautomationpool01","type":"Microsoft.Sql/servers/elasticPools","location":"West
-        US","kind":null,"properties":{"creationDate":"2017-01-18T04:52:18.81Z","edition":"Standard","state":"Ready","dtu":100,"databaseDtuMin":0,"databaseDtuMax":100,"storageMB":102400}}'}
+        US","kind":null,"properties":{"creationDate":"2017-01-19T00:53:37.247Z","edition":"Standard","state":"Ready","dtu":100,"databaseDtuMin":0,"databaseDtuMax":100,"storageMB":102400}}'}
     headers:
       Cache-Control: ['no-store, no-cache']
-      Content-Length: ['448']
+      Content-Length: ['449']
       Content-Type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Wed, 18 Jan 2017 04:53:08 GMT']
+      Date: ['Thu, 19 Jan 2017 00:54:18 GMT']
       Server: [Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-Content-Type-Options: [nosniff]
@@ -92,26 +92,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14986-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.2 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 sqlmanagementclient/0.2.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f40662a4-dd39-11e6-a632-605718c241fa]
+      x-ms-client-request-id: [cf039dee-dde1-11e6-a11c-f45c89b0bb23]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/elasticPools/cliautomationpool01?api-version=2014-04-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/elasticPools/cliautomationpool01","name":"cliautomationpool01","type":"Microsoft.Sql/servers/elasticPools","location":"West
-        US","kind":null,"properties":{"creationDate":"2017-01-18T04:52:18.81Z","edition":"Standard","state":"Ready","dtu":100,"databaseDtuMin":0,"databaseDtuMax":100,"storageMB":102400}}'}
+        US","kind":null,"properties":{"creationDate":"2017-01-19T00:53:37.247Z","edition":"Standard","state":"Ready","dtu":100,"databaseDtuMin":0,"databaseDtuMax":100,"storageMB":102400}}'}
     headers:
       Cache-Control: ['no-store, no-cache']
       Content-Type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Wed, 18 Jan 2017 04:53:10 GMT']
+      Date: ['Thu, 19 Jan 2017 00:54:18 GMT']
       Server: [Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-Content-Type-Options: [nosniff]
-      content-length: ['448']
+      content-length: ['449']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -120,26 +120,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14986-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.2 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 sqlmanagementclient/0.2.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f488838a-dd39-11e6-a181-605718c241fa]
+      x-ms-client-request-id: [cfb4e0b6-dde1-11e6-a97d-f45c89b0bb23]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/elasticPools?api-version=2014-04-01
   response:
     body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/elasticPools/cliautomationpool01","name":"cliautomationpool01","type":"Microsoft.Sql/servers/elasticPools","location":"West
-        US","kind":null,"properties":{"creationDate":"2017-01-18T04:52:18.81Z","edition":"Standard","state":"Ready","dtu":100,"databaseDtuMin":0,"databaseDtuMax":100,"storageMB":102400}}]}'}
+        US","kind":null,"properties":{"creationDate":"2017-01-19T00:53:37.247Z","edition":"Standard","state":"Ready","dtu":100,"databaseDtuMin":0,"databaseDtuMax":100,"storageMB":102400}}]}'}
     headers:
       Cache-Control: ['no-store, no-cache']
       Content-Type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Wed, 18 Jan 2017 04:53:11 GMT']
+      Date: ['Thu, 19 Jan 2017 00:54:20 GMT']
       Server: [Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-Content-Type-Options: [nosniff]
-      content-length: ['460']
+      content-length: ['461']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -148,52 +148,52 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14986-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.2 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 sqlmanagementclient/0.2.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f52340c6-dd39-11e6-9669-605718c241fa]
+      x-ms-client-request-id: [d05b765e-dde1-11e6-9727-f45c89b0bb23]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/elasticPools/cliautomationpool01?api-version=2014-04-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/elasticPools/cliautomationpool01","name":"cliautomationpool01","type":"Microsoft.Sql/servers/elasticPools","location":"West
-        US","kind":null,"properties":{"creationDate":"2017-01-18T04:52:18.81Z","edition":"Standard","state":"Ready","dtu":100,"databaseDtuMin":0,"databaseDtuMax":100,"storageMB":102400}}'}
+        US","kind":null,"properties":{"creationDate":"2017-01-19T00:53:37.247Z","edition":"Standard","state":"Ready","dtu":100,"databaseDtuMin":0,"databaseDtuMax":100,"storageMB":102400}}'}
     headers:
       Cache-Control: ['no-store, no-cache']
       Content-Type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Wed, 18 Jan 2017 04:53:11 GMT']
+      Date: ['Thu, 19 Jan 2017 00:54:21 GMT']
       Server: [Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-Content-Type-Options: [nosniff]
-      content-length: ['448']
+      content-length: ['449']
     status: {code: 200, message: OK}
 - request:
-    body: '{"tags": {"key1": "value1"}, "properties": {"dtu": 100, "databaseDtuMax":
-      100, "databaseDtuMin": 0, "edition": "Standard", "storageMB": 102400}, "location":
-      "West US"}'
+    body: '{"location": "West US", "tags": {"key1": "value1"}, "properties": {"dtu":
+      100, "storageMB": 102400, "edition": "Standard", "databaseDtuMax": 100, "databaseDtuMin":
+      0}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['167']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14986-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.2 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 sqlmanagementclient/0.2.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f5652f9a-dd39-11e6-bdba-605718c241fa]
+      x-ms-client-request-id: [d0c191fa-dde1-11e6-b3aa-f45c89b0bb23]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/elasticPools/cliautomationpool01?api-version=2014-04-01
   response:
-    body: {string: '{"operation":"UPDATE","startTime":"\/Date(1484715192523+0000)\/"}'}
+    body: {string: '{"operation":"UPDATE","startTime":"\/Date(1484787262269+0000)\/"}'}
     headers:
       Cache-Control: ['no-store, no-cache']
       Content-Length: ['65']
       Content-Type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Wed, 18 Jan 2017 04:53:13 GMT']
-      Location: ['https://management.azure.com/subscriptions/88271ab0-9af4-442c-abb0-901d9fa06ca8/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/elasticPools/cliautomationpool01/operationResults/49ae60ab-03d2-4a91-ac40-2842fc54a981?api-version=2014-04-01-Preview']
+      Date: ['Thu, 19 Jan 2017 00:54:22 GMT']
+      Location: ['https://management.azure.com/subscriptions/88271ab0-9af4-442c-abb0-901d9fa06ca8/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/elasticPools/cliautomationpool01/operationResults/f28d5389-7d43-40ab-83a3-4ce2bcccdae8?api-version=2014-04-01-Preview']
       Preference-Applied: [return-content]
       Retry-After: ['30']
       Server: [Microsoft-HTTPAPI/2.0]
@@ -208,26 +208,26 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14986-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.2 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 sqlmanagementclient/0.2.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f5652f9a-dd39-11e6-bdba-605718c241fa]
+      x-ms-client-request-id: [d0c191fa-dde1-11e6-b3aa-f45c89b0bb23]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/elasticPools/cliautomationpool01/operationResults/49ae60ab-03d2-4a91-ac40-2842fc54a981?api-version=2014-04-01-Preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/elasticPools/cliautomationpool01/operationResults/f28d5389-7d43-40ab-83a3-4ce2bcccdae8?api-version=2014-04-01-Preview
   response:
     body: {string: '{"tags":{"key1":"value1"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/elasticPools/cliautomationpool01","name":"cliautomationpool01","type":"Microsoft.Sql/servers/elasticPools","location":"West
-        US","kind":null,"properties":{"creationDate":"2017-01-18T04:52:18.81Z","edition":"Standard","state":"Ready","dtu":100,"databaseDtuMin":0,"databaseDtuMax":100,"storageMB":102400}}'}
+        US","kind":null,"properties":{"creationDate":"2017-01-19T00:53:37.247Z","edition":"Standard","state":"Ready","dtu":100,"databaseDtuMin":0,"databaseDtuMax":100,"storageMB":102400}}'}
     headers:
       Cache-Control: ['no-store, no-cache']
       Content-Type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Wed, 18 Jan 2017 04:53:43 GMT']
+      Date: ['Thu, 19 Jan 2017 00:54:53 GMT']
       Server: [Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-Content-Type-Options: [nosniff]
-      content-length: ['473']
+      content-length: ['474']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -236,51 +236,51 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14986-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.2 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 sqlmanagementclient/0.2.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [0825daf4-dd3a-11e6-a7ec-605718c241fa]
+      x-ms-client-request-id: [e3e6d4d8-dde1-11e6-a212-f45c89b0bb23]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/elasticPools/cliautomationpool01?api-version=2014-04-01
   response:
     body: {string: '{"tags":{"key1":"value1"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/elasticPools/cliautomationpool01","name":"cliautomationpool01","type":"Microsoft.Sql/servers/elasticPools","location":"West
-        US","kind":null,"properties":{"creationDate":"2017-01-18T04:52:18.81Z","edition":"Standard","state":"Ready","dtu":100,"databaseDtuMin":0,"databaseDtuMax":100,"storageMB":102400}}'}
+        US","kind":null,"properties":{"creationDate":"2017-01-19T00:53:37.247Z","edition":"Standard","state":"Ready","dtu":100,"databaseDtuMin":0,"databaseDtuMax":100,"storageMB":102400}}'}
     headers:
       Cache-Control: ['no-store, no-cache']
       Content-Type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Wed, 18 Jan 2017 04:53:44 GMT']
+      Date: ['Thu, 19 Jan 2017 00:54:53 GMT']
       Server: [Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-Content-Type-Options: [nosniff]
-      content-length: ['473']
+      content-length: ['474']
     status: {code: 200, message: OK}
 - request:
-    body: '{"tags": {}, "properties": {"dtu": 100, "databaseDtuMax": 100, "databaseDtuMin":
-      0, "edition": "Standard", "storageMB": 102400}, "location": "West US"}'
+    body: '{"location": "West US", "tags": {}, "properties": {"dtu": 100, "storageMB":
+      102400, "edition": "Standard", "databaseDtuMax": 100, "databaseDtuMin": 0}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['151']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14986-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.2 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 sqlmanagementclient/0.2.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [085b01d8-dd3a-11e6-8c7d-605718c241fa]
+      x-ms-client-request-id: [e436d3a2-dde1-11e6-9f9c-f45c89b0bb23]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/elasticPools/cliautomationpool01?api-version=2014-04-01
   response:
-    body: {string: '{"operation":"UPDATE","startTime":"\/Date(1484715224304+0000)\/"}'}
+    body: {string: '{"operation":"UPDATE","startTime":"\/Date(1484787294183+0000)\/"}'}
     headers:
       Cache-Control: ['no-store, no-cache']
       Content-Length: ['65']
       Content-Type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Wed, 18 Jan 2017 04:53:44 GMT']
-      Location: ['https://management.azure.com/subscriptions/88271ab0-9af4-442c-abb0-901d9fa06ca8/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/elasticPools/cliautomationpool01/operationResults/815bdaf3-c98c-4a62-9fa0-bb3f44cd6705?api-version=2014-04-01-Preview']
+      Date: ['Thu, 19 Jan 2017 00:54:55 GMT']
+      Location: ['https://management.azure.com/subscriptions/88271ab0-9af4-442c-abb0-901d9fa06ca8/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/elasticPools/cliautomationpool01/operationResults/0e57ef89-2f53-4785-8c3b-8c5d3b1d915c?api-version=2014-04-01-Preview']
       Preference-Applied: [return-content]
       Retry-After: ['30']
       Server: [Microsoft-HTTPAPI/2.0]
@@ -295,52 +295,51 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14986-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.2 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 sqlmanagementclient/0.2.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [085b01d8-dd3a-11e6-8c7d-605718c241fa]
+      x-ms-client-request-id: [e436d3a2-dde1-11e6-9f9c-f45c89b0bb23]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/elasticPools/cliautomationpool01/operationResults/815bdaf3-c98c-4a62-9fa0-bb3f44cd6705?api-version=2014-04-01-Preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/elasticPools/cliautomationpool01/operationResults/0e57ef89-2f53-4785-8c3b-8c5d3b1d915c?api-version=2014-04-01-Preview
   response:
     body: {string: '{"tags":{},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/elasticPools/cliautomationpool01","name":"cliautomationpool01","type":"Microsoft.Sql/servers/elasticPools","location":"West
-        US","kind":null,"properties":{"creationDate":"2017-01-18T04:52:18.81Z","edition":"Standard","state":"Ready","dtu":100,"databaseDtuMin":0,"databaseDtuMax":100,"storageMB":102400}}'}
+        US","kind":null,"properties":{"creationDate":"2017-01-19T00:53:37.247Z","edition":"Standard","state":"Ready","dtu":100,"databaseDtuMin":0,"databaseDtuMax":100,"storageMB":102400}}'}
     headers:
       Cache-Control: ['no-store, no-cache']
       Content-Type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Wed, 18 Jan 2017 04:54:15 GMT']
+      Date: ['Thu, 19 Jan 2017 00:55:25 GMT']
       Server: [Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-Content-Type-Options: [nosniff]
-      content-length: ['458']
+      content-length: ['459']
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"elasticPoolName": "cliautomationpool01"}, "location":
-      "westus"}'
+    body: '{"location": "westus", "properties": {"elasticPoolName": "cliautomationpool01"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['80']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14986-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.2 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 sqlmanagementclient/0.2.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [1b21e108-dd3a-11e6-8026-605718c241fa]
+      x-ms-client-request-id: [f74cd3c2-dde1-11e6-bf85-f45c89b0bb23]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/databases/cliautomationdb02?api-version=2014-04-01
   response:
-    body: {string: '{"operation":"CreateLogicalDatabase","startTime":"\/Date(1484715257153+0000)\/"}'}
+    body: {string: '{"operation":"CreateLogicalDatabase","startTime":"\/Date(1484787329260+0000)\/"}'}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/88271ab0-9af4-442c-abb0-901d9fa06ca8/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/databases/cliautomationdb02/azureAsyncOperation/f2f90996-eca7-4056-8c56-42456002ef26?api-version=2014-04-01-Preview']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/88271ab0-9af4-442c-abb0-901d9fa06ca8/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/databases/cliautomationdb02/azureAsyncOperation/2d330d3e-3f5a-4a5f-a920-d358033339ff?api-version=2014-04-01-Preview']
       Cache-Control: ['no-store, no-cache']
       Content-Length: ['80']
       Content-Type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Wed, 18 Jan 2017 04:54:16 GMT']
-      Location: ['https://management.azure.com/subscriptions/88271ab0-9af4-442c-abb0-901d9fa06ca8/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/databases/cliautomationdb02/operationResults/f2f90996-eca7-4056-8c56-42456002ef26?api-version=2014-04-01-Preview']
+      Date: ['Thu, 19 Jan 2017 00:55:27 GMT']
+      Location: ['https://management.azure.com/subscriptions/88271ab0-9af4-442c-abb0-901d9fa06ca8/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/databases/cliautomationdb02/operationResults/2d330d3e-3f5a-4a5f-a920-d358033339ff?api-version=2014-04-01-Preview']
       Preference-Applied: [return-content]
       Retry-After: ['30']
       Server: [Microsoft-HTTPAPI/2.0]
@@ -355,20 +354,20 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14986-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.2 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 sqlmanagementclient/0.2.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [1b21e108-dd3a-11e6-8026-605718c241fa]
+      x-ms-client-request-id: [f74cd3c2-dde1-11e6-bf85-f45c89b0bb23]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/databases/cliautomationdb02/azureAsyncOperation/f2f90996-eca7-4056-8c56-42456002ef26?api-version=2014-04-01-Preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/databases/cliautomationdb02/azureAsyncOperation/2d330d3e-3f5a-4a5f-a920-d358033339ff?api-version=2014-04-01-Preview
   response:
-    body: {string: '{"operationId":"f2f90996-eca7-4056-8c56-42456002ef26","status":"Succeeded","error":null}'}
+    body: {string: '{"operationId":"2d330d3e-3f5a-4a5f-a920-d358033339ff","status":"Succeeded","error":null}'}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/88271ab0-9af4-442c-abb0-901d9fa06ca8/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/databases/cliautomationdb02/azureAsyncOperation/f2f90996-eca7-4056-8c56-42456002ef26?api-version=2014-04-01-Preview']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/88271ab0-9af4-442c-abb0-901d9fa06ca8/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/databases/cliautomationdb02/azureAsyncOperation/2d330d3e-3f5a-4a5f-a920-d358033339ff?api-version=2014-04-01-Preview']
       Cache-Control: ['no-store, no-cache']
       Content-Type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Wed, 18 Jan 2017 04:54:47 GMT']
+      Date: ['Thu, 19 Jan 2017 00:55:57 GMT']
       Server: [Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -383,21 +382,21 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14986-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.2 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 sqlmanagementclient/0.2.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [1b21e108-dd3a-11e6-8026-605718c241fa]
+      x-ms-client-request-id: [f74cd3c2-dde1-11e6-bf85-f45c89b0bb23]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/databases/cliautomationdb02?api-version=2014-04-01
   response:
     body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/databases/cliautomationdb02","name":"cliautomationdb02","type":"Microsoft.Sql/servers/databases","location":"West
-        US","kind":"v12.0,user","properties":{"databaseId":"d7221d09-661a-4b6d-b793-38e915eef815","edition":"Standard","status":"Online","serviceLevelObjective":"ElasticPool","collation":"SQL_Latin1_General_CP1_CI_AS","maxSizeBytes":"268435456000","creationDate":"2017-01-18T04:54:17.357Z","currentServiceObjectiveId":"d1737d22-a8ea-4de7-9bd0-33395d2a7419","requestedServiceObjectiveId":"d1737d22-a8ea-4de7-9bd0-33395d2a7419","requestedServiceObjectiveName":"ElasticPool","sampleName":null,"defaultSecondaryLocation":"East
-        US","earliestRestoreDate":"2017-01-18T05:04:23.903Z","elasticPoolName":"cliautomationpool01","containmentState":2,"readScale":"Disabled"}}'}
+        US","kind":"v12.0,user","properties":{"databaseId":"9a0663c3-9574-4d03-908e-f03ad309b559","edition":"Standard","status":"Online","serviceLevelObjective":"ElasticPool","collation":"SQL_Latin1_General_CP1_CI_AS","maxSizeBytes":"268435456000","creationDate":"2017-01-19T00:55:29.497Z","currentServiceObjectiveId":"d1737d22-a8ea-4de7-9bd0-33395d2a7419","requestedServiceObjectiveId":"d1737d22-a8ea-4de7-9bd0-33395d2a7419","requestedServiceObjectiveName":"ElasticPool","sampleName":null,"defaultSecondaryLocation":"East
+        US","earliestRestoreDate":"2017-01-19T01:05:38.043Z","elasticPoolName":"cliautomationpool01","containmentState":2,"readScale":"Disabled"}}'}
     headers:
       Cache-Control: ['no-store, no-cache']
       Content-Type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
       DataServiceVersion: [3.0;]
-      Date: ['Wed, 18 Jan 2017 04:54:47 GMT']
+      Date: ['Thu, 19 Jan 2017 00:55:58 GMT']
       Server: [Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -411,26 +410,85 @@ interactions:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14986-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.2 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 sqlmanagementclient/0.2.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2e990122-dd3a-11e6-89c0-605718c241fa]
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/databases/cliautomationdb02?api-version=2014-04-01
+      x-ms-client-request-id: [0b665b62-dde2-11e6-91e1-f45c89b0bb23]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/elasticPools/cliautomationpool01/databases?api-version=2014-04-01
   response:
-    body: {string: ''}
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/databases/cliautomationdb02","name":"cliautomationdb02","type":"Microsoft.Sql/servers/databases","location":"West
+        US","kind":"v12.0,user","properties":{"databaseId":"9a0663c3-9574-4d03-908e-f03ad309b559","edition":"Standard","status":"Online","serviceLevelObjective":"ElasticPool","collation":"SQL_Latin1_General_CP1_CI_AS","maxSizeBytes":"268435456000","creationDate":"2017-01-19T00:55:29.497Z","currentServiceObjectiveId":"d1737d22-a8ea-4de7-9bd0-33395d2a7419","requestedServiceObjectiveId":"d1737d22-a8ea-4de7-9bd0-33395d2a7419","requestedServiceObjectiveName":"ElasticPool","createMode":null,"sampleName":null,"sourceDatabaseId":null,"defaultSecondaryLocation":"East
+        US","earliestRestoreDate":"2017-01-19T01:05:38.043Z","restorePointInTime":null,"sourceDatabaseDeletionDate":null,"blobUriAndSasKey":null,"recoveryServicesRecoveryPointResourceId":null,"elasticPoolName":"cliautomationpool01","containmentState":2,"readScale":"Disabled"}}]}'}
     headers:
       Cache-Control: ['no-store, no-cache']
-      Content-Length: ['0']
-      Content-Type: [application/xml; charset=utf-8]
-      DataServiceVersion: [1.0;]
-      Date: ['Wed, 18 Jan 2017 04:54:50 GMT']
+      Content-Type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      DataServiceVersion: [3.0;]
+      Date: ['Thu, 19 Jan 2017 00:56:00 GMT']
       Server: [Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
       X-Content-Type-Options: [nosniff]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      content-length: ['1098']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 sqlmanagementclient/0.2.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [0c337bf6-dde2-11e6-aa0b-f45c89b0bb23]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/elasticPools/cliautomationpool01/databases/cliautomationdb02?api-version=2014-04-01
+  response:
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/databases/cliautomationdb02","name":"cliautomationdb02","type":"Microsoft.Sql/servers/databases","location":"West
+        US","kind":"v12.0,user","properties":{"databaseId":"9a0663c3-9574-4d03-908e-f03ad309b559","edition":"Standard","status":"Online","serviceLevelObjective":"ElasticPool","collation":"SQL_Latin1_General_CP1_CI_AS","maxSizeBytes":"268435456000","creationDate":"2017-01-19T00:55:29.497Z","currentServiceObjectiveId":"d1737d22-a8ea-4de7-9bd0-33395d2a7419","requestedServiceObjectiveId":"d1737d22-a8ea-4de7-9bd0-33395d2a7419","requestedServiceObjectiveName":"ElasticPool","createMode":null,"sampleName":null,"sourceDatabaseId":null,"defaultSecondaryLocation":"East
+        US","earliestRestoreDate":"2017-01-19T01:05:38.043Z","restorePointInTime":null,"sourceDatabaseDeletionDate":null,"blobUriAndSasKey":null,"recoveryServicesRecoveryPointResourceId":null,"elasticPoolName":"cliautomationpool01","containmentState":2,"readScale":"Disabled"}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache']
+      Content-Type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      DataServiceVersion: [3.0;]
+      Date: ['Thu, 19 Jan 2017 00:56:01 GMT']
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      content-length: ['1086']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 sqlmanagementclient/0.2.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [0ce1be46-dde2-11e6-abb5-f45c89b0bb23]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/elasticPools/cliautomationpool01/elasticPoolDatabaseActivity?api-version=2014-04-01
+  response:
+    body: {string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/elasticPools/cliautomationpool01/elasticPoolDatabaseActivity/2d330d3e-3f5a-4a5f-a920-d358033339ff","name":"2d330d3e-3f5a-4a5f-a920-d358033339ff","type":"Microsoft.Sql/servers/elasticPools/elasticPoolDatabaseActivity","location":"West
+        US","properties":{"operationId":"2d330d3e-3f5a-4a5f-a920-d358033339ff","serverName":"cliautomation06","databaseName":"cliautomationdb02","state":"COMPLETED","operation":"CREATE","errorCode":null,"errorMessage":null,"errorSeverity":null,"startTime":"2017-01-19T00:55:29.247","endTime":"2017-01-19T00:55:38.213","percentComplete":100,"currentServiceObjective":"ElasticPool","requestedServiceObjective":null,"currentElasticPoolName":"cliautomationpool01","requestedElasticPoolName":null}}]}'}
+    headers:
+      Cache-Control: ['no-store, no-cache']
+      Content-Type: [application/json; odata=minimalmetadata; streaming=true; charset=utf-8]
+      DataServiceVersion: [3.0;]
+      Date: ['Thu, 19 Jan 2017 00:56:03 GMT']
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      content-length: ['877']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -440,12 +498,12 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14986-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.2 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 sqlmanagementclient/0.2.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [2fd2e48a-dd3a-11e6-b802-605718c241fa]
+      x-ms-client-request-id: [0d899f8a-dde2-11e6-b829-f45c89b0bb23]
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/elasticPools/cliautomationpool01?api-version=2014-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/databases/cliautomationdb02?api-version=2014-04-01
   response:
     body: {string: ''}
     headers:
@@ -453,7 +511,7 @@ interactions:
       Content-Length: ['0']
       Content-Type: [application/xml; charset=utf-8]
       DataServiceVersion: [1.0;]
-      Date: ['Wed, 18 Jan 2017 04:54:51 GMT']
+      Date: ['Thu, 19 Jan 2017 00:56:05 GMT']
       Server: [Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-Content-Type-Options: [nosniff]
@@ -467,10 +525,37 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14986-SP0) requests/2.9.1 msrest/0.4.4
+      User-Agent: [python/3.5.2 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 sqlmanagementclient/0.2.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b1+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [3142e810-dd3a-11e6-9fd3-605718c241fa]
+      x-ms-client-request-id: [0f40dc46-dde2-11e6-822d-f45c89b0bb23]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06/elasticPools/cliautomationpool01?api-version=2014-04-01
+  response:
+    body: {string: ''}
+    headers:
+      Cache-Control: ['no-store, no-cache']
+      Content-Length: ['0']
+      Content-Type: [application/xml; charset=utf-8]
+      DataServiceVersion: [1.0;]
+      Date: ['Thu, 19 Jan 2017 00:56:08 GMT']
+      Server: [Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-Content-Type-Options: [nosniff]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.2 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 sqlmanagementclient/0.2.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b1+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [1098eb54-dde2-11e6-a2d7-f45c89b0bb23]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli-test-sql-mgmt/providers/Microsoft.Sql/servers/cliautomation06?api-version=2014-04-01
   response:
@@ -480,7 +565,7 @@ interactions:
       Content-Length: ['0']
       Content-Type: [application/xml; charset=utf-8]
       DataServiceVersion: [1.0;]
-      Date: ['Wed, 18 Jan 2017 04:54:54 GMT']
+      Date: ['Thu, 19 Jan 2017 00:56:11 GMT']
       Server: [Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-Content-Type-Options: [nosniff]

--- a/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/tests/test_sql_commands.py
+++ b/src/command_modules/azure-cli-sql/azure/cli/command_modules/sql/tests/test_sql_commands.py
@@ -341,6 +341,33 @@ class SqlElasticPoolsMgmtScenarioTest(ResourceGroupVCRTestBase):
                      JMESPathCheck('elasticPoolName', self.pool_name),
                      JMESPathCheck('status', 'Online')])
 
+        # test sql elastic-pools db sub-group commands
+        self.cmd('sql elastic-pools db list -g {} --server-name {} --elastic-pool-name {}'
+                 .format(rg, self.sql_server_name, self.pool_name),
+                 checks=[
+                     JMESPathCheck('length(@)', 1),
+                     JMESPathCheck('[0].resourceGroup', rg),
+                     JMESPathCheck('[0].name', self.database_name),
+                     JMESPathCheck('[0].elasticPoolName', self.pool_name),
+                     JMESPathCheck('[0].status', 'Online')])
+
+        self.cmd('sql elastic-pools db show -g {} --server-name {} --elastic-pool-name {} '
+                 '--database-name {}'
+                 .format(rg, self.sql_server_name, self.pool_name, self.database_name),
+                 checks=[
+                     JMESPathCheck('resourceGroup', rg),
+                     JMESPathCheck('name', self.database_name),
+                     JMESPathCheck('elasticPoolName', self.pool_name),
+                     JMESPathCheck('status', 'Online')])
+
+        self.cmd('sql elastic-pools db show-activity -g {} --server-name {} --elastic-pool-name {}'
+                 .format(rg, self.sql_server_name, self.pool_name),
+                 checks=[
+                     JMESPathCheck('length(@)', 1),
+                     JMESPathCheck('[0].resourceGroup', rg),
+                     JMESPathCheck('[0].serverName', self.sql_server_name),
+                     JMESPathCheck('[0].currentElasticPoolName', self.pool_name)])
+
         # delete sql server database
         self.cmd('sql db delete -g {} --server-name {} --database-name {}'
                  .format(rg, self.sql_server_name, self.database_name), checks=[NoneCheck()])


### PR DESCRIPTION
**Change 1** : Adds nose unit tests and recording for
```
az sql elastic-pools db list
az sql elastic-pools db show
az sql elastic-pools db show-activity
```
**Change 2** : Update documentation for `recommended` sub-group of elastic-pools command. It was showing empty short summary. 
```
(env) vishrut@mac azure-cli (more-elastic-pools) $ az sql elastic-pools recommended -h

Group
    az sql elastic-pools recommended: Commands to see information about an Azure SQL Recommended
    Elastic Pools.

Subgroups:
    db          : Commands to see information about an Azure SQL database inside of Recommended
                  Elastic Pool.

Commands:
    list        : Returns information about Azure SQL Recommended Elastic Pools.
    show        : Gets information about an Azure SQL Recommended Elastic Pool.
    show-metrics: Returns information about an recommended elastic pool metrics.
```

**Change 3**: Update name from `database` to `db` for 
```
(env) vishrut@mac azure-cli (more-elastic-pools) $ az sql elastic-pools recommended db -h

Group
    az sql elastic-pools recommended db: Commands to see information about an Azure SQL database
    inside of Recommended Elastic Pool.

Commands:
    list: Returns information about an Azure SQL database inside of an Azure SQL Recommended Elastic
          Pool.
    show: Gets information about an Azure SQL database inside of an Azure SQL Recommended Elastic
          Pool.
```

Also, manually tested `az sql elastic-pools recommended` as they do not return anything yet. As per my talk with Azure SQL Service team member, It's the recommendation service that does recommendation when it thinks necessary, so I preferred not add those commands with no checks unless you think necessary. 

@troydai / @derekbekoe / @tjprescott Please have a look when you get a chance. Thanks