### PR TITLE
Fix argcomplete 'default_completer' error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 adal==0.4.3
 applicationinsights==0.10.0
-argcomplete==1.3.0
+argcomplete==1.8.0
 colorama==0.3.7
 jmespath
 mock==1.3.0

--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -30,16 +30,10 @@ class CaseInsensitiveChoicesCompleter(argcomplete.completers.ChoicesCompleter): 
 argcomplete.completers.ChoicesCompleter = CaseInsensitiveChoicesCompleter
 
 
-class EmptyDefaultCompletionFinder(argcomplete.CompletionFinder):
-
-    def __init__(self, *args, **kwargs):
-        super(EmptyDefaultCompletionFinder, self).__init__(*args, default_completer=lambda _: (),
-                                                           **kwargs)
-
-
 def enable_autocomplete(parser):
-    argcomplete.autocomplete = EmptyDefaultCompletionFinder()
-    argcomplete.autocomplete(parser, validator=lambda c, p: c.lower().startswith(p.lower()))
+    argcomplete.autocomplete = argcomplete.CompletionFinder()
+    argcomplete.autocomplete(parser, validator=lambda c, p: c.lower().startswith(p.lower()),
+                             default_completer=lambda _: ())
 
 
 class AzCliCommandParser(argparse.ArgumentParser):

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -46,7 +46,7 @@ CLASSIFIERS = [
 DEPENDENCIES = [
     'adal>=0.4.3',
     'applicationinsights',
-    'argcomplete>=1.3.0',
+    'argcomplete>=1.8.0',
     'azure-cli-nspkg',
     'azure-mgmt-trafficmanager==0.30.0rc6',
     'azure-mgmt-dns==0.30.0rc6',


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-cli/issues/1792.

- Prev. argcomplete.autocomplete() could not take a default_completer. Now, it does so we can’t subclass CompletionFinder anymore.
- Require argcomplete 1.8.0 now as the change isn’t backwards compatible.

Will release an update to azure-cli-core once this PR is merged...