### PR TITLE
Add two new storage commands

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/paramutil.py
+++ b/src/azure-cli-core/azure/cli/core/commands/paramutil.py
@@ -1,0 +1,55 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from azure.cli.core.commands.parameters import register_cli_argument, ignore_type
+from azure.cli.core.commands.validators import get_complex_argument_processor
+from azure.cli.core.commands._introspection import (extract_args_from_signature,
+                                                    _option_descriptions)
+from azure.cli.core.commands import _cli_extra_argument_registry
+
+
+class ParametersContext(object):
+    def __init__(self, command):
+        self._commmand = command
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    def ignore(self, argument_name):
+        register_cli_argument(self._commmand, argument_name, ignore_type)
+
+    def argument(self, argument_name, arg_type=None, **kwargs):
+        register_cli_argument(self._commmand, argument_name, arg_type=arg_type, **kwargs)
+
+    def expand(self, argument_name, model_type, group_name=None, patches=None):
+        if not patches:
+            patches = dict()
+
+        self.ignore(argument_name)
+
+        # Fetch the documentation for model parameters first. Note: a class's constructor's
+        # docstring is set on the class itself.
+        parameter_docs = _option_descriptions(model_type)
+
+        expanded_arguments = []
+        for name, arg in extract_args_from_signature(model_type.__init__):
+            if name in parameter_docs:
+                arg.type.settings['help'] = parameter_docs[name]
+
+            if group_name:
+                arg.type.settings['arg_group'] = group_name
+
+            if name in patches:
+                patches[name](arg)
+
+            _cli_extra_argument_registry[self._commmand][name] = arg
+            expanded_arguments.append(name)
+
+        self.argument(argument_name,
+                      arg_type=ignore_type,
+                      validator=get_complex_argument_processor(expanded_arguments, model_type))

--- a/src/azure-cli-core/azure/cli/core/commands/validators.py
+++ b/src/azure-cli-core/azure/cli/core/commands/validators.py
@@ -41,6 +41,25 @@ def generate_deployment_name(namespace):
             'azurecli{}{}'.format(str(time.time()), str(random.randint(1, 100000)))
 
 
+def get_complex_argument_processor(expanded_arguments, model_type):
+    """
+    Return a validator which will aggregate multiple arguments to one complex argument.
+    """
+    def _expension_valiator_impl(namespace):
+        """
+        The validator create a argument of a given type from a sepecific set of arguments from CLI
+        command.
+        :param namespace: The argparse namespace represents the CLI arguments.
+        :return: The argument of specific type.
+        """
+        ns = vars(namespace)
+        kwargs = dict((k, ns[k]) for k in ns if k in set(expanded_arguments))
+
+        namespace.parameters = model_type(**kwargs)
+
+    return _expension_valiator_impl
+
+
 SPECIFIED_SENTINEL = '__SET__'
 
 

--- a/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/tests/recordings/test_acr.yaml
+++ b/src/command_modules/azure-cli-acr/azure/cli/command_modules/acr/tests/recordings/test_acr.yaml
@@ -204,7 +204,7 @@ interactions:
       accept-language: [en-US]
       x-ms-client-request-id: [08d85d80-b11b-11e6-b535-00155da87c02]
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/acr_resource_group/providers/Microsoft.Storage/storageAccounts/acrstorageaccount2/listKeys?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/acr_resource_group/providers/Microsoft.Storage/storageAccounts/acrstorageaccount2/listKeys?api-version=2016-12-01
   response:
     body:
       string: !!binary |
@@ -916,7 +916,7 @@ interactions:
       accept-language: [en-US]
       x-ms-client-request-id: [10cf606c-b11b-11e6-987a-00155da87c02]
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/acr_resource_group/providers/Microsoft.Storage/storageAccounts/acrstorageaccount1/listKeys?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/acr_resource_group/providers/Microsoft.Storage/storageAccounts/acrstorageaccount1/listKeys?api-version=2016-12-01
   response:
     body:
       string: !!binary |
@@ -1125,7 +1125,7 @@ interactions:
       accept-language: [en-US]
       x-ms-client-request-id: [13ff1dbe-b11b-11e6-a392-00155da87c02]
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/checkNameAvailability?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/checkNameAvailability?api-version=2016-12-01
   response:
     body:
       string: !!binary |
@@ -2049,7 +2049,7 @@ interactions:
       accept-language: [en-US]
       x-ms-client-request-id: [2f4242da-b11b-11e6-8c31-00155da87c02]
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/acr_resource_group/providers/Microsoft.Storage/storageAccounts/acrstorageaccount1/listKeys?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/acr_resource_group/providers/Microsoft.Storage/storageAccounts/acrstorageaccount1/listKeys?api-version=2016-12-01
   response:
     body:
       string: !!binary |

