### PR TITLE
vm: support reset ssh

### DIFF
--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
@@ -62,6 +62,7 @@ cli_command(__name__, 'vmss nic show', 'azure.mgmt.network.operations.network_in
 # VM Access
 cli_command(__name__, 'vm access set-linux-user', custom_path.format('set_linux_user'))
 cli_command(__name__, 'vm access delete-linux-user', custom_path.format('delete_linux_user'))
+cli_command(__name__, 'vm access reset-linux-ssh', custom_path.format('reset_linux_ssh'))
 cli_command(__name__, 'vm access reset-windows-admin', custom_path.format('reset_windows_admin'))
 
 # # VM Availability Set

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -378,6 +378,7 @@ def set_linux_user(
                                             protected_settings)
     return ExtensionUpdateLongRunningOperation('setting user', 'done')(poller)
 
+
 def delete_linux_user(
         resource_group_name, vm_name, username):
     '''Remove the user '''
@@ -385,11 +386,13 @@ def delete_linux_user(
                                             {'remove_user': username})
     return ExtensionUpdateLongRunningOperation('deleting user', 'done')(poller)
 
+
 def reset_linux_ssh(resource_group_name, vm_name):
     '''Reset the SSH configuration'''
     poller = _update_linux_access_extension(resource_group_name, vm_name,
                                             {'reset_ssh': True})
     return ExtensionUpdateLongRunningOperation('resetting SSH', 'done')(poller)
+
 
 def _update_linux_access_extension(resource_group_name, vm_name, protected_settings):
     vm = _vm_get(resource_group_name, vm_name, 'instanceView')
@@ -412,6 +415,7 @@ def _update_linux_access_extension(resource_group_name, vm_name, protected_setti
     poller = client.virtual_machine_extensions.create_or_update(resource_group_name, vm_name,
                                                                 _ACCESS_EXT_HANDLER_NAME, ext)
     return poller
+
 
 def disable_boot_diagnostics(resource_group_name, vm_name):
     vm = _vm_get(resource_group_name, vm_name)


### PR DESCRIPTION
fix #1438.
The new command of `az vm access reset-linux-ssh` takes no specific argument, other than the resource group, vm name, and resource-id
For test,  I did following manual verification as it is hard to automate them 
   1.  SSH to the VM
   2.  Update /etc/ssh/sshd_config say change the port to 23
   3.  restart VM
   4.  SSH should fail
   5.  Run the new reset command which will reset the port back to 22
   6. SSH again, it should work
