### PR TITLE
Packaged release 0.1.7 for Debian & Docker

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,6 @@ A list of common install issues and their resolutions are available at `install 
 - `Interactive install script <#interactive-install-script>`__
 - `Pip <#pip>`__
 - `Apt-get <#apt-get>`__
-- `Homebrew <#homebrew>`__
 - `Docker <#docker-versioned>`__
 - `Nightly Builds <#nightly-builds>`__
 - `Developer Setup <#developer-setup>`__
@@ -94,17 +93,6 @@ Run the following:
     $ sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893
     $ sudo apt-get install apt-transport-https
     $ sudo apt-get update && sudo apt-get install azure-cli
-
-Homebrew
-^^^^^^^^
-
-(Pending merge of https://github.com/Homebrew/homebrew-core/pull/8669)
-
-For macOS systems.
-
-.. code-block:: console
-
-    $ brew install azure-cli-2
 
 Docker (versioned)
 ^^^^^^^^^^^^^^^^^^

--- a/packaged_releases/HISTORY.md
+++ b/packaged_releases/HISTORY.md
@@ -1,6 +1,45 @@
 Release History
 ===============
 
+0.1.7 (2017-01-19)
+------------------
+
+* Include az.completion inside the release archive.  
+* Apply the patches directly in the archive rather than relying on each package manager to apply the patch.  
+* See the `HISTORY.rst` files in each module for a changelog.  
+
+Source download:  
+https://azurecliprod.blob.core.windows.net/releases/azure-cli_packaged_0.1.7.tar.gz  
+sha256 9e29ac619cc43afa071e155601da2e3adf3095b1c40c28bed5d3d226052587ac
+
+
+---
+
+<details>
+  <summary>List of component versions in this release (click to expand)</summary><p>
+$ az --version
+azure-cli (0.1.1b2)  
+
+acr (0.1.1b1)  
+acs (0.1.1b1)  
+appservice (0.1.1b1)  
+cloud (0.1.1b1)  
+component (0.1.0rc1)  
+configure (0.1.1b2)  
+container (0.1.1b1)  
+context (0.1.1b1)  
+core (0.1.1b2)  
+feedback (0.1.1b1)  
+network (0.1.1b1)  
+nspkg (0.1.1)  
+profile (0.1.1b1)  
+resource (0.1.1b1)  
+role (0.1.1b1)  
+storage (0.1.1b1)  
+vm (0.1.1b1)  
+</p></details>
+
+
 0.1.6 (2017-01-17)
 ------------------
 

--- a/packaged_releases/README.md
+++ b/packaged_releases/README.md
@@ -22,6 +22,7 @@ $ mkdir azure-cli_packaged_{VERSION}
 Expected folder structure inside of `azure-cli_packaged_{VERSION}`:
 ```
 .
+|-- az.completion
 |-- src
 |   |-- azure-cli
 |       |-- setup.py
@@ -43,6 +44,9 @@ Expected folder structure inside of `azure-cli_packaged_{VERSION}`:
 Notes:  
 - Only the packages that will be in the CLI should be included here; leave out 'optional' components unless there's a specific reason to include any extra components.
 - Make sure the versions of components don't include the `+dev` suffix. Remove these if this is the case.
+
+APPLY ANY PATCHES:  
+Modify the file in question in the directory created from  (You can use the `patch_*` files in `patches` subdirectory for this).  
 
 
 2 - Create release archive
@@ -78,32 +82,13 @@ $ az storage blob url -c releases -n azure-cli_packaged_{VERSION}.tar.gz
 An example URL is `https://azurecliprod.blob.core.windows.net/releases/azure-cli_packaged_{VERSION}.tar.gz`.
 
 
-4 - Modify and publish any updates to patches
----------------------------------------------
-
-This step is only required if there are changes to a patch / or a new patch.  
-If a change is not required, you can use the same patch from the previous version and so there's no need to change the patch URLs.  
-You can determine if a change is required by running `git diff` on the original files to be patched. If they are the same, the previous patch will work fine.
-
-
-To create a new patch do the following:  
-1. Change directory into the git repo.  
-2. Modify the file in question (You can use the `patch_*` files in `patches` subdirectory for this).  
-3. Run git diff to get the patch. (e.g. `git diff src/command_modules/azure-cli-component/azure/cli/command_modules/component/custom.py > patch_{VERSION}_component_custom.diff`)  
-4. Publish the patch publicly. 
-    (e.g.: `az storage blob upload -c patches -f <patch-diff> -n <patch-diff>`)  
-
-Notes:
-- If a patch needs modification, `debian`, `docker` and `homebrew` builds will all need to be modified.
-
-
-5 - Build/Release for Debian, Docker, Homebrew
+4 - Build/Release for Debian, Docker, Homebrew
 ----------------------------------------------
 
 Follow the instructions in the `debian`, `docker` and `homebrew` subdirectories to create these releases.
 
 
-6 - Modify HISTORY.md
+5 - Modify HISTORY.md
 ---------------------
 
 Modify the packaged release history with release notes on this release and create a PR for this change.

--- a/packaged_releases/az.completion
+++ b/packaged_releases/az.completion
@@ -1,0 +1,21 @@
+_python_argcomplete() {
+    local IFS=$'\013'
+    local SUPPRESS_SPACE=0
+    if compopt +o nospace 2> /dev/null; then
+        SUPPRESS_SPACE=1
+    fi
+    COMPREPLY=( $(IFS="$IFS" \
+                  COMP_LINE="$COMP_LINE" \
+                  COMP_POINT="$COMP_POINT" \
+                  COMP_TYPE="$COMP_TYPE" \
+                  _ARGCOMPLETE_COMP_WORDBREAKS="$COMP_WORDBREAKS" \
+                  _ARGCOMPLETE=1 \
+                  _ARGCOMPLETE_SUPPRESS_SPACE=$SUPPRESS_SPACE \
+                  "$1" 8>&1 9>&2 1>/dev/null 2>/dev/null) )
+    if [[ $? != 0 ]]; then
+        unset COMPREPLY
+    elif [[ $SUPPRESS_SPACE == 1 ]] && [[ "$COMPREPLY" =~ [=/:]$ ]]; then
+        compopt -o nospace
+    fi
+}
+complete -o nospace -F _python_argcomplete "az"

--- a/packaged_releases/debian/README.md
+++ b/packaged_releases/debian/README.md
@@ -20,11 +20,9 @@ $ chmod +x debian_build.sh debian_dir_creator.sh
 
 Then execute it with the appropriate environment variable values.
 ```
-$ export CLI_VERSION=0.1.6 \
-    && export CLI_DOWNLOAD_SHA256=bb4bd4694e044bf416941e3afdc505bde7d049bac2e66c8b3fe44c9cb3b57ff8 \
-    && export CLI_PATCH1_SHA256=d61ef29ace9bbdfef9a25dfbb1f475225bbca174263c8f863ee70f87d0a78bbe \
-    && export CLI_PATCH2_SHA256=4b97507cb73b405c6fb2d701eb52ffa72ce547f791097fccadffc491ad6ae194 \
-    && ./debian_build.sh ./debian_dir_creator.sh
+$ export CLI_VERSION=0.1.7 \
+    && export CLI_DOWNLOAD_SHA256=9e29ac619cc43afa071e155601da2e3adf3095b1c40c28bed5d3d226052587ac \
+    && ~/debian_build.sh ~/debian_dir_creator.sh
 ```
 
 Now you have built the package, upload the package to the apt repository.

--- a/packaged_releases/debian/debian_dir_creator.sh
+++ b/packaged_releases/debian/debian_dir_creator.sh
@@ -12,19 +12,32 @@ set -ex
 
 if [ -z "$1" ]
   then
-    echo "No argument supplied"
+    echo "No argument supplied for debian directory."
+    exit 1
+fi
+
+if [ -z "$2" ]
+  then
+    echo "No argument supplied for completion script."
     exit 1
 fi
 
 TAB=$'\t'
 
 debian_dir=$1
+completion_script=$2
 mkdir $debian_dir/source
 
 echo '1.0' > $debian_dir/source/format
 echo '9' > $debian_dir/compat
 
 cat > $debian_dir/changelog <<- EOM
+azure-cli (0.1.7-1) unstable; urgency=low
+
+  * Packaged release 0.1.7.
+
+ -- Azure Python CLI Team <azpycli@microsoft.com>  Thu, 19 Jan 2017 20:00:00 +0000
+
 azure-cli (0.1.6-1) unstable; urgency=low
 
   * Packaged release 0.1.6.
@@ -129,7 +142,7 @@ ${TAB}mkdir -p debian/azure-cli/usr/bin/
 ${TAB}echo "\043!/usr/bin/env bash\n/opt/az/bin/python -m azure.cli \"\044\100\"" > debian/azure-cli/usr/bin/az
 ${TAB}chmod 0755 debian/azure-cli/usr/bin/az
 ${TAB}mkdir -p debian/azure-cli/etc/bash_completion.d/
-${TAB}echo "_python_argcomplete() {\n    local IFS='\v'\n    COMPREPLY=( \044(IFS=\"\044IFS\"                   COMP_LINE=\"\044COMP_LINE\"                   COMP_POINT=\"\044COMP_POINT\"                   _ARGCOMPLETE_COMP_WORDBREAKS=\"\044COMP_WORDBREAKS\"                   _ARGCOMPLETE=1                   \"\044\061\" 8>&1 9>&2 1>/dev/null 2>/dev/null) )\n    if [[ \044? != 0 ]]; then\n        unset COMPREPLY\n    fi\n}\ncomplete -o nospace -F _python_argcomplete "az"" > debian/azure-cli/etc/bash_completion.d/azure-cli
+${TAB}cat ${completion_script} > debian/azure-cli/etc/bash_completion.d/azure-cli
 
 override_dh_strip:
 ${TAB}dh_strip --exclude=_cffi_backend

--- a/packaged_releases/docker/Dockerfile
+++ b/packaged_releases/docker/Dockerfile
@@ -5,10 +5,8 @@
 
 FROM python:3.5.2-alpine
 
-ENV CLI_VERSION 0.1.6
-ENV CLI_DOWNLOAD_SHA256 bb4bd4694e044bf416941e3afdc505bde7d049bac2e66c8b3fe44c9cb3b57ff8
-ENV CLI_PATCH1_SHA256 d61ef29ace9bbdfef9a25dfbb1f475225bbca174263c8f863ee70f87d0a78bbe
-ENV CLI_PATCH2_SHA256 4b97507cb73b405c6fb2d701eb52ffa72ce547f791097fccadffc491ad6ae194
+ENV CLI_VERSION 0.1.7
+ENV CLI_DOWNLOAD_SHA256 9e29ac619cc43afa071e155601da2e3adf3095b1c40c28bed5d3d226052587ac
 
 # INSTALL DEPENDENCIES
 # pip wheel - required for CLI packaging
@@ -34,36 +32,16 @@ RUN src_zip=$(mktemp) \
         && echo "$CLI_DOWNLOAD_SHA256  $src_zip" | sha256sum -c - \
         && tar -xvzf $src_zip -C /cli-src \
         && rm $src_zip
-# Apply patches
-RUN patch1=$(mktemp) \
-        && wget https://azurecliprod.blob.core.windows.net/patches/patch_2_component_custom.diff -qO $patch1 \
-        && echo "$CLI_PATCH1_SHA256  $patch1" | sha256sum -c - \
-        && patch -p1 /cli-src/*/src/command_modules/azure-cli-component/azure/cli/command_modules/component/custom.py $patch1 \
-        && rm $patch1
-RUN patch2=$(mktemp) \
-        && wget https://azurecliprod.blob.core.windows.net/patches/patch_2_pkg_util.diff -qO $patch2 \
-        && echo "$CLI_PATCH2_SHA256  $patch2" | sha256sum -c - \
-        && patch -p1 /cli-src/*/src/azure-cli-core/azure/cli/core/_pkg_util.py $patch2 \
-        && rm $patch2
 # Build and install
 RUN /bin/bash -c 'cd /cli-src/*; tmp_pkg_dir=$(mktemp -d); \
     for d in src/azure-cli src/azure-cli-core src/azure-cli-nspkg src/command_modules/azure-cli-*/; \
     do cd $d; python setup.py bdist_wheel -d $tmp_pkg_dir; cd -; \
     done; \
     pip install azure-cli -f $tmp_pkg_dir;'
-RUN rm -rf /cli-src
-
 # Tab completion
-RUN echo -e "\
-_python_argcomplete() {\n\
-    local IFS='\v'\n\
-    COMPREPLY=( \$(IFS=\"\$IFS\"                   COMP_LINE=\"\$COMP_LINE\"                   COMP_POINT=\"\$COMP_POINT\"                   _ARGCOMPLETE_COMP_WORDBREAKS=\"\$COMP_WORDBREAKS\"                   _ARGCOMPLETE=1                   \"\$1\" 8>&1 9>&2 1>/dev/null 2>/dev/null) )\n\
-    if [[ \$? != 0 ]]; then\n\
-        unset COMPREPLY\n\
-    fi\n\
-}\n\
-complete -o nospace -F _python_argcomplete \"az\"\n\
-" > ~/.bashrc
+RUN cat /cli-src/*/az.completion >> ~/.bashrc
+
+RUN rm -rf /cli-src
 
 WORKDIR /
 

--- a/packaged_releases/docker/README.md
+++ b/packaged_releases/docker/README.md
@@ -7,7 +7,6 @@ Updating the Docker image
 -------------------------
 1. Create a temp directory that only contains the Dockerfile.
 2. In the Dockerfile, modify `CLI_VERSION` and the `CLI_DOWNLOAD_SHA256` hash as appropriate.
-    Also, if required, modify the patch URLs and change the patch SHA256 checksums as appropriate.
 3. Run `docker build` with this Dockerfile.
     When tagging this Docker image, choose an appropriate version number.
       e.g.: `sudo docker build --no-cache -f Dockerfile -t azuresdk/azure-cli-python:${CLI_VERSION} .`
@@ -22,7 +21,7 @@ Verification
 Run the image.
 
 ```
-$ sudo docker run -it azuresdk/azure-cli-python:0.1.5
+$ sudo docker run -it azuresdk/azure-cli-python:${CLI_VERSION}
 $ az
 $ az --version
 ```

--- a/packaged_releases/homebrew/README.md
+++ b/packaged_releases/homebrew/README.md
@@ -1,13 +1,11 @@
 Homebrew Packaging
 ==================
 
-The Homebrew formula is available at https://github.com/Homebrew/homebrew-core/blob/master/Formula/azure-cli-2.rb.
-
 
 Updating the formula
 --------------------
 1. Change the `url` in the formula to point to the new release (e.g. `azure-cli_packaged_0.1.5.tar.gz`).
-2. Modify any patch urls and checksums as required.
+2. Modify any checksums as required.
 3. Run the formula verification commands (see below).
 4. Submit a PR to https://github.com/Homebrew/homebrew-core.
 


### PR DESCRIPTION
* Include az.completion inside the release archive that's used by all packaged releases.
* Apply the patches directly in the archive rather than relying on each package manager to apply the patch.
- Remove Homebrew from README.rst as pushed-back for now.
Also closes https://github.com/Azure/azure-cli/issues/1768