--- a/src/command_modules/azure-cli-acr/setup.py
+++ b/src/command_modules/azure-cli-acr/setup.py
@@ -26,7 +26,7 @@ CLASSIFIERS = [
 DEPENDENCIES = [
     'azure-cli-core',
     'azure-mgmt-resource==0.30.2',
-    'azure-mgmt-storage==0.30.0rc6',
+    'azure-mgmt-storage==0.31.0',
     'azure-mgmt-containerregistry==0.1.1',
 ]
 

--- a/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/tests/recordings/test_batch_account_mgmt.yaml
+++ b/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/tests/recordings/test_batch_account_mgmt.yaml
@@ -14,7 +14,7 @@ interactions:
       accept-language: [en-US]
       x-ms-client-request-id: [10e80561-d467-11e6-8f8d-24be0520f64e]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Storage/storageAccounts/clibatchteststorage2?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Storage/storageAccounts/clibatchteststorage2?api-version=2016-12-01
   response:
     body: {string: !!python/unicode ''}
     headers:

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
@@ -32,6 +32,8 @@ cli_command(__name__, 'storage account delete', 'azure.mgmt.storage.operations.s
 cli_command(__name__, 'storage account show', 'azure.mgmt.storage.operations.storage_accounts_operations#StorageAccountsOperations.get_properties', factory)
 cli_command(__name__, 'storage account create', 'azure.cli.command_modules.storage.custom#create_storage_account')
 cli_command(__name__, 'storage account list', 'azure.cli.command_modules.storage.custom#list_storage_accounts')
+cli_command(__name__, 'storage account list-account-sas', 'azure.mgmt.storage.operations.storage_accounts_operations#StorageAccountsOperations.list_account_sas', factory)
+cli_command(__name__, 'storage account list-service-sas', 'azure.mgmt.storage.operations.storage_accounts_operations#StorageAccountsOperations.list_service_sas', factory)
 cli_command(__name__, 'storage account show-usage', 'azure.cli.command_modules.storage.custom#show_storage_account_usage')
 cli_command(__name__, 'storage account update', 'azure.cli.command_modules.storage.custom#set_storage_account_properties')
 cli_command(__name__, 'storage account show-connection-string', 'azure.cli.command_modules.storage.custom#show_storage_account_connection_string')

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_account_scenario.yaml
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_account_scenario.yaml
@@ -8,13 +8,13 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['73']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 storagemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1
+          msrest/0.4.4 msrest_azure/0.4.6 storagemanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [31be0680-d2a6-11e6-9d93-a0b3ccf7272a]
+      x-ms-client-request-id: [c56886b5-e1ae-11e6-b421-3c15c2cf0610]
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/checkNameAvailability?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/checkNameAvailability?api-version=2016-12-01
   response:
     body: {string: !!python/unicode '{"nameAvailable":true}
 
@@ -23,7 +23,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['23']
       content-type: [application/json]
-      date: ['Wed, 04 Jan 2017 17:49:52 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:03 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
@@ -40,26 +40,26 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['74']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 storagemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1
+          msrest/0.4.4 msrest_azure/0.4.6 storagemanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [3244c2b0-d2a6-11e6-8bc9-a0b3ccf7272a]
+      x-ms-client-request-id: [c6188500-e1ae-11e6-a8df-3c15c2cf0610]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/testcreatedelete?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/testcreatedelete?api-version=2016-12-01
   response:
     body: {string: !!python/unicode ''}
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Wed, 04 Jan 2017 17:49:53 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:05 GMT']
       expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Storage/operations/89606b85-2e37-4613-ba8c-a58865783e5c?monitor=true&api-version=2016-01-01']
+      location: ['https://management.azure.com/subscriptions/00977cdb-163f-435f-9c32-39ec8ae61f4d/providers/Microsoft.Storage/operations/4454b2c4-7ae6-4d7b-bc30-475c2461f2d7?monitor=true&api-version=2016-12-01']
       pragma: [no-cache]
       retry-after: ['17']
       server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -68,22 +68,22 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 storagemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1
+          msrest/0.4.4 msrest_azure/0.4.6 storagemanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [3244c2b0-d2a6-11e6-8bc9-a0b3ccf7272a]
+      x-ms-client-request-id: [c6188500-e1ae-11e6-a8df-3c15c2cf0610]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/operations/89606b85-2e37-4613-ba8c-a58865783e5c?monitor=true&api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/operations/4454b2c4-7ae6-4d7b-bc30-475c2461f2d7?monitor=true&api-version=2016-12-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/testcreatedelete","kind":"Storage","location":"westus","name":"testcreatedelete","properties":{"creationTime":"2017-01-04T17:49:53.7679695Z","primaryEndpoints":{"blob":"https://testcreatedelete.blob.core.windows.net/","file":"https://testcreatedelete.file.core.windows.net/","queue":"https://testcreatedelete.queue.core.windows.net/","table":"https://testcreatedelete.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"}
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/testcreatedelete","kind":"Storage","location":"westus","name":"testcreatedelete","properties":{"creationTime":"2017-01-23T20:59:04.6311129Z","primaryEndpoints":{"blob":"https://testcreatedelete.blob.core.windows.net/","file":"https://testcreatedelete.file.core.windows.net/","queue":"https://testcreatedelete.queue.core.windows.net/","table":"https://testcreatedelete.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available","supportsHttpsTrafficOnly":false},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"}
 
         '}
     headers:
       cache-control: [no-cache]
-      content-length: ['740']
+      content-length: ['773']
       content-type: [application/json]
-      date: ['Wed, 04 Jan 2017 17:50:10 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:22 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
@@ -100,13 +100,13 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['73']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 storagemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1
+          msrest/0.4.4 msrest_azure/0.4.6 storagemanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [3dcd560f-d2a6-11e6-aeb9-a0b3ccf7272a]
+      x-ms-client-request-id: [d24617fa-e1ae-11e6-9af4-3c15c2cf0610]
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/checkNameAvailability?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/checkNameAvailability?api-version=2016-12-01
   response:
     body: {string: !!python/unicode '{"message":"The storage account named testcreatedelete
         is already taken.","nameAvailable":false,"reason":"AlreadyExists"}
@@ -116,7 +116,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['122']
       content-type: [application/json]
-      date: ['Wed, 04 Jan 2017 17:50:12 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:25 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
@@ -131,22 +131,22 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 storagemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1
+          msrest/0.4.4 msrest_azure/0.4.6 storagemanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [3e807970-d2a6-11e6-b768-a0b3ccf7272a]
+      x-ms-client-request-id: [d3c41230-e1ae-11e6-9bbe-3c15c2cf0610]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts?api-version=2016-12-01
   response:
-    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/testcreatedelete","kind":"Storage","location":"westus","name":"testcreatedelete","properties":{"creationTime":"2017-01-04T17:49:53.7679695Z","primaryEndpoints":{"blob":"https://testcreatedelete.blob.core.windows.net/","file":"https://testcreatedelete.file.core.windows.net/","queue":"https://testcreatedelete.queue.core.windows.net/","table":"https://testcreatedelete.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"}]}
+    body: {string: !!python/unicode '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/testcreatedelete","kind":"Storage","location":"westus","name":"testcreatedelete","properties":{"creationTime":"2017-01-23T20:59:04.6311129Z","primaryEndpoints":{"blob":"https://testcreatedelete.blob.core.windows.net/","file":"https://testcreatedelete.file.core.windows.net/","queue":"https://testcreatedelete.queue.core.windows.net/","table":"https://testcreatedelete.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available","supportsHttpsTrafficOnly":false},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"}]}
 
         '}
     headers:
       cache-control: [no-cache]
-      content-length: ['752']
+      content-length: ['785']
       content-type: [application/json]
-      date: ['Wed, 04 Jan 2017 17:50:12 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:27 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
@@ -161,22 +161,22 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 storagemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1
+          msrest/0.4.4 msrest_azure/0.4.6 storagemanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [3ece9970-d2a6-11e6-ad47-a0b3ccf7272a]
+      x-ms-client-request-id: [d5124791-e1ae-11e6-802c-3c15c2cf0610]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/testcreatedelete?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/testcreatedelete?api-version=2016-12-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/testcreatedelete","kind":"Storage","location":"westus","name":"testcreatedelete","properties":{"creationTime":"2017-01-04T17:49:53.7679695Z","primaryEndpoints":{"blob":"https://testcreatedelete.blob.core.windows.net/","file":"https://testcreatedelete.file.core.windows.net/","queue":"https://testcreatedelete.queue.core.windows.net/","table":"https://testcreatedelete.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"}
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/testcreatedelete","kind":"Storage","location":"westus","name":"testcreatedelete","properties":{"creationTime":"2017-01-23T20:59:04.6311129Z","primaryEndpoints":{"blob":"https://testcreatedelete.blob.core.windows.net/","file":"https://testcreatedelete.file.core.windows.net/","queue":"https://testcreatedelete.queue.core.windows.net/","table":"https://testcreatedelete.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available","supportsHttpsTrafficOnly":false},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"}
 
         '}
     headers:
       cache-control: [no-cache]
-      content-length: ['740']
+      content-length: ['773']
       content-type: [application/json]
-      date: ['Wed, 04 Jan 2017 17:50:13 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:29 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
@@ -191,23 +191,23 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 storagemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1
+          msrest/0.4.4 msrest_azure/0.4.6 storagemanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [3f256c00-d2a6-11e6-954d-a0b3ccf7272a]
+      x-ms-client-request-id: [d63181d9-e1ae-11e6-824f-3c15c2cf0610]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/usages?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/usages?api-version=2016-12-01
   response:
     body: {string: !!python/unicode "{\r\n  \"value\": [\r\n    {\r\n      \"unit\"\
-        : \"Count\",\r\n      \"currentValue\": 17,\r\n      \"limit\": 250,\r\n \
+        : \"Count\",\r\n      \"currentValue\": 41,\r\n      \"limit\": 250,\r\n \
         \     \"name\": {\r\n        \"value\": \"StorageAccounts\",\r\n        \"\
         localizedValue\": \"Storage Accounts\"\r\n      }\r\n    }\r\n  ]\r\n}"}
     headers:
       cache-control: [no-cache]
       content-length: ['218']
       content-type: [application/json]
-      date: ['Wed, 04 Jan 2017 17:50:14 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:31 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
@@ -223,86 +223,22 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 storagemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1
+          msrest/0.4.4 msrest_azure/0.4.6 storagemanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [3fa857a1-d2a6-11e6-9ef3-a0b3ccf7272a]
+      x-ms-client-request-id: [d750bbee-e1ae-11e6-a3c0-3c15c2cf0610]
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/testcreatedelete/listKeys?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/testcreatedelete/listKeys?api-version=2016-12-01
   response:
-    body: {string: !!python/unicode '{"keys":[{"keyName":"key1","permissions":"Full","value":"nKXVTi2z8eX9hTCoTqnncIJ6HTiFMzmLN0N+2MpGxfNMeSZcJbJ0qRU67BgzpJH9Tc1iMvSDm5pKFVJtvqfC7w=="},{"keyName":"key2","permissions":"Full","value":"9zCJ4Jd6hWd4jkaiWM+qN8h2CYSLQuv6pWhdupmvO7YfcaAgqvd7fs0XwbU/WZkT05UAzfojgbpi2yKeY6pVGg=="}]}
+    body: {string: !!python/unicode '{"keys":[{"keyName":"key1","permissions":"Full","value":"VF/ZaPmadMa/e0atRsVgqPvE7V+aqc9yitdPVPqGzHFKhEJOfYlCfcTC189kSTCnn+TpuJ5vB1yhqgM5ketV9g=="},{"keyName":"key2","permissions":"Full","value":"pMyw6NibrAeiFErlZYfE2/wOR6bXuQL8Lt2MxaTl3IlMHthzV1nMl4kFL5DNwyA7I0KsgHJv1Ml0QsQonSHBDQ=="}]}
 
         '}
     headers:
       cache-control: [no-cache]
       content-length: ['289']
       content-type: [application/json]
-      date: ['Wed, 04 Jan 2017 17:50:15 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 storagemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [4002858f-d2a6-11e6-91b9-a0b3ccf7272a]
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/testcreatedelete/listKeys?api-version=2016-01-01
-  response:
-    body: {string: !!python/unicode '{"keys":[{"keyName":"key1","permissions":"Full","value":"nKXVTi2z8eX9hTCoTqnncIJ6HTiFMzmLN0N+2MpGxfNMeSZcJbJ0qRU67BgzpJH9Tc1iMvSDm5pKFVJtvqfC7w=="},{"keyName":"key2","permissions":"Full","value":"9zCJ4Jd6hWd4jkaiWM+qN8h2CYSLQuv6pWhdupmvO7YfcaAgqvd7fs0XwbU/WZkT05UAzfojgbpi2yKeY6pVGg=="}]}
-
-        '}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['289']
-      content-type: [application/json]
-      date: ['Wed, 04 Jan 2017 17:50:15 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode '{"keyName": "key1"}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['19']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 storagemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [405d28b0-d2a6-11e6-ba61-a0b3ccf7272a]
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/testcreatedelete/regenerateKey?api-version=2016-01-01
-  response:
-    body: {string: !!python/unicode '{"keys":[{"keyName":"key1","permissions":"Full","value":"NCLgDfcNa016eTT17cOdYvWKjptfY5LsCHLPQGHcvhZUX/qeKq3wtw/fdieDMoUZv3lVr4kUDoH5PIfveH7Fow=="},{"keyName":"key2","permissions":"Full","value":"9zCJ4Jd6hWd4jkaiWM+qN8h2CYSLQuv6pWhdupmvO7YfcaAgqvd7fs0XwbU/WZkT05UAzfojgbpi2yKeY6pVGg=="}]}
-
-        '}
-    headers:
-      cache-control: [no-cache]
-      content-length: ['289']
-      content-type: [application/json]
-      date: ['Wed, 04 Jan 2017 17:50:17 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:33 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
@@ -312,6 +248,70 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes: ['1195']
     status: {code: 200, message: OK}
 - request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1
+          msrest/0.4.4 msrest_azure/0.4.6 storagemanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [d85d8cd7-e1ae-11e6-8537-3c15c2cf0610]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/testcreatedelete/listKeys?api-version=2016-12-01
+  response:
+    body: {string: !!python/unicode '{"keys":[{"keyName":"key1","permissions":"Full","value":"VF/ZaPmadMa/e0atRsVgqPvE7V+aqc9yitdPVPqGzHFKhEJOfYlCfcTC189kSTCnn+TpuJ5vB1yhqgM5ketV9g=="},{"keyName":"key2","permissions":"Full","value":"pMyw6NibrAeiFErlZYfE2/wOR6bXuQL8Lt2MxaTl3IlMHthzV1nMl4kFL5DNwyA7I0KsgHJv1Ml0QsQonSHBDQ=="}]}
+
+        '}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['289']
+      content-type: [application/json]
+      date: ['Mon, 23 Jan 2017 20:59:35 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"keyName": "key1"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['19']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1
+          msrest/0.4.4 msrest_azure/0.4.6 storagemanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [d9479117-e1ae-11e6-a21c-3c15c2cf0610]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/testcreatedelete/regenerateKey?api-version=2016-12-01
+  response:
+    body: {string: !!python/unicode '{"keys":[{"keyName":"key1","permissions":"Full","value":"egc3m+eeej4HeBKSIJdHj0ns2dN4Ngq92W6jPE+iwQ76QskDdVIdS1ZGg+oLTv5hn1K11SKTM44DLUw4kyfBSA=="},{"keyName":"key2","permissions":"Full","value":"pMyw6NibrAeiFErlZYfE2/wOR6bXuQL8Lt2MxaTl3IlMHthzV1nMl4kFL5DNwyA7I0KsgHJv1Ml0QsQonSHBDQ=="}]}
+
+        '}
+    headers:
+      cache-control: [no-cache]
+      content-length: ['289']
+      content-type: [application/json]
+      date: ['Mon, 23 Jan 2017 20:59:36 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 200, message: OK}
+- request:
     body: !!python/unicode '{"keyName": "key2"}'
     headers:
       Accept: [application/json]
@@ -319,22 +319,22 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['19']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 storagemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1
+          msrest/0.4.4 msrest_azure/0.4.6 storagemanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [40dd2e1e-d2a6-11e6-be9a-a0b3ccf7272a]
+      x-ms-client-request-id: [da6d3d85-e1ae-11e6-9f73-3c15c2cf0610]
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/testcreatedelete/regenerateKey?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/testcreatedelete/regenerateKey?api-version=2016-12-01
   response:
-    body: {string: !!python/unicode '{"keys":[{"keyName":"key1","permissions":"Full","value":"NCLgDfcNa016eTT17cOdYvWKjptfY5LsCHLPQGHcvhZUX/qeKq3wtw/fdieDMoUZv3lVr4kUDoH5PIfveH7Fow=="},{"keyName":"key2","permissions":"Full","value":"45mLllIm2d9K2aNrjEVaTEmkPbE8o8zv7lj/AlRgs5MM+2q/KFCxOhSorav+TU3KCgKi9IjxGTP2HorIdSADIg=="}]}
+    body: {string: !!python/unicode '{"keys":[{"keyName":"key1","permissions":"Full","value":"egc3m+eeej4HeBKSIJdHj0ns2dN4Ngq92W6jPE+iwQ76QskDdVIdS1ZGg+oLTv5hn1K11SKTM44DLUw4kyfBSA=="},{"keyName":"key2","permissions":"Full","value":"r10eRIPpSMY8WNMo6yeAB5KtHybd33z/alisu8NP36AZvzXgUF/9p/LVHs3aEclxCdyfY4namTSFPfQkUxClRg=="}]}
 
         '}
     headers:
       cache-control: [no-cache]
       content-length: ['289']
       content-type: [application/json]
-      date: ['Wed, 04 Jan 2017 17:50:17 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:38 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
@@ -351,22 +351,22 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['35']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 storagemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1
+          msrest/0.4.4 msrest_azure/0.4.6 storagemanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [414d06f0-d2a6-11e6-99e2-a0b3ccf7272a]
+      x-ms-client-request-id: [db8a7cd4-e1ae-11e6-975d-3c15c2cf0610]
     method: PATCH
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/testcreatedelete?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/testcreatedelete?api-version=2016-12-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/testcreatedelete","kind":"Storage","location":"westus","name":"testcreatedelete","properties":{"creationTime":"2017-01-04T17:49:53.7679695Z","primaryEndpoints":{"blob":"https://testcreatedelete.blob.core.windows.net/","file":"https://testcreatedelete.file.core.windows.net/","queue":"https://testcreatedelete.queue.core.windows.net/","table":"https://testcreatedelete.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{"cat":"","foo":"bar"},"type":"Microsoft.Storage/storageAccounts"}
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/testcreatedelete","kind":"Storage","location":"westus","name":"testcreatedelete","properties":{"creationTime":"2017-01-23T20:59:04.6311129Z","primaryEndpoints":{"blob":"https://testcreatedelete.blob.core.windows.net/","file":"https://testcreatedelete.file.core.windows.net/","queue":"https://testcreatedelete.queue.core.windows.net/","table":"https://testcreatedelete.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available","supportsHttpsTrafficOnly":false},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{"cat":"","foo":"bar"},"type":"Microsoft.Storage/storageAccounts"}
 
         '}
     headers:
       cache-control: [no-cache]
-      content-length: ['760']
+      content-length: ['793']
       content-type: [application/json]
-      date: ['Wed, 04 Jan 2017 17:50:18 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:41 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
@@ -383,22 +383,22 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['12']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 storagemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1
+          msrest/0.4.4 msrest_azure/0.4.6 storagemanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [41fecac0-d2a6-11e6-8226-a0b3ccf7272a]
+      x-ms-client-request-id: [dca195d1-e1ae-11e6-b11e-3c15c2cf0610]
     method: PATCH
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/testcreatedelete?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/testcreatedelete?api-version=2016-12-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/testcreatedelete","kind":"Storage","location":"westus","name":"testcreatedelete","properties":{"creationTime":"2017-01-04T17:49:53.7679695Z","primaryEndpoints":{"blob":"https://testcreatedelete.blob.core.windows.net/","file":"https://testcreatedelete.file.core.windows.net/","queue":"https://testcreatedelete.queue.core.windows.net/","table":"https://testcreatedelete.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"}
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/testcreatedelete","kind":"Storage","location":"westus","name":"testcreatedelete","properties":{"creationTime":"2017-01-23T20:59:04.6311129Z","primaryEndpoints":{"blob":"https://testcreatedelete.blob.core.windows.net/","file":"https://testcreatedelete.file.core.windows.net/","queue":"https://testcreatedelete.queue.core.windows.net/","table":"https://testcreatedelete.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","statusOfPrimary":"available","supportsHttpsTrafficOnly":false},"sku":{"name":"Standard_LRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"}
 
         '}
     headers:
       cache-control: [no-cache]
-      content-length: ['740']
+      content-length: ['773']
       content-type: [application/json]
-      date: ['Wed, 04 Jan 2017 17:50:20 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:42 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
@@ -415,29 +415,29 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['33']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 storagemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1
+          msrest/0.4.4 msrest_azure/0.4.6 storagemanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [42b39bcf-d2a6-11e6-bab8-a0b3ccf7272a]
+      x-ms-client-request-id: [ddcac0a1-e1ae-11e6-9ba8-3c15c2cf0610]
     method: PATCH
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/testcreatedelete?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/testcreatedelete?api-version=2016-12-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/testcreatedelete","kind":"Storage","location":"westus","name":"testcreatedelete","properties":{"creationTime":"2017-01-04T17:49:53.7679695Z","primaryEndpoints":{"blob":"https://testcreatedelete.blob.core.windows.net/","file":"https://testcreatedelete.file.core.windows.net/","queue":"https://testcreatedelete.queue.core.windows.net/","table":"https://testcreatedelete.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","secondaryLocation":"eastus","statusOfPrimary":"available","statusOfSecondary":"available"},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"}
+    body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/testcreatedelete","kind":"Storage","location":"westus","name":"testcreatedelete","properties":{"creationTime":"2017-01-23T20:59:04.6311129Z","primaryEndpoints":{"blob":"https://testcreatedelete.blob.core.windows.net/","file":"https://testcreatedelete.file.core.windows.net/","queue":"https://testcreatedelete.queue.core.windows.net/","table":"https://testcreatedelete.table.core.windows.net/"},"primaryLocation":"westus","provisioningState":"Succeeded","secondaryLocation":"eastus","statusOfPrimary":"available","statusOfSecondary":"available","supportsHttpsTrafficOnly":false},"sku":{"name":"Standard_GRS","tier":"Standard"},"tags":{},"type":"Microsoft.Storage/storageAccounts"}
 
         '}
     headers:
       cache-control: [no-cache]
-      content-length: ['801']
+      content-length: ['834']
       content-type: [application/json]
-      date: ['Wed, 04 Jan 2017 17:50:20 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:44 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -447,24 +447,24 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 storagemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1
+          msrest/0.4.4 msrest_azure/0.4.6 storagemanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [4352e911-d2a6-11e6-bc5f-a0b3ccf7272a]
+      x-ms-client-request-id: [deebb430-e1ae-11e6-8b41-3c15c2cf0610]
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/testcreatedelete?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_account_scenario/providers/Microsoft.Storage/storageAccounts/testcreatedelete?api-version=2016-12-01
   response:
     body: {string: !!python/unicode ''}
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Wed, 04 Jan 2017 17:50:21 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:46 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+      x-ms-ratelimit-remaining-subscription-writes: ['1194']
     status: {code: 200, message: OK}
 - request:
     body: !!python/unicode '{"type": "Microsoft.Storage/storageAccounts", "name":
@@ -475,13 +475,13 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['73']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 storagemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1
+          msrest/0.4.4 msrest_azure/0.4.6 storagemanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [43f5dfcf-d2a6-11e6-98bb-a0b3ccf7272a]
+      x-ms-client-request-id: [e05f6082-e1ae-11e6-b890-3c15c2cf0610]
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/checkNameAvailability?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/checkNameAvailability?api-version=2016-12-01
   response:
     body: {string: !!python/unicode '{"nameAvailable":true}
 
@@ -490,7 +490,7 @@ interactions:
       cache-control: [no-cache]
       content-length: ['23']
       content-type: [application/json]
-      date: ['Wed, 04 Jan 2017 17:50:22 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:48 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_blob_acl_scenario.yaml
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_blob_acl_scenario.yaml
@@ -7,37 +7,37 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 storagemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1
+          msrest/0.4.4 msrest_azure/0.4.6 storagemanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [51f58db0-d2a6-11e6-b124-a0b3ccf7272a]
+      x-ms-client-request-id: [d3c10145-e1ae-11e6-bae1-3c15c2cf0610]
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Storage/storageAccounts/dummystorage.listKeys?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Storage/storageAccounts/dummystorage.listKeys?api-version=2016-12-01
   response:
-    body: {string: !!python/unicode '{"keys":[{"keyName":"key1","permissions":"Full","value":"T6E04heEEJOu1Dm4jADZ5t8aEb3MU45qJuNq0gwM4JM7ClcsQzW8ZbMXnfIk4HZFU7wbu+BQsOB61ZAl9iB97g=="},{"keyName":"key2","permissions":"Full","value":"Xdqxyj2ATI9H26US14ZqH77WKalGE87bhJUN465WXZcFPbLPMBhl/aP41/Qd90Sfo7rr8aP8aOJMDyN2BagN5g=="}]}
+    body: {string: !!python/unicode '{"keys":[{"keyName":"key1","permissions":"Full","value":"3zqQZT953F2souKWQH7Zm0eExTYGUHNTLmMJHEusOm0bexNmX9nGxyb3s6CfUNr96wnyvodzpue0gbukn5YfnQ=="},{"keyName":"key2","permissions":"Full","value":"OjsVE6nurB552/8vpT3JTMSX0iXiXoHEP0DN+cG8X8QdRCOLXYNE08kmYtcAs+OhcQ0gTQEvduPfZgOVyjEtnA=="}]}
 
         '}
     headers:
       cache-control: [no-cache]
       content-length: ['289']
       content-type: [application/json]
-      date: ['Wed, 04 Jan 2017 17:50:46 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:27 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:50:46 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:29 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
@@ -46,9 +46,9 @@ interactions:
         \ />"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:50:45 GMT']
-      etag: ['"0x8D434CA35F0C73D"']
-      last-modified: ['Wed, 04 Jan 2017 17:50:45 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:29 GMT']
+      etag: ['"0x8D443D2B6FE49D7"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:25 GMT']
       server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -57,9 +57,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:50:47 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:31 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
@@ -68,9 +68,9 @@ interactions:
         \ />"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:50:46 GMT']
-      etag: ['"0x8D434CA35F0C73D"']
-      last-modified: ['Wed, 04 Jan 2017 17:50:45 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:32 GMT']
+      etag: ['"0x8D443D2B6FE49D7"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:25 GMT']
       server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -82,18 +82,18 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['184']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:50:47 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:31 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:50:46 GMT']
-      etag: ['"0x8D434CA36ADB3C9"']
-      last-modified: ['Wed, 04 Jan 2017 17:50:47 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:32 GMT']
+      etag: ['"0x8D443D2BAA5FC9E"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:31 GMT']
       server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -102,9 +102,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:50:47 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:33 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
@@ -112,9 +112,9 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:50:47 GMT']
-      etag: ['"0x8D434CA36ADB3C9"']
-      last-modified: ['Wed, 04 Jan 2017 17:50:47 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:33 GMT']
+      etag: ['"0x8D443D2BAA5FC9E"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:31 GMT']
       server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -126,18 +126,18 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['296']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:50:48 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:33 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:50:47 GMT']
-      etag: ['"0x8D434CA37086CA1"']
-      last-modified: ['Wed, 04 Jan 2017 17:50:47 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:33 GMT']
+      etag: ['"0x8D443D2BB9B348D"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:33 GMT']
       server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -146,9 +146,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:50:48 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:34 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
@@ -156,9 +156,9 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:50:47 GMT']
-      etag: ['"0x8D434CA37086CA1"']
-      last-modified: ['Wed, 04 Jan 2017 17:50:47 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:34 GMT']
+      etag: ['"0x8D443D2BB9B348D"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:33 GMT']
       server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -170,18 +170,18 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['413']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:50:48 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:35 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:50:47 GMT']
-      etag: ['"0x8D434CA3756ED88"']
-      last-modified: ['Wed, 04 Jan 2017 17:50:48 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:34 GMT']
+      etag: ['"0x8D443D2BC9C7A91"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:35 GMT']
       server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -190,9 +190,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:50:49 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:36 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
@@ -200,9 +200,9 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:50:48 GMT']
-      etag: ['"0x8D434CA3756ED88"']
-      last-modified: ['Wed, 04 Jan 2017 17:50:48 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:36 GMT']
+      etag: ['"0x8D443D2BC9C7A91"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:35 GMT']
       server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -214,18 +214,18 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['591']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:50:49 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:36 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:50:48 GMT']
-      etag: ['"0x8D434CA37AD5F95"']
-      last-modified: ['Wed, 04 Jan 2017 17:50:48 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:36 GMT']
+      etag: ['"0x8D443D2BD8619B8"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:36 GMT']
       server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -234,9 +234,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:50:49 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:38 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
@@ -244,9 +244,9 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:50:49 GMT']
-      etag: ['"0x8D434CA37AD5F95"']
-      last-modified: ['Wed, 04 Jan 2017 17:50:48 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:37 GMT']
+      etag: ['"0x8D443D2BD8619B8"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:36 GMT']
       server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -255,9 +255,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:50:50 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:39 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
@@ -265,9 +265,9 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:50:49 GMT']
-      etag: ['"0x8D434CA37AD5F95"']
-      last-modified: ['Wed, 04 Jan 2017 17:50:48 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:40 GMT']
+      etag: ['"0x8D443D2BD8619B8"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:36 GMT']
       server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -276,9 +276,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:50:50 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:41 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
@@ -286,9 +286,9 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:50:49 GMT']
-      etag: ['"0x8D434CA37AD5F95"']
-      last-modified: ['Wed, 04 Jan 2017 17:50:48 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:41 GMT']
+      etag: ['"0x8D443D2BD8619B8"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:36 GMT']
       server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -297,9 +297,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:50:51 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:42 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
@@ -307,9 +307,9 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:50:50 GMT']
-      etag: ['"0x8D434CA37AD5F95"']
-      last-modified: ['Wed, 04 Jan 2017 17:50:48 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:42 GMT']
+      etag: ['"0x8D443D2BD8619B8"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:36 GMT']
       server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -318,9 +318,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:50:51 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:44 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
@@ -328,9 +328,9 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:50:51 GMT']
-      etag: ['"0x8D434CA37AD5F95"']
-      last-modified: ['Wed, 04 Jan 2017 17:50:48 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:44 GMT']
+      etag: ['"0x8D443D2BD8619B8"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:36 GMT']
       server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -339,9 +339,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:50:52 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:45 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
@@ -349,9 +349,9 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:50:51 GMT']
-      etag: ['"0x8D434CA37AD5F95"']
-      last-modified: ['Wed, 04 Jan 2017 17:50:48 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:45 GMT']
+      etag: ['"0x8D443D2BD8619B8"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:36 GMT']
       server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -363,18 +363,18 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['597']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:50:52 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:45 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:50:51 GMT']
-      etag: ['"0x8D434CA39817E1E"']
-      last-modified: ['Wed, 04 Jan 2017 17:50:51 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:45 GMT']
+      etag: ['"0x8D443D2C30A3494"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:46 GMT']
       server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -383,9 +383,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:50:52 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:47 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
@@ -393,9 +393,9 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>r</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:50:52 GMT']
-      etag: ['"0x8D434CA39817E1E"']
-      last-modified: ['Wed, 04 Jan 2017 17:50:51 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:47 GMT']
+      etag: ['"0x8D443D2C30A3494"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:46 GMT']
       server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -404,9 +404,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:50:53 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:48 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
@@ -414,9 +414,9 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>r</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:50:52 GMT']
-      etag: ['"0x8D434CA39817E1E"']
-      last-modified: ['Wed, 04 Jan 2017 17:50:51 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:48 GMT']
+      etag: ['"0x8D443D2C30A3494"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:46 GMT']
       server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -428,18 +428,18 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['491']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:50:53 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:48 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:50:52 GMT']
-      etag: ['"0x8D434CA3A2474C9"']
-      last-modified: ['Wed, 04 Jan 2017 17:50:52 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:48 GMT']
+      etag: ['"0x8D443D2C4D7F461"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:49 GMT']
       server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -448,9 +448,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:50:53 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:50 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/acltestcontainer?comp=acl&restype=container
@@ -458,9 +458,9 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:50:53 GMT']
-      etag: ['"0x8D434CA3A2474C9"']
-      last-modified: ['Wed, 04 Jan 2017 17:50:52 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:50 GMT']
+      etag: ['"0x8D443D2C4D7F461"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:49 GMT']
       server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_blob_copy_scenario.yaml
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_blob_copy_scenario.yaml
@@ -7,47 +7,47 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 storagemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1
+          msrest/0.4.4 msrest_azure/0.4.6 storagemanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [641c770f-d2a6-11e6-8e34-a0b3ccf7272a]
+      x-ms-client-request-id: [d24884cc-e1ae-11e6-ac59-3c15c2cf0610]
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_blob_copy/providers/Microsoft.Storage/storageAccounts/dummystorage.listKeys?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_storage_blob_copy/providers/Microsoft.Storage/storageAccounts/dummystorage.listKeys?api-version=2016-12-01
   response:
-    body: {string: !!python/unicode '{"keys":[{"keyName":"key1","permissions":"Full","value":"lfAZHp355IFY02EF5LsDU6SrItZFbEGrrdnvg3ILxbPWTzrXyBZN2E14jR+czOPZLpUw0M1r9DkuTfFkQoXxkw=="},{"keyName":"key2","permissions":"Full","value":"k9k9wDfjnxlMdXtGOYjLFLesfoORVlAwyAmcy2dNfGlGXnRnD0/K9HJkkqMzUCFDZgY6vdAUVYhZx6eXb1Xmjw=="}]}
+    body: {string: !!python/unicode '{"keys":[{"keyName":"key1","permissions":"Full","value":"dxf0sTLuf2qAS2EmKoawBdnZryd4BihAhgZ0irFlUSCNhWx1M5MMQTZYlRdIjTkOg6jIulTPG/wyXArEvxe3VQ=="},{"keyName":"key2","permissions":"Full","value":"AJzttdub3EU5/8vDxv5d+Nz+mWDaXVcOhPcOu73IV643cBIUXFvf+yuw3zDnFou+WMnkTqXqSQc8Hsu3Wlw12Q=="}]}
 
         '}
     headers:
       cache-control: [no-cache]
       content-length: ['289']
       content-type: [application/json]
-      date: ['Wed, 04 Jan 2017 17:51:16 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:24 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1192']
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:17 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:27 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/cont1?restype=container
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:51:17 GMT']
-      etag: ['"0x8D434CA48973613"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:17 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:27 GMT']
+      etag: ['"0x8D443D2B81551F2"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:27 GMT']
       server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -57,18 +57,18 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:17 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:29 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/cont2?restype=container
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:51:16 GMT']
-      etag: ['"0x8D434CA48F167AC"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:17 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:28 GMT']
+      etag: ['"0x8D443D2B8CEE91A"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:28 GMT']
       server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -79,10 +79,10 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['78']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
       x-ms-blob-type: [BlockBlob]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:18 GMT']
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:30 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/cont1/blob1
@@ -90,9 +90,9 @@ interactions:
     body: {string: !!python/unicode ''}
     headers:
       content-md5: [zeGiTMG1TdAobIHawzap3A==]
-      date: ['Wed, 04 Jan 2017 17:51:18 GMT']
-      etag: ['"0x8D434CA49401373"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:18 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:31 GMT']
+      etag: ['"0x8D443D2B9FE21B8"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:30 GMT']
       server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -103,10 +103,10 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['78']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
       x-ms-blob-type: [BlockBlob]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:18 GMT']
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:31 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/cont1/blob2
@@ -114,9 +114,9 @@ interactions:
     body: {string: !!python/unicode ''}
     headers:
       content-md5: [zeGiTMG1TdAobIHawzap3A==]
-      date: ['Wed, 04 Jan 2017 17:51:18 GMT']
-      etag: ['"0x8D434CA4994109C"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:18 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:31 GMT']
+      etag: ['"0x8D443D2BACAF31C"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:32 GMT']
       server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -126,22 +126,22 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-copy-source: ['https://vcrstorage330098664196.blob.core.windows.net/cont1/blob1']
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:19 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-copy-source: ['https://vcrstorage513153667201.blob.core.windows.net/cont1/blob1']
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:34 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/cont2/blob1
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:51:19 GMT']
-      etag: ['"0x8D434CA4A1FA3A2"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:19 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:34 GMT']
+      etag: ['"0x8D443D2BC96AEC3"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:35 GMT']
       server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
-      x-ms-copy-id: [a44d583c-2e36-45d0-b914-722201fd9847]
+      x-ms-copy-id: [8a4700e9-bfc5-4d74-a135-7a9f4c76fe10]
       x-ms-copy-status: [success]
       x-ms-version: ['2015-07-08']
     status: {code: 202, message: Accepted}
@@ -149,9 +149,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:20 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:36 GMT']
       x-ms-version: ['2015-07-08']
     method: HEAD
     uri: https://dummystorage.blob.core.windows.net/cont2/blob1
@@ -162,15 +162,15 @@ interactions:
       content-length: ['78']
       content-md5: [zeGiTMG1TdAobIHawzap3A==]
       content-type: [application/octet-stream]
-      date: ['Wed, 04 Jan 2017 17:51:19 GMT']
-      etag: ['"0x8D434CA4A1FA3A2"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:19 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:36 GMT']
+      etag: ['"0x8D443D2BC96AEC3"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:35 GMT']
       server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-blob-type: [BlockBlob]
-      x-ms-copy-completion-time: ['Wed, 04 Jan 2017 17:51:19 GMT']
-      x-ms-copy-id: [a44d583c-2e36-45d0-b914-722201fd9847]
+      x-ms-copy-completion-time: ['Mon, 23 Jan 2017 20:59:35 GMT']
+      x-ms-copy-id: [8a4700e9-bfc5-4d74-a135-7a9f4c76fe10]
       x-ms-copy-progress: [78/78]
-      x-ms-copy-source: ['https://vcrstorage330098664196.blob.core.windows.net/cont1/blob1']
+      x-ms-copy-source: ['https://vcrstorage513153667201.blob.core.windows.net/cont1/blob1']
       x-ms-copy-status: [success]
       x-ms-lease-state: [available]
       x-ms-lease-status: [unlocked]
@@ -181,22 +181,22 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-copy-source: ['https://vcrstorage330098664196.blob.core.windows.net/cont1/blob2']
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:20 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-copy-source: ['https://vcrstorage513153667201.blob.core.windows.net/cont1/blob2']
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:38 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/cont2/blob2
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:51:20 GMT']
-      etag: ['"0x8D434CA4ABCC65B"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:20 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:38 GMT']
+      etag: ['"0x8D443D2BE82565D"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:38 GMT']
       server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
-      x-ms-copy-id: [10da51ab-57d6-4b1c-bc91-5f04ff571a5a]
+      x-ms-copy-id: [7e9bc013-2418-45da-b4bd-db1c90e9b42d]
       x-ms-copy-status: [success]
       x-ms-version: ['2015-07-08']
     status: {code: 202, message: Accepted}
@@ -204,9 +204,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:51:21 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:39 GMT']
       x-ms-version: ['2015-07-08']
     method: HEAD
     uri: https://dummystorage.blob.core.windows.net/cont2/blob2
@@ -217,15 +217,15 @@ interactions:
       content-length: ['78']
       content-md5: [zeGiTMG1TdAobIHawzap3A==]
       content-type: [application/octet-stream]
-      date: ['Wed, 04 Jan 2017 17:51:20 GMT']
-      etag: ['"0x8D434CA4ABCC65B"']
-      last-modified: ['Wed, 04 Jan 2017 17:51:20 GMT']
+      date: ['Mon, 23 Jan 2017 20:59:39 GMT']
+      etag: ['"0x8D443D2BE82565D"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:38 GMT']
       server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-blob-type: [BlockBlob]
-      x-ms-copy-completion-time: ['Wed, 04 Jan 2017 17:51:21 GMT']
-      x-ms-copy-id: [10da51ab-57d6-4b1c-bc91-5f04ff571a5a]
+      x-ms-copy-completion-time: ['Mon, 23 Jan 2017 20:59:39 GMT']
+      x-ms-copy-id: [7e9bc013-2418-45da-b4bd-db1c90e9b42d]
       x-ms-copy-progress: [78/78]
-      x-ms-copy-source: ['https://vcrstorage330098664196.blob.core.windows.net/cont1/blob2']
+      x-ms-copy-source: ['https://vcrstorage513153667201.blob.core.windows.net/cont1/blob2']
       x-ms-copy-status: [success]
       x-ms-lease-state: [available]
       x-ms-lease-status: [unlocked]

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_blob_scenario.yaml
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_blob_scenario.yaml
@@ -7,69 +7,69 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 storagemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1
+          msrest/0.4.4 msrest_azure/0.4.6 storagemanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c75f8ec6-d397-11e6-924c-480fcf61db4b]
+      x-ms-client-request-id: [d28a4bfa-e1ae-11e6-a35e-3c15c2cf0610]
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_blob_scenario_test/providers/Microsoft.Storage/storageAccounts/dummystorage.listKeys?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_blob_scenario_test/providers/Microsoft.Storage/storageAccounts/dummystorage.listKeys?api-version=2016-12-01
   response:
-    body: {string: '{"keys":[{"keyName":"key1","permissions":"Full","value":"c7We2TixgweM2y/ov9B4GQhdH/z2Iyfy7uhBZDvzgfoZfNKo/SJiDOJpvUJcKx3evTXjFLaemOVU3dJFSZ0xoQ=="},{"keyName":"key2","permissions":"Full","value":"rd6iezHVQ8E6qG2kTjKHLOUSxwHgkKJ4NHpZwoZ7yFdfxZKMwkpH6JOX+RjRY73tOeJylN6LTah18IG0yBa7SQ=="}]}
+    body: {string: !!python/unicode '{"keys":[{"keyName":"key1","permissions":"Full","value":"Q/5kltOkkidhX6emFq8y4rmFIOQxw8WmaYTPMgmyQ4HDbWK08/nryfNFftKoL76LnlVaZ5BraS2L1zDHu/fiDg=="},{"keyName":"key2","permissions":"Full","value":"vpR/GnXBNCD6Uexc1HcssG+LAtSNR2eAplj4b0zPuPoz3hdgtVVO5UXXOsfwe+0GT5YUnq1aUQlmO3jktSXGHg=="}]}
 
         '}
     headers:
-      Cache-Control: [no-cache]
-      Content-Type: [application/json]
-      Date: ['Thu, 05 Jan 2017 22:39:11 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
+      cache-control: [no-cache]
       content-length: ['289']
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      content-type: [application/json]
+      date: ['Mon, 23 Jan 2017 20:59:25 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:12 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:27 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/cont1?restype=container
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:11 GMT']
-      ETag: ['"0x8D435BBABC47413"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:12 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 20:59:26 GMT']
+      etag: ['"0x8D443D2B798BBEE"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:26 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:13 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:29 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/cont1?restype=container
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:10 GMT']
-      ETag: ['"0x8D435BBABC47413"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:12 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 20:59:29 GMT']
+      etag: ['"0x8D443D2B798BBEE"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:26 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-lease-state: [available]
       x-ms-lease-status: [unlocked]
       x-ms-version: ['2015-07-08']
@@ -78,68 +78,68 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:13 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:31 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.blob.core.windows.net/cont1?restype=container&comp=acl
+    uri: https://dummystorage.blob.core.windows.net/cont1?comp=acl&restype=container
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers\
         \ />"}
     headers:
-      Content-Type: [application/xml]
-      Date: ['Thu, 05 Jan 2017 22:39:13 GMT']
-      ETag: ['"0x8D435BBABC47413"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:12 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      content-type: [application/xml]
+      date: ['Mon, 23 Jan 2017 20:59:31 GMT']
+      etag: ['"0x8D443D2B798BBEE"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:26 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''utf-8''?>
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
 
       <SignedIdentifiers />'
     headers:
       Connection: [keep-alive]
       Content-Length: ['60']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
       x-ms-blob-public-access: [blob]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:13 GMT']
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:31 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.blob.core.windows.net/cont1?restype=container&comp=acl
+    uri: https://dummystorage.blob.core.windows.net/cont1?comp=acl&restype=container
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:13 GMT']
-      ETag: ['"0x8D435BBAC8FE22C"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:13 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 20:59:31 GMT']
+      etag: ['"0x8D443D2BAA3B3AF"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:31 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:14 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:33 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.blob.core.windows.net/cont1?restype=container&comp=acl
+    uri: https://dummystorage.blob.core.windows.net/cont1?comp=acl&restype=container
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers\
         \ />"}
     headers:
-      Content-Type: [application/xml]
-      Date: ['Thu, 05 Jan 2017 22:39:14 GMT']
-      ETag: ['"0x8D435BBAC8FE22C"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:13 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      content-type: [application/xml]
+      date: ['Mon, 23 Jan 2017 20:59:33 GMT']
+      etag: ['"0x8D443D2BAA3B3AF"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:31 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-blob-public-access: [blob]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
@@ -147,88 +147,88 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:14 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:34 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.blob.core.windows.net/cont1?restype=container&comp=acl
+    uri: https://dummystorage.blob.core.windows.net/cont1?comp=acl&restype=container
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers\
         \ />"}
     headers:
-      Content-Type: [application/xml]
-      Date: ['Thu, 05 Jan 2017 22:39:14 GMT']
-      ETag: ['"0x8D435BBAC8FE22C"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:13 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      content-type: [application/xml]
+      date: ['Mon, 23 Jan 2017 20:59:35 GMT']
+      etag: ['"0x8D443D2BAA3B3AF"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:31 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-blob-public-access: [blob]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
-    body: '<?xml version=''1.0'' encoding=''utf-8''?>
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
 
       <SignedIdentifiers />'
     headers:
       Connection: [keep-alive]
       Content-Length: ['60']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:14 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:35 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.blob.core.windows.net/cont1?restype=container&comp=acl
+    uri: https://dummystorage.blob.core.windows.net/cont1?comp=acl&restype=container
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:14 GMT']
-      ETag: ['"0x8D435BBAD43F5AC"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:14 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 20:59:35 GMT']
+      etag: ['"0x8D443D2BCA3095F"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:35 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:15 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:36 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.blob.core.windows.net/cont1?restype=container&comp=acl
+    uri: https://dummystorage.blob.core.windows.net/cont1?comp=acl&restype=container
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers\
         \ />"}
     headers:
-      Content-Type: [application/xml]
-      Date: ['Thu, 05 Jan 2017 22:39:15 GMT']
-      ETag: ['"0x8D435BBAD43F5AC"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:14 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      content-type: [application/xml]
+      date: ['Mon, 23 Jan 2017 20:59:36 GMT']
+      etag: ['"0x8D443D2BCA3095F"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:35 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:15 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:38 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/cont1?restype=container
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:15 GMT']
-      ETag: ['"0x8D435BBAD43F5AC"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:14 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 20:59:38 GMT']
+      etag: ['"0x8D443D2BCA3095F"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:35 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-lease-state: [available]
       x-ms-lease-status: [unlocked]
       x-ms-version: ['2015-07-08']
@@ -237,23 +237,23 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:16 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:39 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/?comp=list
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults\
-        \ ServiceEndpoint=\"https://vcrstorage213990324496.blob.core.windows.net/\"\
-        ><Containers><Container><Name>cont1</Name><Properties><Last-Modified>Thu,\
-        \ 05 Jan 2017 22:39:14 GMT</Last-Modified><Etag>\"0x8D435BBAD43F5AC\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties></Container></Containers><NextMarker\
+        \ ServiceEndpoint=\"https://vcrstorage214781765435.blob.core.windows.net/\"\
+        ><Containers><Container><Name>cont1</Name><Properties><Last-Modified>Mon,\
+        \ 23 Jan 2017 20:59:35 GMT</Last-Modified><Etag>\"0x8D443D2BCA3095F\"</Etag><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties></Container></Containers><NextMarker\
         \ /></EnumerationResults>"}
     headers:
-      Content-Type: [application/xml]
-      Date: ['Thu, 05 Jan 2017 22:39:16 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      content-type: [application/xml]
+      date: ['Mon, 23 Jan 2017 20:59:39 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
@@ -261,42 +261,42 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:16 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:41 GMT']
       x-ms-meta-foo: [bar]
       x-ms-meta-moo: [bak]
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.blob.core.windows.net/cont1?restype=container&comp=metadata
+    uri: https://dummystorage.blob.core.windows.net/cont1?comp=metadata&restype=container
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:16 GMT']
-      ETag: ['"0x8D435BBAE7BFFF8"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:16 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 20:59:40 GMT']
+      etag: ['"0x8D443D2C0507A97"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:41 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:17 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:42 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.blob.core.windows.net/cont1?restype=container&comp=metadata
+    uri: https://dummystorage.blob.core.windows.net/cont1?comp=metadata&restype=container
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:16 GMT']
-      ETag: ['"0x8D435BBAE7BFFF8"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:16 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 20:59:42 GMT']
+      etag: ['"0x8D443D2C0507A97"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:41 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-meta-foo: [bar]
       x-ms-meta-moo: [bak]
       x-ms-version: ['2015-07-08']
@@ -306,86 +306,87 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:17 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:44 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.blob.core.windows.net/cont1?restype=container&comp=metadata
+    uri: https://dummystorage.blob.core.windows.net/cont1?comp=metadata&restype=container
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:18 GMT']
-      ETag: ['"0x8D435BBAF17CA84"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:17 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 20:59:44 GMT']
+      etag: ['"0x8D443D2C216DCE7"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:44 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:18 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:45 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.blob.core.windows.net/cont1?restype=container&comp=metadata
+    uri: https://dummystorage.blob.core.windows.net/cont1?comp=metadata&restype=container
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:17 GMT']
-      ETag: ['"0x8D435BBAF17CA84"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:17 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 20:59:45 GMT']
+      etag: ['"0x8D443D2C216DCE7"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:44 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
-    body: This is a test file for performance of automated tests. DO NOT MOVE OR DELETE!
+    body: !!python/unicode 'This is a test file for performance of automated tests.
+      DO NOT MOVE OR DELETE!'
     headers:
       Connection: [keep-alive]
       Content-Length: ['78']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
       x-ms-blob-type: [BlockBlob]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:18 GMT']
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:47 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Content-MD5: [zeGiTMG1TdAobIHawzap3A==]
-      Date: ['Thu, 05 Jan 2017 22:39:18 GMT']
-      ETag: ['"0x8D435BBAFBCF2F6"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:18 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      content-md5: [zeGiTMG1TdAobIHawzap3A==]
+      date: ['Mon, 23 Jan 2017 20:59:47 GMT']
+      etag: ['"0x8D443D2C3551D53"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:46 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:19 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:48 GMT']
       x-ms-version: ['2015-07-08']
     method: HEAD
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Accept-Ranges: [bytes]
-      Content-Length: ['78']
-      Content-MD5: [zeGiTMG1TdAobIHawzap3A==]
-      Content-Type: [application/octet-stream]
-      Date: ['Thu, 05 Jan 2017 22:39:18 GMT']
-      ETag: ['"0x8D435BBAFBCF2F6"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:18 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      accept-ranges: [bytes]
+      content-length: ['78']
+      content-md5: [zeGiTMG1TdAobIHawzap3A==]
+      content-type: [application/octet-stream]
+      date: ['Mon, 23 Jan 2017 20:59:49 GMT']
+      etag: ['"0x8D443D2C3551D53"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:46 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-blob-type: [BlockBlob]
       x-ms-lease-state: [available]
       x-ms-lease-status: [unlocked]
@@ -396,48 +397,48 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
       x-ms-blob-content-length: ['512']
       x-ms-blob-type: [PageBlob]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:19 GMT']
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:50 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/cont1/testpageblob
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:21 GMT']
-      ETag: ['"0x8D435BBB051DCA4"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:19 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 20:59:50 GMT']
+      etag: ['"0x8D443D2C50BEDAA"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:49 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 201, message: Created}
 - request:
-    body: 'This is a test file for performance of automated tests. DO NOT MOVE OR
-      DELETE!                                                                                                                                                                                                                                                                                                                                                                                                                                                  '
+    body: !!python/unicode 'This is a test file for performance of automated tests.
+      DO NOT MOVE OR DELETE!                                                                                                                                                                                                                                                                                                                                                                                                                                                  '
     headers:
       Connection: [keep-alive]
       Content-Length: ['512']
-      If-Match: ['"0x8D435BBB051DCA4"']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:20 GMT']
+      If-Match: ['"0x8D443D2C50BEDAA"']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:50 GMT']
       x-ms-page-write: [update]
       x-ms-range: [bytes=0-511]
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/cont1/testpageblob?comp=page
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Content-MD5: [JKbxCPFguN3PtJpiW3lCrQ==]
-      Date: ['Thu, 05 Jan 2017 22:39:21 GMT']
-      ETag: ['"0x8D435BBB0597F9F"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:19 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      content-md5: [JKbxCPFguN3PtJpiW3lCrQ==]
+      date: ['Mon, 23 Jan 2017 20:59:50 GMT']
+      etag: ['"0x8D443D2C51368F8"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:49 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-blob-sequence-number: ['0']
       x-ms-version: ['2015-07-08']
     status: {code: 201, message: Created}
@@ -445,22 +446,22 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:20 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:51 GMT']
       x-ms-version: ['2015-07-08']
     method: HEAD
     uri: https://dummystorage.blob.core.windows.net/cont1/testpageblob
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Accept-Ranges: [bytes]
-      Content-Length: ['512']
-      Content-Type: [application/octet-stream]
-      Date: ['Thu, 05 Jan 2017 22:39:20 GMT']
-      ETag: ['"0x8D435BBB0597F9F"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:19 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      accept-ranges: [bytes]
+      content-length: ['512']
+      content-type: [application/octet-stream]
+      date: ['Mon, 23 Jan 2017 20:59:51 GMT']
+      etag: ['"0x8D443D2C51368F8"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:49 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-blob-sequence-number: ['0']
       x-ms-blob-type: [PageBlob]
       x-ms-lease-state: [available]
@@ -471,18 +472,18 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:20 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:52 GMT']
       x-ms-version: ['2015-07-08']
     method: HEAD
     uri: https://dummystorage.blob.core.windows.net/cont1/testappendblob
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:20 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 20:59:52 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 404, message: The specified blob does not exist.}
 - request:
@@ -490,43 +491,44 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
       x-ms-blob-type: [AppendBlob]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:21 GMT']
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:53 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/cont1/testappendblob
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:20 GMT']
-      ETag: ['"0x8D435BBB0F56FE3"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:21 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 20:59:52 GMT']
+      etag: ['"0x8D443D2C69AE449"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:52 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 201, message: Created}
 - request:
-    body: This is a test file for performance of automated tests. DO NOT MOVE OR DELETE!
+    body: !!python/unicode 'This is a test file for performance of automated tests.
+      DO NOT MOVE OR DELETE!'
     headers:
       Connection: [keep-alive]
       Content-Length: ['78']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:21 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:53 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/cont1/testappendblob?comp=appendblock
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Content-MD5: [zeGiTMG1TdAobIHawzap3A==]
-      Date: ['Thu, 05 Jan 2017 22:39:20 GMT']
-      ETag: ['"0x8D435BBB123B700"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:21 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      content-md5: [zeGiTMG1TdAobIHawzap3A==]
+      date: ['Mon, 23 Jan 2017 20:59:52 GMT']
+      etag: ['"0x8D443D2C6A2FBE8"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:52 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-blob-append-offset: ['0']
       x-ms-blob-committed-block-count: ['1']
       x-ms-version: ['2015-07-08']
@@ -535,22 +537,22 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:21 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:54 GMT']
       x-ms-version: ['2015-07-08']
     method: HEAD
     uri: https://dummystorage.blob.core.windows.net/cont1/testappendblob
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Accept-Ranges: [bytes]
-      Content-Length: ['78']
-      Content-Type: [application/octet-stream]
-      Date: ['Thu, 05 Jan 2017 22:39:21 GMT']
-      ETag: ['"0x8D435BBB123B700"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:21 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      accept-ranges: [bytes]
+      content-length: ['78']
+      content-type: [application/octet-stream]
+      date: ['Mon, 23 Jan 2017 20:59:54 GMT']
+      etag: ['"0x8D443D2C6A2FBE8"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:52 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-blob-committed-block-count: ['1']
       x-ms-blob-type: [AppendBlob]
       x-ms-lease-state: [available]
@@ -558,25 +560,26 @@ interactions:
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
-    body: This is a test file for performance of automated tests. DO NOT MOVE OR DELETE!
+    body: !!python/unicode 'This is a test file for performance of automated tests.
+      DO NOT MOVE OR DELETE!'
     headers:
       Connection: [keep-alive]
       Content-Length: ['78']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:21 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:54 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/cont1/testappendblob?comp=appendblock
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Content-MD5: [zeGiTMG1TdAobIHawzap3A==]
-      Date: ['Thu, 05 Jan 2017 22:39:21 GMT']
-      ETag: ['"0x8D435BBB17C9AC0"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:21 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      content-md5: [zeGiTMG1TdAobIHawzap3A==]
+      date: ['Mon, 23 Jan 2017 20:59:54 GMT']
+      etag: ['"0x8D443D2C769A03B"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:53 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-blob-append-offset: ['78']
       x-ms-blob-committed-block-count: ['2']
       x-ms-version: ['2015-07-08']
@@ -585,22 +588,22 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:22 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:55 GMT']
       x-ms-version: ['2015-07-08']
     method: HEAD
     uri: https://dummystorage.blob.core.windows.net/cont1/testappendblob
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Accept-Ranges: [bytes]
-      Content-Length: ['156']
-      Content-Type: [application/octet-stream]
-      Date: ['Thu, 05 Jan 2017 22:39:21 GMT']
-      ETag: ['"0x8D435BBB17C9AC0"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:21 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      accept-ranges: [bytes]
+      content-length: ['156']
+      content-type: [application/octet-stream]
+      date: ['Mon, 23 Jan 2017 20:59:53 GMT']
+      etag: ['"0x8D443D2C769A03B"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:53 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-blob-committed-block-count: ['2']
       x-ms-blob-type: [AppendBlob]
       x-ms-lease-state: [available]
@@ -612,42 +615,42 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:23 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:57 GMT']
       x-ms-meta-a: [b]
       x-ms-meta-c: [d]
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob?comp=metadata
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:22 GMT']
-      ETag: ['"0x8D435BBB239AF97"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:23 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 20:59:56 GMT']
+      etag: ['"0x8D443D2C90FF324"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:56 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:23 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:58 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob?comp=metadata
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:23 GMT']
-      ETag: ['"0x8D435BBB239AF97"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:23 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 20:59:57 GMT']
+      etag: ['"0x8D443D2C90FF324"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:56 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-meta-a: [b]
       x-ms-meta-c: [d]
       x-ms-version: ['2015-07-08']
@@ -657,94 +660,94 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:24 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 20:59:59 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob?comp=metadata
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:24 GMT']
-      ETag: ['"0x8D435BBB2D8117B"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:24 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 20:59:58 GMT']
+      etag: ['"0x8D443D2CA6E5C11"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:58 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:24 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:00 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob?comp=metadata
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:24 GMT']
-      ETag: ['"0x8D435BBB2D8117B"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:24 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 20:59:59 GMT']
+      etag: ['"0x8D443D2CA6E5C11"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:58 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:25 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:02 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
-    uri: https://dummystorage.blob.core.windows.net/cont1?restype=container&comp=list
+    uri: https://dummystorage.blob.core.windows.net/cont1?comp=list&restype=container
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults\
-        \ ServiceEndpoint=\"https://vcrstorage213990324496.blob.core.windows.net/\"\
-        \ ContainerName=\"cont1\"><Blobs><Blob><Name>testappendblob</Name><Properties><Last-Modified>Thu,\
-        \ 05 Jan 2017 22:39:21 GMT</Last-Modified><Etag>0x8D435BBB17C9AC0</Etag><Content-Length>156</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding\
+        \ ServiceEndpoint=\"https://vcrstorage214781765435.blob.core.windows.net/\"\
+        \ ContainerName=\"cont1\"><Blobs><Blob><Name>testappendblob</Name><Properties><Last-Modified>Mon,\
+        \ 23 Jan 2017 20:59:53 GMT</Last-Modified><Etag>0x8D443D2C769A03B</Etag><Content-Length>156</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding\
         \ /><Content-Language /><Content-MD5 /><Cache-Control /><Content-Disposition\
-        \ /><BlobType>AppendBlob</BlobType><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties></Blob><Blob><Name>testblockblob</Name><Properties><Last-Modified>Thu,\
-        \ 05 Jan 2017 22:39:24 GMT</Last-Modified><Etag>0x8D435BBB2D8117B</Etag><Content-Length>78</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding\
+        \ /><BlobType>AppendBlob</BlobType><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties></Blob><Blob><Name>testblockblob</Name><Properties><Last-Modified>Mon,\
+        \ 23 Jan 2017 20:59:58 GMT</Last-Modified><Etag>0x8D443D2CA6E5C11</Etag><Content-Length>78</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding\
         \ /><Content-Language /><Content-MD5>zeGiTMG1TdAobIHawzap3A==</Content-MD5><Cache-Control\
-        \ /><Content-Disposition /><BlobType>BlockBlob</BlobType><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties></Blob><Blob><Name>testpageblob</Name><Properties><Last-Modified>Thu,\
-        \ 05 Jan 2017 22:39:19 GMT</Last-Modified><Etag>0x8D435BBB0597F9F</Etag><Content-Length>512</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding\
+        \ /><Content-Disposition /><BlobType>BlockBlob</BlobType><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties></Blob><Blob><Name>testpageblob</Name><Properties><Last-Modified>Mon,\
+        \ 23 Jan 2017 20:59:49 GMT</Last-Modified><Etag>0x8D443D2C51368F8</Etag><Content-Length>512</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding\
         \ /><Content-Language /><Content-MD5 /><Cache-Control /><Content-Disposition\
         \ /><x-ms-blob-sequence-number>0</x-ms-blob-sequence-number><BlobType>PageBlob</BlobType><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState></Properties></Blob></Blobs><NextMarker\
         \ /></EnumerationResults>"}
     headers:
-      Content-Type: [application/xml]
-      Date: ['Thu, 05 Jan 2017 22:39:24 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      content-type: [application/xml]
+      date: ['Mon, 23 Jan 2017 21:00:01 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:25 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:03 GMT']
       x-ms-version: ['2015-07-08']
     method: HEAD
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Accept-Ranges: [bytes]
-      Content-Length: ['78']
-      Content-MD5: [zeGiTMG1TdAobIHawzap3A==]
-      Content-Type: [application/octet-stream]
-      Date: ['Thu, 05 Jan 2017 22:39:25 GMT']
-      ETag: ['"0x8D435BBB2D8117B"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:24 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      accept-ranges: [bytes]
+      content-length: ['78']
+      content-md5: [zeGiTMG1TdAobIHawzap3A==]
+      content-type: [application/octet-stream]
+      date: ['Mon, 23 Jan 2017 21:00:02 GMT']
+      etag: ['"0x8D443D2CA6E5C11"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:58 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-blob-type: [BlockBlob]
       x-ms-lease-state: [available]
       x-ms-lease-status: [unlocked]
@@ -754,25 +757,25 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:26 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:04 GMT']
       x-ms-range: [bytes=0-33554431]
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob
   response:
-    body: {string: This is a test file for performance of automated tests. DO NOT
-        MOVE OR DELETE!}
+    body: {string: !!python/unicode 'This is a test file for performance of automated
+        tests. DO NOT MOVE OR DELETE!'}
     headers:
-      Accept-Ranges: [bytes]
-      Content-Length: ['78']
-      Content-Range: [bytes 0-77/78]
-      Content-Type: [application/octet-stream]
-      Date: ['Thu, 05 Jan 2017 22:39:25 GMT']
-      ETag: ['"0x8D435BBB2D8117B"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:24 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      accept-ranges: [bytes]
+      content-length: ['78']
+      content-range: [bytes 0-77/78]
+      content-type: [application/octet-stream]
+      date: ['Mon, 23 Jan 2017 21:00:03 GMT']
+      etag: ['"0x8D443D2CA6E5C11"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:58 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-blob-type: [BlockBlob]
       x-ms-lease-state: [available]
       x-ms-lease-status: [unlocked]
@@ -784,9 +787,9 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       If-Modified-Since: ['Fri, 01 Apr 2016 12:00:00 GMT']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:26 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:05 GMT']
       x-ms-lease-action: [acquire]
       x-ms-lease-duration: ['60']
       x-ms-proposed-lease-id: [abcdabcd-abcd-abcd-abcd-abcdabcdabcd]
@@ -794,13 +797,13 @@ interactions:
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob?comp=lease
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:26 GMT']
-      ETag: ['"0x8D435BBB2D8117B"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:24 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 21:00:05 GMT']
+      etag: ['"0x8D443D2CA6E5C11"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:58 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-lease-id: [abcdabcd-abcd-abcd-abcd-abcdabcdabcd]
       x-ms-version: ['2015-07-08']
     status: {code: 201, message: Created}
@@ -808,23 +811,23 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:27 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:06 GMT']
       x-ms-version: ['2015-07-08']
     method: HEAD
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Accept-Ranges: [bytes]
-      Content-Length: ['78']
-      Content-MD5: [zeGiTMG1TdAobIHawzap3A==]
-      Content-Type: [application/octet-stream]
-      Date: ['Thu, 05 Jan 2017 22:39:27 GMT']
-      ETag: ['"0x8D435BBB2D8117B"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:24 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      accept-ranges: [bytes]
+      content-length: ['78']
+      content-md5: [zeGiTMG1TdAobIHawzap3A==]
+      content-type: [application/octet-stream]
+      date: ['Mon, 23 Jan 2017 21:00:06 GMT']
+      etag: ['"0x8D443D2CA6E5C11"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:58 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-blob-type: [BlockBlob]
       x-ms-lease-duration: [fixed]
       x-ms-lease-state: [leased]
@@ -836,9 +839,9 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:27 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:07 GMT']
       x-ms-lease-action: [change]
       x-ms-lease-id: [abcdabcd-abcd-abcd-abcd-abcdabcdabcd]
       x-ms-proposed-lease-id: [dcbadcba-dcba-dcba-dcba-dcbadcbadcba]
@@ -846,13 +849,13 @@ interactions:
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob?comp=lease
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:27 GMT']
-      ETag: ['"0x8D435BBB2D8117B"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:24 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 21:00:07 GMT']
+      etag: ['"0x8D443D2CA6E5C11"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:58 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-lease-id: [dcbadcba-dcba-dcba-dcba-dcbadcbadcba]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
@@ -861,22 +864,22 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:28 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:08 GMT']
       x-ms-lease-action: [renew]
       x-ms-lease-id: [dcbadcba-dcba-dcba-dcba-dcbadcbadcba]
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob?comp=lease
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:27 GMT']
-      ETag: ['"0x8D435BBB2D8117B"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:24 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 21:00:08 GMT']
+      etag: ['"0x8D443D2CA6E5C11"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:58 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-lease-id: [dcbadcba-dcba-dcba-dcba-dcbadcbadcba]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
@@ -884,23 +887,23 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:28 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:09 GMT']
       x-ms-version: ['2015-07-08']
     method: HEAD
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Accept-Ranges: [bytes]
-      Content-Length: ['78']
-      Content-MD5: [zeGiTMG1TdAobIHawzap3A==]
-      Content-Type: [application/octet-stream]
-      Date: ['Thu, 05 Jan 2017 22:39:27 GMT']
-      ETag: ['"0x8D435BBB2D8117B"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:24 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      accept-ranges: [bytes]
+      content-length: ['78']
+      content-md5: [zeGiTMG1TdAobIHawzap3A==]
+      content-type: [application/octet-stream]
+      date: ['Mon, 23 Jan 2017 21:00:09 GMT']
+      etag: ['"0x8D443D2CA6E5C11"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:58 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-blob-type: [BlockBlob]
       x-ms-lease-duration: [fixed]
       x-ms-lease-state: [leased]
@@ -912,22 +915,22 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:29 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:10 GMT']
       x-ms-lease-action: [break]
       x-ms-lease-break-period: ['30']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob?comp=lease
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:28 GMT']
-      ETag: ['"0x8D435BBB2D8117B"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:24 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 21:00:11 GMT']
+      etag: ['"0x8D443D2CA6E5C11"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:58 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-lease-time: ['30']
       x-ms-version: ['2015-07-08']
     status: {code: 202, message: Accepted}
@@ -935,23 +938,23 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:29 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:11 GMT']
       x-ms-version: ['2015-07-08']
     method: HEAD
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Accept-Ranges: [bytes]
-      Content-Length: ['78']
-      Content-MD5: [zeGiTMG1TdAobIHawzap3A==]
-      Content-Type: [application/octet-stream]
-      Date: ['Thu, 05 Jan 2017 22:39:29 GMT']
-      ETag: ['"0x8D435BBB2D8117B"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:24 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      accept-ranges: [bytes]
+      content-length: ['78']
+      content-md5: [zeGiTMG1TdAobIHawzap3A==]
+      content-type: [application/octet-stream]
+      date: ['Mon, 23 Jan 2017 21:00:10 GMT']
+      etag: ['"0x8D443D2CA6E5C11"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:58 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-blob-type: [BlockBlob]
       x-ms-lease-state: [breaking]
       x-ms-lease-status: [locked]
@@ -962,45 +965,45 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:30 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:12 GMT']
       x-ms-lease-action: [release]
       x-ms-lease-id: [dcbadcba-dcba-dcba-dcba-dcbadcbadcba]
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob?comp=lease
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:29 GMT']
-      ETag: ['"0x8D435BBB2D8117B"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:24 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 21:00:13 GMT']
+      etag: ['"0x8D443D2CA6E5C11"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:58 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:30 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:13 GMT']
       x-ms-version: ['2015-07-08']
     method: HEAD
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Accept-Ranges: [bytes]
-      Content-Length: ['78']
-      Content-MD5: [zeGiTMG1TdAobIHawzap3A==]
-      Content-Type: [application/octet-stream]
-      Date: ['Thu, 05 Jan 2017 22:39:29 GMT']
-      ETag: ['"0x8D435BBB2D8117B"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:24 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      accept-ranges: [bytes]
+      content-length: ['78']
+      content-md5: [zeGiTMG1TdAobIHawzap3A==]
+      content-type: [application/octet-stream]
+      date: ['Mon, 23 Jan 2017 21:00:13 GMT']
+      etag: ['"0x8D443D2CA6E5C11"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:58 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-blob-type: [BlockBlob]
       x-ms-lease-state: [available]
       x-ms-lease-status: [unlocked]
@@ -1011,43 +1014,43 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:31 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:14 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.blob.core.windows.net/cont1/testappendblob?comp=snapshot
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:30 GMT']
-      ETag: ['"0x8D435BBB17C9AC0"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:21 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
-      x-ms-snapshot: ['2017-01-05T22:39:31.2700415Z']
+      date: ['Mon, 23 Jan 2017 21:00:14 GMT']
+      etag: ['"0x8D443D2C769A03B"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:53 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
+      x-ms-snapshot: ['2017-01-23T21:00:13.7692297Z']
       x-ms-version: ['2015-07-08']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:31 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:16 GMT']
       x-ms-version: ['2015-07-08']
     method: HEAD
-    uri: https://dummystorage.blob.core.windows.net/cont1/testappendblob?snapshot=2017-01-05T22%3A39%3A31.2700415Z
+    uri: https://dummystorage.blob.core.windows.net/cont1/testappendblob?snapshot=2017-01-23T21%3A00%3A13.7692297Z
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Accept-Ranges: [bytes]
-      Content-Length: ['156']
-      Content-Type: [application/octet-stream]
-      Date: ['Thu, 05 Jan 2017 22:39:30 GMT']
-      ETag: ['"0x8D435BBB17C9AC0"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:21 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      accept-ranges: [bytes]
+      content-length: ['156']
+      content-type: [application/octet-stream]
+      date: ['Mon, 23 Jan 2017 21:00:15 GMT']
+      etag: ['"0x8D443D2C769A03B"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:53 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-blob-committed-block-count: ['2']
       x-ms-blob-type: [AppendBlob]
       x-ms-version: ['2015-07-08']
@@ -1057,36 +1060,36 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:32 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:18 GMT']
       x-ms-version: ['2015-07-08']
     method: DELETE
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:31 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 21:00:17 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 202, message: Accepted}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:32 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:19 GMT']
       x-ms-version: ['2015-07-08']
     method: HEAD
     uri: https://dummystorage.blob.core.windows.net/cont1/testblockblob
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:32 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 21:00:19 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 404, message: The specified blob does not exist.}
 - request:
@@ -1095,23 +1098,23 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       If-Modified-Since: ['Fri, 01 Apr 2016 12:00:00 GMT']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:33 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:21 GMT']
       x-ms-lease-action: [acquire]
       x-ms-lease-duration: ['60']
       x-ms-proposed-lease-id: [abcdabcd-abcd-abcd-abcd-abcdabcdabcd]
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.blob.core.windows.net/cont1?restype=container&comp=lease
+    uri: https://dummystorage.blob.core.windows.net/cont1?comp=lease&restype=container
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:33 GMT']
-      ETag: ['"0x8D435BBAF17CA84"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:17 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 21:00:21 GMT']
+      etag: ['"0x8D443D2C216DCE7"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:44 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-lease-id: [abcdabcd-abcd-abcd-abcd-abcdabcdabcd]
       x-ms-version: ['2015-07-08']
     status: {code: 201, message: Created}
@@ -1119,20 +1122,20 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:33 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:22 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/cont1?restype=container
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:33 GMT']
-      ETag: ['"0x8D435BBAF17CA84"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:17 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 21:00:22 GMT']
+      etag: ['"0x8D443D2C216DCE7"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:44 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-lease-duration: [fixed]
       x-ms-lease-state: [leased]
       x-ms-lease-status: [locked]
@@ -1143,23 +1146,23 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:34 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:24 GMT']
       x-ms-lease-action: [change]
       x-ms-lease-id: [abcdabcd-abcd-abcd-abcd-abcdabcdabcd]
       x-ms-proposed-lease-id: [dcbadcba-dcba-dcba-dcba-dcbadcbadcba]
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.blob.core.windows.net/cont1?restype=container&comp=lease
+    uri: https://dummystorage.blob.core.windows.net/cont1?comp=lease&restype=container
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:34 GMT']
-      ETag: ['"0x8D435BBAF17CA84"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:17 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 21:00:23 GMT']
+      etag: ['"0x8D443D2C216DCE7"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:44 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-lease-id: [dcbadcba-dcba-dcba-dcba-dcbadcbadcba]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
@@ -1168,22 +1171,22 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:34 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:25 GMT']
       x-ms-lease-action: [renew]
       x-ms-lease-id: [dcbadcba-dcba-dcba-dcba-dcbadcbadcba]
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.blob.core.windows.net/cont1?restype=container&comp=lease
+    uri: https://dummystorage.blob.core.windows.net/cont1?comp=lease&restype=container
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:34 GMT']
-      ETag: ['"0x8D435BBAF17CA84"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:17 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 21:00:25 GMT']
+      etag: ['"0x8D443D2C216DCE7"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:44 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-lease-id: [dcbadcba-dcba-dcba-dcba-dcbadcbadcba]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
@@ -1191,20 +1194,20 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:35 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:27 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/cont1?restype=container
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:35 GMT']
-      ETag: ['"0x8D435BBAF17CA84"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:17 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 21:00:27 GMT']
+      etag: ['"0x8D443D2C216DCE7"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:44 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-lease-duration: [fixed]
       x-ms-lease-state: [leased]
       x-ms-lease-status: [locked]
@@ -1215,22 +1218,22 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:35 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:29 GMT']
       x-ms-lease-action: [break]
       x-ms-lease-break-period: ['30']
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.blob.core.windows.net/cont1?restype=container&comp=lease
+    uri: https://dummystorage.blob.core.windows.net/cont1?comp=lease&restype=container
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:34 GMT']
-      ETag: ['"0x8D435BBAF17CA84"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:17 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 21:00:29 GMT']
+      etag: ['"0x8D443D2C216DCE7"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:44 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-lease-time: ['30']
       x-ms-version: ['2015-07-08']
     status: {code: 202, message: Accepted}
@@ -1238,20 +1241,20 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:36 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:31 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/cont1?restype=container
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:36 GMT']
-      ETag: ['"0x8D435BBAF17CA84"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:17 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 21:00:30 GMT']
+      etag: ['"0x8D443D2C216DCE7"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:44 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-lease-state: [breaking]
       x-ms-lease-status: [locked]
       x-ms-version: ['2015-07-08']
@@ -1261,42 +1264,42 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:36 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:32 GMT']
       x-ms-lease-action: [release]
       x-ms-lease-id: [dcbadcba-dcba-dcba-dcba-dcbadcbadcba]
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.blob.core.windows.net/cont1?restype=container&comp=lease
+    uri: https://dummystorage.blob.core.windows.net/cont1?comp=lease&restype=container
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:36 GMT']
-      ETag: ['"0x8D435BBAF17CA84"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:17 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 21:00:30 GMT']
+      etag: ['"0x8D443D2C216DCE7"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:44 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:37 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:33 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/cont1?restype=container
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:36 GMT']
-      ETag: ['"0x8D435BBAF17CA84"']
-      Last-Modified: ['Thu, 05 Jan 2017 22:39:17 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 21:00:32 GMT']
+      etag: ['"0x8D443D2C216DCE7"']
+      last-modified: ['Mon, 23 Jan 2017 20:59:44 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-lease-state: [available]
       x-ms-lease-status: [unlocked]
       x-ms-version: ['2015-07-08']
@@ -1306,39 +1309,39 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:37 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:35 GMT']
       x-ms-version: ['2015-07-08']
     method: DELETE
     uri: https://dummystorage.blob.core.windows.net/cont1?restype=container
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Thu, 05 Jan 2017 22:39:37 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
-      Transfer-Encoding: [chunked]
+      date: ['Mon, 23 Jan 2017 21:00:34 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
     status: {code: 202, message: Accepted}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 3.5.2; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [b076952c-d397-11e6-b48d-480fcf61db4b]
-      x-ms-date: ['Thu, 05 Jan 2017 22:39:38 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:37 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.blob.core.windows.net/cont1?restype=container
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerNotFound</Code><Message>The\
-        \ specified container does not exist.\nRequestId:4d593734-0001-0128-0fa4-67019c000000\n\
-        Time:2017-01-05T22:39:39.1810409Z</Message></Error>"}
+        \ specified container does not exist.\nRequestId:7610a83e-0001-00d2-38bb-75bd6a000000\n\
+        Time:2017-01-23T21:00:37.2881590Z</Message></Error>"}
     headers:
-      Content-Length: ['225']
-      Content-Type: [application/xml]
-      Date: ['Thu, 05 Jan 2017 22:39:38 GMT']
-      Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
+      content-length: ['225']
+      content-type: [application/xml]
+      date: ['Mon, 23 Jan 2017 21:00:36 GMT']
+      server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 404, message: The specified container does not exist.}
 version: 1

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_file_acl_scenario.yaml
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_file_acl_scenario.yaml
@@ -7,37 +7,37 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 storagemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1
+          msrest/0.4.4 msrest_azure/0.4.6 storagemanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [95d46e70-d2a6-11e6-a4ff-a0b3ccf7272a]
+      x-ms-client-request-id: [edef7b42-e1ae-11e6-b91d-3c15c2cf0610]
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Storage/storageAccounts/dummystorage.listKeys?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vcr_resource_group/providers/Microsoft.Storage/storageAccounts/dummystorage.listKeys?api-version=2016-12-01
   response:
-    body: {string: !!python/unicode '{"keys":[{"keyName":"key1","permissions":"Full","value":"8LSOnAlOnt0VbA6+Kk8MQYBeMoh6mRHyKVU3ZR6J+TD2Lc25ZtZJrAvOxp2ta5pcVidSATLqH1/lUDS8Km920g=="},{"keyName":"key2","permissions":"Full","value":"J7bsifeKsqfDJJaQLs82OswYUnX6JKjT34E8pV5opHuaA6nwbuI0Uy6VblvsiziqUYlPnoaWv4dCTqPgFUn9+A=="}]}
+    body: {string: !!python/unicode '{"keys":[{"keyName":"key1","permissions":"Full","value":"1GG66zuBrQ5nZF5uM8VAZuCqcezcYtDPVem0J6TLAc8MPmJk0VSnd4fZLVYLvIk7uvCE/uV7+4wCFcTcVdVwbQ=="},{"keyName":"key2","permissions":"Full","value":"12Z63rxXflpm2ATKWn/Wf7Ig3l0rn7SgocBaE9XxgtOdpnNyqnQCaaUw5FhL+U8OeoepaiaeV82q1HQIhOn0tQ=="}]}
 
         '}
     headers:
       cache-control: [no-cache]
       content-length: ['289']
       content-type: [application/json]
-      date: ['Wed, 04 Jan 2017 17:52:39 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:10 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1194']
+      x-ms-ratelimit-remaining-subscription-writes: ['1192']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:40 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:12 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
@@ -46,9 +46,9 @@ interactions:
         \ />"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:52:40 GMT']
-      etag: ['"0x8D434CA79BA7FE4"']
-      last-modified: ['Wed, 04 Jan 2017 17:52:39 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:11 GMT']
+      etag: ['"0x8D443D2D1F57FA2"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:11 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -57,9 +57,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:41 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:13 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
@@ -68,9 +68,9 @@ interactions:
         \ />"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:52:40 GMT']
-      etag: ['"0x8D434CA79BA7FE4"']
-      last-modified: ['Wed, 04 Jan 2017 17:52:39 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:14 GMT']
+      etag: ['"0x8D443D2D1F57FA2"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:11 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -82,18 +82,18 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['184']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:41 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:13 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:52:40 GMT']
-      etag: ['"0x8D434CA7ACC4DB4"']
-      last-modified: ['Wed, 04 Jan 2017 17:52:41 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:14 GMT']
+      etag: ['"0x8D443D2D3D03DBF"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:14 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -102,9 +102,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:42 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:15 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
@@ -112,9 +112,9 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:52:41 GMT']
-      etag: ['"0x8D434CA7ACC4DB4"']
-      last-modified: ['Wed, 04 Jan 2017 17:52:41 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:15 GMT']
+      etag: ['"0x8D443D2D3D03DBF"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:14 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -126,18 +126,18 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['296']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:42 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:15 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:52:42 GMT']
-      etag: ['"0x8D434CA7B48C7CE"']
-      last-modified: ['Wed, 04 Jan 2017 17:52:42 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:15 GMT']
+      etag: ['"0x8D443D2D4BBE030"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:15 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -146,9 +146,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:42 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:17 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
@@ -156,9 +156,9 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:52:41 GMT']
-      etag: ['"0x8D434CA7B48C7CE"']
-      last-modified: ['Wed, 04 Jan 2017 17:52:42 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:16 GMT']
+      etag: ['"0x8D443D2D4BBE030"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:15 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -170,18 +170,18 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['413']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:43 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:17 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:52:41 GMT']
-      etag: ['"0x8D434CA7BBF4D0F"']
-      last-modified: ['Wed, 04 Jan 2017 17:52:43 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:17 GMT']
+      etag: ['"0x8D443D2D6143DBE"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:17 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -190,9 +190,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:43 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:19 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
@@ -200,9 +200,9 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:52:43 GMT']
-      etag: ['"0x8D434CA7BBF4D0F"']
-      last-modified: ['Wed, 04 Jan 2017 17:52:43 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:17 GMT']
+      etag: ['"0x8D443D2D6143DBE"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:17 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -214,18 +214,18 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['591']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:44 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:19 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:52:43 GMT']
-      etag: ['"0x8D434CA7C534C81"']
-      last-modified: ['Wed, 04 Jan 2017 17:52:43 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:18 GMT']
+      etag: ['"0x8D443D2D733F354"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:19 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -234,9 +234,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:44 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:21 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
@@ -244,9 +244,9 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:52:43 GMT']
-      etag: ['"0x8D434CA7C534C81"']
-      last-modified: ['Wed, 04 Jan 2017 17:52:43 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:22 GMT']
+      etag: ['"0x8D443D2D733F354"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:19 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -255,9 +255,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:45 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:22 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
@@ -265,9 +265,9 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:52:44 GMT']
-      etag: ['"0x8D434CA7C534C81"']
-      last-modified: ['Wed, 04 Jan 2017 17:52:43 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:22 GMT']
+      etag: ['"0x8D443D2D733F354"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:19 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -276,9 +276,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:45 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:24 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
@@ -286,9 +286,9 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:52:45 GMT']
-      etag: ['"0x8D434CA7C534C81"']
-      last-modified: ['Wed, 04 Jan 2017 17:52:43 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:24 GMT']
+      etag: ['"0x8D443D2D733F354"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:19 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -297,9 +297,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:46 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:26 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
@@ -307,9 +307,9 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:52:45 GMT']
-      etag: ['"0x8D434CA7C534C81"']
-      last-modified: ['Wed, 04 Jan 2017 17:52:43 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:25 GMT']
+      etag: ['"0x8D443D2D733F354"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:19 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -318,9 +318,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:46 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:28 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
@@ -328,9 +328,9 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:52:46 GMT']
-      etag: ['"0x8D434CA7C534C81"']
-      last-modified: ['Wed, 04 Jan 2017 17:52:43 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:28 GMT']
+      etag: ['"0x8D443D2D733F354"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:19 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -339,9 +339,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:47 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:30 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
@@ -349,9 +349,9 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>l</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:52:47 GMT']
-      etag: ['"0x8D434CA7C534C81"']
-      last-modified: ['Wed, 04 Jan 2017 17:52:43 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:29 GMT']
+      etag: ['"0x8D443D2D733F354"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:19 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -363,18 +363,18 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['597']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:47 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:30 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:52:47 GMT']
-      etag: ['"0x8D434CA7E7AD0E7"']
-      last-modified: ['Wed, 04 Jan 2017 17:52:47 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:30 GMT']
+      etag: ['"0x8D443D2DDAA206B"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:30 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -383,9 +383,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:48 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:32 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
@@ -393,9 +393,9 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>r</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:52:47 GMT']
-      etag: ['"0x8D434CA7E7AD0E7"']
-      last-modified: ['Wed, 04 Jan 2017 17:52:47 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:32 GMT']
+      etag: ['"0x8D443D2DDAA206B"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:30 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -404,9 +404,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:48 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:33 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
@@ -414,9 +414,9 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>r</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:52:48 GMT']
-      etag: ['"0x8D434CA7E7AD0E7"']
-      last-modified: ['Wed, 04 Jan 2017 17:52:47 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:33 GMT']
+      etag: ['"0x8D443D2DDAA206B"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:30 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -428,18 +428,18 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['491']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:48 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:34 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:52:48 GMT']
-      etag: ['"0x8D434CA7F45F34C"']
-      last-modified: ['Wed, 04 Jan 2017 17:52:48 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:34 GMT']
+      etag: ['"0x8D443D2DFE45A52"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:34 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -448,9 +448,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:52:49 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:36 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.file.core.windows.net/acltestshare?comp=acl&restype=share
@@ -458,9 +458,9 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>rwdl</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:52:48 GMT']
-      etag: ['"0x8D434CA7F45F34C"']
-      last-modified: ['Wed, 04 Jan 2017 17:52:48 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:34 GMT']
+      etag: ['"0x8D443D2DFE45A52"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:34 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_file_copy_scenario.yaml
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_file_copy_scenario.yaml
@@ -7,47 +7,47 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 storagemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1
+          msrest/0.4.4 msrest_azure/0.4.6 storagemanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a9ca2461-d2a6-11e6-a19a-a0b3ccf7272a]
+      x-ms-client-request-id: [f0fa9bb3-e1ae-11e6-95ca-3c15c2cf0610]
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_file_copy_scenario/providers/Microsoft.Storage/storageAccounts/dummystorage.listKeys?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_file_copy_scenario/providers/Microsoft.Storage/storageAccounts/dummystorage.listKeys?api-version=2016-12-01
   response:
-    body: {string: !!python/unicode '{"keys":[{"keyName":"key1","permissions":"Full","value":"FByg8PD4vdXeEphGW/LCDjzZdUh4mSJwxB/79Gcwb5taAYG91VonwK7RbnthROkbxZAiE0MXoJTx/WjQjVM5RA=="},{"keyName":"key2","permissions":"Full","value":"AQ8wbcQ932EpoJda9CCNHFZ9axvwcSepo4rm7wtfRQYihKIC5gFGS9L4jz8UXdzcViqIf3gsyXCtsDRE1F3MHg=="}]}
+    body: {string: !!python/unicode '{"keys":[{"keyName":"key1","permissions":"Full","value":"PUVtnr4irBwIA5HQBnK9xK0v+//fmmeiVEOMqRs52ZN5kvZTe2ONPDzHzQfwNy6R9E1S2zPgUnXQKUa8t7HD6g=="},{"keyName":"key2","permissions":"Full","value":"es1bBC+b32uUi2gpIvKxByobF1ITbz9Y7MBrVShBSmOsGSaB2TWGXMHRWsFq3ESbIC9U+4yEU8H2rYHWSY0UzA=="}]}
 
         '}
     headers:
       cache-control: [no-cache]
       content-length: ['289']
       content-type: [application/json]
-      date: ['Wed, 04 Jan 2017 17:53:12 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:16 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:14 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:18 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.file.core.windows.net/share1?restype=share
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:53:14 GMT']
-      etag: ['"0x8D434CA8E772ED7"']
-      last-modified: ['Wed, 04 Jan 2017 17:53:14 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:18 GMT']
+      etag: ['"0x8D443D2D66C6722"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:18 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -57,18 +57,18 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:14 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:20 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.file.core.windows.net/share2?restype=share
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:53:14 GMT']
-      etag: ['"0x8D434CA8EF28483"']
-      last-modified: ['Wed, 04 Jan 2017 17:53:15 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:20 GMT']
+      etag: ['"0x8D443D2D7BF9026"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:20 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -78,18 +78,18 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:15 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:22 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.file.core.windows.net/share1/dir1?restype=directory
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:53:15 GMT']
-      etag: ['"0x8D434CA8F1E164B"']
-      last-modified: ['Wed, 04 Jan 2017 17:53:15 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:23 GMT']
+      etag: ['"0x8D443D2D9F1A874"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:24 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -99,18 +99,18 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:16 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:24 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.file.core.windows.net/share2/dir2?restype=directory
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:53:15 GMT']
-      etag: ['"0x8D434CA8F78A8FD"']
-      last-modified: ['Wed, 04 Jan 2017 17:53:16 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:23 GMT']
+      etag: ['"0x8D443D2DABC9287"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:25 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -120,10 +120,10 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
       x-ms-content-length: ['78']
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:16 GMT']
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:26 GMT']
       x-ms-type: [file]
       x-ms-version: ['2015-07-08']
     method: PUT
@@ -131,9 +131,9 @@ interactions:
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:53:16 GMT']
-      etag: ['"0x8D434CA8FC751D5"']
-      last-modified: ['Wed, 04 Jan 2017 17:53:16 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:26 GMT']
+      etag: ['"0x8D443D2DBDD7259"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:27 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -144,9 +144,9 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['78']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:16 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:26 GMT']
       x-ms-range: [bytes=0-77]
       x-ms-version: ['2015-07-08']
       x-ms-write: [update]
@@ -156,9 +156,9 @@ interactions:
     body: {string: !!python/unicode ''}
     headers:
       content-md5: [zeGiTMG1TdAobIHawzap3A==]
-      date: ['Wed, 04 Jan 2017 17:53:16 GMT']
-      etag: ['"0x8D434CA8FD3FF30"']
-      last-modified: ['Wed, 04 Jan 2017 17:53:16 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:26 GMT']
+      etag: ['"0x8D443D2DC17EC83"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:28 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -167,9 +167,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:17 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:28 GMT']
       x-ms-version: ['2015-07-08']
     method: HEAD
     uri: https://dummystorage.file.core.windows.net/share1/dir1/src_file.txt
@@ -178,9 +178,9 @@ interactions:
     headers:
       content-length: ['78']
       content-type: [application/octet-stream]
-      date: ['Wed, 04 Jan 2017 17:53:17 GMT']
-      etag: ['"0x8D434CA8FD3FF30"']
-      last-modified: ['Wed, 04 Jan 2017 17:53:16 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:27 GMT']
+      etag: ['"0x8D443D2DC17EC83"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:28 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-type: [File]
       x-ms-version: ['2015-07-08']
@@ -190,22 +190,22 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-copy-source: ['https://vcrstorage218405782896.file.core.windows.net/share1/dir1/src_file.txt']
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:18 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-copy-source: ['https://vcrstorage934534540330.file.core.windows.net/share1/dir1/src_file.txt']
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:32 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.file.core.windows.net/share2/dest_file.txt
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:53:17 GMT']
-      etag: ['"0x8D434CA90D890ED"']
-      last-modified: ['Wed, 04 Jan 2017 17:53:18 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:33 GMT']
+      etag: ['"0x8D443D2E058DA37"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:35 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
-      x-ms-copy-id: [4c9371f0-4a99-43d4-9261-a0c9905351ce]
+      x-ms-copy-id: [c265935c-4faa-4a09-91aa-e25d7c26249f]
       x-ms-copy-status: [success]
       x-ms-version: ['2015-07-08']
     status: {code: 202, message: Accepted}
@@ -213,9 +213,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:18 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:35 GMT']
       x-ms-version: ['2015-07-08']
     method: HEAD
     uri: https://dummystorage.file.core.windows.net/share2/dest_file.txt
@@ -224,14 +224,14 @@ interactions:
     headers:
       content-length: ['78']
       content-type: [application/octet-stream]
-      date: ['Wed, 04 Jan 2017 17:53:17 GMT']
-      etag: ['"0x8D434CA90D890ED"']
-      last-modified: ['Wed, 04 Jan 2017 17:53:18 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:35 GMT']
+      etag: ['"0x8D443D2E058DA37"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:35 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-copy-completion-time: ['Wed, 04 Jan 2017 17:53:18 GMT']
-      x-ms-copy-id: [4c9371f0-4a99-43d4-9261-a0c9905351ce]
+      x-ms-copy-completion-time: ['Mon, 23 Jan 2017 21:00:34 GMT']
+      x-ms-copy-id: [c265935c-4faa-4a09-91aa-e25d7c26249f]
       x-ms-copy-progress: [78/78]
-      x-ms-copy-source: ['https://vcrstorage218405782896.file.core.windows.net/share1/dir1/src_file.txt']
+      x-ms-copy-source: ['https://vcrstorage934534540330.file.core.windows.net/share1/dir1/src_file.txt']
       x-ms-copy-status: [success]
       x-ms-type: [File]
       x-ms-version: ['2015-07-08']
@@ -241,22 +241,22 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-copy-source: ['https://vcrstorage218405782896.file.core.windows.net/share1/dir1/src_file.txt']
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:19 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-copy-source: ['https://vcrstorage934534540330.file.core.windows.net/share1/dir1/src_file.txt']
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:37 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.file.core.windows.net/share2/dir2/dest_file.txt
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:53:19 GMT']
-      etag: ['"0x8D434CA919A3C93"']
-      last-modified: ['Wed, 04 Jan 2017 17:53:19 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:40 GMT']
+      etag: ['"0x8D443D2E3FE5970"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:41 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
-      x-ms-copy-id: [2b944baa-af5b-4355-afab-7d41df977f15]
+      x-ms-copy-id: [4bcce8fe-5f51-4f9d-8a89-34922ad9f2b5]
       x-ms-copy-status: [success]
       x-ms-version: ['2015-07-08']
     status: {code: 202, message: Accepted}
@@ -264,9 +264,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:20 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:41 GMT']
       x-ms-version: ['2015-07-08']
     method: HEAD
     uri: https://dummystorage.file.core.windows.net/share2/dir2/dest_file.txt
@@ -275,14 +275,14 @@ interactions:
     headers:
       content-length: ['78']
       content-type: [application/octet-stream]
-      date: ['Wed, 04 Jan 2017 17:53:20 GMT']
-      etag: ['"0x8D434CA919A3C93"']
-      last-modified: ['Wed, 04 Jan 2017 17:53:19 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:41 GMT']
+      etag: ['"0x8D443D2E3FE5970"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:41 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-copy-completion-time: ['Wed, 04 Jan 2017 17:53:19 GMT']
-      x-ms-copy-id: [2b944baa-af5b-4355-afab-7d41df977f15]
+      x-ms-copy-completion-time: ['Mon, 23 Jan 2017 21:00:40 GMT']
+      x-ms-copy-id: [4bcce8fe-5f51-4f9d-8a89-34922ad9f2b5]
       x-ms-copy-progress: [78/78]
-      x-ms-copy-source: ['https://vcrstorage218405782896.file.core.windows.net/share1/dir1/src_file.txt']
+      x-ms-copy-source: ['https://vcrstorage934534540330.file.core.windows.net/share1/dir1/src_file.txt']
       x-ms-copy-status: [success]
       x-ms-type: [File]
       x-ms-version: ['2015-07-08']
@@ -292,22 +292,22 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-copy-source: ['https://vcrstorage218405782896.file.core.windows.net/share1/dir1\src_file.txt']
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:20 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-copy-source: ['https://vcrstorage934534540330.file.core.windows.net/share1/dir1/src_file.txt']
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:43 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.file.core.windows.net/share2/dest_file.txt
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:53:19 GMT']
-      etag: ['"0x8D434CA9257A167"']
-      last-modified: ['Wed, 04 Jan 2017 17:53:20 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:43 GMT']
+      etag: ['"0x8D443D2E616DFB4"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:44 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
-      x-ms-copy-id: [b84be4e8-9ca2-4159-a094-b809cd090439]
+      x-ms-copy-id: [8a8fd7f7-c1e8-4cd0-9ca9-9c699b86f1e5]
       x-ms-copy-status: [success]
       x-ms-version: ['2015-07-08']
     status: {code: 202, message: Accepted}

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_file_scenario.yaml
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_file_scenario.yaml
@@ -7,47 +7,47 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 storagemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1
+          msrest/0.4.4 msrest_azure/0.4.6 storagemanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [bcab841e-d2a6-11e6-9877-a0b3ccf7272a]
+      x-ms-client-request-id: [f249e647-e1ae-11e6-bf71-3c15c2cf0610]
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_file_scenario/providers/Microsoft.Storage/storageAccounts/dummystorage.listKeys?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_file_scenario/providers/Microsoft.Storage/storageAccounts/dummystorage.listKeys?api-version=2016-12-01
   response:
-    body: {string: !!python/unicode '{"keys":[{"keyName":"key1","permissions":"Full","value":"SNVKgep+C/UlpETp0+m1Yl50XN4ZGX+9GQd5KBMMvFRg6KzqvbXXWV+6C+bzfpbcEPnMzD/e/t3ecGS3FWaviw=="},{"keyName":"key2","permissions":"Full","value":"zkUePcO64zWlZ1UtoLCtfUB68KIEqHEue5PmjZzbHLHkkyHWY5tBJmt5lu9TBJW4V/TJiEnVScAUB/IzL79zgg=="}]}
+    body: {string: !!python/unicode '{"keys":[{"keyName":"key1","permissions":"Full","value":"Jx0UjMS9p2EOEk4jGO3JXZjX+4mFr6muSLc+Quy0jjAvC7eGUKKqF0ljLDgm8GuFpSAIDTu/T+Vj1ZeAUkFCeA=="},{"keyName":"key2","permissions":"Full","value":"aUes3zV3cA0lAScyImnLlcrhjT27hPtttGSDuNjjXcb4+lC34S1teNBa2b34Nm5J2YdQ6KPuNqu8V5YrWV9c0A=="}]}
 
         '}
     headers:
       cache-control: [no-cache]
       content-length: ['289']
       content-type: [application/json]
-      date: ['Wed, 04 Jan 2017 17:53:44 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:18 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1193']
+      x-ms-ratelimit-remaining-subscription-writes: ['1190']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:45 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:20 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.file.core.windows.net/testshare01?restype=share
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:53:45 GMT']
-      etag: ['"0x8D434CAA1490EF0"']
-      last-modified: ['Wed, 04 Jan 2017 17:53:46 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:20 GMT']
+      etag: ['"0x8D443D2D7E54F5D"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:21 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -57,9 +57,9 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:46 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:22 GMT']
       x-ms-meta-cat: [hat]
       x-ms-meta-foo: [bar]
       x-ms-version: ['2015-07-08']
@@ -68,9 +68,9 @@ interactions:
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:53:45 GMT']
-      etag: ['"0x8D434CAA1726DE4"']
-      last-modified: ['Wed, 04 Jan 2017 17:53:46 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:22 GMT']
+      etag: ['"0x8D443D2D8D83568"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:22 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -79,18 +79,18 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:47 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:23 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.file.core.windows.net/testshare01?restype=share
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:53:46 GMT']
-      etag: ['"0x8D434CAA1490EF0"']
-      last-modified: ['Wed, 04 Jan 2017 17:53:46 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:24 GMT']
+      etag: ['"0x8D443D2D7E54F5D"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:21 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-share-quota: ['5120']
@@ -100,18 +100,18 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:47 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:24 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.file.core.windows.net/testshare02?comp=metadata&restype=share
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:53:47 GMT']
-      etag: ['"0x8D434CAA1726DE4"']
-      last-modified: ['Wed, 04 Jan 2017 17:53:46 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:24 GMT']
+      etag: ['"0x8D443D2D8D83568"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:22 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-meta-cat: [hat]
@@ -122,22 +122,22 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:48 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:26 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.file.core.windows.net/?comp=list
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults\
-        \ ServiceEndpoint=\"https://vcrstorage893744343263.file.core.windows.net/\"\
-        ><Shares><Share><Name>testshare01</Name><Properties><Last-Modified>Wed, 04\
-        \ Jan 2017 17:53:46 GMT</Last-Modified><Etag>\"0x8D434CAA1490EF0\"</Etag><Quota>5120</Quota></Properties></Share><Share><Name>testshare02</Name><Properties><Last-Modified>Wed,\
-        \ 04 Jan 2017 17:53:46 GMT</Last-Modified><Etag>\"0x8D434CAA1726DE4\"</Etag><Quota>5120</Quota></Properties></Share></Shares><NextMarker\
+        \ ServiceEndpoint=\"https://vcrstorage444611779656.file.core.windows.net/\"\
+        ><Shares><Share><Name>testshare01</Name><Properties><Last-Modified>Mon, 23\
+        \ Jan 2017 21:00:21 GMT</Last-Modified><Etag>\"0x8D443D2D7E54F5D\"</Etag><Quota>5120</Quota></Properties></Share><Share><Name>testshare02</Name><Properties><Last-Modified>Mon,\
+        \ 23 Jan 2017 21:00:22 GMT</Last-Modified><Etag>\"0x8D443D2D8D83568\"</Etag><Quota>5120</Quota></Properties></Share></Shares><NextMarker\
         \ /></EnumerationResults>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:53:47 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:27 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -147,9 +147,9 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:48 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:28 GMT']
       x-ms-meta-a: [b]
       x-ms-meta-c: [d]
       x-ms-version: ['2015-07-08']
@@ -158,9 +158,9 @@ interactions:
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:53:48 GMT']
-      etag: ['"0x8D434CAA2EE9F47"']
-      last-modified: ['Wed, 04 Jan 2017 17:53:48 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:29 GMT']
+      etag: ['"0x8D443D2DC925EC8"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:28 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -169,18 +169,18 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:49 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:30 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.file.core.windows.net/testshare01?comp=metadata&restype=share
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:53:49 GMT']
-      etag: ['"0x8D434CAA2EE9F47"']
-      last-modified: ['Wed, 04 Jan 2017 17:53:48 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:29 GMT']
+      etag: ['"0x8D443D2DC925EC8"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:28 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-meta-a: [b]
@@ -192,18 +192,18 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:49 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:31 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.file.core.windows.net/testshare01?comp=metadata&restype=share
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:53:49 GMT']
-      etag: ['"0x8D434CAA3A6F86A"']
-      last-modified: ['Wed, 04 Jan 2017 17:53:49 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:30 GMT']
+      etag: ['"0x8D443D2DE5BCDA2"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:31 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -212,18 +212,18 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:50 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:32 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.file.core.windows.net/testshare01?comp=metadata&restype=share
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:53:49 GMT']
-      etag: ['"0x8D434CAA3A6F86A"']
-      last-modified: ['Wed, 04 Jan 2017 17:53:49 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:33 GMT']
+      etag: ['"0x8D443D2DE5BCDA2"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:31 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -233,9 +233,9 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:51 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:34 GMT']
       x-ms-share-quota: ['3']
       x-ms-version: ['2015-07-08']
     method: PUT
@@ -243,9 +243,9 @@ interactions:
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:53:51 GMT']
-      etag: ['"0x8D434CAA45F78A7"']
-      last-modified: ['Wed, 04 Jan 2017 17:53:51 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:34 GMT']
+      etag: ['"0x8D443D2DFCE7BFF"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:34 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -254,18 +254,18 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:51 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:35 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.file.core.windows.net/testshare01?restype=share
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:53:50 GMT']
-      etag: ['"0x8D434CAA45F78A7"']
-      last-modified: ['Wed, 04 Jan 2017 17:53:51 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:35 GMT']
+      etag: ['"0x8D443D2DFCE7BFF"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:34 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-share-quota: ['3']
@@ -276,10 +276,10 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
       x-ms-content-length: ['78']
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:52 GMT']
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:37 GMT']
       x-ms-type: [file]
       x-ms-version: ['2015-07-08']
     method: PUT
@@ -287,9 +287,9 @@ interactions:
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:53:51 GMT']
-      etag: ['"0x8D434CAA51DA700"']
-      last-modified: ['Wed, 04 Jan 2017 17:53:52 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:37 GMT']
+      etag: ['"0x8D443D2E1E97258"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:37 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -300,9 +300,9 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['78']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:52 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:37 GMT']
       x-ms-range: [bytes=0-77]
       x-ms-version: ['2015-07-08']
       x-ms-write: [update]
@@ -312,9 +312,9 @@ interactions:
     body: {string: !!python/unicode ''}
     headers:
       content-md5: [zeGiTMG1TdAobIHawzap3A==]
-      date: ['Wed, 04 Jan 2017 17:53:51 GMT']
-      etag: ['"0x8D434CAA526F824"']
-      last-modified: ['Wed, 04 Jan 2017 17:53:52 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:37 GMT']
+      etag: ['"0x8D443D2E1F53515"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:37 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -323,9 +323,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:52 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:39 GMT']
       x-ms-version: ['2015-07-08']
     method: HEAD
     uri: https://dummystorage.file.core.windows.net/testshare01/testfile.rst
@@ -334,9 +334,9 @@ interactions:
     headers:
       content-length: ['78']
       content-type: [application/octet-stream]
-      date: ['Wed, 04 Jan 2017 17:53:52 GMT']
-      etag: ['"0x8D434CAA526F824"']
-      last-modified: ['Wed, 04 Jan 2017 17:53:52 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:39 GMT']
+      etag: ['"0x8D443D2E1F53515"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:37 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-type: [File]
       x-ms-version: ['2015-07-08']
@@ -345,9 +345,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:53 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:40 GMT']
       x-ms-range: [bytes=0-33554431]
       x-ms-version: ['2015-07-08']
     method: GET
@@ -360,9 +360,9 @@ interactions:
       content-length: ['78']
       content-range: [bytes 0-77/78]
       content-type: [application/octet-stream]
-      date: ['Wed, 04 Jan 2017 17:53:53 GMT']
-      etag: ['"0x8D434CAA526F824"']
-      last-modified: ['Wed, 04 Jan 2017 17:53:52 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:40 GMT']
+      etag: ['"0x8D443D2E1F53515"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:37 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-type: [File]
       x-ms-version: ['2015-07-08']
@@ -372,19 +372,19 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
       x-ms-content-length: ['1234']
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:54 GMT']
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:42 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.file.core.windows.net/testshare01/testfile.rst?comp=properties
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:53:53 GMT']
-      etag: ['"0x8D434CAA6317ECE"']
-      last-modified: ['Wed, 04 Jan 2017 17:53:54 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:43 GMT']
+      etag: ['"0x8D443D2E4EAA077"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:42 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -393,9 +393,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:54 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:44 GMT']
       x-ms-version: ['2015-07-08']
     method: HEAD
     uri: https://dummystorage.file.core.windows.net/testshare01/testfile.rst
@@ -404,9 +404,9 @@ interactions:
     headers:
       content-length: ['1234']
       content-type: [application/octet-stream]
-      date: ['Wed, 04 Jan 2017 17:53:54 GMT']
-      etag: ['"0x8D434CAA6317ECE"']
-      last-modified: ['Wed, 04 Jan 2017 17:53:54 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:44 GMT']
+      etag: ['"0x8D443D2E4EAA077"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:42 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-type: [File]
       x-ms-version: ['2015-07-08']
@@ -416,9 +416,9 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:55 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:45 GMT']
       x-ms-meta-a: [b]
       x-ms-meta-c: [d]
       x-ms-version: ['2015-07-08']
@@ -427,9 +427,9 @@ interactions:
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:53:55 GMT']
-      etag: ['"0x8D434CAA6DF2843"']
-      last-modified: ['Wed, 04 Jan 2017 17:53:55 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:45 GMT']
+      etag: ['"0x8D443D2E6CD6D25"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:46 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -438,18 +438,18 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:56 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:47 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.file.core.windows.net/testshare01/testfile.rst?comp=metadata
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:53:55 GMT']
-      etag: ['"0x8D434CAA6DF2843"']
-      last-modified: ['Wed, 04 Jan 2017 17:53:55 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:46 GMT']
+      etag: ['"0x8D443D2E6CD6D25"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:46 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-meta-a: [b]
@@ -461,18 +461,18 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:56 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:48 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.file.core.windows.net/testshare01/testfile.rst?comp=metadata
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:53:55 GMT']
-      etag: ['"0x8D434CAA7B300E3"']
-      last-modified: ['Wed, 04 Jan 2017 17:53:56 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:48 GMT']
+      etag: ['"0x8D443D2E83F3375"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:48 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -481,18 +481,18 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:57 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:49 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.file.core.windows.net/testshare01/testfile.rst?comp=metadata
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:53:56 GMT']
-      etag: ['"0x8D434CAA7B300E3"']
-      last-modified: ['Wed, 04 Jan 2017 17:53:56 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:48 GMT']
+      etag: ['"0x8D443D2E83F3375"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:48 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -501,20 +501,20 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:58 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:50 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.file.core.windows.net/testshare01?comp=list&restype=directory
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults\
-        \ ServiceEndpoint=\"https://vcrstorage893744343263.file.core.windows.net/\"\
+        \ ServiceEndpoint=\"https://vcrstorage444611779656.file.core.windows.net/\"\
         \ ShareName=\"testshare01\" DirectoryPath=\"\"><Entries><File><Name>testfile.rst</Name><Properties><Content-Length>1234</Content-Length></Properties></File></Entries><NextMarker\
         \ /></EnumerationResults>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:53:57 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:50 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -524,16 +524,16 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:58 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:51 GMT']
       x-ms-version: ['2015-07-08']
     method: DELETE
     uri: https://dummystorage.file.core.windows.net/testshare01/testfile.rst
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:53:58 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:51 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -542,16 +542,16 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:59 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:52 GMT']
       x-ms-version: ['2015-07-08']
     method: HEAD
     uri: https://dummystorage.file.core.windows.net/testshare01/testfile.rst
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:53:58 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:53 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -561,18 +561,18 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:53:59 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:53 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.file.core.windows.net/testshare01/testdir01?restype=directory
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:53:59 GMT']
-      etag: ['"0x8D434CAA9A69B2C"']
-      last-modified: ['Wed, 04 Jan 2017 17:54:00 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:53 GMT']
+      etag: ['"0x8D443D2EB9C7B2E"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:54 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -581,18 +581,18 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:00 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:54 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.file.core.windows.net/testshare01/testdir01?restype=directory
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:54:00 GMT']
-      etag: ['"0x8D434CAA9A69B2C"']
-      last-modified: ['Wed, 04 Jan 2017 17:54:00 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:55 GMT']
+      etag: ['"0x8D443D2EB9C7B2E"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:54 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -602,9 +602,9 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:01 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:55 GMT']
       x-ms-meta-a: [b]
       x-ms-meta-c: [d]
       x-ms-version: ['2015-07-08']
@@ -613,9 +613,9 @@ interactions:
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:54:00 GMT']
-      etag: ['"0x8D434CAAA53A83A"']
-      last-modified: ['Wed, 04 Jan 2017 17:54:01 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:56 GMT']
+      etag: ['"0x8D443D2ECD28932"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:56 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -624,18 +624,18 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:01 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:57 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.file.core.windows.net/testshare01/testdir01?comp=metadata&restype=directory
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:54:00 GMT']
-      etag: ['"0x8D434CAAA53A83A"']
-      last-modified: ['Wed, 04 Jan 2017 17:54:01 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:57 GMT']
+      etag: ['"0x8D443D2ECD28932"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:56 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-meta-a: [b]
@@ -646,18 +646,18 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:02 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:58 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.file.core.windows.net/testshare01/testdir01?restype=directory
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:54:01 GMT']
-      etag: ['"0x8D434CAAA53A83A"']
-      last-modified: ['Wed, 04 Jan 2017 17:54:01 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:57 GMT']
+      etag: ['"0x8D443D2ECD28932"']
+      last-modified: ['Mon, 23 Jan 2017 21:00:56 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-meta-a: [b]
@@ -669,18 +669,18 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:02 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:00:59 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.file.core.windows.net/testshare01/testdir01?comp=metadata&restype=directory
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:54:02 GMT']
-      etag: ['"0x8D434CAAB62EB03"']
-      last-modified: ['Wed, 04 Jan 2017 17:54:02 GMT']
+      date: ['Mon, 23 Jan 2017 21:00:59 GMT']
+      etag: ['"0x8D443D2EF3EF36E"']
+      last-modified: ['Mon, 23 Jan 2017 21:01:00 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -689,18 +689,18 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:03 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:01 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.file.core.windows.net/testshare01/testdir01?comp=metadata&restype=directory
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:54:02 GMT']
-      etag: ['"0x8D434CAAB62EB03"']
-      last-modified: ['Wed, 04 Jan 2017 17:54:02 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:01 GMT']
+      etag: ['"0x8D443D2EF3EF36E"']
+      last-modified: ['Mon, 23 Jan 2017 21:01:00 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -710,10 +710,10 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
       x-ms-content-length: ['78']
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:04 GMT']
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:02 GMT']
       x-ms-type: [file]
       x-ms-version: ['2015-07-08']
     method: PUT
@@ -721,9 +721,9 @@ interactions:
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:54:03 GMT']
-      etag: ['"0x8D434CAAC16FEB3"']
-      last-modified: ['Wed, 04 Jan 2017 17:54:04 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:01 GMT']
+      etag: ['"0x8D443D2F097D45C"']
+      last-modified: ['Mon, 23 Jan 2017 21:01:02 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -734,9 +734,9 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['78']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:04 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:02 GMT']
       x-ms-range: [bytes=0-77]
       x-ms-version: ['2015-07-08']
       x-ms-write: [update]
@@ -746,9 +746,9 @@ interactions:
     body: {string: !!python/unicode ''}
     headers:
       content-md5: [zeGiTMG1TdAobIHawzap3A==]
-      date: ['Wed, 04 Jan 2017 17:54:03 GMT']
-      etag: ['"0x8D434CAAC209E0A"']
-      last-modified: ['Wed, 04 Jan 2017 17:54:04 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:01 GMT']
+      etag: ['"0x8D443D2F0A14C97"']
+      last-modified: ['Mon, 23 Jan 2017 21:01:02 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -757,9 +757,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:04 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:03 GMT']
       x-ms-version: ['2015-07-08']
     method: HEAD
     uri: https://dummystorage.file.core.windows.net/testshare01/testdir01/testfile.rst
@@ -768,9 +768,9 @@ interactions:
     headers:
       content-length: ['78']
       content-type: [application/octet-stream]
-      date: ['Wed, 04 Jan 2017 17:54:04 GMT']
-      etag: ['"0x8D434CAAC209E0A"']
-      last-modified: ['Wed, 04 Jan 2017 17:54:04 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:02 GMT']
+      etag: ['"0x8D443D2F0A14C97"']
+      last-modified: ['Mon, 23 Jan 2017 21:01:02 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-type: [File]
       x-ms-version: ['2015-07-08']
@@ -779,9 +779,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:05 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:04 GMT']
       x-ms-range: [bytes=0-33554431]
       x-ms-version: ['2015-07-08']
     method: GET
@@ -794,9 +794,9 @@ interactions:
       content-length: ['78']
       content-range: [bytes 0-77/78]
       content-type: [application/octet-stream]
-      date: ['Wed, 04 Jan 2017 17:54:04 GMT']
-      etag: ['"0x8D434CAAC209E0A"']
-      last-modified: ['Wed, 04 Jan 2017 17:54:04 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:03 GMT']
+      etag: ['"0x8D443D2F0A14C97"']
+      last-modified: ['Mon, 23 Jan 2017 21:01:02 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-type: [File]
       x-ms-version: ['2015-07-08']
@@ -805,20 +805,20 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:05 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:05 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.file.core.windows.net/testshare01/testdir01?comp=list&restype=directory
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults\
-        \ ServiceEndpoint=\"https://vcrstorage893744343263.file.core.windows.net/\"\
+        \ ServiceEndpoint=\"https://vcrstorage444611779656.file.core.windows.net/\"\
         \ ShareName=\"testshare01\" DirectoryPath=\"testdir01\"><Entries><File><Name>testfile.rst</Name><Properties><Content-Length>78</Content-Length></Properties></File></Entries><NextMarker\
         \ /></EnumerationResults>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:54:05 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:06 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -827,9 +827,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:06 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:07 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.file.core.windows.net/testshare01?comp=stats&restype=share
@@ -837,7 +837,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><ShareStats><ShareUsage>1</ShareUsage></ShareStats>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:54:05 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:07 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -847,16 +847,16 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:07 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:08 GMT']
       x-ms-version: ['2015-07-08']
     method: DELETE
     uri: https://dummystorage.file.core.windows.net/testshare01/testdir01/testfile.rst
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:54:06 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:08 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -865,16 +865,16 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:07 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:09 GMT']
       x-ms-version: ['2015-07-08']
     method: HEAD
     uri: https://dummystorage.file.core.windows.net/testshare01/testfile.rst
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:54:07 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:10 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -884,16 +884,16 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:08 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:11 GMT']
       x-ms-version: ['2015-07-08']
     method: DELETE
     uri: https://dummystorage.file.core.windows.net/testshare01/testdir01?restype=directory
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:54:07 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:11 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -902,20 +902,20 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:08 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:12 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.file.core.windows.net/testshare01/testdir01?restype=directory
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ResourceNotFound</Code><Message>The\
-        \ specified resource does not exist.\nRequestId:b8d65d64-001a-0047-70b3-663269000000\n\
-        Time:2017-01-04T17:54:09.1596249Z</Message></Error>"}
+        \ specified resource does not exist.\nRequestId:1244ccb1-001a-0099-3dbb-756bca000000\n\
+        Time:2017-01-23T21:01:13.0423307Z</Message></Error>"}
     headers:
       content-length: ['223']
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:54:08 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:12 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 404, message: The specified resource does not exist.}
@@ -924,9 +924,9 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:09 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:13 GMT']
       x-ms-meta-cat: [hat]
       x-ms-meta-foo: [bar]
       x-ms-version: ['2015-07-08']
@@ -935,9 +935,9 @@ interactions:
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:54:08 GMT']
-      etag: ['"0x8D434CAAF6108AD"']
-      last-modified: ['Wed, 04 Jan 2017 17:54:09 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:13 GMT']
+      etag: ['"0x8D443D2F7A3CC5F"']
+      last-modified: ['Mon, 23 Jan 2017 21:01:14 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -946,18 +946,18 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:10 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:16 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.file.core.windows.net/testshare01/testdir02?comp=metadata&restype=directory
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:54:09 GMT']
-      etag: ['"0x8D434CAAF6108AD"']
-      last-modified: ['Wed, 04 Jan 2017 17:54:09 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:16 GMT']
+      etag: ['"0x8D443D2F7A3CC5F"']
+      last-modified: ['Mon, 23 Jan 2017 21:01:14 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-meta-cat: [hat]
@@ -969,16 +969,16 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:10 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:17 GMT']
       x-ms-version: ['2015-07-08']
     method: DELETE
     uri: https://dummystorage.file.core.windows.net/testshare01/testdir02?restype=directory
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:54:09 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:18 GMT']
       server: [Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_queue_scenario.yaml
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_queue_scenario.yaml
@@ -7,38 +7,38 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 storagemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1
+          msrest/0.4.4 msrest_azure/0.4.6 storagemanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [da9598e1-d2a6-11e6-bfd3-a0b3ccf7272a]
+      x-ms-client-request-id: [0f1022cc-e1af-11e6-aca1-3c15c2cf0610]
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_queue_scenario_test/providers/Microsoft.Storage/storageAccounts/dummystorage.listKeys?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_queue_scenario_test/providers/Microsoft.Storage/storageAccounts/dummystorage.listKeys?api-version=2016-12-01
   response:
-    body: {string: !!python/unicode '{"keys":[{"keyName":"key1","permissions":"Full","value":"1a8L0zRPLsdS4VtmDdluIpWYRo2ReteCwNJ5u7uNcMFa8bNlJn1PeAgWBoFL0t7H8AlQEthZENh18poEwjHlFg=="},{"keyName":"key2","permissions":"Full","value":"DNe0T0RaQmaIcPy1YoHkXCSkbv63UA9lqmYB7lhQwOXke3PzcL1skzv4mza5VGtFOGh9giBTEBuqcc0f8Hg3+g=="}]}
+    body: {string: !!python/unicode '{"keys":[{"keyName":"key1","permissions":"Full","value":"B/mf+9zidAHxMcNF5Pa1DSZqEivy6r67Tgm2WzfD0cV9sNcC3V5jlQNLI38H8qZARqZLLBpzOeNpbL3V6MgGzw=="},{"keyName":"key2","permissions":"Full","value":"680hK0PD26CXSQB4I0PauZxfPv+H+u7Pb8HMY54xgfLdLi4uckmczilEVZT5LL/29QDnr6/pgY3O+AyQC59cfQ=="}]}
 
         '}
     headers:
       cache-control: [no-cache]
       content-length: ['289']
       content-type: [application/json]
-      date: ['Wed, 04 Jan 2017 17:54:35 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:07 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1190']
+      x-ms-ratelimit-remaining-subscription-writes: ['1192']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:36 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:08 GMT']
       x-ms-meta-a: [b]
       x-ms-meta-c: [d]
       x-ms-version: ['2015-07-08']
@@ -47,7 +47,7 @@ interactions:
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:54:35 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:08 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -56,9 +56,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:37 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:09 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1?comp=metadata
@@ -66,7 +66,7 @@ interactions:
     body: {string: !!python/unicode ''}
     headers:
       cache-control: [no-cache]
-      date: ['Wed, 04 Jan 2017 17:54:36 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:10 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-approximate-messages-count: ['0']
@@ -78,20 +78,20 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:37 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:11 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/?comp=list
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults\
-        \ ServiceEndpoint=\"https://vcrstorage287273453364.queue.core.windows.net/\"\
+        \ ServiceEndpoint=\"https://vcrstorage754202842339.queue.core.windows.net/\"\
         ><Queues><Queue><Name>queue1</Name></Queue></Queues><NextMarker /></EnumerationResults>"}
     headers:
       cache-control: [no-cache]
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:54:36 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:10 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -100,9 +100,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:38 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:12 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1?comp=metadata
@@ -110,7 +110,7 @@ interactions:
     body: {string: !!python/unicode ''}
     headers:
       cache-control: [no-cache]
-      date: ['Wed, 04 Jan 2017 17:54:37 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:11 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-approximate-messages-count: ['0']
@@ -123,9 +123,9 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:38 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:13 GMT']
       x-ms-meta-e: [f]
       x-ms-meta-g: [h]
       x-ms-version: ['2015-07-08']
@@ -135,7 +135,7 @@ interactions:
     body: {string: !!python/unicode ''}
     headers:
       content-length: ['0']
-      date: ['Wed, 04 Jan 2017 17:54:37 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:14 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 204, message: No Content}
@@ -143,9 +143,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:39 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:14 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1?comp=metadata
@@ -153,7 +153,7 @@ interactions:
     body: {string: !!python/unicode ''}
     headers:
       cache-control: [no-cache]
-      date: ['Wed, 04 Jan 2017 17:54:39 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:15 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-approximate-messages-count: ['0']
@@ -165,9 +165,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:39 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:16 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
@@ -177,7 +177,7 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:54:39 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:16 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -186,9 +186,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:40 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:17 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
@@ -198,7 +198,7 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:54:39 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:17 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -210,9 +210,9 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['253']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:40 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:18 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
@@ -220,7 +220,7 @@ interactions:
     body: {string: !!python/unicode ''}
     headers:
       content-length: ['0']
-      date: ['Wed, 04 Jan 2017 17:54:39 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:17 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 204, message: No Content}
@@ -228,9 +228,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:41 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:19 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
@@ -239,7 +239,7 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:54:40 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:19 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -248,9 +248,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:41 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:21 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
@@ -259,7 +259,7 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:54:41 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:20 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -268,9 +268,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:42 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:22 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
@@ -279,7 +279,7 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:54:41 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:23 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -291,9 +291,9 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['257']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:42 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:22 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
@@ -301,7 +301,7 @@ interactions:
     body: {string: !!python/unicode ''}
     headers:
       content-length: ['0']
-      date: ['Wed, 04 Jan 2017 17:54:41 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:24 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 204, message: No Content}
@@ -309,9 +309,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:42 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:23 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
@@ -320,7 +320,7 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:54:41 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:23 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -329,9 +329,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:43 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:25 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
@@ -340,7 +340,7 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:54:43 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:24 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -352,9 +352,9 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['60']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:43 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:25 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
@@ -362,7 +362,7 @@ interactions:
     body: {string: !!python/unicode ''}
     headers:
       content-length: ['0']
-      date: ['Wed, 04 Jan 2017 17:54:43 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:24 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 204, message: No Content}
@@ -370,9 +370,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:43 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:26 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1?comp=acl
@@ -382,7 +382,7 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:54:42 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:26 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -394,16 +394,16 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['107']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:44 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:27 GMT']
       x-ms-version: ['2015-07-08']
     method: POST
     uri: https://dummystorage.queue.core.windows.net/queue1/messages
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:54:43 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:30 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -412,21 +412,21 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:45 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:29 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1/messages?peekonly=true
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>3678bfa9-6c28-4438-89e3-87064e48af25</MessageId><InsertionTime>Wed,\
-        \ 04 Jan 2017 17:54:44 GMT</InsertionTime><ExpirationTime>Wed, 11 Jan 2017\
-        \ 17:54:44 GMT</ExpirationTime><DequeueCount>0</DequeueCount><MessageText>test\
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>7e955088-7638-4376-a573-0ebf811da2c4</MessageId><InsertionTime>Mon,\
+        \ 23 Jan 2017 21:01:28 GMT</InsertionTime><ExpirationTime>Mon, 30 Jan 2017\
+        \ 21:01:28 GMT</ExpirationTime><DequeueCount>0</DequeueCount><MessageText>test\
         \ message</MessageText></QueueMessage></QueueMessagesList>"}
     headers:
       cache-control: [no-cache]
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:54:44 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:28 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -435,22 +435,22 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:45 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:30 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1/messages
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>3678bfa9-6c28-4438-89e3-87064e48af25</MessageId><InsertionTime>Wed,\
-        \ 04 Jan 2017 17:54:44 GMT</InsertionTime><ExpirationTime>Wed, 11 Jan 2017\
-        \ 17:54:44 GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAR8EytLNm0gE=</PopReceipt><TimeNextVisible>Wed,\
-        \ 04 Jan 2017 17:55:15 GMT</TimeNextVisible><DequeueCount>1</DequeueCount><MessageText>test\
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>7e955088-7638-4376-a573-0ebf811da2c4</MessageId><InsertionTime>Mon,\
+        \ 23 Jan 2017 21:01:28 GMT</InsertionTime><ExpirationTime>Mon, 30 Jan 2017\
+        \ 21:01:28 GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAzK7Q8Lt10gE=</PopReceipt><TimeNextVisible>Mon,\
+        \ 23 Jan 2017 21:02:00 GMT</TimeNextVisible><DequeueCount>1</DequeueCount><MessageText>test\
         \ message</MessageText></QueueMessage></QueueMessagesList>"}
     headers:
       cache-control: [no-cache]
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:54:45 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:30 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -462,41 +462,41 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['107']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:46 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:31 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
-    uri: https://dummystorage.queue.core.windows.net/queue1/messages/3678bfa9-6c28-4438-89e3-87064e48af25?popreceipt=AgAAAAMAAAAAAAAAR8EytLNm0gE%3D&visibilitytimeout=1
+    uri: https://dummystorage.queue.core.windows.net/queue1/messages/7e955088-7638-4376-a573-0ebf811da2c4?popreceipt=AgAAAAMAAAAAAAAAzK7Q8Lt10gE%3D&visibilitytimeout=1
   response:
     body: {string: !!python/unicode ''}
     headers:
       content-length: ['0']
-      date: ['Wed, 04 Jan 2017 17:54:45 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:30 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-popreceipt: [AwAAAAMAAAAAAAAAKHxGo7Nm0gEBAAAA]
-      x-ms-time-next-visible: ['Wed, 04 Jan 2017 17:54:47 GMT']
+      x-ms-popreceipt: [AwAAAAMAAAAAAAAAMn8t4Lt10gEBAAAA]
+      x-ms-time-next-visible: ['Mon, 23 Jan 2017 21:01:32 GMT']
       x-ms-version: ['2015-07-08']
     status: {code: 204, message: No Content}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:48 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:34 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1/messages?peekonly=true
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>3678bfa9-6c28-4438-89e3-87064e48af25</MessageId><InsertionTime>Wed,\
-        \ 04 Jan 2017 17:54:44 GMT</InsertionTime><ExpirationTime>Wed, 11 Jan 2017\
-        \ 17:54:44 GMT</ExpirationTime><DequeueCount>1</DequeueCount><MessageText>new\
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>7e955088-7638-4376-a573-0ebf811da2c4</MessageId><InsertionTime>Mon,\
+        \ 23 Jan 2017 21:01:28 GMT</InsertionTime><ExpirationTime>Mon, 30 Jan 2017\
+        \ 21:01:28 GMT</ExpirationTime><DequeueCount>1</DequeueCount><MessageText>new\
         \ message!</MessageText></QueueMessage></QueueMessagesList>"}
     headers:
       cache-control: [no-cache]
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:54:48 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:34 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -508,16 +508,16 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['109']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:49 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:35 GMT']
       x-ms-version: ['2015-07-08']
     method: POST
     uri: https://dummystorage.queue.core.windows.net/queue1/messages
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:54:48 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:35 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -529,16 +529,16 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['108']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:50 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:36 GMT']
       x-ms-version: ['2015-07-08']
     method: POST
     uri: https://dummystorage.queue.core.windows.net/queue1/messages
   response:
     body: {string: !!python/unicode ''}
     headers:
-      date: ['Wed, 04 Jan 2017 17:54:49 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:36 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -547,27 +547,27 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:50 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:37 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1/messages?peekonly=true&numofmessages=32
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>3678bfa9-6c28-4438-89e3-87064e48af25</MessageId><InsertionTime>Wed,\
-        \ 04 Jan 2017 17:54:44 GMT</InsertionTime><ExpirationTime>Wed, 11 Jan 2017\
-        \ 17:54:44 GMT</ExpirationTime><DequeueCount>1</DequeueCount><MessageText>new\
-        \ message!</MessageText></QueueMessage><QueueMessage><MessageId>7f51471a-6ad3-4a4f-bd74-34e072cc7e9b</MessageId><InsertionTime>Wed,\
-        \ 04 Jan 2017 17:54:49 GMT</InsertionTime><ExpirationTime>Wed, 11 Jan 2017\
-        \ 17:54:49 GMT</ExpirationTime><DequeueCount>0</DequeueCount><MessageText>second\
-        \ message</MessageText></QueueMessage><QueueMessage><MessageId>ec1c204c-fb9c-41a3-9762-30935af49201</MessageId><InsertionTime>Wed,\
-        \ 04 Jan 2017 17:54:49 GMT</InsertionTime><ExpirationTime>Wed, 11 Jan 2017\
-        \ 17:54:49 GMT</ExpirationTime><DequeueCount>0</DequeueCount><MessageText>third\
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>7e955088-7638-4376-a573-0ebf811da2c4</MessageId><InsertionTime>Mon,\
+        \ 23 Jan 2017 21:01:28 GMT</InsertionTime><ExpirationTime>Mon, 30 Jan 2017\
+        \ 21:01:28 GMT</ExpirationTime><DequeueCount>1</DequeueCount><MessageText>new\
+        \ message!</MessageText></QueueMessage><QueueMessage><MessageId>109b4d3f-485d-41ba-a4b2-eb5e4e26f4be</MessageId><InsertionTime>Mon,\
+        \ 23 Jan 2017 21:01:36 GMT</InsertionTime><ExpirationTime>Mon, 30 Jan 2017\
+        \ 21:01:36 GMT</ExpirationTime><DequeueCount>0</DequeueCount><MessageText>second\
+        \ message</MessageText></QueueMessage><QueueMessage><MessageId>4c8d19c6-0ebb-4a20-bbc3-34ec99c84464</MessageId><InsertionTime>Mon,\
+        \ 23 Jan 2017 21:01:37 GMT</InsertionTime><ExpirationTime>Mon, 30 Jan 2017\
+        \ 21:01:37 GMT</ExpirationTime><DequeueCount>0</DequeueCount><MessageText>third\
         \ message</MessageText></QueueMessage></QueueMessagesList>"}
     headers:
       cache-control: [no-cache]
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:54:49 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:37 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -576,22 +576,22 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:51 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:38 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1/messages
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>3678bfa9-6c28-4438-89e3-87064e48af25</MessageId><InsertionTime>Wed,\
-        \ 04 Jan 2017 17:54:44 GMT</InsertionTime><ExpirationTime>Wed, 11 Jan 2017\
-        \ 17:54:44 GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAM7N9t7Nm0gE=</PopReceipt><TimeNextVisible>Wed,\
-        \ 04 Jan 2017 17:55:21 GMT</TimeNextVisible><DequeueCount>2</DequeueCount><MessageText>new\
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>7e955088-7638-4376-a573-0ebf811da2c4</MessageId><InsertionTime>Mon,\
+        \ 23 Jan 2017 21:01:28 GMT</InsertionTime><ExpirationTime>Mon, 30 Jan 2017\
+        \ 21:01:28 GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAMZUK9rt10gE=</PopReceipt><TimeNextVisible>Mon,\
+        \ 23 Jan 2017 21:02:09 GMT</TimeNextVisible><DequeueCount>2</DequeueCount><MessageText>new\
         \ message!</MessageText></QueueMessage></QueueMessagesList>"}
     headers:
       cache-control: [no-cache]
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:54:51 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:40 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -601,17 +601,17 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:51 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:39 GMT']
       x-ms-version: ['2015-07-08']
     method: DELETE
-    uri: https://dummystorage.queue.core.windows.net/queue1/messages/3678bfa9-6c28-4438-89e3-87064e48af25?popreceipt=AgAAAAMAAAAAAAAAM7N9t7Nm0gE%3D
+    uri: https://dummystorage.queue.core.windows.net/queue1/messages/7e955088-7638-4376-a573-0ebf811da2c4?popreceipt=AgAAAAMAAAAAAAAAMZUK9rt10gE%3D
   response:
     body: {string: !!python/unicode ''}
     headers:
       content-length: ['0']
-      date: ['Wed, 04 Jan 2017 17:54:51 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:39 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 204, message: No Content}
@@ -619,24 +619,24 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:52 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:40 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1/messages?peekonly=true&numofmessages=32
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>7f51471a-6ad3-4a4f-bd74-34e072cc7e9b</MessageId><InsertionTime>Wed,\
-        \ 04 Jan 2017 17:54:49 GMT</InsertionTime><ExpirationTime>Wed, 11 Jan 2017\
-        \ 17:54:49 GMT</ExpirationTime><DequeueCount>0</DequeueCount><MessageText>second\
-        \ message</MessageText></QueueMessage><QueueMessage><MessageId>ec1c204c-fb9c-41a3-9762-30935af49201</MessageId><InsertionTime>Wed,\
-        \ 04 Jan 2017 17:54:49 GMT</InsertionTime><ExpirationTime>Wed, 11 Jan 2017\
-        \ 17:54:49 GMT</ExpirationTime><DequeueCount>0</DequeueCount><MessageText>third\
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>109b4d3f-485d-41ba-a4b2-eb5e4e26f4be</MessageId><InsertionTime>Mon,\
+        \ 23 Jan 2017 21:01:36 GMT</InsertionTime><ExpirationTime>Mon, 30 Jan 2017\
+        \ 21:01:36 GMT</ExpirationTime><DequeueCount>0</DequeueCount><MessageText>second\
+        \ message</MessageText></QueueMessage><QueueMessage><MessageId>4c8d19c6-0ebb-4a20-bbc3-34ec99c84464</MessageId><InsertionTime>Mon,\
+        \ 23 Jan 2017 21:01:37 GMT</InsertionTime><ExpirationTime>Mon, 30 Jan 2017\
+        \ 21:01:37 GMT</ExpirationTime><DequeueCount>0</DequeueCount><MessageText>third\
         \ message</MessageText></QueueMessage></QueueMessagesList>"}
     headers:
       cache-control: [no-cache]
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:54:52 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:40 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -646,9 +646,9 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:52 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:42 GMT']
       x-ms-version: ['2015-07-08']
     method: DELETE
     uri: https://dummystorage.queue.core.windows.net/queue1/messages
@@ -656,7 +656,7 @@ interactions:
     body: {string: !!python/unicode ''}
     headers:
       content-length: ['0']
-      date: ['Wed, 04 Jan 2017 17:54:52 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:42 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 204, message: No Content}
@@ -664,9 +664,9 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:53 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:44 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1/messages?peekonly=true&numofmessages=32
@@ -676,7 +676,7 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:54:53 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:43 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -686,9 +686,9 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:54 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:45 GMT']
       x-ms-version: ['2015-07-08']
     method: DELETE
     uri: https://dummystorage.queue.core.windows.net/queue1
@@ -696,7 +696,7 @@ interactions:
     body: {string: !!python/unicode ''}
     headers:
       content-length: ['0']
-      date: ['Wed, 04 Jan 2017 17:54:53 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:44 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 204, message: No Content}
@@ -704,20 +704,20 @@ interactions:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:54:54 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:46 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.queue.core.windows.net/queue1?comp=metadata
   response:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>QueueNotFound</Code><Message>The\
-        \ specified queue does not exist.\nRequestId:8c029230-0003-0067-30b3-669e4e000000\n\
-        Time:2017-01-04T17:54:54.8284084Z</Message></Error>"}
+        \ specified queue does not exist.\nRequestId:651dd93e-0003-00de-48bb-75bdab000000\n\
+        Time:2017-01-23T21:01:47.1980599Z</Message></Error>"}
     headers:
       content-length: ['217']
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:54:54 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:46 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 404, message: The specified queue does not exist.}

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_table_scenario.yaml
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_table_scenario.yaml
@@ -7,29 +7,29 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.11 (Windows-10-10.0.14393) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 storagemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b11+dev]
+      User-Agent: [python/2.7.13 (Darwin-16.3.0-x86_64-i386-64bit) requests/2.9.1
+          msrest/0.4.4 msrest_azure/0.4.6 storagemanagementclient/0.31.0 Azure-SDK-For-Python
+          AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [f48f87b0-d2a6-11e6-88d6-a0b3ccf7272a]
+      x-ms-client-request-id: [0f40cfe3-e1af-11e6-8b91-3c15c2cf0610]
     method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_table_scenario_test/providers/Microsoft.Storage/storageAccounts/dummystorage.listKeys?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test_table_scenario_test/providers/Microsoft.Storage/storageAccounts/dummystorage.listKeys?api-version=2016-12-01
   response:
-    body: {string: !!python/unicode '{"keys":[{"keyName":"key1","permissions":"Full","value":"lvepbjQQkyoAXfHlYzvtOM68B4Ju7uuZQDR+kYSQeGc+NCOLQDYo6/FJEJBfbmiQbxGa+eGyqd2hPOClTki+1g=="},{"keyName":"key2","permissions":"Full","value":"TVOscZiApoYNLTzQNCXpgXHruXNjwqAY69IgC3a6NwvN/AO2OFHS48JPqSVoqUF5xbawEF/iJ8mGwwobNHMfEA=="}]}
+    body: {string: !!python/unicode '{"keys":[{"keyName":"key1","permissions":"Full","value":"GMoUIOAFJpNGx5ZFxi4nA5oLKafF9e1PtUgVyixl+g4RegRuL72eLm8fOXC3w2J+MLJ4pYLYmkP5kcSaeOd4ew=="},{"keyName":"key2","permissions":"Full","value":"Fe4qEchqo8UVFKdav1LMREqoljEiy+98q8pO9yIkCsBIa7tyeoPyIYRN2dN49vwqT5h0TXA+r1jJWaJCVmQckg=="}]}
 
         '}
     headers:
       cache-control: [no-cache]
       content-length: ['289']
       content-type: [application/json]
-      date: ['Wed, 04 Jan 2017 17:55:19 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:07 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       transfer-encoding: [chunked]
       vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1193']
+      x-ms-ratelimit-remaining-subscription-writes: ['1190']
     status: {code: 200, message: OK}
 - request:
     body: !!python/unicode '{"TableName": "table1"}'
@@ -41,9 +41,9 @@ interactions:
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       Prefer: [return-no-content]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:19 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:08 GMT']
       x-ms-version: ['2015-07-08']
     method: POST
     uri: https://dummystorage.table.core.windows.net/Tables
@@ -52,9 +52,9 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      dataserviceid: ['https://vcrstorage614234605324.table.core.windows.net/Tables(''table1'')']
-      date: ['Wed, 04 Jan 2017 17:55:19 GMT']
-      location: ['https://vcrstorage614234605324.table.core.windows.net/Tables(''table1'')']
+      dataserviceid: ['https://vcrstorage434487525842.table.core.windows.net/Tables(''table1'')']
+      date: ['Mon, 23 Jan 2017 21:01:09 GMT']
+      location: ['https://vcrstorage434487525842.table.core.windows.net/Tables(''table1'')']
       preference-applied: [return-no-content]
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-content-type-options: [nosniff]
@@ -67,9 +67,9 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:20 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:10 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/Tables('table1')
@@ -78,7 +78,7 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-type: [application/json;odata=nometadata;streaming=true;charset=utf-8]
-      date: ['Wed, 04 Jan 2017 17:55:19 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:09 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
@@ -91,9 +91,9 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:21 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:11 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/Tables
@@ -102,7 +102,7 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-type: [application/json;odata=nometadata;streaming=true;charset=utf-8]
-      date: ['Wed, 04 Jan 2017 17:55:20 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:11 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
@@ -114,9 +114,9 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:21 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:12 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
@@ -125,7 +125,7 @@ interactions:
         \ />"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:55:20 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:13 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -136,9 +136,9 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:22 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:14 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
@@ -147,7 +147,7 @@ interactions:
         \ />"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:55:21 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:15 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -161,9 +161,9 @@ interactions:
       Content-Length: ['184']
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:22 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:14 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
@@ -171,7 +171,7 @@ interactions:
     body: {string: !!python/unicode ''}
     headers:
       content-length: ['0']
-      date: ['Wed, 04 Jan 2017 17:55:21 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:15 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 204, message: No Content}
@@ -181,9 +181,9 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:22 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:16 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
@@ -191,7 +191,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:55:22 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:16 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -205,9 +205,9 @@ interactions:
       Content-Length: ['296']
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:22 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:16 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
@@ -215,7 +215,7 @@ interactions:
     body: {string: !!python/unicode ''}
     headers:
       content-length: ['0']
-      date: ['Wed, 04 Jan 2017 17:55:22 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:16 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 204, message: No Content}
@@ -225,9 +225,9 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:23 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:17 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
@@ -235,7 +235,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:55:23 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:15 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -249,9 +249,9 @@ interactions:
       Content-Length: ['413']
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:23 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:18 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
@@ -259,7 +259,7 @@ interactions:
     body: {string: !!python/unicode ''}
     headers:
       content-length: ['0']
-      date: ['Wed, 04 Jan 2017 17:55:23 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:15 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 204, message: No Content}
@@ -269,9 +269,9 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:24 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:19 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
@@ -279,7 +279,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:55:23 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:18 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -293,9 +293,9 @@ interactions:
       Content-Length: ['591']
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:24 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:19 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
@@ -303,7 +303,7 @@ interactions:
     body: {string: !!python/unicode ''}
     headers:
       content-length: ['0']
-      date: ['Wed, 04 Jan 2017 17:55:23 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:18 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 204, message: No Content}
@@ -313,9 +313,9 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:24 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:20 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
@@ -323,7 +323,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:55:24 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:20 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -334,9 +334,9 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:25 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:22 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
@@ -344,7 +344,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:55:24 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:22 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -355,9 +355,9 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:25 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:24 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
@@ -365,7 +365,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:55:25 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:26 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -376,9 +376,9 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:26 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:26 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
@@ -386,7 +386,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:55:26 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:25 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -397,9 +397,9 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:27 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:27 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
@@ -407,7 +407,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:55:26 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:27 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -418,9 +418,9 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:27 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:29 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
@@ -428,7 +428,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>a</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:55:26 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:27 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -442,9 +442,9 @@ interactions:
       Content-Length: ['598']
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:27 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:29 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
@@ -452,7 +452,7 @@ interactions:
     body: {string: !!python/unicode ''}
     headers:
       content-length: ['0']
-      date: ['Wed, 04 Jan 2017 17:55:26 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:27 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 204, message: No Content}
@@ -462,9 +462,9 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:28 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:30 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
@@ -472,7 +472,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>au</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:55:27 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:29 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -483,9 +483,9 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:28 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:31 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
@@ -493,7 +493,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test1</Id><AccessPolicy><Permission>au</Permission></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:55:28 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:32 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -507,9 +507,9 @@ interactions:
       Content-Length: ['491']
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:29 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:32 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
@@ -517,7 +517,7 @@ interactions:
     body: {string: !!python/unicode ''}
     headers:
       content-length: ['0']
-      date: ['Wed, 04 Jan 2017 17:55:28 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:32 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-version: ['2015-07-08']
     status: {code: 204, message: No Content}
@@ -527,9 +527,9 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:29 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:33 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1?comp=acl
@@ -537,7 +537,7 @@ interactions:
     body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><SignedIdentifiers><SignedIdentifier><Id>test3</Id><AccessPolicy><Expiry>2018-01-01T00:00:00.0000000Z</Expiry></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test2</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start></AccessPolicy></SignedIdentifier><SignedIdentifier><Id>test4</Id><AccessPolicy><Start>2016-01-01T00:00:00.0000000Z</Start><Expiry>2016-05-01T00:00:00.0000000Z</Expiry><Permission>raud</Permission></AccessPolicy></SignedIdentifier></SignedIdentifiers>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 04 Jan 2017 17:55:29 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:33 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-ms-version: ['2015-07-08']
@@ -553,9 +553,9 @@ interactions:
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
       Prefer: [return-no-content]
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:30 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:34 GMT']
       x-ms-version: ['2015-07-08']
     method: POST
     uri: https://dummystorage.table.core.windows.net/table1
@@ -564,10 +564,10 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      dataserviceid: ['https://vcrstorage614234605324.table.core.windows.net/table1(PartitionKey=''001'',RowKey=''001'')']
-      date: ['Wed, 04 Jan 2017 17:55:29 GMT']
-      etag: [W/"datetime'2017-01-04T17%3A55%3A30.1426744Z'"]
-      location: ['https://vcrstorage614234605324.table.core.windows.net/table1(PartitionKey=''001'',RowKey=''001'')']
+      dataserviceid: ['https://vcrstorage434487525842.table.core.windows.net/table1(PartitionKey=''001'',RowKey=''001'')']
+      date: ['Mon, 23 Jan 2017 21:01:34 GMT']
+      etag: [W/"datetime'2017-01-23T21%3A01%3A34.3356254Z'"]
+      location: ['https://vcrstorage434487525842.table.core.windows.net/table1(PartitionKey=''001'',RowKey=''001'')']
       preference-applied: [return-no-content]
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-content-type-options: [nosniff]
@@ -580,19 +580,19 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:30 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:35 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1(PartitionKey='001',RowKey='001')
   response:
-    body: {string: !!python/unicode '{"odata.metadata":"https://vcrstorage614234605324.table.core.windows.net/$metadata#table1/@Element","odata.etag":"W/\"datetime''2017-01-04T17%3A55%3A30.1426744Z''\"","PartitionKey":"001","RowKey":"001","Timestamp":"2017-01-04T17:55:30.1426744Z","name":"test","value":"something"}'}
+    body: {string: !!python/unicode '{"odata.metadata":"https://vcrstorage434487525842.table.core.windows.net/$metadata#table1/@Element","odata.etag":"W/\"datetime''2017-01-23T21%3A01%3A34.3356254Z''\"","PartitionKey":"001","RowKey":"001","Timestamp":"2017-01-23T21:01:34.3356254Z","name":"test","value":"something"}'}
     headers:
       cache-control: [no-cache]
       content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
-      date: ['Wed, 04 Jan 2017 17:55:30 GMT']
-      etag: [W/"datetime'2017-01-04T17%3A55%3A30.1426744Z'"]
+      date: ['Mon, 23 Jan 2017 21:01:35 GMT']
+      etag: [W/"datetime'2017-01-23T21%3A01%3A34.3356254Z'"]
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
@@ -605,19 +605,19 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:31 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:36 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1(PartitionKey='001',RowKey='001')?%24select=name
   response:
-    body: {string: !!python/unicode '{"odata.metadata":"https://vcrstorage614234605324.table.core.windows.net/$metadata#table1/@Element&$select=name","odata.etag":"W/\"datetime''2017-01-04T17%3A55%3A30.1426744Z''\"","name":"test"}'}
+    body: {string: !!python/unicode '{"odata.metadata":"https://vcrstorage434487525842.table.core.windows.net/$metadata#table1/@Element&$select=name","odata.etag":"W/\"datetime''2017-01-23T21%3A01%3A34.3356254Z''\"","name":"test"}'}
     headers:
       cache-control: [no-cache]
       content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
-      date: ['Wed, 04 Jan 2017 17:55:31 GMT']
-      etag: [W/"datetime'2017-01-04T17%3A55%3A30.1426744Z'"]
+      date: ['Mon, 23 Jan 2017 21:01:36 GMT']
+      etag: [W/"datetime'2017-01-23T21%3A01%3A34.3356254Z'"]
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
@@ -634,9 +634,9 @@ interactions:
       DataServiceVersion: [3.0;NetFx]
       If-Match: ['*']
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:31 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:37 GMT']
       x-ms-version: ['2015-07-08']
     method: MERGE
     uri: https://dummystorage.table.core.windows.net/table1(PartitionKey='001',RowKey='001')
@@ -645,8 +645,8 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Wed, 04 Jan 2017 17:55:30 GMT']
-      etag: [W/"datetime'2017-01-04T17%3A55%3A31.9681969Z'"]
+      date: ['Mon, 23 Jan 2017 21:01:36 GMT']
+      etag: [W/"datetime'2017-01-23T21%3A01%3A38.9358439Z'"]
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-content-type-options: [nosniff]
       x-ms-version: ['2015-07-08']
@@ -658,19 +658,19 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:32 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:38 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1(PartitionKey='001',RowKey='001')
   response:
-    body: {string: !!python/unicode '{"odata.metadata":"https://vcrstorage614234605324.table.core.windows.net/$metadata#table1/@Element","odata.etag":"W/\"datetime''2017-01-04T17%3A55%3A31.9681969Z''\"","PartitionKey":"001","RowKey":"001","Timestamp":"2017-01-04T17:55:31.9681969Z","name":"test","value":"newval"}'}
+    body: {string: !!python/unicode '{"odata.metadata":"https://vcrstorage434487525842.table.core.windows.net/$metadata#table1/@Element","odata.etag":"W/\"datetime''2017-01-23T21%3A01%3A38.9358439Z''\"","PartitionKey":"001","RowKey":"001","Timestamp":"2017-01-23T21:01:38.9358439Z","name":"test","value":"newval"}'}
     headers:
       cache-control: [no-cache]
       content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
-      date: ['Wed, 04 Jan 2017 17:55:32 GMT']
-      etag: [W/"datetime'2017-01-04T17%3A55%3A31.9681969Z'"]
+      date: ['Mon, 23 Jan 2017 21:01:38 GMT']
+      etag: [W/"datetime'2017-01-23T21%3A01%3A38.9358439Z'"]
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
@@ -686,9 +686,9 @@ interactions:
       DataServiceVersion: [3.0;NetFx]
       If-Match: ['*']
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:32 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:39 GMT']
       x-ms-version: ['2015-07-08']
     method: PUT
     uri: https://dummystorage.table.core.windows.net/table1(PartitionKey='001',RowKey='001')
@@ -697,8 +697,8 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Wed, 04 Jan 2017 17:55:32 GMT']
-      etag: [W/"datetime'2017-01-04T17%3A55%3A33.124326Z'"]
+      date: ['Mon, 23 Jan 2017 21:01:39 GMT']
+      etag: [W/"datetime'2017-01-23T21%3A01%3A40.9768686Z'"]
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-content-type-options: [nosniff]
       x-ms-version: ['2015-07-08']
@@ -710,19 +710,19 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:33 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:40 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1(PartitionKey='001',RowKey='001')
   response:
-    body: {string: !!python/unicode '{"odata.metadata":"https://vcrstorage614234605324.table.core.windows.net/$metadata#table1/@Element","odata.etag":"W/\"datetime''2017-01-04T17%3A55%3A33.124326Z''\"","PartitionKey":"001","RowKey":"001","Timestamp":"2017-01-04T17:55:33.124326Z","cat":"hat"}'}
+    body: {string: !!python/unicode '{"odata.metadata":"https://vcrstorage434487525842.table.core.windows.net/$metadata#table1/@Element","odata.etag":"W/\"datetime''2017-01-23T21%3A01%3A40.9768686Z''\"","PartitionKey":"001","RowKey":"001","Timestamp":"2017-01-23T21:01:40.9768686Z","cat":"hat"}'}
     headers:
       cache-control: [no-cache]
       content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
-      date: ['Wed, 04 Jan 2017 17:55:32 GMT']
-      etag: [W/"datetime'2017-01-04T17%3A55%3A33.124326Z'"]
+      date: ['Mon, 23 Jan 2017 21:01:40 GMT']
+      etag: [W/"datetime'2017-01-23T21%3A01%3A40.9768686Z'"]
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
@@ -737,9 +737,9 @@ interactions:
       DataServiceVersion: [3.0;NetFx]
       If-Match: ['*']
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:34 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:42 GMT']
       x-ms-version: ['2015-07-08']
     method: DELETE
     uri: https://dummystorage.table.core.windows.net/table1(PartitionKey='001',RowKey='001')
@@ -748,7 +748,7 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Wed, 04 Jan 2017 17:55:33 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:41 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-content-type-options: [nosniff]
       x-ms-version: ['2015-07-08']
@@ -760,19 +760,19 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:34 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:44 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/table1(PartitionKey='001',RowKey='001')
   response:
     body: {string: !!python/unicode '{"odata.error":{"code":"ResourceNotFound","message":{"lang":"en-US","value":"The
-        specified resource does not exist.\nRequestId:b52ff8e9-0002-009b-55b3-66603a000000\nTime:2017-01-04T17:55:34.5549767Z"}}}'}
+        specified resource does not exist.\nRequestId:b9527891-0002-003e-74bb-758657000000\nTime:2017-01-23T21:01:44.7737406Z"}}}'}
     headers:
       cache-control: [no-cache]
       content-type: [application/json;odata=minimalmetadata;streaming=true;charset=utf-8]
-      date: ['Wed, 04 Jan 2017 17:55:34 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:43 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-content-type-options: [nosniff]
@@ -786,9 +786,9 @@ interactions:
       Content-Length: ['0']
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:35 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:45 GMT']
       x-ms-version: ['2015-07-08']
     method: DELETE
     uri: https://dummystorage.table.core.windows.net/Tables('table1')
@@ -797,7 +797,7 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Wed, 04 Jan 2017 17:55:35 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:44 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       x-content-type-options: [nosniff]
       x-ms-version: ['2015-07-08']
@@ -809,19 +809,19 @@ interactions:
       Connection: [keep-alive]
       DataServiceVersion: [3.0;NetFx]
       MaxDataServiceVersion: ['3.0']
-      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.11; Windows 10) AZURECLI/0.1.0b11+dev]
-      x-ms-client-request-id: [30459751-d2a6-11e6-89b6-a0b3ccf7272a]
-      x-ms-date: ['Wed, 04 Jan 2017 17:55:35 GMT']
+      User-Agent: [Azure-Storage/0.33.0 (Python CPython 2.7.13; Darwin 16.3.0) AZURECLI/0.1.1b2+dev]
+      x-ms-client-request-id: [bf322142-e1ae-11e6-aa6d-3c15c2cf0610]
+      x-ms-date: ['Mon, 23 Jan 2017 21:01:47 GMT']
       x-ms-version: ['2015-07-08']
     method: GET
     uri: https://dummystorage.table.core.windows.net/Tables('table1')
   response:
     body: {string: !!python/unicode '{"odata.error":{"code":"ResourceNotFound","message":{"lang":"en-US","value":"The
-        specified resource does not exist.\nRequestId:7240034d-0002-0054-6cb3-660788000000\nTime:2017-01-04T17:55:36.0027807Z"}}}'}
+        specified resource does not exist.\nRequestId:d2fc924f-0002-006d-5ebb-759a58000000\nTime:2017-01-23T21:01:47.2341296Z"}}}'}
     headers:
       cache-control: [no-cache]
       content-type: [application/json;odata=nometadata;streaming=true;charset=utf-8]
-      date: ['Wed, 04 Jan 2017 17:55:35 GMT']
+      date: ['Mon, 23 Jan 2017 21:01:46 GMT']
       server: [Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0]
       transfer-encoding: [chunked]
       x-content-type-options: [nosniff]

--- a/src/command_modules/azure-cli-storage/setup.py
+++ b/src/command_modules/azure-cli-storage/setup.py
@@ -25,7 +25,7 @@ CLASSIFIERS = [
 
 DEPENDENCIES = [
     'azure-storage==0.33.0',
-    'azure-mgmt-storage==0.30.0rc6',
+    'azure-mgmt-storage==0.31.0',
     'azure-cli-core',
 ]
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_create_vm_no_wait.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_create_vm_no_wait.yaml
@@ -107,7 +107,7 @@ interactions:
       accept-language: [en-US]
       x-ms-client-request-id: [3f645dca-b67a-11e6-a776-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_rg_vm_no_wait2/providers/Microsoft.Storage/storageAccounts?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_rg_vm_no_wait2/providers/Microsoft.Storage/storageAccounts?api-version=2016-12-01
   response:
     body: {string: '{"value":[]}
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_create_custom_ip.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_create_custom_ip.yaml
@@ -186,7 +186,7 @@ interactions:
       accept-language: [en-US]
       x-ms-client-request-id: [f531afba-d377-11e6-b052-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Storage/storageAccounts?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vm_create_custom_ip_rg3/providers/Microsoft.Storage/storageAccounts?api-version=2016-12-01
   response:
     body: {string: '{"value":[]}
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_create_existing_options.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_create_existing_options.yaml
@@ -179,7 +179,7 @@ interactions:
       accept-language: [en-US]
       x-ms-client-request-id: [23d342be-d378-11e6-8cfe-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Storage/storageAccounts/azureclivrfstorage0011?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vm_create_existing_options_rg/providers/Microsoft.Storage/storageAccounts/azureclivrfstorage0011?api-version=2016-12-01
   response:
     body: {string: ''}
     headers:

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_create_none_options.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_create_none_options.yaml
@@ -109,7 +109,7 @@ interactions:
       accept-language: [en-US]
       x-ms-client-request-id: [d27d2500-d377-11e6-8678-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VMCreate_none_options/providers/Microsoft.Storage/storageAccounts?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VMCreate_none_options/providers/Microsoft.Storage/storageAccounts?api-version=2016-12-01
   response:
     body: {string: '{"value":[]}
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_create_state_modifications.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_create_state_modifications.yaml
@@ -1139,7 +1139,7 @@ interactions:
       accept-language: [en-US]
       x-ms-client-request-id: [95885e51-d377-11e6-b9d1-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmStateMod2/providers/Microsoft.Storage/storageAccounts/mystorage010101abcd?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmStateMod2/providers/Microsoft.Storage/storageAccounts/mystorage010101abcd?api-version=2016-12-01
   response:
     body: {string: !!python/unicode '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitestrg_vmstatemod2_t1vp_/providers/Microsoft.Storage/storageAccounts/mystorage010101abcd","kind":"Storage","location":"eastus","name":"mystorage010101abcd","properties":{"creationTime":"2017-01-05T18:46:23.6616858Z","primaryEndpoints":{"blob":"https://mystorage010101abcd.blob.core.windows.net/"},"primaryLocation":"eastus","provisioningState":"Succeeded","statusOfPrimary":"available"},"sku":{"name":"Premium_LRS","tier":"Premium"},"tags":{"firsttag":"1","secondtag":"2","thirdtag":""},"type":"Microsoft.Storage/storageAccounts"}
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_create_ubuntu.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_create_ubuntu.yaml
@@ -160,7 +160,7 @@ interactions:
       accept-language: [en-US]
       x-ms-client-request-id: [dce9e80f-d375-11e6-8838-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Storage/storageAccounts?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VMCreate_Ubuntu2/providers/Microsoft.Storage/storageAccounts?api-version=2016-12-01
   response:
     body: {string: !!python/unicode '{"value":[]}
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_data_disk.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_data_disk.yaml
@@ -179,7 +179,7 @@ interactions:
       accept-language: [en-US]
       x-ms-client-request-id: [f86b69c2-85b3-11e6-8624-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Storage/storageAccounts?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_datadisk/providers/Microsoft.Storage/storageAccounts?api-version=2016-12-01
   response:
     body:
       string: !!binary |

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_enable_disable_boot_diagnostic.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_enable_disable_boot_diagnostic.yaml
@@ -63,7 +63,7 @@ interactions:
       accept-language: [en-US]
       x-ms-client-request-id: [fc04c400-3a45-11e6-b68b-a0999b14fe87]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/storageAccounts?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/storageAccounts?api-version=2016-12-01
   response:
     body:
       string: !!binary |

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_generalize.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_generalize.yaml
@@ -179,7 +179,7 @@ interactions:
       accept-language: [en-US]
       x-ms-client-request-id: [208d5374-85b4-11e6-ad51-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Storage/storageAccounts?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmGeneralize/providers/Microsoft.Storage/storageAccounts?api-version=2016-12-01
   response:
     body:
       string: !!binary |

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_multi_nic_scenario.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_multi_nic_scenario.yaml
@@ -135,7 +135,7 @@ interactions:
       accept-language: [en-US]
       x-ms-client-request-id: [0a48acc0-d378-11e6-92d9-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_multi_nic_vm/providers/Microsoft.Storage/storageAccounts?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_multi_nic_vm/providers/Microsoft.Storage/storageAccounts?api-version=2016-12-01
   response:
     body: {string: '{"value":[]}
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_show_list_sizes_list_ip_addresses.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_show_list_sizes_list_ip_addresses.yaml
@@ -114,7 +114,7 @@ interactions:
       accept-language: [en-US]
       x-ms-client-request-id: [59608eb6-e195-11e6-adfc-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Storage/storageAccounts?api-version=2016-01-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Storage/storageAccounts?api-version=2016-12-01
   response:
     body: {string: '{"value":[]}
 


### PR DESCRIPTION
Here's the help:
```
$ az storage account list-account-sas -h

Command
    az storage account list-account-sas: List SAS credentials of a storage account.

Arguments
    --account-name              [Required]: The name of the storage account within the specified
                                            resource group. Storage account names must be between 3
                                            and 24 characters in length and use numbers and lower-
                                            case letters only.
    --resource-group -g         [Required]: Name of resource group.

Account SAS Arguments
    --permissions               [Required]: The signed permissions for the account SAS. Choices
                                            include: Read (r), Write (w), Delete (d), List (l), Add
                                            (a), Create (c), Update (u) and Process (p).
    --resource-types            [Required]: The signed resource types that are accessible with the
                                            account SAS. Service (s): Access to service-level APIs;
                                            Container (c): Access to container-level APIs; Object
                                            (o): Access to object-level APIs for blobs, queue
                                            messages, table entities, and files.
    --services                  [Required]: The signed services accessible with the account SAS.
                                            Choices include: Blob (b), Queue (q), Table (t), File
                                            (f).
    --shared-access-expiry-time [Required]: The time at which the shared access signature becomes
                                            invalid.
    --ip-address-or-range                 : An IP address or a range of IP addresses from which to
                                            accept requests.
    --key-to-sign                         : The key to sign the account SAS token with.
    --protocols                           : The protocol permitted for a request made with the
                                            account SAS.
    --shared-access-start-time            : The time at which the SAS becomes valid.

Global Arguments
    --debug                               : Increase logging verbosity to show all debug logs.
    --help -h                             : Show this help message and exit.
    --output -o                           : Output format.  Allowed values: json, jsonc, list,
                                            table, tsv.  Default: json.
    --query                               : JMESPath query string. See http://jmespath.org/ for more
                                            information and examples.
    --verbose                             : Increase logging verbosity. Use --debug for full debug
                                            logs.
```
```
$ az storage account list-service-sas -h

Command
    az storage account list-service-sas: List service SAS credentials of a specific resource.

Arguments
    --account-name           [Required]: The name of the storage account within the specified
                                         resource group. Storage account names must be between 3 and
                                         24 characters in length and use numbers and lower-case
                                         letters only.
    --resource-group -g      [Required]: Name of resource group.

Service SAS Arguments
    --canonicalized-resource [Required]: The canonical path to the signed resource.
    --resource               [Required]: The signed services accessible with the service SAS.
                                         Choices include: Blob (b), Container (c), File (f), Share
                                         (s).
    --cache-control                    : The response header override for cache control.
    --content-disposition              : The response header override for content disposition.
    --content-encoding                 : The response header override for content encoding.
    --content-language                 : The response header override for content language.
    --content-type                     : The response header override for content type.
    --identifier                       : A unique value up to 64 characters in length that
                                         correlates to an access policy specified for the container,
                                         queue, or table.
    --ip-address-or-range              : An IP address or a range of IP addresses from which to
                                         accept requests.
    --key-to-sign                      : The key to sign the account SAS token with.
    --partition-key-end                : The end of partition key.
    --partition-key-start              : The start of partition key.
    --permissions                      : The signed permissions for the service SAS. Choices
                                         include: Read (r), Write (w), Delete (d), List (l), Add
                                         (a), Create (c), Update (u) and Process (p).
    --protocols                        : The protocol permitted for a request made with the account
                                         SAS.
    --row-key-end                      : The end of row key.
    --row-key-start                    : The start of row key.
    --shared-access-expiry-time        : The time at which the shared access signature becomes
                                         invalid.
    --shared-access-start-time         : The time at which the SAS becomes valid.

Global Arguments
    --debug                            : Increase logging verbosity to show all debug logs.
    --help -h                          : Show this help message and exit.
    --output -o                        : Output format.  Allowed values: json, jsonc, list, table,
                                         tsv.  Default: json.
    --query                            : JMESPath query string. See http://jmespath.org/ for more
                                         information and examples.
    --verbose                          : Increase logging verbosity. Use --debug for full debug
                                         logs.
```