### PR TITLE
Rename the property names in storage op results

### DIFF
--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
@@ -702,14 +702,6 @@ def create_boolean_result_output_transformer(property_name):
     return _transformer
 
 
-def transform_storage_boolean_output(result):
-    return {'success': result}
-
-
-def transform_storage_exists_output(result):
-    return {'exists': result}
-
-
 def transform_storage_list_output(result):
     return list(result)
 

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_validators.py
@@ -695,6 +695,13 @@ def transform_metrics_list_output(result):
     return new_result
 
 
+def create_boolean_result_output_transformer(property_name):
+    def _transformer(result):
+        return {property_name: result}
+
+    return _transformer
+
+
 def transform_storage_boolean_output(result):
     return {'success': result}
 

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
@@ -14,8 +14,8 @@ from azure.cli.command_modules.storage._factory import \
 from azure.cli.command_modules.storage._validators import \
     (transform_acl_list_output, transform_cors_list_output, transform_entity_query_output,
      transform_logging_list_output, transform_metrics_list_output,
-     transform_url, transform_storage_list_output, transform_storage_exists_output,
-     transform_container_permission_output, create_boolean_result_output_transformer)
+     transform_url, transform_storage_list_output, transform_container_permission_output,
+     create_boolean_result_output_transformer)
 from azure.cli.command_modules.storage._format import \
     (transform_container_list, transform_container_show,
      transform_blob_output,
@@ -53,7 +53,7 @@ cli_storage_data_plane_command('storage container lease renew', 'azure.storage.b
 cli_storage_data_plane_command('storage container lease release', 'azure.storage.blob.blockblobservice#BlockBlobService.release_container_lease', factory)
 cli_storage_data_plane_command('storage container lease change', 'azure.storage.blob.blockblobservice#BlockBlobService.change_container_lease', factory)
 cli_storage_data_plane_command('storage container lease break', 'azure.storage.blob.blockblobservice#BlockBlobService.break_container_lease', factory)
-cli_storage_data_plane_command('storage container exists', 'azure.storage.blob.baseblobservice#BaseBlobService.exists', factory, transform=transform_storage_exists_output, table_transformer=transform_boolean_for_table)
+cli_storage_data_plane_command('storage container exists', 'azure.storage.blob.baseblobservice#BaseBlobService.exists', factory, transform=create_boolean_result_output_transformer('exists'), table_transformer=transform_boolean_for_table)
 cli_storage_data_plane_command('storage container set-permission', 'azure.storage.blob.baseblobservice#BaseBlobService.set_container_acl', factory)
 cli_storage_data_plane_command('storage container show-permission', 'azure.storage.blob.baseblobservice#BaseBlobService.get_container_acl', factory, transform=transform_container_permission_output)
 cli_storage_data_plane_command('storage container policy create', 'azure.cli.command_modules.storage.custom#create_acl_policy', factory)
@@ -70,7 +70,7 @@ cli_storage_data_plane_command('storage blob url', 'azure.storage.blob.blockblob
 cli_storage_data_plane_command('storage blob snapshot', 'azure.storage.blob.blockblobservice#BlockBlobService.snapshot_blob', factory)
 cli_storage_data_plane_command('storage blob show', 'azure.storage.blob.blockblobservice#BlockBlobService.get_blob_properties', factory, table_transformer=transform_blob_output)
 cli_storage_data_plane_command('storage blob update', 'azure.storage.blob.blockblobservice#BlockBlobService.set_blob_properties', factory)
-cli_storage_data_plane_command('storage blob exists', 'azure.storage.blob.baseblobservice#BaseBlobService.exists', factory, transform=transform_storage_exists_output)
+cli_storage_data_plane_command('storage blob exists', 'azure.storage.blob.baseblobservice#BaseBlobService.exists', factory, transform=create_boolean_result_output_transformer('exists'))
 cli_storage_data_plane_command('storage blob download', 'azure.storage.blob.baseblobservice#BaseBlobService.get_blob_to_path', factory)
 cli_storage_data_plane_command('storage blob upload', 'azure.cli.command_modules.storage.custom#upload_blob', factory)
 cli_storage_data_plane_command('storage blob metadata show', 'azure.storage.blob.blockblobservice#BlockBlobService.get_blob_metadata', factory)
@@ -104,7 +104,7 @@ cli_storage_data_plane_command('storage share show', 'azure.storage.file.fileser
 cli_storage_data_plane_command('storage share update', 'azure.storage.file.fileservice#FileService.set_share_properties', factory)
 cli_storage_data_plane_command('storage share metadata show', 'azure.storage.file.fileservice#FileService.get_share_metadata', factory)
 cli_storage_data_plane_command('storage share metadata update', 'azure.storage.file.fileservice#FileService.set_share_metadata', factory)
-cli_storage_data_plane_command('storage share exists', 'azure.storage.file.fileservice#FileService.exists', factory, transform=transform_storage_exists_output)
+cli_storage_data_plane_command('storage share exists', 'azure.storage.file.fileservice#FileService.exists', factory, transform=create_boolean_result_output_transformer('exists'))
 cli_storage_data_plane_command('storage share policy create', 'azure.cli.command_modules.storage.custom#create_acl_policy', factory)
 cli_storage_data_plane_command('storage share policy delete', 'azure.cli.command_modules.storage.custom#delete_acl_policy', factory)
 cli_storage_data_plane_command('storage share policy show', 'azure.cli.command_modules.storage.custom#get_acl_policy', factory)
@@ -115,7 +115,7 @@ cli_storage_data_plane_command('storage share policy update', 'azure.cli.command
 cli_storage_data_plane_command('storage directory create', 'azure.storage.file.fileservice#FileService.create_directory', factory, transform=create_boolean_result_output_transformer('created'), table_transformer=transform_boolean_for_table)
 cli_storage_data_plane_command('storage directory delete', 'azure.storage.file.fileservice#FileService.delete_directory', factory, transform=create_boolean_result_output_transformer('deleted'), table_transformer=transform_boolean_for_table)
 cli_storage_data_plane_command('storage directory show', 'azure.storage.file.fileservice#FileService.get_directory_properties', factory, table_transformer=transform_file_output)
-cli_storage_data_plane_command('storage directory exists', 'azure.storage.file.fileservice#FileService.exists', factory, transform=transform_storage_exists_output)
+cli_storage_data_plane_command('storage directory exists', 'azure.storage.file.fileservice#FileService.exists', factory, transform=create_boolean_result_output_transformer('exists'))
 cli_storage_data_plane_command('storage directory metadata show', 'azure.storage.file.fileservice#FileService.get_directory_metadata', factory)
 cli_storage_data_plane_command('storage directory metadata update', 'azure.storage.file.fileservice#FileService.set_directory_metadata', factory)
 
@@ -127,7 +127,7 @@ cli_storage_data_plane_command('storage file url', 'azure.storage.file.fileservi
 cli_storage_data_plane_command('storage file generate-sas', 'azure.storage.file.fileservice#FileService.generate_file_shared_access_signature', factory)
 cli_storage_data_plane_command('storage file show', 'azure.storage.file.fileservice#FileService.get_file_properties', factory, table_transformer=transform_file_output)
 cli_storage_data_plane_command('storage file update', 'azure.storage.file.fileservice#FileService.set_file_properties', factory)
-cli_storage_data_plane_command('storage file exists', 'azure.storage.file.fileservice#FileService.exists', factory, transform=transform_storage_exists_output)
+cli_storage_data_plane_command('storage file exists', 'azure.storage.file.fileservice#FileService.exists', factory, transform=create_boolean_result_output_transformer('exists'))
 cli_storage_data_plane_command('storage file download', 'azure.storage.file.fileservice#FileService.get_file_to_path', factory)
 cli_storage_data_plane_command('storage file upload', 'azure.storage.file.fileservice#FileService.create_file_from_path', factory)
 cli_storage_data_plane_command('storage file metadata show', 'azure.storage.file.fileservice#FileService.get_file_metadata', factory)
@@ -153,7 +153,7 @@ cli_storage_data_plane_command('storage table generate-sas', 'azure.storage.tabl
 cli_storage_data_plane_command('storage table stats', 'azure.storage.table.tableservice#TableService.get_table_service_stats', factory)
 cli_storage_data_plane_command('storage table list', 'azure.storage.table.tableservice#TableService.list_tables', factory, transform=transform_storage_list_output)
 cli_storage_data_plane_command('storage table create', 'azure.storage.table.tableservice#TableService.create_table', factory, transform=create_boolean_result_output_transformer('created'), table_transformer=transform_boolean_for_table)
-cli_storage_data_plane_command('storage table exists', 'azure.storage.table.tableservice#TableService.exists', factory, transform=transform_storage_exists_output)
+cli_storage_data_plane_command('storage table exists', 'azure.storage.table.tableservice#TableService.exists', factory, transform=create_boolean_result_output_transformer('exists'))
 cli_storage_data_plane_command('storage table delete', 'azure.storage.table.tableservice#TableService.delete_table', factory, transform=create_boolean_result_output_transformer('deleted'), table_transformer=transform_boolean_for_table)
 cli_storage_data_plane_command('storage table policy create', 'azure.cli.command_modules.storage.custom#create_acl_policy', factory)
 cli_storage_data_plane_command('storage table policy delete', 'azure.cli.command_modules.storage.custom#delete_acl_policy', factory)
@@ -178,7 +178,7 @@ cli_storage_data_plane_command('storage queue create', 'azure.storage.queue.queu
 cli_storage_data_plane_command('storage queue delete', 'azure.storage.queue.queueservice#QueueService.delete_queue', factory, transform=create_boolean_result_output_transformer('deleted'), table_transformer=transform_boolean_for_table)
 cli_storage_data_plane_command('storage queue metadata show', 'azure.storage.queue.queueservice#QueueService.get_queue_metadata', factory)
 cli_storage_data_plane_command('storage queue metadata update', 'azure.storage.queue.queueservice#QueueService.set_queue_metadata', factory)
-cli_storage_data_plane_command('storage queue exists', 'azure.storage.queue.queueservice#QueueService.exists', factory, transform=transform_storage_exists_output)
+cli_storage_data_plane_command('storage queue exists', 'azure.storage.queue.queueservice#QueueService.exists', factory, transform=create_boolean_result_output_transformer('exists'))
 cli_storage_data_plane_command('storage queue policy create', 'azure.cli.command_modules.storage.custom#create_acl_policy', factory)
 cli_storage_data_plane_command('storage queue policy delete', 'azure.cli.command_modules.storage.custom#delete_acl_policy', factory)
 cli_storage_data_plane_command('storage queue policy show', 'azure.cli.command_modules.storage.custom#get_acl_policy', factory)

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
@@ -15,7 +15,7 @@ from azure.cli.command_modules.storage._validators import \
     (transform_acl_list_output, transform_cors_list_output, transform_entity_query_output,
      transform_logging_list_output, transform_metrics_list_output,
      transform_url, transform_storage_list_output, transform_storage_exists_output,
-     transform_storage_boolean_output, transform_container_permission_output)
+     transform_container_permission_output, create_boolean_result_output_transformer)
 from azure.cli.command_modules.storage._format import \
     (transform_container_list, transform_container_show,
      transform_blob_output,
@@ -42,9 +42,9 @@ cli_storage_data_plane_command('storage account generate-sas', 'azure.storage.cl
 # container commands
 factory = blob_data_service_factory
 cli_storage_data_plane_command('storage container list', 'azure.storage.blob.blockblobservice#BlockBlobService.list_containers', factory, transform=transform_storage_list_output, table_transformer=transform_container_list)
-cli_storage_data_plane_command('storage container delete', 'azure.storage.blob.blockblobservice#BlockBlobService.delete_container', factory, transform=transform_storage_boolean_output, table_transformer=transform_boolean_for_table)
+cli_storage_data_plane_command('storage container delete', 'azure.storage.blob.blockblobservice#BlockBlobService.delete_container', factory, transform=create_boolean_result_output_transformer('deleted'), table_transformer=transform_boolean_for_table)
 cli_storage_data_plane_command('storage container show', 'azure.storage.blob.blockblobservice#BlockBlobService.get_container_properties', factory, table_transformer=transform_container_show)
-cli_storage_data_plane_command('storage container create', 'azure.storage.blob.blockblobservice#BlockBlobService.create_container', factory, transform=transform_storage_boolean_output, table_transformer=transform_boolean_for_table)
+cli_storage_data_plane_command('storage container create', 'azure.storage.blob.blockblobservice#BlockBlobService.create_container', factory, transform=create_boolean_result_output_transformer('created'), table_transformer=transform_boolean_for_table)
 cli_storage_data_plane_command('storage container generate-sas', 'azure.storage.blob.blockblobservice#BlockBlobService.generate_container_shared_access_signature', factory)
 cli_storage_data_plane_command('storage container metadata update', 'azure.storage.blob.blockblobservice#BlockBlobService.set_container_metadata', factory)
 cli_storage_data_plane_command('storage container metadata show', 'azure.storage.blob.blockblobservice#BlockBlobService.get_container_metadata', factory)
@@ -64,7 +64,7 @@ cli_storage_data_plane_command('storage container policy update', 'azure.cli.com
 
 # blob commands
 cli_storage_data_plane_command('storage blob list', 'azure.storage.blob.blockblobservice#BlockBlobService.list_blobs', factory, transform=transform_storage_list_output, table_transformer=transform_blob_output)
-cli_storage_data_plane_command('storage blob delete', 'azure.storage.blob.blockblobservice#BlockBlobService.delete_blob', factory, transform=transform_storage_boolean_output, table_transformer=transform_boolean_for_table)
+cli_storage_data_plane_command('storage blob delete', 'azure.storage.blob.blockblobservice#BlockBlobService.delete_blob', factory, transform=create_boolean_result_output_transformer('deleted'), table_transformer=transform_boolean_for_table)
 cli_storage_data_plane_command('storage blob generate-sas', 'azure.storage.blob.blockblobservice#BlockBlobService.generate_blob_shared_access_signature', factory)
 cli_storage_data_plane_command('storage blob url', 'azure.storage.blob.blockblobservice#BlockBlobService.make_blob_url', factory, transform=transform_url)
 cli_storage_data_plane_command('storage blob snapshot', 'azure.storage.blob.blockblobservice#BlockBlobService.snapshot_blob', factory)
@@ -96,8 +96,8 @@ cli_storage_data_plane_command('storage blob download-batch',
 # share commands
 factory = file_data_service_factory
 cli_storage_data_plane_command('storage share list', 'azure.storage.file.fileservice#FileService.list_shares', factory, transform=transform_storage_list_output, table_transformer=transform_share_list)
-cli_storage_data_plane_command('storage share create', 'azure.storage.file.fileservice#FileService.create_share', factory, transform=transform_storage_boolean_output, table_transformer=transform_boolean_for_table)
-cli_storage_data_plane_command('storage share delete', 'azure.storage.file.fileservice#FileService.delete_share', factory, transform=transform_storage_boolean_output, table_transformer=transform_boolean_for_table)
+cli_storage_data_plane_command('storage share create', 'azure.storage.file.fileservice#FileService.create_share', factory, transform=create_boolean_result_output_transformer('created'), table_transformer=transform_boolean_for_table)
+cli_storage_data_plane_command('storage share delete', 'azure.storage.file.fileservice#FileService.delete_share', factory, transform=create_boolean_result_output_transformer('deleted'), table_transformer=transform_boolean_for_table)
 cli_storage_data_plane_command('storage share generate-sas', 'azure.storage.file.fileservice#FileService.generate_share_shared_access_signature', factory)
 cli_storage_data_plane_command('storage share stats', 'azure.storage.file.fileservice#FileService.get_share_stats', factory)
 cli_storage_data_plane_command('storage share show', 'azure.storage.file.fileservice#FileService.get_share_properties', factory)
@@ -112,8 +112,8 @@ cli_storage_data_plane_command('storage share policy list', 'azure.cli.command_m
 cli_storage_data_plane_command('storage share policy update', 'azure.cli.command_modules.storage.custom#set_acl_policy', factory)
 
 # directory commands
-cli_storage_data_plane_command('storage directory create', 'azure.storage.file.fileservice#FileService.create_directory', factory, transform=transform_storage_boolean_output, table_transformer=transform_boolean_for_table)
-cli_storage_data_plane_command('storage directory delete', 'azure.storage.file.fileservice#FileService.delete_directory', factory, transform=transform_storage_boolean_output, table_transformer=transform_boolean_for_table)
+cli_storage_data_plane_command('storage directory create', 'azure.storage.file.fileservice#FileService.create_directory', factory, transform=create_boolean_result_output_transformer('created'), table_transformer=transform_boolean_for_table)
+cli_storage_data_plane_command('storage directory delete', 'azure.storage.file.fileservice#FileService.delete_directory', factory, transform=create_boolean_result_output_transformer('deleted'), table_transformer=transform_boolean_for_table)
 cli_storage_data_plane_command('storage directory show', 'azure.storage.file.fileservice#FileService.get_directory_properties', factory, table_transformer=transform_file_output)
 cli_storage_data_plane_command('storage directory exists', 'azure.storage.file.fileservice#FileService.exists', factory, transform=transform_storage_exists_output)
 cli_storage_data_plane_command('storage directory metadata show', 'azure.storage.file.fileservice#FileService.get_directory_metadata', factory)
@@ -121,7 +121,7 @@ cli_storage_data_plane_command('storage directory metadata update', 'azure.stora
 
 # file commands
 cli_storage_data_plane_command('storage file list', 'azure.storage.file.fileservice#FileService.list_directories_and_files', factory, table_transformer=transform_file_output)
-cli_storage_data_plane_command('storage file delete', 'azure.storage.file.fileservice#FileService.delete_file', factory, transform=transform_storage_boolean_output, table_transformer=transform_boolean_for_table)
+cli_storage_data_plane_command('storage file delete', 'azure.storage.file.fileservice#FileService.delete_file', factory, transform=create_boolean_result_output_transformer('deleted'), table_transformer=transform_boolean_for_table)
 cli_storage_data_plane_command('storage file resize', 'azure.storage.file.fileservice#FileService.resize_file', factory)
 cli_storage_data_plane_command('storage file url', 'azure.storage.file.fileservice#FileService.make_file_url', factory, transform=transform_url)
 cli_storage_data_plane_command('storage file generate-sas', 'azure.storage.file.fileservice#FileService.generate_file_shared_access_signature', factory)
@@ -152,9 +152,9 @@ factory = table_data_service_factory
 cli_storage_data_plane_command('storage table generate-sas', 'azure.storage.table.tableservice#TableService.generate_table_shared_access_signature', factory)
 cli_storage_data_plane_command('storage table stats', 'azure.storage.table.tableservice#TableService.get_table_service_stats', factory)
 cli_storage_data_plane_command('storage table list', 'azure.storage.table.tableservice#TableService.list_tables', factory, transform=transform_storage_list_output)
-cli_storage_data_plane_command('storage table create', 'azure.storage.table.tableservice#TableService.create_table', factory, transform=transform_storage_boolean_output, table_transformer=transform_boolean_for_table)
+cli_storage_data_plane_command('storage table create', 'azure.storage.table.tableservice#TableService.create_table', factory, transform=create_boolean_result_output_transformer('created'), table_transformer=transform_boolean_for_table)
 cli_storage_data_plane_command('storage table exists', 'azure.storage.table.tableservice#TableService.exists', factory, transform=transform_storage_exists_output)
-cli_storage_data_plane_command('storage table delete', 'azure.storage.table.tableservice#TableService.delete_table', factory, transform=transform_storage_boolean_output, table_transformer=transform_boolean_for_table)
+cli_storage_data_plane_command('storage table delete', 'azure.storage.table.tableservice#TableService.delete_table', factory, transform=create_boolean_result_output_transformer('deleted'), table_transformer=transform_boolean_for_table)
 cli_storage_data_plane_command('storage table policy create', 'azure.cli.command_modules.storage.custom#create_acl_policy', factory)
 cli_storage_data_plane_command('storage table policy delete', 'azure.cli.command_modules.storage.custom#delete_acl_policy', factory)
 cli_storage_data_plane_command('storage table policy show', 'azure.cli.command_modules.storage.custom#get_acl_policy', factory)
@@ -167,15 +167,15 @@ cli_storage_data_plane_command('storage entity show', 'azure.storage.table.table
 cli_storage_data_plane_command('storage entity insert', 'azure.cli.command_modules.storage.custom#insert_table_entity', factory)
 cli_storage_data_plane_command('storage entity replace', 'azure.storage.table.tableservice#TableService.update_entity', factory)
 cli_storage_data_plane_command('storage entity merge', 'azure.storage.table.tableservice#TableService.merge_entity', factory)
-cli_storage_data_plane_command('storage entity delete', 'azure.storage.table.tableservice#TableService.delete_entity', factory, transform=transform_storage_boolean_output, table_transformer=transform_boolean_for_table)
+cli_storage_data_plane_command('storage entity delete', 'azure.storage.table.tableservice#TableService.delete_entity', factory, transform=create_boolean_result_output_transformer('deleted'), table_transformer=transform_boolean_for_table)
 
 # queue commands
 factory = queue_data_service_factory
 cli_storage_data_plane_command('storage queue generate-sas', 'azure.storage.queue.queueservice#QueueService.generate_queue_shared_access_signature', factory)
 cli_storage_data_plane_command('storage queue stats', 'azure.storage.queue.queueservice#QueueService.get_queue_service_stats', factory)
 cli_storage_data_plane_command('storage queue list', 'azure.storage.queue.queueservice#QueueService.list_queues', factory, transform=transform_storage_list_output)
-cli_storage_data_plane_command('storage queue create', 'azure.storage.queue.queueservice#QueueService.create_queue', factory, transform=transform_storage_boolean_output, table_transformer=transform_boolean_for_table)
-cli_storage_data_plane_command('storage queue delete', 'azure.storage.queue.queueservice#QueueService.delete_queue', factory, transform=transform_storage_boolean_output, table_transformer=transform_boolean_for_table)
+cli_storage_data_plane_command('storage queue create', 'azure.storage.queue.queueservice#QueueService.create_queue', factory, transform=create_boolean_result_output_transformer('created'), table_transformer=transform_boolean_for_table)
+cli_storage_data_plane_command('storage queue delete', 'azure.storage.queue.queueservice#QueueService.delete_queue', factory, transform=create_boolean_result_output_transformer('deleted'), table_transformer=transform_boolean_for_table)
 cli_storage_data_plane_command('storage queue metadata show', 'azure.storage.queue.queueservice#QueueService.get_queue_metadata', factory)
 cli_storage_data_plane_command('storage queue metadata update', 'azure.storage.queue.queueservice#QueueService.set_queue_metadata', factory)
 cli_storage_data_plane_command('storage queue exists', 'azure.storage.queue.queueservice#QueueService.exists', factory, transform=transform_storage_exists_output)
@@ -189,7 +189,7 @@ cli_storage_data_plane_command('storage queue policy update', 'azure.cli.command
 cli_storage_data_plane_command('storage message put', 'azure.storage.queue.queueservice#QueueService.put_message', factory)
 cli_storage_data_plane_command('storage message get', 'azure.storage.queue.queueservice#QueueService.get_messages', factory, table_transformer=transform_message_show)
 cli_storage_data_plane_command('storage message peek', 'azure.storage.queue.queueservice#QueueService.peek_messages', factory, table_transformer=transform_message_show)
-cli_storage_data_plane_command('storage message delete', 'azure.storage.queue.queueservice#QueueService.delete_message', factory, transform=transform_storage_boolean_output, table_transformer=transform_boolean_for_table)
+cli_storage_data_plane_command('storage message delete', 'azure.storage.queue.queueservice#QueueService.delete_message', factory, transform=create_boolean_result_output_transformer('deleted'), table_transformer=transform_boolean_for_table)
 cli_storage_data_plane_command('storage message clear', 'azure.storage.queue.queueservice#QueueService.clear_messages', factory)
 cli_storage_data_plane_command('storage message update', 'azure.storage.queue.queueservice#QueueService.update_message', factory)
 

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/test_storage.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/test_storage.py
@@ -206,7 +206,7 @@ class StorageBlobScenarioTest(StorageAccountVCRTestBase):
         date = s.date
         _get_connection_string(self)
 
-        s.cmd('storage container create --name {} --fail-on-exist'.format(container), checks=JMESPathCheck('success', True))
+        s.cmd('storage container create --name {} --fail-on-exist'.format(container), checks=JMESPathCheck('created', True))
         s.cmd('storage container exists -n {}'.format(container), checks=JMESPathCheck('exists', True))
 
         s.cmd('storage container set-permission -n {} --public-access blob'.format(container))
@@ -255,7 +255,7 @@ class StorageBlobScenarioTest(StorageAccountVCRTestBase):
         ])
 
         # verify delete operation
-        s.cmd('storage container delete --name {} --fail-not-exist'.format(container), checks=JMESPathCheck('success', True))
+        s.cmd('storage container delete --name {} --fail-not-exist'.format(container), checks=JMESPathCheck('deleted', True))
         s.cmd('storage container exists -n {}'.format(container), checks=JMESPathCheck('exists', False))
 
 
@@ -331,7 +331,7 @@ class StorageFileScenarioTest(StorageAccountVCRTestBase):
         s = self
         dir = 'testdir01'
         s.cmd('storage directory create --share-name {} --name {} --fail-on-exist'.format(share, dir),
-              checks=JMESPathCheck('success', True))
+              checks=JMESPathCheck('created', True))
         s.cmd('storage directory exists --share-name {} -n {}'.format(share, dir),
               checks=JMESPathCheck('exists', True))
         s.cmd('storage directory metadata update --share-name {} -n {} --metadata a=b c=d'.format(share, dir))
@@ -348,20 +348,20 @@ class StorageFileScenarioTest(StorageAccountVCRTestBase):
               checks=NoneCheck())
         s._storage_file_in_subdir_scenario(share, dir)
         s.cmd('storage directory delete --share-name {} --name {} --fail-not-exist'.format(share, dir),
-              checks=JMESPathCheck('success', True))
+              checks=JMESPathCheck('deleted', True))
         s.cmd('storage directory exists --share-name {} --name {}'.format(share, dir),
               checks=JMESPathCheck('exists', False))
 
         # verify a directory can be created with metadata and then delete
         dir = 'testdir02'
         s.cmd('storage directory create --share-name {} --name {} --fail-on-exist --metadata foo=bar cat=hat'.format(share, dir),
-              checks=JMESPathCheck('success', True))
+              checks=JMESPathCheck('created', True))
         s.cmd('storage directory metadata show --share-name {} -n {}'.format(share, dir), checks=[
             JMESPathCheck('cat', 'hat'),
             JMESPathCheck('foo', 'bar')
         ])
         s.cmd('storage directory delete --share-name {} --name {} --fail-not-exist'.format(share, dir),
-              checks=JMESPathCheck('success', True))
+              checks=JMESPathCheck('deleted', True))
 
     def _storage_file_scenario(self, share):
         source_file = os.path.join(TEST_DIR, 'testfile.rst')
@@ -437,9 +437,9 @@ class StorageFileScenarioTest(StorageAccountVCRTestBase):
         _get_connection_string(self)
 
         s.cmd('storage share create --name {} --fail-on-exist'.format(share1),
-              checks=JMESPathCheck('success', True))
+              checks=JMESPathCheck('created', True))
         s.cmd('storage share create -n {} --fail-on-exist --metadata foo=bar cat=hat'.format(share2),
-              checks=JMESPathCheck('success', True))
+              checks=JMESPathCheck('created', True))
         s.cmd('storage share exists -n {}'.format(share1),
               checks=JMESPathCheck('exists', True))
         s.cmd('storage share metadata show --name {}'.format(share2), checks=[
@@ -601,7 +601,7 @@ class StorageTableScenarioTest(StorageAccountVCRTestBase):
         table = s.table
         _get_connection_string(self)
 
-        s.cmd('storage table create -n {} --fail-on-exist'.format(table), checks=JMESPathCheck('success', True))
+        s.cmd('storage table create -n {} --fail-on-exist'.format(table), checks=JMESPathCheck('created', True))
         s.cmd('storage table exists -n {}'.format(table), checks=JMESPathCheck('exists', True))
 
         res = s.cmd('storage table list')
@@ -612,7 +612,7 @@ class StorageTableScenarioTest(StorageAccountVCRTestBase):
         s._storage_entity_scenario(table)
 
         # verify delete operation
-        s.cmd('storage table delete --name {} --fail-not-exist'.format(table), checks=JMESPathCheck('success', True))
+        s.cmd('storage table delete --name {} --fail-not-exist'.format(table), checks=JMESPathCheck('deleted', True))
         s.cmd('storage table exists -n {}'.format(table), checks=JMESPathCheck('exists', False))
 
 
@@ -680,7 +680,7 @@ class StorageQueueScenarioTest(StorageAccountVCRTestBase):
         queue = s.queue
         _get_connection_string(self)
 
-        s.cmd('storage queue create -n {} --fail-on-exist --metadata a=b c=d'.format(queue), checks=JMESPathCheck('success', True))
+        s.cmd('storage queue create -n {} --fail-on-exist --metadata a=b c=d'.format(queue), checks=JMESPathCheck('created', True))
         s.cmd('storage queue exists -n {}'.format(queue), checks=JMESPathCheck('exists', True))
 
         res = s.cmd('storage queue list')
@@ -701,7 +701,7 @@ class StorageQueueScenarioTest(StorageAccountVCRTestBase):
         s._storage_message_scenario(queue)
 
         # verify delete operation
-        s.cmd('storage queue delete -n {} --fail-not-exist'.format(queue), checks=JMESPathCheck('success', True))
+        s.cmd('storage queue delete -n {} --fail-not-exist'.format(queue), checks=JMESPathCheck('deleted', True))
         s.cmd('storage queue exists -n {}'.format(queue), checks=JMESPathCheck('exists', False))
 
 


### PR DESCRIPTION
The change is inspired by #1564 and #1565. Though the change doesn't entirely address the issue.

The change is simple. Instead of returning following structure to indicate if the operation of creation and deletion failed:
``` JSON
{ "success": false }
```
It will return these
``` JSON
{ "created": false }
{ "deleted": false } 
```
The goal is simply to give a clear response in the situation where there is not a fatal error but the operation doesn't take any effect. Currently, as the original issue stated, there are two pieces of return information: 1) exit code; 2) JSON printed to stdout. This prompts a lengthy discussion between me and Johen about what should be the convention for us to return errors. And here's the conclusion:

For operation end with a fatal error, the exit code is non-zero. Nothing should be expected on stdout, and error messages should be printed to stderr. In addition, a structured result like JSON shouldn't be expected because of the fatal error may interrupt and formatting effort.

For operation accomplish without fatal error, the exit could be zero or non-zero. The key to determining that is whether the operation's failure should interrupt a script's execution. 

Last, for a successful operation, the exit code is zero. But the operation may not take effect just like in this situation. Now we should make the best effort to make the return result meaningful and intuitive. A 'success': false in a successfully finished command return result just feel awkward. The updated property name gave a clearer signal.

Of course, another problem that we offer not enough information regarding the failure remain unsolved. This is a limitation on SDK. If SDK doesn't provide a failure reason, it is out of CLI's capability to determine the cause.