### PR TITLE
Prerequisites only apply to Linux

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Interactive install script
 
 On Windows, install via `pip <#pip>`__.
 
-On Linux or Mac, see our `prerequisites <https://github.com/Azure/azure-cli/blob/master/doc/install_linux_prerequisites.md>`__ then install as follows:
+On Linux, see our `prerequisites <https://github.com/Azure/azure-cli/blob/master/doc/install_linux_prerequisites.md>`__ then install as follows:
 
 .. code-block:: console
 


### PR DESCRIPTION
Wasn't sure why this commit https://github.com/Azure/azure-cli/commit/5a684046452a18cbebb710db94df0a52a493d0cb was made as prerequisites only apply to Linux.

@twitchax If we do still need the change, I can close this PR.