### PR TITLE
Change SHA256 hash & exit script if error

### DIFF
--- a/scripts/curl_install_pypi/install
+++ b/scripts/curl_install_pypi/install
@@ -15,7 +15,11 @@ _TTY=/dev/tty
 install_script=$(mktemp -t azure_cli_install_tmp_XXXX) || exit
 echo "Downloading Azure CLI install script from $INSTALL_SCRIPT_URL to $install_script."
 curl -# $INSTALL_SCRIPT_URL > $install_script || exit
-echo "$INSTALL_SCRIPT_SHA256  $install_script" | shasum -a 256 -c -
+shasum -v
+if [ "$?" -eq 0 ]
+then
+  echo "$INSTALL_SCRIPT_SHA256  $install_script" | shasum -a 256 -c - || exit
+fi
 chmod 775 $install_script
 echo "Running install script."
 $install_script < $_TTY

--- a/scripts/curl_install_pypi/install
+++ b/scripts/curl_install_pypi/install
@@ -8,8 +8,9 @@
 # 
 # Bash script to install the Azure CLI
 #
+set -e
 INSTALL_SCRIPT_URL="https://azurecliprod.blob.core.windows.net/install.py"
-INSTALL_SCRIPT_SHA256=d4b508d554f0af5363ca08f1aa2afb83ca43bc8163bc5450fda3b273ca0f7a1c
+INSTALL_SCRIPT_SHA256=25520ec542b14826d33359a392c18c84b6601d89a5522dfa2b5831b5de19a472
 _TTY=/dev/tty
 
 install_script=$(mktemp -t azure_cli_install_tmp_XXXX) || exit

--- a/scripts/curl_install_pypi/install
+++ b/scripts/curl_install_pypi/install
@@ -8,7 +8,6 @@
 # 
 # Bash script to install the Azure CLI
 #
-set -e
 INSTALL_SCRIPT_URL="https://azurecliprod.blob.core.windows.net/install.py"
 INSTALL_SCRIPT_SHA256=25520ec542b14826d33359a392c18c84b6601d89a5522dfa2b5831b5de19a472
 _TTY=/dev/tty
@@ -16,7 +15,7 @@ _TTY=/dev/tty
 install_script=$(mktemp -t azure_cli_install_tmp_XXXX) || exit
 echo "Downloading Azure CLI install script from $INSTALL_SCRIPT_URL to $install_script."
 curl -# $INSTALL_SCRIPT_URL > $install_script || exit
-echo "$INSTALL_SCRIPT_SHA256  $install_script" | sha256sum -c -
+echo "$INSTALL_SCRIPT_SHA256  $install_script" | shasum -a 256 -c -
 chmod 775 $install_script
 echo "Running install script."
 $install_script < $_TTY


### PR DESCRIPTION
- After uploading the script, the sha256 had changed.
- set -e exits the script if a command exits with non-zero exit code (like checksum failure)