### PR TITLE
expose flags to show vm ip-address, power state

### DIFF
--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -58,6 +58,9 @@ register_cli_argument('vm', 'size', completer=get_vm_size_completion_list)
 register_cli_argument('vm', 'tags', tags_type)
 register_cli_argument('vm', 'name', arg_type=name_arg_type)
 
+for item in ['show', 'list']:
+    register_cli_argument('vm {}'.format(item), 'show_details', action='store_true', options_list=('--show-details', '-d'), help='show public ip address, FQDN, and power states. command will run slow')
+
 register_cli_argument('vm disk', 'vm_name', arg_type=existing_vm_name, options_list=('--vm-name',))
 register_cli_argument('vm disk', 'disk_name', options_list=('--name', '-n'), help='The data disk name. If missing, will retrieve from vhd uri')
 register_cli_argument('vm disk', 'disk_size', help='Size of disk (GiB)', default=1023, type=int)

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
@@ -36,6 +36,7 @@ def transform_ip_addresses(result):
 
     return transformed
 
+
 def transform_vm(result):
     return OrderedDict([('name', result['name']),
                         ('resourceGroup', result['resourceGroup']),
@@ -44,8 +45,10 @@ def transform_vm(result):
                         ('fqdns', result.get('fqdns')),
                         ('location', result['location'])])
 
+
 def transform_vm_list(vm_list):
     return [transform_vm(v) for v in vm_list]
+
 
 cli_command(__name__, 'vm create', 'azure.cli.command_modules.vm.mgmt_vm.lib.operations.vm_operations#VmOperations.create_or_update', cf_vm_create,
             transform=DeploymentOutputLongRunningOperation('Starting vm create'), no_wait_param='raw')

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/commands.py
@@ -36,6 +36,16 @@ def transform_ip_addresses(result):
 
     return transformed
 
+def transform_vm(result):
+    return OrderedDict([('name', result['name']),
+                        ('resourceGroup', result['resourceGroup']),
+                        ('powerState', result.get('powerState')),
+                        ('publicIps', result.get('publicIps')),
+                        ('fqdns', result.get('fqdns')),
+                        ('location', result['location'])])
+
+def transform_vm_list(vm_list):
+    return [transform_vm(v) for v in vm_list]
 
 cli_command(__name__, 'vm create', 'azure.cli.command_modules.vm.mgmt_vm.lib.operations.vm_operations#VmOperations.create_or_update', cf_vm_create,
             transform=DeploymentOutputLongRunningOperation('Starting vm create'), no_wait_param='raw')
@@ -45,7 +55,7 @@ op_class = 'VirtualMachinesOperations'
 cli_command(__name__, 'vm delete', mgmt_path.format(op_var, op_class, 'delete'), cf_vm, confirmation=True)
 cli_command(__name__, 'vm deallocate', mgmt_path.format(op_var, op_class, 'deallocate'), cf_vm)
 cli_command(__name__, 'vm generalize', mgmt_path.format(op_var, op_class, 'generalize'), cf_vm)
-cli_command(__name__, 'vm show', mgmt_path.format(op_var, op_class, 'get'), cf_vm)
+cli_command(__name__, 'vm show', custom_path.format('show_vm'), table_transformer=transform_vm)
 cli_command(__name__, 'vm list-vm-resize-options', mgmt_path.format(op_var, op_class, 'list_available_sizes'), cf_vm)
 cli_command(__name__, 'vm stop', mgmt_path.format(op_var, op_class, 'power_off'), cf_vm)
 cli_command(__name__, 'vm restart', mgmt_path.format(op_var, op_class, 'restart'), cf_vm)
@@ -53,7 +63,7 @@ cli_command(__name__, 'vm start', mgmt_path.format(op_var, op_class, 'start'), c
 cli_command(__name__, 'vm redeploy', mgmt_path.format(op_var, op_class, 'redeploy'), cf_vm)
 cli_command(__name__, 'vm list-ip-addresses', custom_path.format('list_ip_addresses'), table_transformer=transform_ip_addresses)
 cli_command(__name__, 'vm get-instance-view', custom_path.format('get_instance_view'))
-cli_command(__name__, 'vm list', custom_path.format('list_vm'))
+cli_command(__name__, 'vm list', custom_path.format('list_vm'), table_transformer=transform_vm_list)
 cli_command(__name__, 'vm resize', custom_path.format('resize_vm'))
 cli_command(__name__, 'vm capture', custom_path.format('capture_vm'))
 cli_command(__name__, 'vm open-port', custom_path.format('vm_open_port'))

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -143,10 +143,10 @@ def list_vm(resource_group_name=None, show_details=False):
     ccf = _compute_client_factory()
     vm_list = ccf.virtual_machines.list(resource_group_name=resource_group_name) \
         if resource_group_name else ccf.virtual_machines.list_all()
-    if not show_details:
-        return list(vm_list)
-    else:
+    if show_details:
         return [_vm_get_details(_parse_rg_name(v.id)[0], v.name) for v in vm_list]
+    else:
+        return list(vm_list)
 
 
 def show_vm(resource_group_name, vm_name, show_details=False):

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -148,11 +148,13 @@ def list_vm(resource_group_name=None, show_details=False):
     else:
         return [_vm_get_details(_parse_rg_name(v.id)[0], v.name) for v in vm_list]
 
+
 def show_vm(resource_group_name, vm_name, show_details=False):
     if show_details:
         return _vm_get_details(resource_group_name, vm_name)
     else:
         return _vm_get(resource_group_name, vm_name)
+
 
 def _vm_get_details(resource_group_name, vm_name):
     from azure.mgmt.network import NetworkManagementClient
@@ -160,10 +162,11 @@ def _vm_get_details(resource_group_name, vm_name):
     network_client = get_mgmt_service_client(NetworkManagementClient)
     public_ips = []
     fqdns = []
+    # pylint: disable=line-too-long,no-member
     for nic_ref in result.network_profile.network_interfaces:
         nic = network_client.network_interfaces.get(resource_group_name, nic_ref.id.split('/')[-1])
         for ip_configuration in nic.ip_configurations:
-            if ip_configuration.public_ip_address: 
+            if ip_configuration.public_ip_address:
                 public_ip_info = network_client.public_ip_addresses.get(resource_group_name,
                                                                         ip_configuration.public_ip_address.id.split('/')[-1])
                 if public_ip_info.ip_address:
@@ -174,8 +177,9 @@ def _vm_get_details(resource_group_name, vm_name):
     setattr(result, 'power_state', ','.join([s.display_status for s in result.instance_view.statuses if s.code.startswith('PowerState/')]))
     setattr(result, 'public_ips', ','.join(public_ips))
     setattr(result, 'fqdns', ','.join(fqdns))
-    del result.instance_view #we don't need other instance_view info as people won't care
+    del result.instance_view  # we don't need other instance_view info as people won't care
     return result
+
 
 def list_vm_images(image_location=None, publisher_name=None, offer=None, sku=None,
                    all=False):  # pylint: disable=redefined-builtin

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -138,13 +138,44 @@ class ExtensionUpdateLongRunningOperation(LongRunningOperation):  # pylint: disa
         return None
 
 
-def list_vm(resource_group_name=None):
+def list_vm(resource_group_name=None, show_details=False):
     ''' List Virtual Machines. '''
     ccf = _compute_client_factory()
     vm_list = ccf.virtual_machines.list(resource_group_name=resource_group_name) \
         if resource_group_name else ccf.virtual_machines.list_all()
-    return list(vm_list)
+    if not show_details:
+        return list(vm_list)
+    else:
+        return [_vm_get_details(_parse_rg_name(v.id)[0], v.name) for v in vm_list]
 
+def show_vm(resource_group_name, vm_name, show_details=False):
+    if show_details:
+        return _vm_get_details(resource_group_name, vm_name)
+    else:
+        return _vm_get(resource_group_name, vm_name)
+
+def _vm_get_details(resource_group_name, vm_name):
+    from azure.mgmt.network import NetworkManagementClient
+    result = get_instance_view(resource_group_name, vm_name)
+    network_client = get_mgmt_service_client(NetworkManagementClient)
+    public_ips = []
+    fqdns = []
+    for nic_ref in result.network_profile.network_interfaces:
+        nic = network_client.network_interfaces.get(resource_group_name, nic_ref.id.split('/')[-1])
+        for ip_configuration in nic.ip_configurations:
+            if ip_configuration.public_ip_address: 
+                public_ip_info = network_client.public_ip_addresses.get(resource_group_name,
+                                                                        ip_configuration.public_ip_address.id.split('/')[-1])
+                if public_ip_info.ip_address:
+                    public_ips.append(public_ip_info.ip_address)
+                if public_ip_info.dns_settings:
+                    fqdns.append(public_ip_info.dns_settings.fqdn)
+
+    setattr(result, 'power_state', ','.join([s.display_status for s in result.instance_view.statuses if s.code.startswith('PowerState/')]))
+    setattr(result, 'public_ips', ','.join(public_ips))
+    setattr(result, 'fqdns', ','.join(fqdns))
+    del result.instance_view #we don't need other instance_view info as people won't care
+    return result
 
 def list_vm_images(image_location=None, publisher_name=None, offer=None, sku=None,
                    all=False):  # pylint: disable=redefined-builtin

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_show_list_sizes_list_ip_addresses.yaml
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/recordings/test_vm_show_list_sizes_list_ip_addresses.yaml
@@ -6,77 +6,24 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b7]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c46cb29e-85b5-11e6-95a3-a0b3ccf7272a]
+      x-ms-client-request-id: [57ff4e62-e195-11e6-9e87-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/publicIPAddresses?api-version=2016-09-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS9X/zRMlvQLx9lP2gWy7w9eLDz6Uejj4oZfXS3WU+aaV2s2qJaNnd3Jrvnn+4/2N3enZzv
-        bO/PZtl2lk/vbU8nD/ce7J3vPLz/cOdunTfVup7mn9fVetXcnTaL+uLTnYNP767q6rKY5XVz94ti
-        WldNdd6OX+TtVVW/vbtaT8pievbyeDaj95u8uRtik7fZBeHz3bu/70eznZ2DbD/7dHuSP5gREg/2
-        tie7O5Pthw8ezg7u7WX7+9OD3/cjeqe9XmFYt+iMGpfVNMMg6YWrvGnX+Iz6bD569Is/eptf08dC
-        r18y+ojGscrrtqD36Ev667Jo6M1iefG6zVp0+Xo9neb5LJ8REOpByLFmit7L8538008/3c4f7GTb
-        +5Od/e2D83vT7Qf3zrO9nYOH+59O79NbHRR/kqhGXdD7Zy8v9/3vS4P4F3k7r9DD02uaz2JKjYpZ
-        mb8pFnm1bs+WXxTLdQuU90cfzZbN67xtCWP6+xd/NKsWWbF8kS3y59kkLwmGEv/Tg4cg/vkvmqFr
-        78Ox0Gg8Lav1LFutxtkP1nU+nlaLj37JL/klI8tS86ya/uQXBILHfvfDuQkA64v3ZCW8xFh4XLSz
-        ++DTh3vT8+2Dyf4ezcPe+fbDh9N8e3e6tz+ZnN+/d/Dg4TfDRYTrB7DLzsH53qcPZ9vns/v3tvfz
-        LNt+eG//4fb0fO98ku3fe3gwu0dvFSvFgl7ZvTd+eG+8++mD8YOAU6TBN8xJxeqkWp4XF+uaX8UI
-        Ge+7P5SpJm7Ez7Nlm9fn2VSn+nJx/97dDmINfTDlD3ZDDl1P1st2mydre3fn4YP9/d37+/vbq2LF
-        w6YWdz98KGVxmc/zkthg43DsVMhU0XA2Yudx88Fedv5g8un59r2Dh7vb+3sz0ir5ZLad33t4797e
-        /fPsfDr5fwM3P8zu3/v03qfb9w92zrf3Hz58sJ3tHtzfnj7Ye3hw736+l/FbHVy+YZa9UfltJLrq
-        wuE2m1QjYRWyJRBgytz9oTFZX2YGxrIspiQ0AbqeFO1/erB3b//e/v7DnZ1Qol7q7FzW5+WEKPZN
-        ja+ZZmXe5O3vP61z4rTfP39XNJjF378SoL9/fbG3ceSWbYSt8uZuF1VPos73d7NPH+zNth+Q7Gzv
-        f5p/uv1w72CyPcseTnYn+1OQ6ZuRKOoTjEjMQcjT7H1N2XqYne9NDibn8CQm2/v3dz/dPnhwb7I9
-        ebh7/97ubDY52MdbHay+UdnyuYBIerloGkNhfok+vvvN80FTLFZlTrP/npPfx9Cb/tmD/Ul279OM
-        3IO9B9v7B/ne9sFePt3+9OGDfC8njXq+f/7/qunfu3+we5A/PNi+PzkgR+HhLjkKs3sPt++f53s7
-        k4MH9x8ePKC3Olj9rE3/u1WZtW9ojK/z6XJ2tno+eZG1ewc7/DZ9f/fD+cB28fkJMwJ3ce89mcAC
-        6ePpccNkf5Jnn+4+JInKiLj3J5CtSba9d+/+g9nOven04P43pAwI+6/PA0TF+/d3Jve39/JPH27v
-        75wfbD/MzylQevDw/OBedrBzL8NbHVy+UR6gL0KTgWEwcnc/fMav1xfZ8uJq4xSXVTZ7kpXZcorv
-        9Y3tcnL3vK7I5C1nZy8D/Jq7z703nqHR6XIWWjQDZdfTFT/MMdkJkQkjttW3Aow8fv00z++dT8lk
-        ZQ/O97f3d/fy7QPijO18di/fOb+384BM9zfDr9QnTfsHa6+H+w8nDyb3d7cn+xkZr4PZfQrn7+1s
-        7xzs7OT3dg8O7t/rhTk7++O93Z3xvYPx7s4BfdlB+f9fbN332vSt7d2f/OLFJk/NtovyNCxgwEXf
-        8KAAf+PA7KzIrLmB4c0AM4+/d3d39mazT3fJOhNX7++RKj649yDf3vn0nJI/92fT3Xz3/138fTCb
-        fLpzf2/7008pgt+/n+2RaD7c26bgbLpH2aDzB3vMfR5/7++MHxyMHx6M7/9s2236ImQeDJDRvvvD
-        44Oo3sZb27sfprzZws+q6ducxkEuPKj1TQ2OYcN7+Pwnv3jKXew9vL+7cZx2omQiid8ZSAdBj9fv
-        PZjsPry/M92ePdwho37+8CFlgPbIE909v7e3S4xz//zD0p15prxOaH99Did0sux8J9+ezXYpXnqw
-        P9s+mJLdmWS7uxnZngfTWUZvdXD5hvl4dlNoH9B6tmw+Fa9Yg/rYt2MhTzScH2QzsrAAy4S5+7PB
-        Zp8+2Ln/IWymCHpsNrs328vuUbx4f+/TA9JQu7vb2QHpqsmDGc149jA7mD34fwGbkdqfTR9QXLa/
-        Q5Tbf3j/PqFJKwD57sNZvvNgZ3r/4Jze6uDyc81mlMFFrwNshm83sRlh8rOnnxmZ9+Otvi/CQChf
-        NGMAuzs7D8j9CFB2/sju/v1PH+wf3N89+PTefkSGiMhtsfr0YGePKPazMUqJFu/Rs3GUlkWEhcwo
-        A/Q8+Zncn9FS1MH+NkWDhFX+6f3tg08Psm1K1u9mO/l0ursz/SD5ofG0c3BJ1hSsST9EjHann+5O
-        Dz6l2OD8Hqc3DrazDJnj83sHk8nO7N6n95EP8/0RWlZ48Ol49x79f/8hfddB9+dExKg1TQa13d99
-        gPjAF7DguzGN3lHv51bKbsl/A1KGYZGkfXrw6UMSqQBhX8Y+ffApIfPgwcP9+xEZ2ybk2vn27v7e
-        wcGDXWqDxDXR7xsf7k9+8fq1jHfvwcbRWm4RbjKjHULUEzwyCJPJfbJZlIMhBs5mO4TfZI+yXwfT
-        +3uT+wd7ux8WCzAKhnXoKxrG1xe8B+cPaGnx4WQ7z7Oc1ARFu5SXoeTibO8eqcUJCV4gPILSz4Jw
-        3SxcQ7T3hSza5v81wnZr7huQtf7oSPJIyALMfal7QJlD0ja7n+7cu63UwYz83A28w2fDA1dMPbl7
-        sLe3f3Cwt7P9cPeAFtDv39/fzij/CIc/I8t+b48WSf7fI3ezye4BxSGzbVpGpwTT9Jwik/0pYTub
-        Ue7pwe793R04xB2U/t8jdyD+jYK39/89yQvDfn6/P7RNCQAfwIYEgAK9d+/+Lv2Poh/Qi2j6czdy
-        y0rCah3R6yHqSd5ssjel5Oi97cl98tv26a/tg+zBZPvhNLt3/9Ppw2zn4cP/90je5PxTWkIlE/fw
-        HmW99qe08P9wtp9v59nD872Dh/fy/AHe6qD0cyl5PdpHBC9scwu5G+LI+w/u75DhuH8AONQX0+zu
-        //sYsounx4+E2r3ZzkPSqAcPz+HTUOonowz+zu79/Dy/n+/s3/v0/z38eH6wd3C+lxMdaRmfElUP
-        ptsPP83Otw8eZrTcn93L7u2DlToo/VzyY5f0EXYMmtyCGwm1/zdZgc3+lxvcbdyv3d393ft7txQ4
-        mNWfu2FbHhIeGxy2IuqJ3EMKFLLJwafbswkt+e8//PTT7YcHB+fkzlCe9eFOnt3bnfy/R+QmB/en
-        +f7Og+2HGS3x7dPyzHZGhN2+9+k+LVAe5Dt7D3fprQ5K/68ROdD+Jpn7/5Xr5Ub2dTyv7/+S/wd4
-        UPdBXC4AAA==
+    body: {string: '{"value":[{"name":"PublicIPvrflb","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_existing_options_hqs8_/providers/Microsoft.Network/publicIPAddresses/PublicIPvrflb","etag":"W/\"a8cd2e8e-dcce-4dae-bce4-1b453a38ecff\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"9fefd544-bebf-4cad-a06a-ff89e3b22e1f","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_existing_options_hqs8_/providers/Microsoft.Network/loadBalancers/vrflb/frontendIPConfigurations/LoadBalancerFrontEnd"}}},{"name":"basica01PublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/publicIPAddresses/basica01PublicIP","etag":"W/\"f8ae08f7-c944-489c-ab3c-707c4cfc2953\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"3bd4e2d0-b853-41ea-9025-da9cd2c86b85","ipAddress":"104.40.2.165","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkInterfaces/basica01VMNic/ipConfigurations/ipconfigbasica01"}}},{"name":"basica0PublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/publicIPAddresses/basica0PublicIP","etag":"W/\"6016d0ab-0f50-4497-b159-400e7a4f5b76\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"023d12be-f4d4-4053-8593-1bf76148e334","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkInterfaces/basica0VMNic/ipConfigurations/ipconfigbasica0"}}},{"name":"ubunt-westu-1097441544-pip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/livehelper/providers/Microsoft.Network/publicIPAddresses/ubunt-westu-1097441544-pip","etag":"W/\"82af7b6f-3891-42d4-8ebd-e393325fafcb\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"39a53636-580f-4997-a185-c729835e2aed","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"ubunt-westu-1097441544-pip","fqdn":"ubunt-westu-1097441544-pip.westus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/livehelper/providers/Microsoft.Network/networkInterfaces/ubunt-westu-1097441544-nic/ipConfigurations/ipconfig1468234344900"}}},{"name":"armdemo133168PublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/publicIPAddresses/armdemo133168PublicIP","etag":"W/\"5ee6059e-1457-4537-ab66-d64cbf65220a\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{"demo":"deploy_1_33168"},"properties":{"provisioningState":"Succeeded","resourceGuid":"e069cf3b-bdfd-42f1-8ab4-e922257da729","ipAddress":"104.42.185.88","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"armdemo133168","fqdn":"armdemo133168.westus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/armdemo133168NIC/ipConfigurations/ipconfig1"}}},{"name":"pipa953","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg953/providers/Microsoft.Network/publicIPAddresses/pipa953","etag":"W/\"4a050a33-7ada-471d-8caf-70641e453cbe\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"766d7a85-1012-4779-a5d1-f4c963428cda","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"pipa953","fqdn":"pipa953.westus.cloudapp.azure.com"}}},{"name":"pipb953","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg953/providers/Microsoft.Network/publicIPAddresses/pipb953","etag":"W/\"2a588937-ea97-4061-843c-3d30e0361f63\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"96551aa4-0c2e-4db6-a675-180343c38d91","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"pipb953","fqdn":"pipb953.westus.cloudapp.azure.com"}}},{"name":"linvmPublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/publicIPAddresses/linvmPublicIP","etag":"W/\"81e24d64-1836-46c4-8dbd-cea9d370a699\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"5607d3c9-fa54-4b5a-a43e-5531b1ae9dca","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkInterfaces/linvmVMNic/ipConfigurations/ipconfiglinvm"}}},{"name":"winvmPublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/publicIPAddresses/winvmPublicIP","etag":"W/\"a64152bc-3ddd-425b-aee7-9f275d5845f1\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"3b5c9a46-8fe9-4a1e-9113-88481fa0f3db","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkInterfaces/winvmVMNic/ipConfigurations/ipconfigwinvm"}}},{"name":"vmssPublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmssrg/providers/Microsoft.Network/publicIPAddresses/vmssPublicIP","etag":"W/\"dadee489-2bd0-4fa0-8313-61368d1e0b18\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"fa86ad45-af60-46c0-a937-598d57ab02af","ipAddress":"52.160.105.31","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmssrg/providers/Microsoft.Network/loadBalancers/vmsslb/frontendIPConfigurations/LoadBalancerFrontEnd"}}},{"name":"xplatTestSecndIpLbNat280","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/xplatTestGCreateLbNat3/providers/Microsoft.Network/publicIPAddresses/xplatTestSecndIpLbNat280","etag":"W/\"b4bea619-87a3-45b6-87ba-2357d03cc854\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"0b1550b5-2e69-40f8-9ef6-b79f83a803ad","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/loadBalancers/yugangw-lb/frontendIPConfigurations/LoadBalancerFrontEnd"}}},{"name":"dcos-agent-ip-yugangw-acs-yugangw-0b1f64agents-B90D500F","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/dcos-agent-ip-yugangw-acs-yugangw-0b1f64agents-B90D500F","etag":"W/\"fae6e4e7-c17c-4035-9674-7ffe01d61ffe\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"4743221e-e5f6-4d08-af86-b5d27bcb214e","ipAddress":"104.42.38.245","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"yugangw-acs-yugangw-0b1f64agents","fqdn":"yugangw-acs-yugangw-0b1f64agents.westus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/loadBalancers/dcos-agent-lb-B90D500F/frontendIPConfigurations/dcos-agent-lbFrontEnd-B90D500F"}}},{"name":"dcos-master-ip-yugangw-acs-yugangw-0b1f64mgmt-B90D500F","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/dcos-master-ip-yugangw-acs-yugangw-0b1f64mgmt-B90D500F","etag":"W/\"b99f90f8-7f3d-4cac-9643-3487c8cbb49b\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"cb011a9f-dc2e-438a-90c7-3fe031145249","ipAddress":"104.42.38.224","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"yugangw-acs-yugangw-0b1f64mgmt","fqdn":"yugangw-acs-yugangw-0b1f64mgmt.westus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/loadBalancers/dcos-master-lb-B90D500F/frontendIPConfigurations/dcos-master-lbFrontEnd-B90D500F"}}},{"name":"yugangw-1PublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-1PublicIP","etag":"W/\"4439608b-8a81-4416-85cf-fc378d4df6e1\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"949b7b51-b4ab-48d5-9730-0800e3188533","ipAddress":"104.210.38.108","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-1VMNic/ipConfigurations/ipconfigyugangw-1"}}},{"name":"yugangw-3PublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-3PublicIP","etag":"W/\"46555775-8b95-48dd-96bf-c9d2e2a54c62\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"71bc5a60-2a14-4756-bd3d-327b81ad43dc","ipAddress":"52.160.103.58","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-3VMNic/ipConfigurations/ipconfigyugangw-3"}}},{"name":"yugangw-9PublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-9PublicIP","etag":"W/\"2266f488-861b-429a-9e13-23718d847038\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"f21eb208-0c78-4238-b979-6dfcebcdf92d","ipAddress":"104.42.231.246","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"yugangw9","fqdn":"yugangw9.westus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-9VMNic/ipConfigurations/ipconfigyugangw-9"}}},{"name":"yugangw-fat1PublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-fat1PublicIP","etag":"W/\"e1f75fdb-abf6-4e62-ad2f-628e59279962\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"258010ce-5600-4ed9-8a31-94c5b9141a22","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-fat1VMNic/ipConfigurations/ipconfigyugangw-fat1"}}},{"name":"yugangw-j1PublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-j1PublicIP","etag":"W/\"d576b3f1-752a-4500-b408-65eb147ce506\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"f2eb0bdb-ceb3-4a71-9dac-9b88833d4d88","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-j1VMNic/ipConfigurations/ipconfigyugangw-j1"}}},{"name":"yugangw-junkvmPublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-junkvmPublicIP","etag":"W/\"b7b163ba-666b-4043-a4f8-bae4b8c55a75\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"afe61529-aeec-4d61-b342-02c5118dc564","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-junkvmVMNic/ipConfigurations/ipconfigyugangw-junkvm"}}},{"name":"yugangw-k1PublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-k1PublicIP","etag":"W/\"217ead67-3d86-4569-85dc-f0f3af39d57f\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"c441a91a-c315-4148-b992-ddd956de5f9b","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-k1VMNic/ipConfigurations/ipconfigyugangw-k1"}}},{"name":"yugangw-kernelPublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-kernelPublicIP","etag":"W/\"7a2a4f46-f50d-433e-93ed-f35a8d715130\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"529aa56e-c63d-4c88-9147-3bbf34ca7787","ipAddress":"13.91.103.115","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-kernelVMNic/ipConfigurations/ipconfigyugangw-kernel"}}},{"name":"yugangw-portal-ip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-portal-ip","etag":"W/\"cf2fcf87-905b-42dc-8dd7-e8ceae9f9354\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"927b1492-d93a-400b-a52f-80aa76021c6a","ipAddress":"23.101.198.127","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-portal857/ipConfigurations/ipconfig1"}}},{"name":"pip95963778","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMV29c1708752/providers/Microsoft.Network/publicIPAddresses/pip95963778","etag":"W/\"8cdb13f1-a34b-4b68-8cac-17f60549549a\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"bc82fdae-9f26-4d47-b172-4e6bc2b1ba8c","ipAddress":"40.114.7.151","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"pip5f01708752","fqdn":"pip5f01708752.eastus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMV29c1708752/providers/Microsoft.Network/networkInterfaces/nic805981da395/ipConfigurations/primary"}}},{"name":"pip68662aac","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMV8963671476/providers/Microsoft.Network/publicIPAddresses/pip68662aac","etag":"W/\"85ffaf90-48b5-4f0f-afed-daf45f2b1dfc\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"9fc2652f-13cf-4ce0-9b6d-7862ec27801a","ipAddress":"23.96.88.97","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"pipce03671476","fqdn":"pipce03671476.eastus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMV8963671476/providers/Microsoft.Network/networkInterfaces/nic45269808de6/ipConfigurations/primary"}}},{"name":"pip43883167","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMVc857134170/providers/Microsoft.Network/publicIPAddresses/pip43883167","etag":"W/\"f1d8f9f3-de7f-480a-ba17-6b03565fc962\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"4373e512-c2d6-48e4-938d-677f25dfc663","ipAddress":"13.82.140.52","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"pip6d27134170","fqdn":"pip6d27134170.eastus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMVc857134170/providers/Microsoft.Network/networkInterfaces/nic925565cccfd/ipConfigurations/primary"}}},{"name":"pip5596555f","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMVe714461387/providers/Microsoft.Network/publicIPAddresses/pip5596555f","etag":"W/\"c85c074d-8f6a-4d62-be12-c3287cb75fc9\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"aecd1143-1394-43e0-bda1-c0838efd09b8","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"pip8604461387","fqdn":"pip8604461387.eastus.cloudapp.azure.com"}}},{"name":"pip1-intlb1-b5756104d","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Network/publicIPAddresses/pip1-intlb1-b5756104d","etag":"W/\"ec3f34b0-d18c-4260-9d0b-d489727969c2\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"64e7def9-fa8b-4813-8b19-f89d1b05b010","ipAddress":"40.71.80.146","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"pip1-intlb1-b5756104d","fqdn":"pip1-intlb1-b5756104d.eastus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Network/loadBalancers/intlb1-b5756104d/frontendIPConfigurations/intlb1-b5756104d-FE1"}}},{"name":"pip7748c9a6","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/publicIPAddresses/pip7748c9a6","etag":"W/\"bb928a68-f19e-49ae-a4e7-4a785c0c1c68\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"4534d937-f345-4618-a1ce-31c209e14917","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"pip1c3186528ff6c4d","fqdn":"pip1c3186528ff6c4d.eastus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/networkInterfaces/nic142986528ce1315/ipConfigurations/primary"}}},{"name":"pip34643db7","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv_f442667004ba/providers/Microsoft.Network/publicIPAddresses/pip34643db7","etag":"W/\"2e6784f9-cb29-4284-a66b-0e8d631e336b\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"db2037d0-eb08-4fa8-9395-b78b83ec9ff4","ipAddress":"40.71.93.62","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"empip-30069611762","fqdn":"empip-30069611762.eastus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv_f442667004ba/providers/Microsoft.Network/networkInterfaces/nic951517fadc0/ipConfigurations/primary"}}}]}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Length: ['2743']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 28 Sep 2016 19:57:21 GMT']
+      Date: ['Mon, 23 Jan 2017 17:57:02 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
-      x-ms-original-request-ids: [d1f96040-3ee2-4da5-b2bd-0ea74300c958, 611fba60-056e-48cb-b2fe-e484a378a57b,
-        501491f2-3968-4319-b592-49891e6740e7]
+      content-length: ['21772']
+      x-ms-original-request-ids: [4b01eeab-be13-457c-89ee-b5c30f872984, be45d98b-b06e-47ca-ba62-c91a9caeec43]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -85,84 +32,25 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b7]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c4f57f4a-85b5-11e6-844a-a0b3ccf7272a]
+      x-ms-client-request-id: [58645634-e195-11e6-b967-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/networkInterfaces?api-version=2016-09-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS9X/zRMlvQLx/Ns2p6ubh/76PRR8WM/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdn
-        s2w7y6f3tqeTh3sP9s53Ht5/uHO3zptqXU/zz+tqvWruAmR9cXdVV5fFLK+bu18U07pqqvN2/CJv
-        r6r67d2l/Dxbtnl9nk1zeUnxyNvsgjD57t3f96ODe9N7D/LZp9uz/f0H2/v3Hs62Jwc7+9v759Ns
-        f+/T/P7uZOf3/YjeKatpBozpvau8adcNfUYIrPK6LfLmo0e/GH9dFg01KZYXr9usxeBfr6fTPJ/l
-        M2ptB7FmOmS7u5PZ7my6fe/84cH2/sGnu9sP985n2/m9nU/PD/Znew/2H9BbxeqkWp4XF+uau6ee
-        HGmL1ZS/20U7wLz7c0zbu11s6QOH4tchO+HxHiRe1cUlfXr28ng2o3HROx/t7ox3xzvj+8G3pZnN
-        L/J2XoFyT6+JpsUUrdaTsphSIwPiF/8wadvpXWn7k1989EtGHxECRPpvEqHr9UW2vLjaiNFlUbfr
-        rNQ/7Tvbl4TLXUKBfrgP5W8gS8ReZPX1R4/aep3zn0p7GdhPUmeENg3j7OXl/ke/5Jd8f/TRbNm8
-        ztuW5papzn/Wl9SQeJ6+zlarsshnTzsfF2DDZVY+rRZZsXxBkvF6fX5evCPQ7dW7+3uz6qez3Z/O
-        f5CvdmerfDppfjrbycazd2Pz4nhaVusZQR8r6otsqlgSjJ2d7Z2n2/eOt+/tbj/d335wQCySL7NJ
-        SWN5VtVXWT0jhD96dJ6VDY2TQIBMr/Ppui7aa6YzBvNNzRi44QYWiqEgLwob0VT4M6Pz+0U2nRdL
-        EqgfCq4n1WK1bnPDXNq5vAIsCc32ekXYfOTe6YzPqR8alFWJ68l62W6zht7e3Xn4YH9/9/7+/vaS
-        RfubGlhZXObzvCTFFB3cIKJ3N2Lnqcdpfr6T7e/Mth/uTh9u79/PPt1+uL+TbU93z6eTvfx8cvBg
-        yurR6DF6j6F+sFXav797cD+/N9mePLxPVil/eL79cLp/f5uQOZjOzneze9Mdequr50kU7RRYlb//
-        6cHevf17+/sPd/gdwL/7/0rqk5kKx0MfxAfxdSaJsCRkbzshJJ6BpqSvyYbBiu0H3/4c2bBbUr+D
-        wTD1V8WK5PcjQowm7OcAUdVA+ucgmoG1G2jT0JcYC82Rr2DpT50yocU3Zfqop0FDRN99Pf1pDPnu
-        T37xglnpm5oOBbxxLnqYmbccOp787X06vbe/C1W1t/vp9v7De3vbBwe7s+1sL79//nD//v17D3OW
-        PyMo9B7PGZQkgSEi/mKiEyFEPHJb6bSjEnV5MNvdu5ffn27Pdj4lSuwdTLcz6nv7/s55Pj3P9qdE
-        DXqrq15o+izFjaaxQ0V7wL77/w6ikyoMkacP+hh/nXkhrN6D8l0xoq9JL8K3/3+FXlRibCR1p3uf
-        1C/1K5LFjwgZmpQfNnJdRajvhJrPfCh/A1ki/A9D2ZFMgEHJXf9Z9/Pvbe8/2d55SOwyqF5/9v18
-        JfTGGYvhYN/c3n3x+nOMkmbEnyCdZvW4f1goD/n7+g6pkK/v8iuMywU5cjRp3/BwLhdN8x5Dej3N
-        ypy4O3h/e7fTijDqj8m9IQPxVGq2++nezu69h9vTfJfYkxIk25Od6WR7Jzvf3dnd3b83yb6OSrUj
-        FmN2fnDvYPbw3mx7d3dKqZjsYLJ9kN3/dHsve3D//qd7u5NPd3J6q2sPSDz7c2FsBNoD9t3/r08I
-        Wb1w2O5bb6w/+3NG4hwoWPqazCD+u70ZpLmgwaK3H9bcGEFWquufwXvkbrw4fXOXcCHcOt+85g9J
-        6DFAX5vRnzpeoUbH3MD3y2ZPsjJbTvP6STZ9my9n2vRlVZVEPeLdHzYRfJyCt7Z3y8ndSR/LsM0k
-        X9GHH8GS+pDOlpNqvZy9yNpX6xK89P+6kRUhhuH3y6zFsMY7NLCfHS/h7du9i52dn/5FF+VbEolV
-        ce9676cp+jyfnX89L2H3ZPs+u77LQS+B2NPnVuV+1TkY1Q9rgj5QN5J1/v+6wd29Qb/TQDzl/ene
-        p+f704cPt+99+uB8m5I/+fbB3qefbtO6DOXE8r1s8uD+11DedsRicO/t7T3YfUhkmexMyER8+ukB
-        RUoZLQE92CdbvP/w4N7ep/RW1/IQp/fnwjNCDPvu/9cn5L0N7qc/O3NGMhyYGPpaDe7t15RoLmiw
-        6O2HNTdGIyvV9c/gvR8ZXBoomaWf5waXQq9vzuD+LBpcWns7oV+Ixf7/b3BpTnyD+25VZi2pxFlF
-        nFrfOzh4QFT4pkbCwN9QXvTzn/ziKXew9/D+bnRQhutoovDTU9wMpIuhp5tnk72HlCmfbu/kB7Te
-        v793f3vy6UNKDGa02vSQMqUHD/dZNxslSu/lmeZqCZX30Nd2eGJjDw72DnZmxEaEwi5lI/en2wf3
-        s4Ptezs5Ldt8ev8BdU1vdY0NS7OS35ibXcpdHuxSWPfpwQF0P8O/+//aGegb0KGBfJ2JIuzeY1JI
-        LgOzQV+rEYXNcN/+cI0o0+z9CK+Sqn8qCKE5EqUH+58+vEuI0a/Bd/LRwwf3yJXm8fpaiv7U4Qtx
-        Ojb1Zyca2lvev7c+f7vK3l2vL6urKvtF80n5i3aX62w8eW/lvEsUp9XiE5ql/zcoZyb87eY1rqcV
-        xOVixm8/PNi/T9PwdROUDMuK5u7ODpTjz95YP32wcz861kFkBUgXQ08rPDh/8HC2R1O8l+/NSCtk
-        97YfHkzy7QcPzs+Jpx8+zHYkl2XEl977ZtR3lj/YvZcfUEyU3SOn/v59curv3cu2P93N8t18sv/w
-        4cN79FZX1RH7W/J7Wu/TB/sH93cPPr0HrcPw7/6/dgZIW4djog/iA/k6E0XYvcekkOQGGoq+fm/1
-        3Vn8Qrc/hzPQwcbMgJC/WN3befCARPgjwo3m6ucYV9VN+qeCEExhc3YP9u/dJcTo1+A7+ejT+/dJ
-        dxH5Q+VLf+qcCQF+ODaneHdvb7k7v3cxzX+a4oD1L9ppz9/d35/lG23OoEmh7z5AI7c0CSRxnx58
-        yg7gz8L8ntQ50fgePRvnt4eqAAnx84T83uTe3r39B9n2Qb67t72/l59vH5zvZNs7B/s794mZdrM9
-        SXQYaaT3CMd2DpWcNUVGXxE+7yH/doyqlPcn2f4uUWPy4EG+vZ8fECqT8wfbu+e04j99eO/e5CHc
-        yq4CI/6wM+B02acPPiViPnjwkGwsvQP4d/9fOg2kgcMR0QfxYXyd2SLc3mNKugJMX/+/VSXfkv4d
-        bHz6F6tPD3b2SII/Isxonn6OMY0qZOAJdby/e7B7l9CiX71v5IN79x78v0YZ77fre/vrssju//R6
-        crFazHfnF9UsO2/Ox8UGZRwPAI53tmmlcw+u2KC25nH6w1Yyqs+NUf0czOkNAcC93T1yMD/Q998m
-        5Nr59u7+HoXlu6QhtkmhEKm+8eH+5BevX8t49x5ERzuIs8AYQtRTZ/cPHtzLd/JPtx/M7lOC4NM8
-        2364c/7p9sMHD/PZ9MHDnVn+Kaszo3foPYb6TRmfh4Tcg/zhwfaD83v3t/cf3JttP5zuHtAye3Z/
-        8un5+b29+zm91VXVJA92UpzWfkDJod0H93Y/3QHrMvy7/2+fDzI64dDog/h4vs60EZbvMTck0YHm
-        oq/ZCu3+v8wK3XoiOsgMTwQlsknOPyIcae5+bnFW1aV/KoQ+xjBOdwk/+jHYpqEvMSyaOV9T0586
-        kUKWH4qBog7m11W7rJYX+f2yrqvr5eLqKivvbTZQg/aHvvtwHX7/wf0dErP7B5BEYt6fu1nvoSww
-        BvD0VMHs3sP9h/ey3e2cEgiUt8sn29lkj9afJ+TT703u7dzLpqwKjMzSewz0G9Pg9wmx6d759nk+
-        IfrkBwekhj7d2z6fkEN8b3ow3XuIPrpqjhjGTklH4+3u7u/e38M7gH/3/+XTQfo6HBl9EB/O15k1
-        QvI9pqYr2fT1/58VuJuH/4/ob4fwoPp2TRr6DoOiafs5195EnXWxdz97+4PL9flPTy/O96t372ZZ
-        QYu/Pwzt/f1f8v8AvcxZHYs+AAA=
+    body: {string: '{"value":[{"name":"basica01VMNic","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkInterfaces/basica01VMNic","etag":"W/\"703df84e-5116-4e13-a909-f96175112b63\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"70dc51d3-a1df-451f-8c96-1db875e8853a","ipConfigurations":[{"name":"ipconfigbasica01","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkInterfaces/basica01VMNic/ipConfigurations/ipconfigbasica01","etag":"W/\"703df84e-5116-4e13-a909-f96175112b63\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/publicIPAddresses/basica01PublicIP"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/virtualNetworks/basica0VNET/subnets/basica0Subnet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"pfp4lc1vfohelkea43gpafi04f.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-35-5F-C3","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkSecurityGroups/basica01NSG"},"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Compute/virtualMachines/basica01"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"basica0VMNic","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkInterfaces/basica0VMNic","etag":"W/\"281f8b3d-4d71-4af5-9739-6bff86f2a4a1\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"88083e0e-f750-4d7c-9880-30f48cbc2f95","ipConfigurations":[{"name":"ipconfigbasica0","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkInterfaces/basica0VMNic/ipConfigurations/ipconfigbasica0","etag":"W/\"281f8b3d-4d71-4af5-9739-6bff86f2a4a1\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/publicIPAddresses/basica0PublicIP"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/virtualNetworks/basica0VNET/subnets/basica0Subnet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"pfp4lc1vfohelkea43gpafi04f.dx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkSecurityGroups/basica0NSG"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"ubunt-westu-1097441544-nic","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/livehelper/providers/Microsoft.Network/networkInterfaces/ubunt-westu-1097441544-nic","etag":"W/\"cef0a40d-91c9-45a6-940a-c1fcb2efb87c\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"45185e3b-b958-4e9f-9c45-40d8cdf1a3c0","ipConfigurations":[{"name":"ipconfig1468234344900","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/livehelper/providers/Microsoft.Network/networkInterfaces/ubunt-westu-1097441544-nic/ipConfigurations/ipconfig1468234344900","etag":"W/\"cef0a40d-91c9-45a6-940a-c1fcb2efb87c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.1.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/livehelper/providers/Microsoft.Network/publicIPAddresses/ubunt-westu-1097441544-pip"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/livehelper/providers/Microsoft.Network/virtualNetworks/ubunt-westu-1097441544-vnet/subnets/ubunt-westu-1097441544-snet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false},"type":"Microsoft.Network/networkInterfaces"},{"name":"armdemo133168NIC","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/armdemo133168NIC","etag":"W/\"313c7c8e-f3ab-432f-9eef-5aa96923d600\"","location":"westus","tags":{"demo":"deploy_1_33168"},"properties":{"provisioningState":"Succeeded","resourceGuid":"9b4f5373-e950-4fda-b663-da05d116b99c","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/armdemo133168NIC/ipConfigurations/ipconfig1","etag":"W/\"313c7c8e-f3ab-432f-9eef-5aa96923d600\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/publicIPAddresses/armdemo133168PublicIP"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/myVNET/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"pbijbawf3hmeriihr2qocjhd2f.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-EE-10","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/armdemo133168VM"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic01653878289","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic01653878289","etag":"W/\"6f921991-cf48-47ec-8227-d3440e63a366\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"df85022e-68ef-4106-96d9-5244e5093975","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic01653878289/ipConfigurations/primary","etag":"W/\"6f921991-cf48-47ec-8227-d3440e63a366\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.16","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-E1-1D","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-3"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic019673b7dc0","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic019673b7dc0","etag":"W/\"d39e7e78-2991-44d5-a878-4ecfaf0d029a\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"b9e09dba-dfab-4bba-a884-911f6eff7daf","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic019673b7dc0/ipConfigurations/primary","etag":"W/\"d39e7e78-2991-44d5-a878-4ecfaf0d029a\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.11","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-EE-5C","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-19"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic0636470a525","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic0636470a525","etag":"W/\"de4d1cae-005f-495b-b079-26b3fe24f5b3\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"9005b601-9629-42d1-86f7-01452b679aa1","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic0636470a525/ipConfigurations/primary","etag":"W/\"de4d1cae-005f-495b-b079-26b3fe24f5b3\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.15","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-EE-89","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-8"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic150168efa2f","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic150168efa2f","etag":"W/\"c94782dd-afe1-46d7-b592-15b33bc128f2\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"c2b6065c-c641-4d8d-96a3-e74c98227333","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic150168efa2f/ipConfigurations/primary","etag":"W/\"c94782dd-afe1-46d7-b592-15b33bc128f2\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.9","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-E1-C7","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-13"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic170770fac41","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic170770fac41","etag":"W/\"fe26f2a4-c40a-4dfc-a06d-290cf4924d09\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"b5cbe88c-6d68-4f52-a799-5487c819b0bb","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic170770fac41/ipConfigurations/primary","etag":"W/\"fe26f2a4-c40a-4dfc-a06d-290cf4924d09\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.10","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-E3-3F","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-0"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic24432ea21b1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic24432ea21b1","etag":"W/\"0ae19e2e-a2ee-4cda-89de-3eb1828e57ce\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"84e95aa3-4a80-446f-96e6-73776d1b6825","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic24432ea21b1/ipConfigurations/primary","etag":"W/\"0ae19e2e-a2ee-4cda-89de-3eb1828e57ce\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.12","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-E0-31","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-14"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic26097065678","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic26097065678","etag":"W/\"094e49da-e817-4979-a919-9f160d41332b\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"89b53bf4-1e8f-4756-aa4c-30e383c0c4fd","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic26097065678/ipConfigurations/primary","etag":"W/\"094e49da-e817-4979-a919-9f160d41332b\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.13","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-EE-C2","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-17"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic3775129c814","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic3775129c814","etag":"W/\"ba6ecf9c-68bc-4c4d-94dc-8948e1ddf942\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"4ef02f77-0d5d-428b-bbc4-0776cae31b87","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic3775129c814/ipConfigurations/primary","etag":"W/\"ba6ecf9c-68bc-4c4d-94dc-8948e1ddf942\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.20","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-E6-66","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-16"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic38353219b48","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic38353219b48","etag":"W/\"aec2e617-3c16-4d66-bd2b-23ad64e9e7aa\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"ef65061e-b0bb-4752-a12f-3d7b9bd4dbc1","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic38353219b48/ipConfigurations/primary","etag":"W/\"aec2e617-3c16-4d66-bd2b-23ad64e9e7aa\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-EE-46","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-12"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic44894e0b1ae","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic44894e0b1ae","etag":"W/\"5872b87b-95db-4d22-9672-2bfee27947e1\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"e832b386-68a2-4a6c-9d44-e9d83580a328","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic44894e0b1ae/ipConfigurations/primary","etag":"W/\"5872b87b-95db-4d22-9672-2bfee27947e1\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.18","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-EB-DB","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-5"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic50379d47723","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic50379d47723","etag":"W/\"f9049fbe-8132-4124-bfbd-f1f6f1b721bd\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"de2d41a5-657e-4c62-89ca-81beca82e71d","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic50379d47723/ipConfigurations/primary","etag":"W/\"f9049fbe-8132-4124-bfbd-f1f6f1b721bd\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.19","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-EF-68","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-10"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic59728afad3c","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic59728afad3c","etag":"W/\"07a9fe8d-256e-4453-b8e1-9e9ea80e28c1\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"38f00d36-a736-46f5-9cb9-8b3510d41dd1","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic59728afad3c/ipConfigurations/primary","etag":"W/\"07a9fe8d-256e-4453-b8e1-9e9ea80e28c1\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.22","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-EF-4D","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-4"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic6852829e356","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic6852829e356","etag":"W/\"b987ffae-cc50-480b-8bed-ae2ed92d0283\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"5d87ee2c-6ad3-4361-aa01-68b08bb2857d","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic6852829e356/ipConfigurations/primary","etag":"W/\"b987ffae-cc50-480b-8bed-ae2ed92d0283\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.21","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-E6-B6","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-15"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic733897ee67f","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic733897ee67f","etag":"W/\"3be88d5a-af19-428c-ad13-6ea5a8961395\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"3dd330dc-3e21-4820-9f44-a0e63e1df379","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic733897ee67f/ipConfigurations/primary","etag":"W/\"3be88d5a-af19-428c-ad13-6ea5a8961395\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.6","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-E7-A1","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-7"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic75316ebac3c","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic75316ebac3c","etag":"W/\"364ec5fa-c551-49fb-bdd4-53db078e84d0\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"92ca9f5d-1785-471e-b478-8bcc1b212370","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic75316ebac3c/ipConfigurations/primary","etag":"W/\"364ec5fa-c551-49fb-bdd4-53db078e84d0\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.14","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-E1-22","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-6"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic79561772dfc","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic79561772dfc","etag":"W/\"11543a89-63ce-488b-a6e8-dd4a1ba03ac6\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"a0b9aadf-a813-4096-bceb-028302bb4ec9","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic79561772dfc/ipConfigurations/primary","etag":"W/\"11543a89-63ce-488b-a6e8-dd4a1ba03ac6\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.8","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-E4-D8","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-18"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic8214787b869","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic8214787b869","etag":"W/\"8a532095-69f0-4f28-842c-189b426b468b\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"b9230cef-41b7-4711-bcc6-f255554cd03a","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic8214787b869/ipConfigurations/primary","etag":"W/\"8a532095-69f0-4f28-842c-189b426b468b\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.5","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-E3-74","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-9"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic8338895e30f","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic8338895e30f","etag":"W/\"074a2be9-92b8-4632-bef2-92eeffeeca52\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"e99813e4-dc8f-4159-bbf0-94469d73dbe9","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic8338895e30f/ipConfigurations/primary","etag":"W/\"074a2be9-92b8-4632-bef2-92eeffeeca52\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.7","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-EF-DE","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-2"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic9483581c582","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic9483581c582","etag":"W/\"7c224923-73ba-46e1-85a7-072e619838bc\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"f960ab0f-bf1a-418c-9843-4b6b4d59e252","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic9483581c582/ipConfigurations/primary","etag":"W/\"7c224923-73ba-46e1-85a7-072e619838bc\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.23","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-EA-22","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-11"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic97029453209","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic97029453209","etag":"W/\"9f80dda8-99f3-4bf6-9af0-8a3766f906d3\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"6c9201de-a633-4b19-b958-6c1f55664496","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic97029453209/ipConfigurations/primary","etag":"W/\"9f80dda8-99f3-4bf6-9af0-8a3766f906d3\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.17","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-EF-40","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-1"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"linvmVMNic","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkInterfaces/linvmVMNic","etag":"W/\"2bb35afe-3f6a-42a6-8b03-99c219f6297e\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"f1e957b7-28eb-4c0c-b6e0-2a821b84a8f9","ipConfigurations":[{"name":"ipconfiglinvm","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkInterfaces/linvmVMNic/ipConfigurations/ipconfiglinvm","etag":"W/\"2bb35afe-3f6a-42a6-8b03-99c219f6297e\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/publicIPAddresses/linvmPublicIP"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/virtualNetworks/linvmVNET/subnets/linvmSubnet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkSecurityGroups/linvmNSG"},"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Compute/virtualMachines/linvm"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"winvmVMNic","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkInterfaces/winvmVMNic","etag":"W/\"8ff069ea-8500-4608-88dc-1096099a4a34\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"f156c647-65c7-4abf-a5e4-1c9c648bf472","ipConfigurations":[{"name":"ipconfigwinvm","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkInterfaces/winvmVMNic/ipConfigurations/ipconfigwinvm","etag":"W/\"8ff069ea-8500-4608-88dc-1096099a4a34\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/publicIPAddresses/winvmPublicIP"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/virtualNetworks/linvmVNET/subnets/linvmSubnet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkSecurityGroups/winvmNSG"},"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Compute/virtualMachines/winvm"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"dcos-master-B90D500F-nic-0","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/dcos-master-B90D500F-nic-0","etag":"W/\"b3f97e12-7488-442f-ba73-ac1d5e1da580\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"cb1dbe3d-9ca9-4d90-b5e5-03238980e320","ipConfigurations":[{"name":"ipConfigNode","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/dcos-master-B90D500F-nic-0/ipConfigurations/ipConfigNode","etag":"W/\"b3f97e12-7488-442f-ba73-ac1d5e1da580\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.16.0.5","privateIPAllocationMethod":"Static","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/virtualNetworks/dcos-vnet-B90D500F/subnets/dcos-masterSubnet"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/loadBalancers/dcos-master-lb-B90D500F/backendAddressPools/dcos-master-pool-B90D500F"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/loadBalancers/dcos-master-lb-B90D500F/inboundNatRules/SSH-dcos-master-B90D500F-0"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/loadBalancers/dcos-master-lb-B90D500F/inboundNatRules/SSHPort22-dcos-master-B90D500F-0"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"efocew30decu1ily4yieqpwzzc.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-2F-F3","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/dcos-master-nsg-B90D500F"},"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Compute/virtualMachines/dcos-master-B90D500F-0"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"dcos-master-B90D500F-nic-1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/dcos-master-B90D500F-nic-1","etag":"W/\"50272d42-18bb-4aff-86f4-773ebcc3a0e3\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"35f53971-fe38-4735-8ffe-70982ac06abf","ipConfigurations":[{"name":"ipConfigNode","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/dcos-master-B90D500F-nic-1/ipConfigurations/ipConfigNode","etag":"W/\"50272d42-18bb-4aff-86f4-773ebcc3a0e3\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.16.0.6","privateIPAllocationMethod":"Static","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/virtualNetworks/dcos-vnet-B90D500F/subnets/dcos-masterSubnet"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/loadBalancers/dcos-master-lb-B90D500F/backendAddressPools/dcos-master-pool-B90D500F"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/loadBalancers/dcos-master-lb-B90D500F/inboundNatRules/SSH-dcos-master-B90D500F-1"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"efocew30decu1ily4yieqpwzzc.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-26-BB","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/dcos-master-nsg-B90D500F"},"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Compute/virtualMachines/dcos-master-B90D500F-1"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"dcos-master-B90D500F-nic-2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/dcos-master-B90D500F-nic-2","etag":"W/\"607cf1c6-1474-4dc5-b2db-16d2f65aa5b1\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"c868210e-51a6-4ea1-8645-43181d172ace","ipConfigurations":[{"name":"ipConfigNode","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/dcos-master-B90D500F-nic-2/ipConfigurations/ipConfigNode","etag":"W/\"607cf1c6-1474-4dc5-b2db-16d2f65aa5b1\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.16.0.7","privateIPAllocationMethod":"Static","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/virtualNetworks/dcos-vnet-B90D500F/subnets/dcos-masterSubnet"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/loadBalancers/dcos-master-lb-B90D500F/backendAddressPools/dcos-master-pool-B90D500F"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/loadBalancers/dcos-master-lb-B90D500F/inboundNatRules/SSH-dcos-master-B90D500F-2"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"efocew30decu1ily4yieqpwzzc.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-2E-FF","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/dcos-master-nsg-B90D500F"},"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Compute/virtualMachines/dcos-master-B90D500F-2"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"yugangw-1VMNic","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-1VMNic","etag":"W/\"c5e3578e-49fc-42cd-b5bb-0c7763c28217\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"8d123e5c-d060-428c-af94-50fecfa4c2f0","ipConfigurations":[{"name":"ipconfigyugangw-1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-1VMNic/ipConfigurations/ipconfigyugangw-1","etag":"W/\"c5e3578e-49fc-42cd-b5bb-0c7763c28217\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.1.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-1PublicIP"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/virtualNetworks/yugangw-vnet/subnets/yugangw-subnet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"twx52doja1jezep1dpecbsja0a.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-33-4B-09","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-1NSG"},"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Compute/virtualMachines/yugangw-1"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"yugangw-3VMNic","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-3VMNic","etag":"W/\"a6930746-4d35-447c-829a-a3f5b1b885ef\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"44041eb0-e5c2-4c6f-a8c7-5c28a39ff4d7","ipConfigurations":[{"name":"ipconfigyugangw-3","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-3VMNic/ipConfigurations/ipconfigyugangw-3","etag":"W/\"a6930746-4d35-447c-829a-a3f5b1b885ef\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.16.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-3PublicIP"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/virtualNetworks/dcos-vnet-B90D500F/subnets/dcos-masterSubnet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"efocew30decu1ily4yieqpwzzc.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-31-79-87","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-3NSG"},"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Compute/virtualMachines/yugangw-3"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"yugangw-9VMNic","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-9VMNic","etag":"W/\"26c5aa1e-1893-4aa2-b019-fea27859dc88\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"08d663e4-b6c6-4bc1-a8c2-e987192248a1","ipConfigurations":[{"name":"ipconfigyugangw-9","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-9VMNic/ipConfigurations/ipconfigyugangw-9","etag":"W/\"26c5aa1e-1893-4aa2-b019-fea27859dc88\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.16.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-9PublicIP"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/virtualNetworks/dcos-vnet-B90D500F/subnets/dcos-masterSubnet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"efocew30decu1ily4yieqpwzzc.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-31-3B-85","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-9NSG"},"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Compute/virtualMachines/yugangw-9"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"yugangw-fat1VMNic","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-fat1VMNic","etag":"W/\"54e61f0c-f70c-4472-bf2d-7a9ffb537bd0\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"959f5fa8-b359-4cbf-8ef0-a0ece238dc1c","ipConfigurations":[{"name":"ipconfigyugangw-fat1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-fat1VMNic/ipConfigurations/ipconfigyugangw-fat1","etag":"W/\"54e61f0c-f70c-4472-bf2d-7a9ffb537bd0\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.1.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-fat1PublicIP"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/virtualNetworks/yugangw-vnet/subnets/yugangw-subnet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"macAddress":"00-0D-3A-34-3F-57","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-fat1NSG"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"yugangw-j1VMNic","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-j1VMNic","etag":"W/\"3dc63907-031e-46bf-a56f-cecf80aa946d\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"ba23ba6d-3e7a-44f7-a342-6acbc8044952","ipConfigurations":[{"name":"ipconfigyugangw-j1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-j1VMNic/ipConfigurations/ipconfigyugangw-j1","etag":"W/\"3dc63907-031e-46bf-a56f-cecf80aa946d\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.1.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-j1PublicIP"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/virtualNetworks/yugangw-vnet/subnets/yugangw-subnet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"macAddress":"00-0D-3A-32-7E-55","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-j1NSG"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"yugangw-junkvmVMNic","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-junkvmVMNic","etag":"W/\"cf17b3ad-b448-4464-9b63-c426db232639\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"3f800013-6d84-449f-94cd-b32cc341f187","ipConfigurations":[{"name":"ipconfigyugangw-junkvm","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-junkvmVMNic/ipConfigurations/ipconfigyugangw-junkvm","etag":"W/\"cf17b3ad-b448-4464-9b63-c426db232639\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.1.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-junkvmPublicIP"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/virtualNetworks/yugangw-vnet/subnets/yugangw-subnet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"macAddress":"00-0D-3A-30-F6-1B","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-junkvmNSG"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"yugangw-k1VMNic","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-k1VMNic","etag":"W/\"dbdbfad7-800e-4666-b255-1f48f5cc8994\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"5e4bb34c-bdc5-4987-8f68-e6027a18a30f","ipConfigurations":[{"name":"ipconfigyugangw-k1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-k1VMNic/ipConfigurations/ipconfigyugangw-k1","etag":"W/\"dbdbfad7-800e-4666-b255-1f48f5cc8994\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.1.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-k1PublicIP"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/virtualNetworks/yugangw-vnet/subnets/yugangw-subnet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"macAddress":"00-0D-3A-35-D8-A9","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-k1NSG"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"yugangw-kernelVMNic","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-kernelVMNic","etag":"W/\"8d1d90a9-c16b-4f5b-a629-a020b64d43c1\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"005f6afb-359a-45b8-b500-c6e217fbc26d","ipConfigurations":[{"name":"ipconfigyugangw-kernel","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-kernelVMNic/ipConfigurations/ipconfigyugangw-kernel","etag":"W/\"8d1d90a9-c16b-4f5b-a629-a020b64d43c1\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.1.0.9","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-kernelPublicIP"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/virtualNetworks/yugangw-vnet/subnets/yugangw-subnet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"twx52doja1jezep1dpecbsja0a.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-31-E6-57","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-kernelNSG"},"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Compute/virtualMachines/yugangw-kernel"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"yugangw-portal857","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-portal857","etag":"W/\"32ab6e95-3793-4c8a-85cf-4676a7bb0d8e\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"3308ce27-78a3-4d7a-a79d-5d25e7f043dc","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-portal857/ipConfigurations/ipconfig1","etag":"W/\"32ab6e95-3793-4c8a-85cf-4676a7bb0d8e\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.1.0.10","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-portal-ip"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/virtualNetworks/yugangw-vnet/subnets/yugangw-subnet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"twx52doja1jezep1dpecbsja0a.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-32-CE-5A","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-portal-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Compute/virtualMachines/yugangw-portal"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic805981da395","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMV29c1708752/providers/Microsoft.Network/networkInterfaces/nic805981da395","etag":"W/\"dca5f5cf-b6c4-474d-85bf-7ed92ebb9838\"","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"d89e6634-c07d-4fe8-ba47-bf29eae26d47","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMV29c1708752/providers/Microsoft.Network/networkInterfaces/nic805981da395/ipConfigurations/primary","etag":"W/\"dca5f5cf-b6c4-474d-85bf-7ed92ebb9838\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMV29c1708752/providers/Microsoft.Network/publicIPAddresses/pip95963778"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMV29c1708752/providers/Microsoft.Network/virtualNetworks/vnet63525bf143/subnets/subnet1"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"3x1hjztffnnu3hiwgm223iby1c.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-16-9C-18","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMV29c1708752/providers/Microsoft.Compute/virtualMachines/VM178c1708739"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic45269808de6","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMV8963671476/providers/Microsoft.Network/networkInterfaces/nic45269808de6","etag":"W/\"305676d5-b517-409c-be9e-91cdc557531c\"","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"efe4a08a-a74c-4218-a72c-cdf6f42ea77c","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMV8963671476/providers/Microsoft.Network/networkInterfaces/nic45269808de6/ipConfigurations/primary","etag":"W/\"305676d5-b517-409c-be9e-91cdc557531c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMV8963671476/providers/Microsoft.Network/publicIPAddresses/pip68662aac"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMV8963671476/providers/Microsoft.Network/virtualNetworks/vnet308455accd/subnets/subnet1"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"1sx1penfov4epep0uhxz4czy2c.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-14-C7-4E","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMV8963671476/providers/Microsoft.Compute/virtualMachines/VM1d3a3671463"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic925565cccfd","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMVc857134170/providers/Microsoft.Network/networkInterfaces/nic925565cccfd","etag":"W/\"a459e285-f10f-4350-a695-d6daeeab2e27\"","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"c01c3ba1-0c0c-406a-b377-add9c62c0895","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMVc857134170/providers/Microsoft.Network/networkInterfaces/nic925565cccfd/ipConfigurations/primary","etag":"W/\"a459e285-f10f-4350-a695-d6daeeab2e27\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMVc857134170/providers/Microsoft.Network/publicIPAddresses/pip43883167"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMVc857134170/providers/Microsoft.Network/virtualNetworks/vnet64915f6090/subnets/subnet1"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"konxdqfg111upjswd4kk5mj4lg.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-18-33-74","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMVc857134170/providers/Microsoft.Compute/virtualMachines/VM166e7134158"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic821783025af","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMVe3e3280593/providers/Microsoft.Network/networkInterfaces/nic821783025af","etag":"W/\"027c6ace-f94d-45ba-a5b9-a63d4ab28de4\"","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"73b148dc-ecba-4556-a7a4-dab896a712a6","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMVe3e3280593/providers/Microsoft.Network/networkInterfaces/nic821783025af/ipConfigurations/primary","etag":"W/\"027c6ace-f94d-45ba-a5b9-a63d4ab28de4\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMVe3e3280593/providers/Microsoft.Network/virtualNetworks/vnet822252482e/subnets/subnet1"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"macAddress":"00-0D-3A-15-75-69","enableAcceleratedNetworking":false,"enableIPForwarding":false},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic02223b8537f","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMVef97261861/providers/Microsoft.Network/networkInterfaces/nic02223b8537f","etag":"W/\"6a0d202a-69c4-4f24-813e-7f7cec462825\"","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"4f22e7c1-99df-4ee3-a7cb-ad78fed96809","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMVef97261861/providers/Microsoft.Network/networkInterfaces/nic02223b8537f/ipConfigurations/primary","etag":"W/\"6a0d202a-69c4-4f24-813e-7f7cec462825\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMVef97261861/providers/Microsoft.Network/virtualNetworks/vnet4155548017/subnets/subnet1"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"tlngqfzsdgyujdsvwjud3t1pnc.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-15-E4-15","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMVef97261861/providers/Microsoft.Compute/virtualMachines/wVM07c7261818"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic12ca12786339c8c","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Network/networkInterfaces/nic12ca12786339c8c","etag":"W/\"7dc70912-e151-491a-8626-b854da7488f4\"","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"29dc2377-fb33-4012-94da-e0b153e4d228","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Network/networkInterfaces/nic12ca12786339c8c/ipConfigurations/primary","etag":"W/\"7dc70912-e151-491a-8626-b854da7488f4\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.16.1.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Network/virtualNetworks/vnetb5a61654eea736/subnets/Front-end"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Network/loadBalancers/intlb1-b5756104d/backendAddressPools/intlb1-b5756104d-BAP1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Network/loadBalancers/intlb1-b5756104d/backendAddressPools/intlb1-b5756104d-BAP2"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Network/loadBalancers/intlb1-b5756104d/inboundNatRules/nat5000to22forVM1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Network/loadBalancers/intlb1-b5756104d/inboundNatRules/nat5001to23forVM1"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"3rbsiikfqtkulehoo3xdq4kj0d.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-19-57-49","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Compute/virtualMachines/lvm1a1b0334299c1d7"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic289174924e3ef1a","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Network/networkInterfaces/nic289174924e3ef1a","etag":"W/\"177605ac-c34e-442d-9f26-0f7937718842\"","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"f1079e50-3203-41b4-ad90-0f314b27f647","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Network/networkInterfaces/nic289174924e3ef1a/ipConfigurations/primary","etag":"W/\"177605ac-c34e-442d-9f26-0f7937718842\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.16.1.5","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Network/virtualNetworks/vnetb5a61654eea736/subnets/Front-end"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Network/loadBalancers/intlb1-b5756104d/backendAddressPools/intlb1-b5756104d-BAP1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Network/loadBalancers/intlb1-b5756104d/backendAddressPools/intlb1-b5756104d-BAP2"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Network/loadBalancers/intlb1-b5756104d/inboundNatRules/nat5002to22forVM2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Network/loadBalancers/intlb1-b5756104d/inboundNatRules/nat5003to23forVM2"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"3rbsiikfqtkulehoo3xdq4kj0d.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-19-57-B2","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Compute/virtualMachines/lvm24c966729877280"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic142986528ce1315","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/networkInterfaces/nic142986528ce1315","etag":"W/\"47f20159-b8f1-47d3-9f5d-719aa8cff18a\"","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"d639f702-1fed-4da5-9678-7167121c588f","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/networkInterfaces/nic142986528ce1315/ipConfigurations/primary","etag":"W/\"47f20159-b8f1-47d3-9f5d-719aa8cff18a\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.16.1.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/publicIPAddresses/pip7748c9a6"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/virtualNetworks/vnet7f086527859abf/subnets/Front-end"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ase355m2vjnuvbg20qdt3tbq4a.bx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":true,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/networkSecurityGroups/fensg3fa8652774b03"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic951517fadc0","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv_f442667004ba/providers/Microsoft.Network/networkInterfaces/nic951517fadc0","etag":"W/\"cb100564-bc26-40f3-ab3e-9941e7af5d4b\"","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"f601dab8-23be-47e1-99ae-71535ebf3872","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv_f442667004ba/providers/Microsoft.Network/networkInterfaces/nic951517fadc0/ipConfigurations/primary","etag":"W/\"cb100564-bc26-40f3-ab3e-9941e7af5d4b\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv_f442667004ba/providers/Microsoft.Network/publicIPAddresses/pip34643db7"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv_f442667004ba/providers/Microsoft.Network/virtualNetworks/vnet884626d0e9/subnets/subnet1"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"vke4trr01qkupe1ljnni1ggdie.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-18-1D-ED","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv_f442667004ba/providers/Microsoft.Compute/virtualMachines/employeesvm-720959"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nicjavavm5a1330061","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmexttest32530/providers/Microsoft.Network/networkInterfaces/nicjavavm5a1330061","etag":"W/\"8c2ced02-dacc-489e-9661-1ebe1ff108f0\"","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"e2b4cdc0-8361-4144-99bc-80fcc8e0fce1","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmexttest32530/providers/Microsoft.Network/networkInterfaces/nicjavavm5a1330061/ipConfigurations/primary","etag":"W/\"8c2ced02-dacc-489e-9661-1ebe1ff108f0\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmexttest32530/providers/Microsoft.Network/virtualNetworks/vnet395084dbaa/subnets/subnet1"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"zdd1o3hyanee1cp0uq1t1fpusd.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-17-48-56","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmexttest32530/providers/Microsoft.Compute/virtualMachines/javavm"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nicjavavma8d43895c","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg57927/providers/Microsoft.Network/networkInterfaces/nicjavavma8d43895c","etag":"W/\"f22008c7-f1e9-4f8d-88d7-349dc858d392\"","location":"southcentralus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"b1e1f2a4-4d7b-421b-9944-4bff611dfffc","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg57927/providers/Microsoft.Network/networkInterfaces/nicjavavma8d43895c/ipConfigurations/primary","etag":"W/\"f22008c7-f1e9-4f8d-88d7-349dc858d392\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg57927/providers/Microsoft.Network/virtualNetworks/vnet597907e53e/subnets/subnet1"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"itwk5wrj2h0urk0050tnehvaxf.jx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false},"type":"Microsoft.Network/networkInterfaces"}]}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Length: ['3155']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 28 Sep 2016 19:57:21 GMT']
+      Date: ['Mon, 23 Jan 2017 17:57:02 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
-      x-ms-original-request-ids: [ce590f17-c0bc-4d74-a2c5-1374d2853b9e, a94a3d70-8c08-4812-9895-ccd6f4d0f495,
-        83a5a38d-f745-4d7a-91f9-618c66990b0c]
+      content-length: ['76514']
+      x-ms-original-request-ids: [74220ecb-c896-46d0-bac9-21574f3e58c1, 1c072ac7-9a03-40a4-8ebe-094209471cec,
+        f8be7a84-2a06-43ce-9d0e-4de06aed3075]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -171,31 +59,48 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 resourcemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b7]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          resourcemanagementclient/0.30.2 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c589aefa-85b5-11e6-9bcf-a0b3ccf7272a]
+      x-ms-client-request-id: [58def654-e195-11e6-9b78-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?$filter=resourceGroup%20eq%20%27cliTestRg_VmListIpAddresses%27%20and%20name%20eq%20%27vm-with-public-ip%27%20and%20resourceType%20eq%20%27Microsoft.Compute%2FvirtualMachines%27&api-version=2016-09-01
+  response:
+    body: {string: '{"value":[]}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 17:57:04 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['12']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          resourcemanagementclient/0.30.2 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [593282f4-e195-11e6-812f-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses?api-version=2016-09-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXenZfEmb9pXF7//Ty6eF017tjqezahNkzcfjT5aZouc+tncqKymGRCghlfUao3PVnW1
-        yuu2oAaPfjH+uiwaalIsL163WQuYr9fTaZ7P8tlHv+SX/D/OsNKWzwAAAA==
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses","name":"cliTestRg_VmListIpAddresses","location":"westus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Length: ['271']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 28 Sep 2016 19:57:23 GMT']
+      Date: ['Mon, 23 Jan 2017 17:57:03 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
+      content-length: ['244']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -204,29 +109,27 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 storagemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b7]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          storagemanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c595e9c0-85b5-11e6-994b-a0b3ccf7272a]
+      x-ms-client-request-id: [59608eb6-e195-11e6-adfc-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Storage/storageAccounts?api-version=2016-01-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS97/+S5P8BxWZBqg0AAAA=
+    body: {string: '{"value":[]}
+
+        '}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Wed, 28 Sep 2016 19:57:22 GMT']
+      Date: ['Mon, 23 Jan 2017 17:57:04 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
+      content-length: ['13']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -235,31 +138,23 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 resourcemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b7]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          resourcemanagementclient/0.30.2 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c5b795e6-85b5-11e6-80d6-a0b3ccf7272a]
+      x-ms-client-request-id: [598cfd50-e195-11e6-91ec-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses?api-version=2016-09-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXenZfEmb9pXF7//Ty6eF017tjqezahNkzcfjT5aZouc+tncqKymGRCghlfUao3PVnW1
-        yuu2oAaPfjH+uiwaalIsL163WQuYr9fTaZ7P8tlHv+SX/D/OsNKWzwAAAA==
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses","name":"cliTestRg_VmListIpAddresses","location":"westus","tags":{"use":"az-test"},"properties":{"provisioningState":"Succeeded"}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Length: ['271']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 28 Sep 2016 19:57:22 GMT']
+      Date: ['Mon, 23 Jan 2017 17:57:04 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
+      content-length: ['244']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -268,111 +163,65 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b7]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c5c77738-85b5-11e6-b3e7-a0b3ccf7272a]
+      x-ms-client-request-id: [59b7d136-e195-11e6-86a7-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/virtualNetworks?api-version=2016-09-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS97/+S/wdC6kBEDAAAAA==
+    body: {string: '{"value":[]}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Length: ['133']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 28 Sep 2016 19:57:22 GMT']
+      Date: ['Mon, 23 Jan 2017 17:57:04 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
+      content-length: ['12']
     status: {code: 200, message: OK}
 - request:
-    body: null
+    body: '{"properties": {"parameters": {"publicIpAddressAllocation": {"value": "dynamic"},
+      "dnsNameType": {"value": "none"}, "networkInterfaceType": {"value": "new"},
+      "storageAccount": {"value": "vhd14851942256089"}, "osPublisher": {"value": "Canonical"},
+      "size": {"value": "Standard_DS1"}, "name": {"value": "vm-with-public-ip"}, "storageSuffix":
+      {"value": "core.windows.net"}, "storageContainerName": {"value": "vhds"}, "storageCaching":
+      {"value": "ReadWrite"}, "location": {"value": "westus"}, "_artifactsLocation":
+      {"value": "https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2017-1-5"},
+      "osSKU": {"value": "14.04.4-LTS"}, "customOsDiskType": {"value": "windows"},
+      "osDiskName": {"value": "osdisk14851942262269"}, "networkSecurityGroupRule":
+      {"value": "SSH"}, "adminUsername": {"value": "ubuntu"}, "osDiskType": {"value":
+      "provided"}, "virtualNetworkIpAddressPrefix": {"value": "10.0.0.0/16"}, "osType":
+      {"value": "Custom"}, "osVersion": {"value": "latest"}, "authenticationType":
+      {"value": "password"}, "storageType": {"value": "Premium_LRS"}, "subnetIpAddressPrefix":
+      {"value": "10.0.0.0/24"}, "privateIpAddressAllocation": {"value": "dynamic"},
+      "adminPassword": {"value": "testPassword0"}, "osOffer": {"value": "UbuntuServer"}},
+      "mode": "Incremental", "templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2017-1-5/azuredeploy.json"}}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
+      Content-Length: ['1380']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 resourcemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b7]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c5dbb364-85b5-11e6-a61b-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resources?$filter=resourceGroup%20eq%20%27cliTestRg_VmListIpAddresses%27%20and%20name%20eq%20%27vm-with-public-ip%27%20and%20resourceType%20eq%20%27Microsoft.Compute%2FvirtualMachines%27&api-version=2016-09-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS97/+S/wdC6kBEDAAAAA==
-    headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Length: ['133']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 28 Sep 2016 19:57:23 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJwcm9wZXJ0aWVzIjogeyJ0ZW1wbGF0ZUxpbmsiOiB7InVyaSI6ICJodHRwczovL2F6dXJlc2Rr
-      Y2kuYmxvYi5jb3JlLndpbmRvd3MubmV0L3RlbXBsYXRlaG9zdC9DcmVhdGVWbV8yMDE2LTA3LTE5
-      L2F6dXJlZGVwbG95Lmpzb24ifSwgInBhcmFtZXRlcnMiOiB7Il9hcnRpZmFjdHNMb2NhdGlvbiI6
-      IHsidmFsdWUiOiAiaHR0cHM6Ly9henVyZXNka2NpLmJsb2IuY29yZS53aW5kb3dzLm5ldC90ZW1w
-      bGF0ZWhvc3QvQ3JlYXRlVm1fMjAxNi0wNy0xOSJ9LCAicHJpdmF0ZUlwQWRkcmVzc0FsbG9jYXRp
-      b24iOiB7InZhbHVlIjogImR5bmFtaWMifSwgIm5ldHdvcmtTZWN1cml0eUdyb3VwUnVsZSI6IHsi
-      dmFsdWUiOiAiU1NIIn0sICJvc1B1Ymxpc2hlciI6IHsidmFsdWUiOiAiQ2Fub25pY2FsIn0sICJv
-      c09mZmVyIjogeyJ2YWx1ZSI6ICJVYnVudHVTZXJ2ZXIifSwgImRuc05hbWVUeXBlIjogeyJ2YWx1
-      ZSI6ICJub25lIn0sICJ2aXJ0dWFsTmV0d29ya0lwQWRkcmVzc1ByZWZpeCI6IHsidmFsdWUiOiAi
-      MTAuMC4wLjAvMTYifSwgIm5ldHdvcmtJbnRlcmZhY2VUeXBlIjogeyJ2YWx1ZSI6ICJuZXcifSwg
-      Im9zU0tVIjogeyJ2YWx1ZSI6ICIxNC4wNC40LUxUUyJ9LCAic3RvcmFnZUFjY291bnQiOiB7InZh
-      bHVlIjogInZoZDE0NzUwOTI2NDMwNjUifSwgIm9zVHlwZSI6IHsidmFsdWUiOiAiQ3VzdG9tIn0s
-      ICJzdG9yYWdlVHlwZSI6IHsidmFsdWUiOiAiUHJlbWl1bV9MUlMifSwgImN1c3RvbU9zRGlza1R5
-      cGUiOiB7InZhbHVlIjogIndpbmRvd3MifSwgInNpemUiOiB7InZhbHVlIjogIlN0YW5kYXJkX0RT
-      MSJ9LCAiYWRtaW5QYXNzd29yZCI6IHsidmFsdWUiOiAidGVzdFBhc3N3b3JkMCJ9LCAic3VibmV0
-      SXBBZGRyZXNzUHJlZml4IjogeyJ2YWx1ZSI6ICIxMC4wLjAuMC8yNCJ9LCAibmFtZSI6IHsidmFs
-      dWUiOiAidm0td2l0aC1wdWJsaWMtaXAifSwgImxvY2F0aW9uIjogeyJ2YWx1ZSI6ICJ3ZXN0dXMi
-      fSwgInN0b3JhZ2VDb250YWluZXJOYW1lIjogeyJ2YWx1ZSI6ICJ2aGRzIn0sICJhZG1pblVzZXJu
-      YW1lIjogeyJ2YWx1ZSI6ICJ1YnVudHUifSwgInB1YmxpY0lwQWRkcmVzc0FsbG9jYXRpb24iOiB7
-      InZhbHVlIjogImR5bmFtaWMifSwgIm9zRGlza1R5cGUiOiB7InZhbHVlIjogInByb3ZpZGVkIn0s
-      ICJzdG9yYWdlQ2FjaGluZyI6IHsidmFsdWUiOiAiUmVhZFdyaXRlIn0sICJvc1ZlcnNpb24iOiB7
-      InZhbHVlIjogImxhdGVzdCJ9LCAiYXV0aGVudGljYXRpb25UeXBlIjogeyJ2YWx1ZSI6ICJwYXNz
-      d29yZCJ9LCAib3NEaXNrTmFtZSI6IHsidmFsdWUiOiAib3NkaXNrMTQ3NTA5MjY0NDY3NjIifX0s
-      ICJtb2RlIjogIkluY3JlbWVudGFsIn19
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['1335']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
-      accept-language: [en-US]
-      x-ms-client-request-id: [c5f16e98-85b5-11e6-af89-a0b3ccf7272a]
+      x-ms-client-request-id: [59f42076-e195-11e6-9a4c-64510658e3b3]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/azurecli-test-deployment-vm-list-ips","name":"azurecli-test-deployment-vm-list-ips","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-07-19/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2016-07-19"},"adminPassword":{"type":"SecureString"},"adminUsername":{"type":"String","value":"ubuntu"},"authenticationType":{"type":"String","value":"password"},"availabilitySet":{"type":"String","value":""},"availabilitySetType":{"type":"String","value":"none"},"customOsDiskType":{"type":"String","value":"windows"},"customOsDiskUri":{"type":"String","value":""},"dnsNameForPublicIP":{"type":"String","value":""},"dnsNameType":{"type":"String","value":"none"},"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"vm-with-public-ip"},"networkInterfaceIds":{"type":"Array","value":[{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/networkInterfaces/vm-with-public-ipVMNic"}]},"networkInterfaceType":{"type":"String","value":"new"},"networkSecurityGroup":{"type":"String","value":"vm-with-public-ipNSG"},"networkSecurityGroupRule":{"type":"String","value":"SSH"},"networkSecurityGroupType":{"type":"String","value":"new"},"osDiskName":{"type":"String","value":"osdisk14750926446762"},"osDiskType":{"type":"String","value":"provided"},"osDiskUri":{"type":"String","value":"https://vhd1475092643065.blob.core.windows.net/vhds/osdisk14750926446762.vhd"},"osOffer":{"type":"String","value":"UbuntuServer"},"osPublisher":{"type":"String","value":"Canonical"},"osSKU":{"type":"String","value":"14.04.4-LTS"},"osType":{"type":"String","value":"Custom"},"osVersion":{"type":"String","value":"latest"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddress":{"type":"String","value":"vm-with-public-ipPublicIP"},"publicIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddressType":{"type":"String","value":"new"},"size":{"type":"String","value":"Standard_DS1"},"sshDestKeyPath":{"type":"String","value":"/home/ubuntu/.ssh/authorized_keys"},"sshKeyValue":{"type":"String","value":""},"storageAccount":{"type":"String","value":"vhd1475092643065"},"storageAccountType":{"type":"String","value":"new"},"storageCaching":{"type":"String","value":"ReadWrite"},"storageContainerName":{"type":"String","value":"vhds"},"storageType":{"type":"String","value":"Premium_LRS"},"subnetIpAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetName":{"type":"String","value":"vm-with-public-ipSubnet"},"tags":{"type":"Object","value":{}},"virtualNetwork":{"type":"String","value":"vm-with-public-ipVNET"},"virtualNetworkIpAddressPrefix":{"type":"String","value":"10.0.0.0/16"},"virtualNetworkType":{"type":"String","value":"new"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-09-28T19:57:24.8600868Z","duration":"PT0.2055912S","correlationId":"b87c44de-c65f-4776-9e6f-b9af32f43a64","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipVNet","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipVNet"},{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipNSG","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipNSG"}],"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipNicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipNicIp"},{"dependsOn":[{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-iprcc5nrkgyxcse","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-iprcc5nrkgyxcse"},{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipNicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipNicIp"}],"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipVM"},{"dependsOn":[{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipVM"}],"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-iph2hph5unfy62ynew","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-iph2hph5unfy62ynew"},{"dependsOn":[{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipVM"}],"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-iph2hph5unfy62ynewfqdn","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-iph2hph5unfy62ynewfqdn"},{"dependsOn":[{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipVM"}],"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipvm-with-public-ipVMNicmac","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipvm-with-public-ipVMNicmac"}]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/azurecli-test-deployment-vm-list-ips","name":"azurecli-test-deployment-vm-list-ips","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2017-1-5/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2017-1-5"},"adminPassword":{"type":"SecureString"},"adminUsername":{"type":"String","value":"ubuntu"},"authenticationType":{"type":"String","value":"password"},"availabilitySet":{"type":"String","value":""},"availabilitySetType":{"type":"String","value":"none"},"customOsDiskType":{"type":"String","value":"windows"},"customOsDiskUri":{"type":"String","value":""},"dnsNameForPublicIP":{"type":"String","value":""},"dnsNameType":{"type":"String","value":"none"},"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"vm-with-public-ip"},"networkSecurityGroup":{"type":"String","value":"vm-with-public-ipNSG"},"networkSecurityGroupRule":{"type":"String","value":"SSH"},"networkSecurityGroupType":{"type":"String","value":"new"},"networkInterfaceIds":{"type":"Array","value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/networkInterfaces/vm-with-public-ipVMNic"}]},"networkInterfaceType":{"type":"String","value":"new"},"osDiskName":{"type":"String","value":"osdisk14851942262269"},"osDiskType":{"type":"String","value":"provided"},"osDiskUri":{"type":"String","value":"https://vhd14851942256089.blob.core.windows.net/vhds/osdisk14851942262269.vhd"},"osOffer":{"type":"String","value":"UbuntuServer"},"osPublisher":{"type":"String","value":"Canonical"},"osSKU":{"type":"String","value":"14.04.4-LTS"},"osType":{"type":"String","value":"Custom"},"osVersion":{"type":"String","value":"latest"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddress":{"type":"String","value":"vm-with-public-ipPublicIP"},"publicIpAddressType":{"type":"String","value":"new"},"size":{"type":"String","value":"Standard_DS1"},"sshDestKeyPath":{"type":"String","value":"/home/ubuntu/.ssh/authorized_keys"},"sshKeyValue":{"type":"String","value":""},"storageAccount":{"type":"String","value":"vhd14851942256089"},"storageAccountType":{"type":"String","value":"new"},"storageCaching":{"type":"String","value":"ReadWrite"},"storageContainerName":{"type":"String","value":"vhds"},"storageSuffix":{"type":"String","value":"core.windows.net"},"storageType":{"type":"String","value":"Premium_LRS"},"subnetIpAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetName":{"type":"String","value":"vm-with-public-ipSubnet"},"tags":{"type":"Object","value":{}},"virtualNetworkIpAddressPrefix":{"type":"String","value":"10.0.0.0/16"},"virtualNetwork":{"type":"String","value":"vm-with-public-ipVNET"},"virtualNetworkType":{"type":"String","value":"new"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-01-23T17:57:07.5582194Z","duration":"PT0.668393S","correlationId":"840bc14d-3a5e-4436-81e9-5a733bfec2f0","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipVNet","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipVNet"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipNSG","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipNSG"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipNicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipNicIp"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipenfs235r2ibu2","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipenfs235r2ibu2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipNicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipNicIp"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipVM"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipVM"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-iph2hph5unfy62ynew","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-iph2hph5unfy62ynew"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipVM"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-iph2hph5unfy62ynewfqdn","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-iph2hph5unfy62ynewfqdn"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipVM"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipvm-with-public-ipVMNicmac","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipvm-with-public-ipVMNicmac"}]}}'}
     headers:
-      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/azurecli-test-deployment-vm-list-ips/operationStatuses/08587265142408231944?api-version=2015-11-01']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/azurecli-test-deployment-vm-list-ips/operationStatuses/08587164126585879091?api-version=2015-11-01']
       Cache-Control: [no-cache]
-      Content-Length: ['6676']
+      Content-Length: ['6818']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 28 Sep 2016 19:57:24 GMT']
+      Date: ['Mon, 23 Jan 2017 17:57:07 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1191']
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -381,28 +230,23 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c5f16e98-85b5-11e6-af89-a0b3ccf7272a]
+      x-ms-client-request-id: [59f42076-e195-11e6-9a4c-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587265142408231944?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587164126585879091?api-version=2015-11-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
+    body: {string: '{"status":"Running"}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Length: ['140']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 28 Sep 2016 19:57:55 GMT']
+      Date: ['Mon, 23 Jan 2017 17:57:13 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
+      content-length: ['20']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -411,28 +255,23 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c5f16e98-85b5-11e6-af89-a0b3ccf7272a]
+      x-ms-client-request-id: [59f42076-e195-11e6-9a4c-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587265142408231944?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587164126585879091?api-version=2015-11-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
+    body: {string: '{"status":"Running"}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Length: ['140']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 28 Sep 2016 19:58:25 GMT']
+      Date: ['Mon, 23 Jan 2017 17:57:17 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
+      content-length: ['20']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -441,28 +280,23 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c5f16e98-85b5-11e6-af89-a0b3ccf7272a]
+      x-ms-client-request-id: [59f42076-e195-11e6-9a4c-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587265142408231944?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587164126585879091?api-version=2015-11-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
+    body: {string: '{"status":"Running"}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Length: ['140']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 28 Sep 2016 19:58:54 GMT']
+      Date: ['Mon, 23 Jan 2017 17:57:23 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
+      content-length: ['20']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -471,28 +305,23 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c5f16e98-85b5-11e6-af89-a0b3ccf7272a]
+      x-ms-client-request-id: [59f42076-e195-11e6-9a4c-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587265142408231944?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587164126585879091?api-version=2015-11-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
+    body: {string: '{"status":"Running"}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Length: ['140']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 28 Sep 2016 19:59:25 GMT']
+      Date: ['Mon, 23 Jan 2017 17:57:29 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
+      content-length: ['20']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -501,28 +330,23 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c5f16e98-85b5-11e6-af89-a0b3ccf7272a]
+      x-ms-client-request-id: [59f42076-e195-11e6-9a4c-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587265142408231944?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587164126585879091?api-version=2015-11-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvVovl8Xy4qNf8v8Aicy9SRQAAAA=
+    body: {string: '{"status":"Running"}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Length: ['140']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 28 Sep 2016 19:59:56 GMT']
+      Date: ['Mon, 23 Jan 2017 17:57:34 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
+      content-length: ['20']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -531,28 +355,23 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c5f16e98-85b5-11e6-af89-a0b3ccf7272a]
+      x-ms-client-request-id: [59f42076-e195-11e6-9a4c-64510658e3b3]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587265142408231944?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587164126585879091?api-version=2015-11-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
+    body: {string: '{"status":"Running"}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Length: ['141']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 28 Sep 2016 20:00:26 GMT']
+      Date: ['Mon, 23 Jan 2017 17:57:39 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
+      content-length: ['20']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -561,55 +380,623 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b7]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c5f16e98-85b5-11e6-af89-a0b3ccf7272a]
+      x-ms-client-request-id: [59f42076-e195-11e6-9a4c-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587164126585879091?api-version=2015-11-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 17:57:45 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [59f42076-e195-11e6-9a4c-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587164126585879091?api-version=2015-11-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 17:57:50 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [59f42076-e195-11e6-9a4c-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587164126585879091?api-version=2015-11-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 17:57:55 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [59f42076-e195-11e6-9a4c-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587164126585879091?api-version=2015-11-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 17:58:00 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [59f42076-e195-11e6-9a4c-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587164126585879091?api-version=2015-11-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 17:58:06 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [59f42076-e195-11e6-9a4c-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587164126585879091?api-version=2015-11-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 17:58:11 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [59f42076-e195-11e6-9a4c-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587164126585879091?api-version=2015-11-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 17:58:16 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [59f42076-e195-11e6-9a4c-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587164126585879091?api-version=2015-11-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 17:58:21 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [59f42076-e195-11e6-9a4c-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587164126585879091?api-version=2015-11-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 17:58:26 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [59f42076-e195-11e6-9a4c-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587164126585879091?api-version=2015-11-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 17:58:32 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [59f42076-e195-11e6-9a4c-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587164126585879091?api-version=2015-11-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 17:58:37 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [59f42076-e195-11e6-9a4c-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587164126585879091?api-version=2015-11-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 17:58:43 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [59f42076-e195-11e6-9a4c-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587164126585879091?api-version=2015-11-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 17:58:49 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [59f42076-e195-11e6-9a4c-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587164126585879091?api-version=2015-11-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 17:58:54 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [59f42076-e195-11e6-9a4c-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587164126585879091?api-version=2015-11-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 17:58:59 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [59f42076-e195-11e6-9a4c-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587164126585879091?api-version=2015-11-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 17:59:04 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [59f42076-e195-11e6-9a4c-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587164126585879091?api-version=2015-11-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 17:59:10 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [59f42076-e195-11e6-9a4c-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587164126585879091?api-version=2015-11-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 17:59:15 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [59f42076-e195-11e6-9a4c-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587164126585879091?api-version=2015-11-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 17:59:20 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [59f42076-e195-11e6-9a4c-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587164126585879091?api-version=2015-11-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 17:59:26 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [59f42076-e195-11e6-9a4c-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587164126585879091?api-version=2015-11-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 17:59:31 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [59f42076-e195-11e6-9a4c-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587164126585879091?api-version=2015-11-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 17:59:36 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [59f42076-e195-11e6-9a4c-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587164126585879091?api-version=2015-11-01
+  response:
+    body: {string: '{"status":"Running"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 17:59:42 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['20']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [59f42076-e195-11e6-9a4c-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587164126585879091?api-version=2015-11-01
+  response:
+    body: {string: '{"status":"Succeeded"}'}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 17:59:48 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['22']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          vmcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [59f42076-e195-11e6-9a4c-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXenZfEmb9pXF7//Ty6eF017tjqezahNkzd3V3V1Wczyurn7RTGtq6Y6b8ev9PXm7ixf
-        ldX1Il+2zd3sB+s6J1DbLcHadt9sXy62S4K6Xayaj0YfLbNFTmjfsjV1v8rrtsibjx794o/afLEq
-        szZ/Xizf4u91XRCoeduumkd3BYFm9nZajCdlNRlPqzofXxXLWXXVjJd5e9e8Pq+a9u5JndOvP7n4
-        /fd2dj/d3nmwvftQIAgu459uqiUhMK2WLaH1k0QBoi/1tjvewX8f/RJCLqtpMC19BWR+/4zwPM+m
-        bfO8mmaYDXzaXq8w3NdtXSwvCN5lVq7xwTeGNBDJZoti+TJrmquqJp5wveZTgq59m3ZfNXktk+Da
-        SQuH3XqyXrZrfmXdzmn8hYzoDbcffm9lcMCbl1lRZpOiLNrr13m76bVI85t6WlbLHK9N101bLb5s
-        nhbN25veUbJ2X/sKXDT8FprPls2LbJE/q+qX60lZTM9e3vKNm1AywyhvwTJXJClrxv6m6SMZuira
-        +faKkSVR4pfylqbm7Rnxc01smp/NmG0VxnFdZ9cOxPd+7rTLC8Hzbhff5m5vWD/5xYti+tEv+X5k
-        dDcSPr/yiMKCQozHKG96rYfCi9efD8F5tS7plWFYr19/e+jVW2JfMf+CzzY1rpoZtdrdf3B/5+He
-        p/v7nz74dM+9fVNXOkUs0vLGDfJiNNvlfGb7vLfz6f0B/UbNmrsxFMf0jXT65fl5Xm/q8itWV6/z
-        +pLa8Sssps2c/tzw2klG4kearZR3Xv9eX21qvbs/3tkf728/f/Na2t9EuRPWMdLW2o/h5lDyTYvm
-        q7q4pD+soGx6K9b+uLyNOpldkxqB+BAAUGtq39/0Vk8AmNJQiH04H4rHTQRWKWiKH9Bfw81et9ly
-        ltWz3//p611u38yfEqV/r/z6ZdbON715d14t8rtiDO+O6b27MIdVTR3Ofv+3+TUrY/qYQP2kvDIM
-        i5u2VZ1d5MfTaUUgN7Um3rfSAOHpv31b4shLJ9l0ju83vPAqz2bfJQ3E9si8Rt5PVizz+iYdQ/gK
-        MeS9m5B7WeeLYr34/Z+/YlkiI0OqwM47fXtevNv0/i55YPjv7t6+e/9GHLus+5pfA4A2u/C5/svJ
-        T+fT1r36i38Jtbks6nadlWqe6EPT+vWNHf3ki9M36CYE8XXGu/tpH85NxGZOoLcW1Qx/ni2nRH3y
-        6UjvkchBvUM10TskKDT7BGE9nebkB8/o+7ZYkKxkC7KKH4nT+XB77+DN7sNH9+l/n47vPdi/v7f/
-        8Keo6Wxdq7B/9PLN3hf3dscP9nZ29h7ee01fkt6vc1Jx9P0ZHIvJwYPp/v4s355+ev98e//Bg0+3
-        H+afnm9PHmbn9/bO9+9ln+7Ta4weHAR2SUhR5M2KrDsBcA6DDUeoPZGTfwdN5B3/E3pNvHsMH82N
-        fkLT5bosv0++xPdpJPkqX87y5ZTjDgIiHzRf0tjor58rz8gONIi7ItxGTB2SgvC9AYz3gshRjIsJ
-        7i8Z/b9+/HDJ3Gi+seEDLJjj/+2jhwH1hvPNjZ8BY/7pvf/vSEM9nd5f1m8vrt9Nm9wb5jdGl7AD
-        0Of/5RSRiXQD+8YoIYD/PyAjP/mFN5pvbPgEFbNPL/1/RzoIZzewb5QS/+/ngvnefDW/v16eX3+6
-        dw0nyQ3sG6NEr48fcYiB+v9BDjn/RTPkhAkwv/2NUSPaz484xUD9/wCn9D7g1OQim3oj/MZI0vvA
-        dgZKVet2tSY4FBGCaMNx4d0fPjVPqgXhlt/VAPYLzkpQ296IiPu72aBNQ9m7N374cHx/b/zgHt5k
-        +dnQHG26SbNN7TX85lwDkfkWb+zsbO883b53vH3v3vanJ9sPTzkCl6mx0+6E+utRqPcyBWhICLxH
-        6vxGGEFaOgKHo6JhKNLu7KWSLIaJl0AcBKPU0D8jQDTD0gPwWvJRdzUvpbkzAtDLr33/l/yS/wfK
-        Px2DUh0AAA==
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/azurecli-test-deployment-vm-list-ips","name":"azurecli-test-deployment-vm-list-ips","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2017-1-5/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"_artifactsLocation":{"type":"String","value":"https://azuresdkci.blob.core.windows.net/templatehost/CreateVm_2017-1-5"},"adminPassword":{"type":"SecureString"},"adminUsername":{"type":"String","value":"ubuntu"},"authenticationType":{"type":"String","value":"password"},"availabilitySet":{"type":"String","value":""},"availabilitySetType":{"type":"String","value":"none"},"customOsDiskType":{"type":"String","value":"windows"},"customOsDiskUri":{"type":"String","value":""},"dnsNameForPublicIP":{"type":"String","value":""},"dnsNameType":{"type":"String","value":"none"},"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"vm-with-public-ip"},"networkSecurityGroup":{"type":"String","value":"vm-with-public-ipNSG"},"networkSecurityGroupRule":{"type":"String","value":"SSH"},"networkSecurityGroupType":{"type":"String","value":"new"},"networkInterfaceIds":{"type":"Array","value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/networkInterfaces/vm-with-public-ipVMNic"}]},"networkInterfaceType":{"type":"String","value":"new"},"osDiskName":{"type":"String","value":"osdisk14851942262269"},"osDiskType":{"type":"String","value":"provided"},"osDiskUri":{"type":"String","value":"https://vhd14851942256089.blob.core.windows.net/vhds/osdisk14851942262269.vhd"},"osOffer":{"type":"String","value":"UbuntuServer"},"osPublisher":{"type":"String","value":"Canonical"},"osSKU":{"type":"String","value":"14.04.4-LTS"},"osType":{"type":"String","value":"Custom"},"osVersion":{"type":"String","value":"latest"},"privateIpAddress":{"type":"String","value":""},"privateIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddressAllocation":{"type":"String","value":"dynamic"},"publicIpAddress":{"type":"String","value":"vm-with-public-ipPublicIP"},"publicIpAddressType":{"type":"String","value":"new"},"size":{"type":"String","value":"Standard_DS1"},"sshDestKeyPath":{"type":"String","value":"/home/ubuntu/.ssh/authorized_keys"},"sshKeyValue":{"type":"String","value":""},"storageAccount":{"type":"String","value":"vhd14851942256089"},"storageAccountType":{"type":"String","value":"new"},"storageCaching":{"type":"String","value":"ReadWrite"},"storageContainerName":{"type":"String","value":"vhds"},"storageSuffix":{"type":"String","value":"core.windows.net"},"storageType":{"type":"String","value":"Premium_LRS"},"subnetIpAddressPrefix":{"type":"String","value":"10.0.0.0/24"},"subnetName":{"type":"String","value":"vm-with-public-ipSubnet"},"tags":{"type":"Object","value":{}},"virtualNetworkIpAddressPrefix":{"type":"String","value":"10.0.0.0/16"},"virtualNetwork":{"type":"String","value":"vm-with-public-ipVNET"},"virtualNetworkType":{"type":"String","value":"new"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-01-23T17:59:42.5854303Z","duration":"PT2M35.6956039S","correlationId":"840bc14d-3a5e-4436-81e9-5a733bfec2f0","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipVNet","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipVNet"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipNSG","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipNSG"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipNicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipNicIp"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipenfs235r2ibu2","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipenfs235r2ibu2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipNicIp","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipNicIp"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipVM"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipVM"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-iph2hph5unfy62ynew","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-iph2hph5unfy62ynew"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipVM"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-iph2hph5unfy62ynewfqdn","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-iph2hph5unfy62ynewfqdn"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipVM","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipVM"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Resources/deployments/vm-with-public-ipvm-with-public-ipVMNicmac","resourceType":"Microsoft.Resources/deployments","resourceName":"vm-with-public-ipvm-with-public-ipVMNicmac"}],"outputs":{"id":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Compute/virtualMachines/vm-with-public-ip"},"publicIpAddress":{"type":"String","value":"40.112.223.195"},"fqdn":{"type":"String","value":""},"privateIpAddress":{"type":"String","value":"10.0.0.4"},"macAddress":{"type":"String","value":"00-0D-3A-32-A4-3B"}},"outputResources":[{"id":"Microsoft.Compute/virtualMachines/vm-with-public-ip"},{"id":"Microsoft.Network/networkInterfaces/vm-with-public-ipVMNic"},{"id":"Microsoft.Network/networkSecurityGroups/vm-with-public-ipNSG"},{"id":"Microsoft.Network/publicIPAddresses/vm-with-public-ipPublicIP"},{"id":"Microsoft.Network/virtualNetworks/vm-with-public-ipVNET"},{"id":"Microsoft.Storage/storageAccounts/vhd14851942256089"}]}}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Length: ['1660']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 28 Sep 2016 20:00:27 GMT']
+      Date: ['Mon, 23 Jan 2017 17:59:48 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
+      content-length: ['7659']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -618,46 +1005,59 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 computemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b7]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          computemanagementclient/0.32.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [33ad6ab6-85b6-11e6-a5e1-a0b3ccf7272a]
+      x-ms-client-request-id: [bbf16836-e195-11e6-9a08-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Compute/virtualMachines/vm-with-public-ip?api-version=2016-03-30&$expand=instanceView
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UerulrldVvkzUePUv6IPrxcnM3oz492dmcPHk7OH2zv7d2fbO9Pdx9sZw/ze9sPJjvZ/v5k/3x3
-        uvPRSF+aZ/XsKqvzl3V1XpQ5va/g6LvLxeviB/joo9dttpxRy9//6evdj+T7X2IgNG1VZxdRAMWC
-        vniVn+d1vpwGX9GXq/WkLJp5XtPnH51ky2pZTLPSIIbno+qcXsXXX03Wy3b9Oq8v6W+/RfN2je93
-        98c7++P97edvXgdfU/OmqJZoUmZt3rSKvEOfGlXN06J5S2187KrmzfUKKH/0vFiu3wVQl9mCv6ma
-        Gb24u//g/s7DvU/39z998Ole0HBa59Trl6tWcXhWV4sz0CRodTnHtHmd02fruqDPPpq37ap5dPcu
-        NbHd3Nv59P54UlaT8bSq8/FVsZxVV814mbdo1tyNYTWmb+zQ/cFTV9NsOi+WF+juVZ7NvlsXbW7b
-        upYfzbI2A6HAct/7vnxsviZSxOZ/Wi1W6zavXyjBLhfbV0U73+apn24XK0eHj7LZolh+1eS1oe6a
-        59xrUWIiTqrleXGxrjOlqe2MGtC4s0mZv8ya5qqqZ8frdp4vW+IqbXuelU1u2hvU6b0mp4lqo+Mi
-        qhKot97gzEdnSxrYeTaFCH7vF39U0Bx+dLdZT5ppXfCEN3d3Jrvnn+4/2N3enZzvbO/PZtl2lk/v
-        bU8nD/ce7J3vPLz/cOdunTfVup7mn9fVetXcnZbFG+LTVxe//08unhdNe7Y6ns2oTZM3d0nqL4sZ
-        sfTdL4ppXTXVeTt+Idjc7WF1t0fsn/ziRTH96Jd83w6O4UE+aPpJwmnaieyv19Npns/ymaH8R8Wy
-        IfGf5j9Z5FfUwlKcpvP4ggjsf+Y+/UnCk0DTlx9995hliD/e3hvvjHc/NcDxkAbJ2jUNkNp+z32c
-        +lDxEDvNGEWajRDvu00XafN8VOaXeYmXzpbnVe9b4phVmV0DyBrdfwQJuO41WxD9IbXU4PM1zQ6P
-        JC2atF4vgURK2jHNCAWaePprmV+lU59Pm3EPZFsIl+/t7H66vfNwe+/gzd7Oox3634NP8O+OFUE8
-        v8T98X0P0kf5uzZfghLfJgxKojiBNDxMb9mmGKgIrvmkQ91b6zRqOjRdHZB4vs6U0VsbJ42+JxTD
-        afPBp5sgR8i++/DR/YNHezvjh5/ev7d7sBshP5HS/9MS2PvcTcsAfQLavD9dNtHk69FjiBYPH907
-        GN+7v7t3/9N7PVo4lhocUXWV18Akv6vS0en2vQbyk18YGfORML/qRPDfghnr4fTnQhGfiK27e1nU
-        7Torv2CrSm17aliGbAVu6PtW3Y8be9D2ZWXt3EdXhDjRT75oswuQ8hcTlX7J/wOPjEfLPgoAAA==
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"162730d8-84b3-45af-88be-9f22f7b6d4bb\"\
+        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1\"\r\n\
+        \    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n  \
+        \      \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
+        ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
+        \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
+        \      \"name\": \"osdisk14851942262269\",\r\n        \"createOption\": \"\
+        FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://vhd14851942256089.blob.core.windows.net/vhds/osdisk14851942262269.vhd\"\
+        \r\n        },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n     \
+        \ \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
+        : \"vm-with-public-ip\",\r\n      \"adminUsername\": \"ubuntu\",\r\n     \
+        \ \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":\
+        \ false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\"\
+        : {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/networkInterfaces/vm-with-public-ipVMNic\"\
+        }]},\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\"\
+        : {\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\": \"WALinuxAgent-2.0.16\"\
+        ,\r\n        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\"\
+        ,\r\n            \"level\": \"Info\",\r\n            \"displayStatus\": \"\
+        Ready\",\r\n            \"message\": \"GuestAgent is running and accepting\
+        \ new configurations.\",\r\n            \"time\": \"2017-01-23T17:59:50+00:00\"\
+        \r\n          }\r\n        ],\r\n        \"extensionHandlers\": []\r\n   \
+        \   },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"osdisk14851942262269\"\
+        ,\r\n          \"statuses\": [\r\n            {\r\n              \"code\"\
+        : \"ProvisioningState/succeeded\",\r\n              \"level\": \"Info\",\r\
+        \n              \"displayStatus\": \"Provisioning succeeded\",\r\n       \
+        \       \"time\": \"2017-01-23T17:58:01.4243952+00:00\"\r\n            }\r\
+        \n          ]\r\n        }\r\n      ],\r\n      \"statuses\": [\r\n      \
+        \  {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n         \
+        \ \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\"\
+        ,\r\n          \"time\": \"2017-01-23T17:59:24.4158166+00:00\"\r\n       \
+        \ },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n     \
+        \     \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\
+        \n        }\r\n      ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\"\
+        ,\r\n  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Compute/virtualMachines/vm-with-public-ip\"\
+        ,\r\n  \"name\": \"vm-with-public-ip\"\r\n}"}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 28 Sep 2016 20:00:27 GMT']
+      Date: ['Mon, 23 Jan 2017 17:59:50 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
+      content-length: ['2635']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -666,40 +1066,393 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 computemanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b7]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [33ec8900-85b6-11e6-8ad3-a0b3ccf7272a]
+      x-ms-client-request-id: [bc12bf9c-e195-11e6-8dc6-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/networkInterfaces/vm-with-public-ipVMNic?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"name\": \"vm-with-public-ipVMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/networkInterfaces/vm-with-public-ipVMNic\"\
+        ,\r\n  \"etag\": \"W/\\\"20860781-2faf-4d0e-8dff-7656dd21889f\\\"\",\r\n \
+        \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n\
+        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e3f3c12d-a426-432f-a742-5dec6e89bffe\"\
+        ,\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigvm-with-public-ip\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/networkInterfaces/vm-with-public-ipVMNic/ipConfigurations/ipconfigvm-with-public-ip\"\
+        ,\r\n        \"etag\": \"W/\\\"20860781-2faf-4d0e-8dff-7656dd21889f\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\"\
+        : \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\":\
+        \ \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/publicIPAddresses/vm-with-public-ipPublicIP\"\
+        \r\n          },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/virtualNetworks/vm-with-public-ipVNET/subnets/vm-with-public-ipSubnet\"\
+        \r\n          },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\"\
+        : \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n\
+        \      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"\
+        internalDomainNameSuffix\": \"qhcdpfxo244ujpe5xruitwmkfb.dx.internal.cloudapp.net\"\
+        \r\n    },\r\n    \"macAddress\": \"00-0D-3A-32-A4-3B\",\r\n    \"enableAcceleratedNetworking\"\
+        : false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\"\
+        : {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/networkSecurityGroups/vm-with-public-ipNSG\"\
+        \r\n    },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n    \
+        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Compute/virtualMachines/vm-with-public-ip\"\
+        \r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\
+        \n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 17:59:49 GMT']
+      ETag: [W/"20860781-2faf-4d0e-8dff-7656dd21889f"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['2383']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bc2bf3e4-e195-11e6-a112-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/publicIPAddresses/vm-with-public-ipPublicIP?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"name\": \"vm-with-public-ipPublicIP\",\r\n  \"id\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/publicIPAddresses/vm-with-public-ipPublicIP\"\
+        ,\r\n  \"etag\": \"W/\\\"f55cd8c9-dc8d-4f68-b561-c84ea3d62b37\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n  \"location\": \"\
+        westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
+        : \"Succeeded\",\r\n    \"resourceGuid\": \"f9f94ea7-1f5e-42e1-b9ef-143a61f17248\"\
+        ,\r\n    \"ipAddress\": \"40.112.223.195\",\r\n    \"publicIPAddressVersion\"\
+        : \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\"\
+        : 4,\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/networkInterfaces/vm-with-public-ipVMNic/ipConfigurations/ipconfigvm-with-public-ip\"\
+        \r\n    }\r\n  }\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 17:59:50 GMT']
+      ETag: [W/"f55cd8c9-dc8d-4f68-b561-c84ea3d62b37"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['912']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          computemanagementclient/0.32.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bc7b3898-e195-11e6-bdca-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Compute/virtualMachines?api-version=2016-03-30
+  response:
+    body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"properties\": {\r\n  \
+        \      \"vmId\": \"162730d8-84b3-45af-88be-9f22f7b6d4bb\",\r\n        \"hardwareProfile\"\
+        : {\r\n          \"vmSize\": \"Standard_DS1\"\r\n        },\r\n        \"\
+        storageProfile\": {\r\n          \"imageReference\": {\r\n            \"publisher\"\
+        : \"Canonical\",\r\n            \"offer\": \"UbuntuServer\",\r\n         \
+        \   \"sku\": \"14.04.4-LTS\",\r\n            \"version\": \"latest\"\r\n \
+        \         },\r\n          \"osDisk\": {\r\n            \"osType\": \"Linux\"\
+        ,\r\n            \"name\": \"osdisk14851942262269\",\r\n            \"createOption\"\
+        : \"FromImage\",\r\n            \"vhd\": {\r\n              \"uri\": \"https://vhd14851942256089.blob.core.windows.net/vhds/osdisk14851942262269.vhd\"\
+        \r\n            },\r\n            \"caching\": \"ReadWrite\"\r\n         \
+        \ },\r\n          \"dataDisks\": []\r\n        },\r\n        \"osProfile\"\
+        : {\r\n          \"computerName\": \"vm-with-public-ip\",\r\n          \"\
+        adminUsername\": \"ubuntu\",\r\n          \"linuxConfiguration\": {\r\n  \
+        \          \"disablePasswordAuthentication\": false\r\n          },\r\n  \
+        \        \"secrets\": []\r\n        },\r\n        \"networkProfile\": {\"\
+        networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/networkInterfaces/vm-with-public-ipVMNic\"\
+        }]},\r\n        \"provisioningState\": \"Succeeded\"\r\n      },\r\n     \
+        \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n      \"location\":\
+        \ \"westus\",\r\n      \"tags\": {},\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Compute/virtualMachines/vm-with-public-ip\"\
+        ,\r\n      \"name\": \"vm-with-public-ip\"\r\n    }\r\n  ]\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 17:59:50 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['1630']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          computemanagementclient/0.32.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bc940be8-e195-11e6-8e72-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Compute/virtualMachines/vm-with-public-ip?api-version=2016-03-30&$expand=instanceView
+  response:
+    body: {string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"162730d8-84b3-45af-88be-9f22f7b6d4bb\"\
+        ,\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1\"\r\n\
+        \    },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n  \
+        \      \"publisher\": \"Canonical\",\r\n        \"offer\": \"UbuntuServer\"\
+        ,\r\n        \"sku\": \"14.04.4-LTS\",\r\n        \"version\": \"latest\"\r\
+        \n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n  \
+        \      \"name\": \"osdisk14851942262269\",\r\n        \"createOption\": \"\
+        FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://vhd14851942256089.blob.core.windows.net/vhds/osdisk14851942262269.vhd\"\
+        \r\n        },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n     \
+        \ \"dataDisks\": []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\"\
+        : \"vm-with-public-ip\",\r\n      \"adminUsername\": \"ubuntu\",\r\n     \
+        \ \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":\
+        \ false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\"\
+        : {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/networkInterfaces/vm-with-public-ipVMNic\"\
+        }]},\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\"\
+        : {\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\": \"WALinuxAgent-2.0.16\"\
+        ,\r\n        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/succeeded\"\
+        ,\r\n            \"level\": \"Info\",\r\n            \"displayStatus\": \"\
+        Ready\",\r\n            \"message\": \"GuestAgent is running and accepting\
+        \ new configurations.\",\r\n            \"time\": \"2017-01-23T17:59:50+00:00\"\
+        \r\n          }\r\n        ],\r\n        \"extensionHandlers\": []\r\n   \
+        \   },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"osdisk14851942262269\"\
+        ,\r\n          \"statuses\": [\r\n            {\r\n              \"code\"\
+        : \"ProvisioningState/succeeded\",\r\n              \"level\": \"Info\",\r\
+        \n              \"displayStatus\": \"Provisioning succeeded\",\r\n       \
+        \       \"time\": \"2017-01-23T17:58:01.4243952+00:00\"\r\n            }\r\
+        \n          ]\r\n        }\r\n      ],\r\n      \"statuses\": [\r\n      \
+        \  {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n         \
+        \ \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning succeeded\"\
+        ,\r\n          \"time\": \"2017-01-23T17:59:24.4158166+00:00\"\r\n       \
+        \ },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n     \
+        \     \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\
+        \n        }\r\n      ]\r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\"\
+        ,\r\n  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Compute/virtualMachines/vm-with-public-ip\"\
+        ,\r\n  \"name\": \"vm-with-public-ip\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 17:59:51 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['2635']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bcb96fc6-e195-11e6-85b9-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/networkInterfaces/vm-with-public-ipVMNic?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"name\": \"vm-with-public-ipVMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/networkInterfaces/vm-with-public-ipVMNic\"\
+        ,\r\n  \"etag\": \"W/\\\"20860781-2faf-4d0e-8dff-7656dd21889f\\\"\",\r\n \
+        \ \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n\
+        \    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e3f3c12d-a426-432f-a742-5dec6e89bffe\"\
+        ,\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigvm-with-public-ip\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/networkInterfaces/vm-with-public-ipVMNic/ipConfigurations/ipconfigvm-with-public-ip\"\
+        ,\r\n        \"etag\": \"W/\\\"20860781-2faf-4d0e-8dff-7656dd21889f\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\"\
+        : \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\":\
+        \ \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/publicIPAddresses/vm-with-public-ipPublicIP\"\
+        \r\n          },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/virtualNetworks/vm-with-public-ipVNET/subnets/vm-with-public-ipSubnet\"\
+        \r\n          },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\"\
+        : \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n\
+        \      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"\
+        internalDomainNameSuffix\": \"qhcdpfxo244ujpe5xruitwmkfb.dx.internal.cloudapp.net\"\
+        \r\n    },\r\n    \"macAddress\": \"00-0D-3A-32-A4-3B\",\r\n    \"enableAcceleratedNetworking\"\
+        : false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\"\
+        : {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/networkSecurityGroups/vm-with-public-ipNSG\"\
+        \r\n    },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n    \
+        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Compute/virtualMachines/vm-with-public-ip\"\
+        \r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\
+        \n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 17:59:50 GMT']
+      ETag: [W/"20860781-2faf-4d0e-8dff-7656dd21889f"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['2383']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bccfab88-e195-11e6-8021-64510658e3b3]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/publicIPAddresses/vm-with-public-ipPublicIP?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"name\": \"vm-with-public-ipPublicIP\",\r\n  \"id\": \"\
+        /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/publicIPAddresses/vm-with-public-ipPublicIP\"\
+        ,\r\n  \"etag\": \"W/\\\"f55cd8c9-dc8d-4f68-b561-c84ea3d62b37\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n  \"location\": \"\
+        westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
+        : \"Succeeded\",\r\n    \"resourceGuid\": \"f9f94ea7-1f5e-42e1-b9ef-143a61f17248\"\
+        ,\r\n    \"ipAddress\": \"40.112.223.195\",\r\n    \"publicIPAddressVersion\"\
+        : \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\"\
+        : 4,\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/networkInterfaces/vm-with-public-ipVMNic/ipConfigurations/ipconfigvm-with-public-ip\"\
+        \r\n    }\r\n  }\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 17:59:50 GMT']
+      ETag: [W/"f55cd8c9-dc8d-4f68-b561-c84ea3d62b37"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['912']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          computemanagementclient/0.32.1 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [bd1e5954-e195-11e6-8766-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Compute/virtualMachines/vm-with-public-ip/vmSizes?api-version=2016-03-30
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UeXWbnOP3qUfg9/pSl/iOejZbbA5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN
-        29fFD/Kz5RdP8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p1suW
-        vt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPYvXewtz80kHv3D/a9r/oD
-        2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL2wzk/oaBeGh+7YFsnJHd/Xv3PvW+64/kPaZk
-        f8NIPHJ97ZF8uvvw/t7XH8nup/LtbYby6Yah/Kxz197Bpw88EJGhvAd7Pdgwkp/1Sbn/4N6+R67I
-        SG6elCdZU0z/P25HdAw/20Zkf+fhp0Nj+HAjooP42bYgn+7uD0rGhxsQHcTPtvXY3ds7GGanD7Ye
-        OoqfbYW7t3//wTBDfZMK9+nPtmjc393bGRrJjVx1o2i4cfxsS8fuDhnzoYHcyFg3iocbyM+2hLC+
-        HRrIzbx1o4i4kfxsSwlr3aGR3GzL30tKNomJ183XHsvuJva6eVbeg792N0nKzzqD3Twt78Fgu5tk
-        5Wedw74JH8sbyyZp2fVm/2sP5mD34bAq3t3d//TAI1lkNPfeQxu/3iQv34RZ6WhcfyjfpFV5vUlY
-        PCy/9ji6ou0PpDPG/kDeQ+pfbxIVj1xfeyBdwfYH0h1kfyTvIfSvNwmKR6+vPZKuXPsj6Y6yP5L3
-        kfnXu5vExOvna4+li68/lptn5X3462fdrHzYtLwPg/2sm5WesvXH0h1nfyzvx2KbxOUbsSt7ew/v
-        PfAABaPpDbU/HGtX8OP7v3HyS/4fWrq+cesWAAA=
+    body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"Standard_A0\"\
+        ,\r\n      \"numberOfCores\": 1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n\
+        \      \"resourceDiskSizeInMB\": 20480,\r\n      \"memoryInMB\": 768,\r\n\
+        \      \"maxDataDiskCount\": 1\r\n    },\r\n    {\r\n      \"name\": \"Standard_A1\"\
+        ,\r\n      \"numberOfCores\": 1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n\
+        \      \"resourceDiskSizeInMB\": 71680,\r\n      \"memoryInMB\": 1792,\r\n\
+        \      \"maxDataDiskCount\": 2\r\n    },\r\n    {\r\n      \"name\": \"Standard_A2\"\
+        ,\r\n      \"numberOfCores\": 2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n\
+        \      \"resourceDiskSizeInMB\": 138240,\r\n      \"memoryInMB\": 3584,\r\n\
+        \      \"maxDataDiskCount\": 4\r\n    },\r\n    {\r\n      \"name\": \"Standard_A3\"\
+        ,\r\n      \"numberOfCores\": 4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n\
+        \      \"resourceDiskSizeInMB\": 291840,\r\n      \"memoryInMB\": 7168,\r\n\
+        \      \"maxDataDiskCount\": 8\r\n    },\r\n    {\r\n      \"name\": \"Standard_A5\"\
+        ,\r\n      \"numberOfCores\": 2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n\
+        \      \"resourceDiskSizeInMB\": 138240,\r\n      \"memoryInMB\": 14336,\r\
+        \n      \"maxDataDiskCount\": 4\r\n    },\r\n    {\r\n      \"name\": \"Standard_A4\"\
+        ,\r\n      \"numberOfCores\": 8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n\
+        \      \"resourceDiskSizeInMB\": 619520,\r\n      \"memoryInMB\": 14336,\r\
+        \n      \"maxDataDiskCount\": 16\r\n    },\r\n    {\r\n      \"name\": \"\
+        Standard_A6\",\r\n      \"numberOfCores\": 4,\r\n      \"osDiskSizeInMB\"\
+        : 1047552,\r\n      \"resourceDiskSizeInMB\": 291840,\r\n      \"memoryInMB\"\
+        : 28672,\r\n      \"maxDataDiskCount\": 8\r\n    },\r\n    {\r\n      \"name\"\
+        : \"Standard_A7\",\r\n      \"numberOfCores\": 8,\r\n      \"osDiskSizeInMB\"\
+        : 1047552,\r\n      \"resourceDiskSizeInMB\": 619520,\r\n      \"memoryInMB\"\
+        : 57344,\r\n      \"maxDataDiskCount\": 16\r\n    },\r\n    {\r\n      \"\
+        name\": \"Basic_A0\",\r\n      \"numberOfCores\": 1,\r\n      \"osDiskSizeInMB\"\
+        : 1047552,\r\n      \"resourceDiskSizeInMB\": 20480,\r\n      \"memoryInMB\"\
+        : 768,\r\n      \"maxDataDiskCount\": 1\r\n    },\r\n    {\r\n      \"name\"\
+        : \"Basic_A1\",\r\n      \"numberOfCores\": 1,\r\n      \"osDiskSizeInMB\"\
+        : 1047552,\r\n      \"resourceDiskSizeInMB\": 40960,\r\n      \"memoryInMB\"\
+        : 1792,\r\n      \"maxDataDiskCount\": 2\r\n    },\r\n    {\r\n      \"name\"\
+        : \"Basic_A2\",\r\n      \"numberOfCores\": 2,\r\n      \"osDiskSizeInMB\"\
+        : 1047552,\r\n      \"resourceDiskSizeInMB\": 61440,\r\n      \"memoryInMB\"\
+        : 3584,\r\n      \"maxDataDiskCount\": 4\r\n    },\r\n    {\r\n      \"name\"\
+        : \"Basic_A3\",\r\n      \"numberOfCores\": 4,\r\n      \"osDiskSizeInMB\"\
+        : 1047552,\r\n      \"resourceDiskSizeInMB\": 122880,\r\n      \"memoryInMB\"\
+        : 7168,\r\n      \"maxDataDiskCount\": 8\r\n    },\r\n    {\r\n      \"name\"\
+        : \"Basic_A4\",\r\n      \"numberOfCores\": 8,\r\n      \"osDiskSizeInMB\"\
+        : 1047552,\r\n      \"resourceDiskSizeInMB\": 245760,\r\n      \"memoryInMB\"\
+        : 14336,\r\n      \"maxDataDiskCount\": 16\r\n    },\r\n    {\r\n      \"\
+        name\": \"Standard_D1\",\r\n      \"numberOfCores\": 1,\r\n      \"osDiskSizeInMB\"\
+        : 1047552,\r\n      \"resourceDiskSizeInMB\": 51200,\r\n      \"memoryInMB\"\
+        : 3584,\r\n      \"maxDataDiskCount\": 2\r\n    },\r\n    {\r\n      \"name\"\
+        : \"Standard_D2\",\r\n      \"numberOfCores\": 2,\r\n      \"osDiskSizeInMB\"\
+        : 1047552,\r\n      \"resourceDiskSizeInMB\": 102400,\r\n      \"memoryInMB\"\
+        : 7168,\r\n      \"maxDataDiskCount\": 4\r\n    },\r\n    {\r\n      \"name\"\
+        : \"Standard_D3\",\r\n      \"numberOfCores\": 4,\r\n      \"osDiskSizeInMB\"\
+        : 1047552,\r\n      \"resourceDiskSizeInMB\": 204800,\r\n      \"memoryInMB\"\
+        : 14336,\r\n      \"maxDataDiskCount\": 8\r\n    },\r\n    {\r\n      \"name\"\
+        : \"Standard_D4\",\r\n      \"numberOfCores\": 8,\r\n      \"osDiskSizeInMB\"\
+        : 1047552,\r\n      \"resourceDiskSizeInMB\": 409600,\r\n      \"memoryInMB\"\
+        : 28672,\r\n      \"maxDataDiskCount\": 16\r\n    },\r\n    {\r\n      \"\
+        name\": \"Standard_D11\",\r\n      \"numberOfCores\": 2,\r\n      \"osDiskSizeInMB\"\
+        : 1047552,\r\n      \"resourceDiskSizeInMB\": 102400,\r\n      \"memoryInMB\"\
+        : 14336,\r\n      \"maxDataDiskCount\": 4\r\n    },\r\n    {\r\n      \"name\"\
+        : \"Standard_D12\",\r\n      \"numberOfCores\": 4,\r\n      \"osDiskSizeInMB\"\
+        : 1047552,\r\n      \"resourceDiskSizeInMB\": 204800,\r\n      \"memoryInMB\"\
+        : 28672,\r\n      \"maxDataDiskCount\": 8\r\n    },\r\n    {\r\n      \"name\"\
+        : \"Standard_D13\",\r\n      \"numberOfCores\": 8,\r\n      \"osDiskSizeInMB\"\
+        : 1047552,\r\n      \"resourceDiskSizeInMB\": 409600,\r\n      \"memoryInMB\"\
+        : 57344,\r\n      \"maxDataDiskCount\": 16\r\n    },\r\n    {\r\n      \"\
+        name\": \"Standard_D14\",\r\n      \"numberOfCores\": 16,\r\n      \"osDiskSizeInMB\"\
+        : 1047552,\r\n      \"resourceDiskSizeInMB\": 819200,\r\n      \"memoryInMB\"\
+        : 114688,\r\n      \"maxDataDiskCount\": 32\r\n    },\r\n    {\r\n      \"\
+        name\": \"Standard_DS1\",\r\n      \"numberOfCores\": 1,\r\n      \"osDiskSizeInMB\"\
+        : 1047552,\r\n      \"resourceDiskSizeInMB\": 7168,\r\n      \"memoryInMB\"\
+        : 3584,\r\n      \"maxDataDiskCount\": 2\r\n    },\r\n    {\r\n      \"name\"\
+        : \"Standard_DS2\",\r\n      \"numberOfCores\": 2,\r\n      \"osDiskSizeInMB\"\
+        : 1047552,\r\n      \"resourceDiskSizeInMB\": 14336,\r\n      \"memoryInMB\"\
+        : 7168,\r\n      \"maxDataDiskCount\": 4\r\n    },\r\n    {\r\n      \"name\"\
+        : \"Standard_DS3\",\r\n      \"numberOfCores\": 4,\r\n      \"osDiskSizeInMB\"\
+        : 1047552,\r\n      \"resourceDiskSizeInMB\": 28672,\r\n      \"memoryInMB\"\
+        : 14336,\r\n      \"maxDataDiskCount\": 8\r\n    },\r\n    {\r\n      \"name\"\
+        : \"Standard_DS4\",\r\n      \"numberOfCores\": 8,\r\n      \"osDiskSizeInMB\"\
+        : 1047552,\r\n      \"resourceDiskSizeInMB\": 57344,\r\n      \"memoryInMB\"\
+        : 28672,\r\n      \"maxDataDiskCount\": 16\r\n    },\r\n    {\r\n      \"\
+        name\": \"Standard_DS11\",\r\n      \"numberOfCores\": 2,\r\n      \"osDiskSizeInMB\"\
+        : 1047552,\r\n      \"resourceDiskSizeInMB\": 28672,\r\n      \"memoryInMB\"\
+        : 14336,\r\n      \"maxDataDiskCount\": 4\r\n    },\r\n    {\r\n      \"name\"\
+        : \"Standard_DS12\",\r\n      \"numberOfCores\": 4,\r\n      \"osDiskSizeInMB\"\
+        : 1047552,\r\n      \"resourceDiskSizeInMB\": 57344,\r\n      \"memoryInMB\"\
+        : 28672,\r\n      \"maxDataDiskCount\": 8\r\n    },\r\n    {\r\n      \"name\"\
+        : \"Standard_DS13\",\r\n      \"numberOfCores\": 8,\r\n      \"osDiskSizeInMB\"\
+        : 1047552,\r\n      \"resourceDiskSizeInMB\": 114688,\r\n      \"memoryInMB\"\
+        : 57344,\r\n      \"maxDataDiskCount\": 16\r\n    },\r\n    {\r\n      \"\
+        name\": \"Standard_DS14\",\r\n      \"numberOfCores\": 16,\r\n      \"osDiskSizeInMB\"\
+        : 1047552,\r\n      \"resourceDiskSizeInMB\": 229376,\r\n      \"memoryInMB\"\
+        : 114688,\r\n      \"maxDataDiskCount\": 32\r\n    }\r\n  ]\r\n}"}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 28 Sep 2016 20:00:28 GMT']
+      Date: ['Mon, 23 Jan 2017 17:59:52 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
+      content-length: ['5867']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -708,81 +1461,24 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b7]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [342d36a8-85b6-11e6-a068-a0b3ccf7272a]
+      x-ms-client-request-id: [bd70fd30-e195-11e6-a6e2-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/publicIPAddresses?api-version=2016-09-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS9X/zRMlvQLx9dLravina+vVpPymK6Xaxe8i9nLz8afVTMqMHdZj1ppnWxaotq2dzdmeye
-        f7r/YHd7d3K+s70/m2XbWT69tz2dPNx7sHe+8/D+w527dd5U63qaf15X61Vzd1oWb/KmfXXx+//k
-        4nnRtGer49mM2jR5c3dVV5fFLK+bu18U07pqqvN2/CJvr6r67V3B6eyla70J27zNLgjf7979fT+6
-        n+d7DyZ7+9vTnQf3tvcPHu5tP8zz3e1PH+w9mE0+ffDg/sHB7/sRvdNer0CEW3RNjctqmoEI9MIV
-        DWeNz6jP5qNHv/iXjD6igazyui2o6aNfjL8ui4YaF8uL123WopfX6+k0z2f5jN4joEKhNRN559PZ
-        7vTh7t72bj49396//2C2nWUPptsPPr23vz892Jtmn35KbxWGcPTK3r3xw4fj+3vjB/fomw6+P0kE
-        pc6p2dnLy33/+9KM4ou8nVfo++k1sUIxpUbFrMzfFIu8Wrdnyy+K5brFYPbpi9VJtTwvLtY1v4oB
-        Mtp3f+54Yyk/z5ZtXp9nU2rd442f/OJFMb3bwb2hD6b8Qa/9R7/kl/ySkRWM7AfNgjo5eLDDlP+m
-        htss6otPdw4+3Tg4QYlmy5IixMZj9dnOzkG2n326PcmJafZnD/a2J7s7k+2HDx7ODu7tZWCfb5TV
-        P3qbX9PHokg+lO/v5flO/umnn27nD3ay7f3Jzv72wfk94vt759nezsHD/U+n9+mtDorfMHfPls3r
-        vG0JY/r7F380qxZZsXyRLfLn2SQvCYYS/9ODhyD++S+aoWvvw7HQaDwtq/UsW63G2Q/WdT6eVouQ
-        peZZNf3JLwgEj/3uh3MTANYX78lKeImx8LhoZ/fBpw/3SPUcTPb3aB72zrcfPpzm27vTvf3J5Pz+
-        vYMHD78ZLiJcP4Bddg7O9z59ONs+n90nvZ5n2fbDe/sPt6fne+eTbP/ew4MZlKGvJndJTd4b7376
-        YPwg4BRp8A1zUkfXYISM990fylQTN+KnpxLx0uXi/j3SeQFiTgnuhhy6nqyX7TZP1vbuzsMH+/u7
-        9/f3t1ekHGl039BQyuIyn+clscHG4dipkKmi4WzEzuPmg73s/MHk0/PtewcPd7f392akVfLJbDu/
-        9/Devb3759n5dPL/Bm5+mN2/9+m9T7fvH+yQ0X/48MF2tntwf3v6YO/hwb37+V7Gb3Vw+YZZ9kbl
-        t5HoqguH22xSjYRVyJZAgClz94fGZH2ZGRjLcpMrsbv/6cHevX3y1R7u7IQSZRzUy/q8nBDFvqnx
-        NdOszJu8/f2ndU6c9vvn78h5oln8/SsB+vvXF3sbR27ZRtgqb+52UfUkKt+ZTch3nmzvTPc/3d7f
-        zXa2s4f3D4hfz3dyMh3nD3fufTMSRX2CEYk5CHmava8pWw+z873JweQcnsSEHOrdT7cPHtybbE8e
-        7t6/tzubTQ728VYHq29Ytjr8gmEwcnf/XzD9ZZXNnmRltpzie57yu+d1RXKwnJ29DPBu7j73Gj9D
-        o9PlLGRzAnC5aBrDQkwV+vju/wtGaudQ5jjn0XaQ9Vn9/sPsIJ8RUjmht59Nyce4v0+25GGWnWef
-        Tg929s//X8XqhNB0/+G9ve1P9/fJKcqy6XZ2j6zdbHpvlpN39OD8ANLcweobZfWfG05oisWqzGn+
-        v8npf/Dpzs7k3sP97fPz3QeUOiB7fAB1R7NP4RRpefrk/1XTv3f/YPcgf3iwfX9yQNP/cJf4dXbv
-        4fb983xvZ3Lw4P7Dgwf0lu8TS+rg093x7j0ENB2Ev1HOoC9+eErwdgzR03xghvKDtN+7VZm1SGO8
-        zqfL2dnq+eRF1u4d7DBd6Pu7Hz5W28XnJzxY7uLexoHaeZN5zT0gfTw9EZjsT/Ls092HZDEz4qj7
-        E9jOSba9d4/yUjv3ptOD+/vfjAgQ9l+f8YmK9+/vTO5v7+WfPtze3zk/oCTfOSVCHjw8P7iXHezc
-        y/BWB5f/73D39foiW15cbZzikJf1je0PY2YDZddTkD/MMdkJkQkjttW3Aow8fv00z++dT/NPt7MH
-        5/vknO7l2wfEGdtkxPOd83s7D8g1/2b4lfqkaf9glf1w/+HkweT+7vZkPyPn9GB2n9J193a2dw52
-        dvJ7u2Rh7vXSGDv7473dnfG9g/HuzgF92UH5/19s3Y/K9K3t3RuSurZdlKeh6QMu+oYHBfgbB2Zn
-        RWbNDQxvBph5/L27u7M3m326S8k54ur9PVLFB/ce5Ns7n55Tcvf+bLqb7/6/i78PaJFl5z55pJ9S
-        hm7/frZHoklrMJR8me5Rtvf8wR5zn8ff+zvjBwfjhwfj+3BWOvj+f465MZsb+SCqt/HW9u6HKW+2
-        8LNq+jancTzcOwC1vqnBMWx4D5//5BdPuYu9h/d3N47TTpRMJPE7A+kg6PH6vQeT3Yf3d6bbs4c7
-        ZNTPHz6kDO/edPvT3fN7e7vEOPfPP2w5I8+U1wntr8/hhA5Fgzv59ozW7bb3H+zPtg+mZHcm2e5u
-        RrbnwXSW0VsdXL5hPp7dlLoLaD1bNp9KKKBJu9i3YyFPNF03yGZkYQGWCXP3Z4PNPn2wc/9D2EwR
-        9Nhsdm+2l92jfND9vU8PSEPt7m5nB6SrJg9mNOMZZQBmD/5fwGak9mfTB5+SDt0hyu0/vH+f0KQV
-        vnz34SzfebAzvX9wTm91cBlmsx8Om9EKDZh7gM3w7SY2I0x+9vQzI/N+vNX3RRgI5YNnDGB3Z+cB
-        uR8Bys4f2d2//+mD/YP7uwe0kh+RISJyW6w+PdjZI4r9bIxSosV79GwcZYeFzCgD9Dz5mdyf0VLz
-        wf42RYOEVf4pZUk+Pci2Kd1EyZJ8Ot3dmX6Q/NB42jm4JGsK1qQfIka70093pwefUmxwfg85nZwS
-        1xlWhs7vHUwmO7N7n95Hhsz3R2jZ8MGnyI+Md/cf0ncddH9ORIxa02RQ2/3dB4gPfAELvhvT6B31
-        fm6l7Jb8NyBlGBZJ2qcHnz4kkQoQ9mXs0wefEjIPHjzcvx+RsW1Crp1v7+7vHRw82KU2WJgi+n3j
-        w/3JL16/lvHuPdg4Wsstwk1mtEOIeoJHBmEyuU82i3IwxMDZjBZi8skepfwOpvf3JvcP9nY/LBZg
-        FAzr0Fc0jK8veA/OH9ynNdjJdp5nOakJinYpL7O3fTDbu0dqcUKCFwiPoPRzIlxDtPeFLNrm/zXC
-        dmvuG5C1/uhI8kjIAsx9qXtAmUPSNruf7ty7rdTBjPzcDdzykfDZ8MAVU0/uHuzt0VrAHq0D7B7s
-        kcN4f387o/wjHP6MLPu9vcn+/4sM3myyS4sW92kN6D75uPvTc4pM9qeE7WxGuacHu/d3d+AQd1D6
-        f4/cgfg3Ct7e//ckLwz7+f3+0DYlAHwAGxIACvTevfu79D+KfkAvounP3cgtKwmrdUSvh6gnebPJ
-        3pSSo/e2J/fJb9unv7YPsgeT7YfT7N79T6cPs52HD//fI3mT808fUGKADPI9ynrtT3fOyTTv59t5
-        9vB87+DhvTx/gLc6KP1cSl6P9hHBC9vcQu6GOPL+g/s7ZDjuHwAO9cU0u/v/Pobs4unxI6F2b7bz
-        kDTqwcNz+DSU+skog7+zez8/z+/nO/v3Pv1/Dz+eH+wdnO/lRMfdCcU/Dx5Mtx9+mp1vHzzMHuzN
-        snvZvX2wUgeln0t+7JI+wo5Bk1twI6H2/yYrsNn/coO7jfu1u7u/e3/vlgIHs/pzN2zLQ8Jjg8NW
-        RD2Re0iBQjY5+HR7NnlIJuDhp59uPzw4OCd3hvKsD3fy7N7u5P89Ijc5uD/N93cebD/MaIlvn5Zn
-        tjMi7Pa9T/dpgfIg39l7uEtvdVD6f43IgfY3ydz/r1wvN7Kv43l9/5f8P3WVb/9VNQAA
+    body: {string: '{"value":[{"name":"vm-with-public-ipPublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/publicIPAddresses/vm-with-public-ipPublicIP","etag":"W/\"f55cd8c9-dc8d-4f68-b561-c84ea3d62b37\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"f9f94ea7-1f5e-42e1-b9ef-143a61f17248","ipAddress":"40.112.223.195","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/networkInterfaces/vm-with-public-ipVMNic/ipConfigurations/ipconfigvm-with-public-ip"}}},{"name":"PublicIPvrflb","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_existing_options_hqs8_/providers/Microsoft.Network/publicIPAddresses/PublicIPvrflb","etag":"W/\"a8cd2e8e-dcce-4dae-bce4-1b453a38ecff\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"9fefd544-bebf-4cad-a06a-ff89e3b22e1f","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_create_existing_options_hqs8_/providers/Microsoft.Network/loadBalancers/vrflb/frontendIPConfigurations/LoadBalancerFrontEnd"}}},{"name":"basica01PublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/publicIPAddresses/basica01PublicIP","etag":"W/\"f8ae08f7-c944-489c-ab3c-707c4cfc2953\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"3bd4e2d0-b853-41ea-9025-da9cd2c86b85","ipAddress":"104.40.2.165","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkInterfaces/basica01VMNic/ipConfigurations/ipconfigbasica01"}}},{"name":"basica0PublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/publicIPAddresses/basica0PublicIP","etag":"W/\"6016d0ab-0f50-4497-b159-400e7a4f5b76\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"023d12be-f4d4-4053-8593-1bf76148e334","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkInterfaces/basica0VMNic/ipConfigurations/ipconfigbasica0"}}},{"name":"ubunt-westu-1097441544-pip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/livehelper/providers/Microsoft.Network/publicIPAddresses/ubunt-westu-1097441544-pip","etag":"W/\"82af7b6f-3891-42d4-8ebd-e393325fafcb\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"39a53636-580f-4997-a185-c729835e2aed","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"ubunt-westu-1097441544-pip","fqdn":"ubunt-westu-1097441544-pip.westus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/livehelper/providers/Microsoft.Network/networkInterfaces/ubunt-westu-1097441544-nic/ipConfigurations/ipconfig1468234344900"}}},{"name":"armdemo133168PublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/publicIPAddresses/armdemo133168PublicIP","etag":"W/\"5ee6059e-1457-4537-ab66-d64cbf65220a\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{"demo":"deploy_1_33168"},"properties":{"provisioningState":"Succeeded","resourceGuid":"e069cf3b-bdfd-42f1-8ab4-e922257da729","ipAddress":"104.42.185.88","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"armdemo133168","fqdn":"armdemo133168.westus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/armdemo133168NIC/ipConfigurations/ipconfig1"}}},{"name":"pipa953","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg953/providers/Microsoft.Network/publicIPAddresses/pipa953","etag":"W/\"4a050a33-7ada-471d-8caf-70641e453cbe\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"766d7a85-1012-4779-a5d1-f4c963428cda","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"pipa953","fqdn":"pipa953.westus.cloudapp.azure.com"}}},{"name":"pipb953","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg953/providers/Microsoft.Network/publicIPAddresses/pipb953","etag":"W/\"2a588937-ea97-4061-843c-3d30e0361f63\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"96551aa4-0c2e-4db6-a675-180343c38d91","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"pipb953","fqdn":"pipb953.westus.cloudapp.azure.com"}}},{"name":"linvmPublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/publicIPAddresses/linvmPublicIP","etag":"W/\"81e24d64-1836-46c4-8dbd-cea9d370a699\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"5607d3c9-fa54-4b5a-a43e-5531b1ae9dca","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkInterfaces/linvmVMNic/ipConfigurations/ipconfiglinvm"}}},{"name":"winvmPublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/publicIPAddresses/winvmPublicIP","etag":"W/\"a64152bc-3ddd-425b-aee7-9f275d5845f1\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"3b5c9a46-8fe9-4a1e-9113-88481fa0f3db","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkInterfaces/winvmVMNic/ipConfigurations/ipconfigwinvm"}}},{"name":"vmssPublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmssrg/providers/Microsoft.Network/publicIPAddresses/vmssPublicIP","etag":"W/\"dadee489-2bd0-4fa0-8313-61368d1e0b18\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"fa86ad45-af60-46c0-a937-598d57ab02af","ipAddress":"52.160.105.31","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmssrg/providers/Microsoft.Network/loadBalancers/vmsslb/frontendIPConfigurations/LoadBalancerFrontEnd"}}},{"name":"xplatTestSecndIpLbNat280","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/xplatTestGCreateLbNat3/providers/Microsoft.Network/publicIPAddresses/xplatTestSecndIpLbNat280","etag":"W/\"b4bea619-87a3-45b6-87ba-2357d03cc854\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"0b1550b5-2e69-40f8-9ef6-b79f83a803ad","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/loadBalancers/yugangw-lb/frontendIPConfigurations/LoadBalancerFrontEnd"}}},{"name":"dcos-agent-ip-yugangw-acs-yugangw-0b1f64agents-B90D500F","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/dcos-agent-ip-yugangw-acs-yugangw-0b1f64agents-B90D500F","etag":"W/\"fae6e4e7-c17c-4035-9674-7ffe01d61ffe\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"4743221e-e5f6-4d08-af86-b5d27bcb214e","ipAddress":"104.42.38.245","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"yugangw-acs-yugangw-0b1f64agents","fqdn":"yugangw-acs-yugangw-0b1f64agents.westus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/loadBalancers/dcos-agent-lb-B90D500F/frontendIPConfigurations/dcos-agent-lbFrontEnd-B90D500F"}}},{"name":"dcos-master-ip-yugangw-acs-yugangw-0b1f64mgmt-B90D500F","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/dcos-master-ip-yugangw-acs-yugangw-0b1f64mgmt-B90D500F","etag":"W/\"b99f90f8-7f3d-4cac-9643-3487c8cbb49b\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"cb011a9f-dc2e-438a-90c7-3fe031145249","ipAddress":"104.42.38.224","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"yugangw-acs-yugangw-0b1f64mgmt","fqdn":"yugangw-acs-yugangw-0b1f64mgmt.westus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/loadBalancers/dcos-master-lb-B90D500F/frontendIPConfigurations/dcos-master-lbFrontEnd-B90D500F"}}},{"name":"yugangw-1PublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-1PublicIP","etag":"W/\"4439608b-8a81-4416-85cf-fc378d4df6e1\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"949b7b51-b4ab-48d5-9730-0800e3188533","ipAddress":"104.210.38.108","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-1VMNic/ipConfigurations/ipconfigyugangw-1"}}},{"name":"yugangw-3PublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-3PublicIP","etag":"W/\"46555775-8b95-48dd-96bf-c9d2e2a54c62\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"71bc5a60-2a14-4756-bd3d-327b81ad43dc","ipAddress":"52.160.103.58","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-3VMNic/ipConfigurations/ipconfigyugangw-3"}}},{"name":"yugangw-9PublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-9PublicIP","etag":"W/\"2266f488-861b-429a-9e13-23718d847038\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"f21eb208-0c78-4238-b979-6dfcebcdf92d","ipAddress":"104.42.231.246","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"yugangw9","fqdn":"yugangw9.westus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-9VMNic/ipConfigurations/ipconfigyugangw-9"}}},{"name":"yugangw-fat1PublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-fat1PublicIP","etag":"W/\"e1f75fdb-abf6-4e62-ad2f-628e59279962\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"258010ce-5600-4ed9-8a31-94c5b9141a22","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-fat1VMNic/ipConfigurations/ipconfigyugangw-fat1"}}},{"name":"yugangw-j1PublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-j1PublicIP","etag":"W/\"d576b3f1-752a-4500-b408-65eb147ce506\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"f2eb0bdb-ceb3-4a71-9dac-9b88833d4d88","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-j1VMNic/ipConfigurations/ipconfigyugangw-j1"}}},{"name":"yugangw-junkvmPublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-junkvmPublicIP","etag":"W/\"b7b163ba-666b-4043-a4f8-bae4b8c55a75\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"afe61529-aeec-4d61-b342-02c5118dc564","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-junkvmVMNic/ipConfigurations/ipconfigyugangw-junkvm"}}},{"name":"yugangw-k1PublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-k1PublicIP","etag":"W/\"217ead67-3d86-4569-85dc-f0f3af39d57f\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"c441a91a-c315-4148-b992-ddd956de5f9b","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-k1VMNic/ipConfigurations/ipconfigyugangw-k1"}}},{"name":"yugangw-kernelPublicIP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-kernelPublicIP","etag":"W/\"7a2a4f46-f50d-433e-93ed-f35a8d715130\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"529aa56e-c63d-4c88-9147-3bbf34ca7787","ipAddress":"13.91.103.115","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-kernelVMNic/ipConfigurations/ipconfigyugangw-kernel"}}},{"name":"yugangw-portal-ip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-portal-ip","etag":"W/\"cf2fcf87-905b-42dc-8dd7-e8ceae9f9354\"","type":"Microsoft.Network/publicIPAddresses","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"927b1492-d93a-400b-a52f-80aa76021c6a","ipAddress":"23.101.198.127","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-portal857/ipConfigurations/ipconfig1"}}},{"name":"pip95963778","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMV29c1708752/providers/Microsoft.Network/publicIPAddresses/pip95963778","etag":"W/\"8cdb13f1-a34b-4b68-8cac-17f60549549a\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"bc82fdae-9f26-4d47-b172-4e6bc2b1ba8c","ipAddress":"40.114.7.151","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"pip5f01708752","fqdn":"pip5f01708752.eastus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMV29c1708752/providers/Microsoft.Network/networkInterfaces/nic805981da395/ipConfigurations/primary"}}},{"name":"pip68662aac","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMV8963671476/providers/Microsoft.Network/publicIPAddresses/pip68662aac","etag":"W/\"85ffaf90-48b5-4f0f-afed-daf45f2b1dfc\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"9fc2652f-13cf-4ce0-9b6d-7862ec27801a","ipAddress":"23.96.88.97","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"pipce03671476","fqdn":"pipce03671476.eastus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMV8963671476/providers/Microsoft.Network/networkInterfaces/nic45269808de6/ipConfigurations/primary"}}},{"name":"pip43883167","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMVc857134170/providers/Microsoft.Network/publicIPAddresses/pip43883167","etag":"W/\"f1d8f9f3-de7f-480a-ba17-6b03565fc962\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"4373e512-c2d6-48e4-938d-677f25dfc663","ipAddress":"13.82.140.52","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"pip6d27134170","fqdn":"pip6d27134170.eastus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMVc857134170/providers/Microsoft.Network/networkInterfaces/nic925565cccfd/ipConfigurations/primary"}}},{"name":"pip5596555f","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMVe714461387/providers/Microsoft.Network/publicIPAddresses/pip5596555f","etag":"W/\"c85c074d-8f6a-4d62-be12-c3287cb75fc9\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"aecd1143-1394-43e0-bda1-c0838efd09b8","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"pip8604461387","fqdn":"pip8604461387.eastus.cloudapp.azure.com"}}},{"name":"pip1-intlb1-b5756104d","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Network/publicIPAddresses/pip1-intlb1-b5756104d","etag":"W/\"ec3f34b0-d18c-4260-9d0b-d489727969c2\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"64e7def9-fa8b-4813-8b19-f89d1b05b010","ipAddress":"40.71.80.146","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"pip1-intlb1-b5756104d","fqdn":"pip1-intlb1-b5756104d.eastus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Network/loadBalancers/intlb1-b5756104d/frontendIPConfigurations/intlb1-b5756104d-FE1"}}},{"name":"pip7748c9a6","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/publicIPAddresses/pip7748c9a6","etag":"W/\"bb928a68-f19e-49ae-a4e7-4a785c0c1c68\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"4534d937-f345-4618-a1ce-31c209e14917","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"pip1c3186528ff6c4d","fqdn":"pip1c3186528ff6c4d.eastus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/networkInterfaces/nic142986528ce1315/ipConfigurations/primary"}}},{"name":"pip34643db7","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv_f442667004ba/providers/Microsoft.Network/publicIPAddresses/pip34643db7","etag":"W/\"2e6784f9-cb29-4284-a66b-0e8d631e336b\"","type":"Microsoft.Network/publicIPAddresses","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"db2037d0-eb08-4fa8-9395-b78b83ec9ff4","ipAddress":"40.71.93.62","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"empip-30069611762","fqdn":"empip-30069611762.eastus.cloudapp.azure.com"},"ipConfiguration":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv_f442667004ba/providers/Microsoft.Network/networkInterfaces/nic951517fadc0/ipConfigurations/primary"}}}]}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Length: ['3015']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 28 Sep 2016 20:00:28 GMT']
+      Date: ['Mon, 23 Jan 2017 17:59:52 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
-      x-ms-original-request-ids: [ccc7fe48-161e-4897-b364-c2133998a329, 3c778b8b-2163-48cb-9584-e73272e65d0f,
-        03b8d2bf-9426-4ce8-b68c-08fa4ebad143]
+      content-length: ['22580']
+      x-ms-original-request-ids: [2bc8b24a-7d89-4a90-8703-ffd6a6cd7e6e, 709c6622-a43a-4b4e-b170-f24f79f9a743]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -791,122 +1487,24 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.1.0b7]
+      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.6
+          networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [34e972ca-85b6-11e6-ad53-a0b3ccf7272a]
+      x-ms-client-request-id: [bdbb6ed0-e195-11e6-9a28-64510658e3b3]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/networkInterfaces?api-version=2016-09-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS9X/zRMlvQLx9dLravina+vVpPymK6Xax+8osXxfSj0UfFjL6926wnzbQuVm1RLZu7O5Pd
-        80/3H+xu707Od7b3Z7NsO8un97ank4d7D/bOdx7ef7hzt86bal1P88/rar1q7k7L4k3etK8ufv+f
-        XDwvmvZsdTybUZsmb+6u6uqymOV1c/eLYlpXTXXejl/k7VVVv727lJ9nyzavz7MptR5ENW+zC0L2
-        u3d/34/unU8P8k/v72/v7uycb+/v7u9vPzzI8u18N/v03v3d/d3Z9OD3/YjeKatphkHRe1eE3rqh
-        zwhM89GjX/xLRh8RYqu8boscf+Ovy6KhxsXy4nWbtaDb6/V0muezfEbv0WhkxGsm2t6D++e7Dyb7
-        2+f5Qba9/3A223442zvYfrh7/vDhwf3ZNN/7lN4qVifV8ry4WNeMCPXkZqVYTfm73pDxHvq4+//+
-        ibnbHSB9MDyqrzOHhOV7zNKqLi7p07OXOkz6endnjP/2g29Lwxpf5O28ArGfXtO0MKcJxtTIgPjF
-        P+fT0UGJWvfI+5J/OXv5EXE2IUoT+P8GxC+Lul1npf4ZQfsnX5y+uUv4Eb6Rb1/zFxgSTd0iq68/
-        etTW65z/1JkUNH6SuqfB0WDPXl7uf/RLfsn3Rx/Nls3rvG2JU3gO+c/6khqSENLX2WpVFvnsaefj
-        Aiy/zMqn1SIrli9IVF+vz8+LdwT68qez86bI3+WXl+v5cn1vZ9Wsqp8+/0X38/Hs3di8OJ6W1XpG
-        0MeK+iKbKpYEY2dne+fp9r3j7Xv3tj892X54SgyXL7NJSWN5VtVXWT0jhD96dJ6VDY2TQIBwr/Pp
-        ui7aa54NDObnel5jeEXm78Xrz0EBmi1/8pQpvsim82JJEvxzN5yTarFat7lhU8UoMhDiKDId1yvC
-        9iP3eocaTlvSoK2aX1bVqr1cNM2StcvPwlC/eP36pM5JHH7/ZbXMf3/qjqHefsCvp1mZk6w0dy2y
-        B50mhGR/mK65jM3T7/v75w/29/LJdna+84Ds4yTfPjg4f7Cdzx5OHua7+3vnDx98Df1uiSBWeLIz
-        m5w/vD/dvr9/L9/ev59/up3tZHvb+afnRLq9AyIi9H7XSJGk96fHGC60B+y7/z+cI7LOISXct97w
-        f/ankRRCoL7p6/c20zQ9NFj09nM7XUYJ6Fzonx5lDwIb5z7+f5dx++l39bt6sXN1cb7Oy4t27/Lq
-        3Xm1W7eL+dcxbvvbB7vb9/ZomjYYNxqnP2wloDIzRvVzO7EfIoc0Sf8/NAG7N6gXGpunO+4dTPey
-        /N7O9oN79x5u79P4trN7s/vbn04eTPf39nd2s4c7X0N3WCKICXiwvzO5d/98f3tvem+6vb9HxmAy
-        eXCwfX7vwYPsfHr+6WyW01tdxUfy0J8eTwcy7Lv/P5yj9zYBP0vTSMIfKDn6Wk3A/eDbH5kAQvH/
-        oybgYPvZAU3Tz0sTsEuT9P9DE7B3g3qhsXm6Y3eXkmQHn062PyX0t/f39s63D7JsZ/vh/v1ZtnP/
-        /N69/cnX0B2WCGICJvcnpKP2Jtv3phRV709nMAH38+1sb0Y/sk/3KEagt7qKj+ShPz2eDmTYd/9/
-        OEfvbQJ+lqaRhD9QcvS1mgCkTt23PzIBhOI3ZgKop2GN/XB774SoukFj6wCV2dDrzy3hP0ROiIie
-        ip5n1fRycf8ejf+bGhJA1hdRvJVDIqKKlxQPTwYPSLk9yGefbs/29ykSv/dwtj052Nnf3j+fZvt7
-        n+b3dyfihhlhoffsogch8B5yaQch6jXb3Z3MKB+/fe/84cH2/sGnu9sP985n2+QTfnp+sD/be7D/
-        gN7qKhXiNUtao1Z20Q4w7/4c07avAn0Uvw7ZCY/3IHFXuOlrUn27pPpu7/1KcpIaGRDfnCiCTDfQ
-        ttO70vYnv4AmIwSI9N8kQtfri2x5cbURIxVv/dO+s31JuNwlFOiH+1D+BrJE7B+G2iXGBxuSAx3x
-        vNurd/f3ZtVPZ7s/nf8gX+3OVvl00vw05TK/jue9u/10f/vBDZ43gQCZggw+BvNNzRi44QYWiqEg
-        Lwob0VT4M6Pzq+r7h4Rr3LzIK8CS0Px6ywLryXrZbrOGpjXQhw/293fv0yIouWc0bx8yMH9gZXGZ
-        z/OSFFN0cIOI3t2Inacep/n5Tra/Q4vfu1PyDO9nn5JTuJNtT3fPp5O9/Hxy8GDK6tHoMXqPoX6w
-        Vdq/v3twP7832Z48vE9WKX94vv1wun9/m5A5mM7Od7N70x16q6vnSRTtFFiVv//pwd69/Xv7+w93
-        +B3Av/vhbPWzQH0yU+F46IP4IL7OJBGWhOxtJ4TEM9CU9DXZMFix2yfxO1YE3f6Qqd/BYJj6K6wC
-        /mzYtlsiqhpI/xxEM7B2A20a+hJjoTnyFSz9qVMmtPimTB/1NGiI6Luvpz8v63N49espSQUx0jc1
-        GQ0ChyZvf/+pxB/5O1pGJnRNDPL71xd70WmKGwoXhyi+ne8Jyf4wTVszNk+Ud853Zg9n+xR/51O4
-        o1OK2e7N9rYpLbu7Ozuf3ZtMv856nCWC6NZP79/P7z8kFz/bvUe9wOPP7u3e257t5uQLH2ST/YOM
-        3urqIprr/vQY/YT2gH33/4dzREo4pIT71hv+z/40dgWYvmaN/HO7rPq1p8voAZ0O/VOISzjeJdTo
-        B/8tv5J+wCjfQ6fBMclmT7IyW07z+kk2fZsvZ9r0ZVWVRELi6f/XUMJHlsddTu5O+kjfXVxP8hX9
-        9tEv+f7X1tokr+B2ijsiAcu7nXvn+WUzn9eLfP72Xb6zejfLflA2bydfJ2Ah7n+6vfuEZmPQTvBM
-        +hOrTKEyilH9nM/S11YvZFr/f2jZYiuR2taMzVOJk/zBwcPz3cn2/u5+RirxPvnzDw7y7Z1plu89
-        fDi9v7v7dRItlghi2e59Op1MP314b3t3Suy3fzDZgyv8YPvB5MFkb+/g/MGDB3irq89JHvrT46l2
-        hn33/4dz9N6W7WdpGkn4AzVOX6tlu32+jKaHBovefs6ny+hznQ79U4hLON4l1OgH/y2/QnnSKH0F
-        SH/qoIUkP7JsNLP8p2fCyPb8XFu2++Ta0Wz8vLRsnUVwbcaahUjy/9lhxRZYta0Zm6cSZ0D9nJYQ
-        9s5zGtK9+9n25MFOvj19+ODh7jlZn2xy8DVUoiWCWLaH2cOHnz7cn27PJhTh70+pFwop8m1aoLm3
-        t/spxW8TKIWuPid56E+Pp9oZ9t3/H87Re1u2n6VpJOEP1Dh9rZbt53IR/GtPl9HnOh36pxCXcLxL
-        qNEP/lt+hfKkUfoKkP7UQQtJfmTZaGb5T8+Eke35ubZsu9ufntJs/Ly0bHtRy/bpLyLNQiT52RpW
-        UyxWZU6D+UbHsiG9ZQbk6cF7uw8mu9nOZHt6/il7+Hvbk09JD+7t7uT7+/fu7e1P7n8NPWhHLuZs
-        d/bpgwdT6uV8kuXb+58S3bKH+/e2d3Zn1Dn1cv4QqxxdJU5C0J8TT58z7Lv/f5mYQRsWjPlnf+5I
-        zAOFTV+rDYO2dt/+3NqwzXNk1LXOgf5pKfqTL07f3CWcCEf72Wv+EzqShujrOfpTRyz0+H+VAbsd
-        GXwM7YDLuOXSb635Csd3tpxU6+XsRda+WhMi/y8eWxFiar5ZZi0GNqY03c+SZZ79dP2L7jVXs6vZ
-        Xr67zO79ovtltdvOz+s8Yplvssz37m1/erK9+4zY7P+NlnnzFH1tTfn/I3O8ISdnBuSp9OkES/g7
-        B9uzTyf3tvfz+zvbB7Pp/e179ybZwacHD873Hsy+hkq3I1dz/ODB7qef3ifWupfRgtX04NPtycPs
-        3nZ2/3y2f2/34f1PD87pra49Is7vz4lnmhj23f+/TMx7m+Ofpbkj2Q7MD32t5vj/TcnSzXNkdLXO
-        gf5pKfojc0wDLn9em2PKLf5/xRzTItMxsdnPH3NMc/P/G3O8IZFoBuSp9J1snwzldHd7tr8z296/
-        v/9we3L/4Wz7/oNPs92DKS023p98DZVuRy7m+P7uZCebfXpv+95kSnHc9Hwfq2wPtu9TGnIn23mY
-        nT88oLe69og4vz8nnmli2Hf//zIx722Of5bmjmQ7MD/0tZrj/zdleDfPkdHVOgf6p6Xoj8wxDbj8
-        eW2OKSH6/xVzfLq99//WvPXmKframjI0x9fri2x5cbW9+5NfvGDt8k2NRgFHcTfsRbODn57O1rcc
-        Op5K3vt0em9/995ke0JrmNv7D+/tbR8c7M62s738/vnD/fv37z3MWSUb3UnvXeVNu27oMwJDc/+L
-        iRcIofdQ2HZUYmwPZrt79/L7tLK68ylRYu9guk32dX/7/s55Pj3P9qdEDXqra22Iry3Fjb2xQ0V7
-        wL77/w6i901lDOOvMy+E1XtQnuQuMA30NZnKXTKVsAvu202mcrWelMWUGhkQ35y0KjE2krrTvU/q
-        l/oVtBMhQ5Pyw0ZOFYP+ad/ZDpZmzYfyN5AlwvvqkP7UeZAxdgz4z44VaK/e3d+bVT+d7f50/oN8
-        tTtb5dNJ89PZTvb1rMD+k+2dh8QuG6wAgQCZXufTdV2010xnDOaHOWMxHOyb27svXn+OUdKM+BOk
-        06z6/4eFctw62XdIhZAR+qi9XhFGH7nXOiN1OooGZhWowrhckF9Pk/YND4eN5u2H5Ayu9/72bqcV
-        YdQfk3tDBuKp1Gz3072d3XsPt6f5LrHn3qf59mRnOtneyc53d3Z39ykn+HVUqh2xGLPzg3sHs4f3
-        Ztu7u9P97f3sYLJ9kN3/dHsve3D//qd7u1gOpLe69oDEsz8XxkagPWDf/f/6hJDVC4ftvvXG+rM/
-        ZyTOgYKlr8kM4r/bm0GaCxosevthzY0RZKW6/hm8R+6GHykG3/x/I170UN5IBB+n4K3t3TIeJwZt
-        fg6iRa//DxhZN0oMvjexIq3W/SzFim/f7l3s7Pz0L7oo35JIrIp713s/vSpW57Pzr+cl7J5s32fX
-        dznoJRB7+tyq3K86B6P6YU3QB+pGss7/Xze4sQU6+4YMxFPen+59er4/ffhw+96nD8639/cf5tsH
-        e59+un2wP9vPH+Z72eTB/a+hvO2IxeDe29t7sPuQyDLZwRrfp58eUKSUzbbzB/tki/cfHtzbQxqw
-        a3mI0/tz4Rkhhn03NiH/X5qQ9za4n/7szBnJcGBi6Gs1uD+XK6aWFgNzYzSyUl3/DN77kcGlgZJZ
-        +nlucCn0+v+Ewd3ffnBCvxCL/f/f4NKc+Ab33arMWlKJs4o4tb53cPCAqPBNjYSBv6G86Oc/+cVT
-        7mDv4f3d6KAM19FE4aenuBlIF0NPN88mew93dx5Ot3dyWorc39+7vz359CElBrOD+/lDypQePNxn
-        3WyUKL2XZ5qrJVTeQ1/b4YmNPTjYO9iZERsRCruUjdyfbh/czw627+3ku9OHn95/QF3TW11jQ8xt
-        yW/MzS7lLg92Kaz79OAAup/h3/1/7Qz0DejQQL7ORBF27zEpJJeB2aCv1YjCZrhvf7hGlGn2foRX
-        SdU/FYTQHInSg/1PH94lxOjX4Dv56OGDe+RK83h9LUV/6vCFOB2b+rOjnPeW9++tz9+usnfX68vq
-        qsp+0XxS/qLd5TobT95bOe8SxQ+2909olv7foJyZ8Leb17ieVhCXixm//fBg/z5Nw9dNUDIsK5q7
-        OztQjj97Y/30wc796FgHkRUgXQw9rfDg/MHD2R5N8V6+NyOtkN3bfngwybcfPDg/J55++DDbkVyW
-        EV9675tR31n+YPdefkAxUXaPnPr798mpv3cv2/50N8t388n+w4cP79FbXVVH7G/J72m9Tx/sH9zf
-        Pfj0HrQOw7/7/9oZIG0djok+iA/k60wUYfcek0KSG2go+vq91Xdn8Qvd/hzOQAcbMwNC/mJ1b+fB
-        AxLhjwg3mqufY1xVN+mfCkIwhc3ZPdi/d5cQo1+D7+SjT+/fJ91F5A+VL/2pcyYE+OHYnOLdvb3l
-        7vzexTT/aYoD1r9opz1/d39/lm+0OYMmhb77AI3c0iSQxH168Ck7gD8L83tS50Tje/RsnN8eqgIk
-        xM8T8nuTe3v39h9k2wf57t72/l5+vn1wvpNt7xzs79wnZtrN9iTRYaSR3iMc2zlUctYUGX1F+LyH
-        /NsxqlLen2T7u0SNyYMH+fZ+fkCoTM4fbO+e04r/9OG9e5OHcCu7Coz4w86A02WfPviUiPngwUOy
-        sfQO4N/9f+k0kAYOR0QfxIfxdWaLcHuPKekKMH39/1aVfEv6d7Dx6V+sPj3Y2SMJ/ogwo3n6OcY0
-        qpCBJ9Tx/u7B7l1Ci371vpEP7t178P8aZbzfru/tr8siu//T68nFajHfnV9Us+y8OR8XG5RxPAA4
-        3tmmlc49uGKD2prH6Q9byag+N0b1czCnNwQA93b3yMH8QN9/m5Br59u7+3sUlu+ShtgmhUKk+saH
-        +5NfvH4t4917EB3tIM4CYwhRT53dP3hwL9/JP91+MLtPCYJP82z74c75p9sPHzzMZ9MHD3dm+aes
-        zozeofcY6jdlfB4Scg/yhwfbD87v3d/ef3Bvtv1wuntAy+zZ/cmn5+f39u7n9FZXVZM82ElxWvsB
-        JYd2H9zb/XQHrMvw7/6/fT7I6IRDow/i4/k600ZYvsfckEQHmou+Ziu0+/8yK3TrieggMzwRlMgm
-        Of+IcKS5+7nFWVWX/qkQ+hjDON0l/OjHYJuGvsSwaOZ8TU1/6kQKWX4oBoo6mF9X7bJaXuT3y7qu
-        rpeLq6usvLfZQA3aH/ruw3X4/Qf3d0jM7h9AEol5f+5mvYeywBjA01MFs3sP9x/ey3a3c0ogUN4u
-        n2xnkz1af56QT783ubdzL5uyKjAyS+8x0G9Mg98nxKZ759vn+YTokx8ckBr6dG/7fEIO8b3pwXTv
-        IfroqjliGDslHY23u7u/e38P7wD+3f+XTwfp63Bk9EF8ON1Zu82sEZKDU0PDIPr4U9OVbPr6/88K
-        3M3D/0f0t0N4UH27Jg19h0HRtP2ca2+izrrYu5+9/cHl+vynpxfn+9W7d7OsoMXfH4b2/v4v+X8A
-        d2jmNOyCAAA=
+    body: {string: '{"value":[{"name":"vm-with-public-ipVMNic","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/networkInterfaces/vm-with-public-ipVMNic","etag":"W/\"20860781-2faf-4d0e-8dff-7656dd21889f\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"e3f3c12d-a426-432f-a742-5dec6e89bffe","ipConfigurations":[{"name":"ipconfigvm-with-public-ip","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/networkInterfaces/vm-with-public-ipVMNic/ipConfigurations/ipconfigvm-with-public-ip","etag":"W/\"20860781-2faf-4d0e-8dff-7656dd21889f\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/publicIPAddresses/vm-with-public-ipPublicIP"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/virtualNetworks/vm-with-public-ipVNET/subnets/vm-with-public-ipSubnet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"qhcdpfxo244ujpe5xruitwmkfb.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-32-A4-3B","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Network/networkSecurityGroups/vm-with-public-ipNSG"},"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliTestRg_VmListIpAddresses/providers/Microsoft.Compute/virtualMachines/vm-with-public-ip"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"basica01VMNic","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkInterfaces/basica01VMNic","etag":"W/\"703df84e-5116-4e13-a909-f96175112b63\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"70dc51d3-a1df-451f-8c96-1db875e8853a","ipConfigurations":[{"name":"ipconfigbasica01","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkInterfaces/basica01VMNic/ipConfigurations/ipconfigbasica01","etag":"W/\"703df84e-5116-4e13-a909-f96175112b63\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/publicIPAddresses/basica01PublicIP"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/virtualNetworks/basica0VNET/subnets/basica0Subnet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"pfp4lc1vfohelkea43gpafi04f.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-35-5F-C3","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkSecurityGroups/basica01NSG"},"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Compute/virtualMachines/basica01"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"basica0VMNic","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkInterfaces/basica0VMNic","etag":"W/\"281f8b3d-4d71-4af5-9739-6bff86f2a4a1\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"88083e0e-f750-4d7c-9880-30f48cbc2f95","ipConfigurations":[{"name":"ipconfigbasica0","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkInterfaces/basica0VMNic/ipConfigurations/ipconfigbasica0","etag":"W/\"281f8b3d-4d71-4af5-9739-6bff86f2a4a1\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/publicIPAddresses/basica0PublicIP"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/virtualNetworks/basica0VNET/subnets/basica0Subnet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"pfp4lc1vfohelkea43gpafi04f.dx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkSecurityGroups/basica0NSG"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"ubunt-westu-1097441544-nic","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/livehelper/providers/Microsoft.Network/networkInterfaces/ubunt-westu-1097441544-nic","etag":"W/\"cef0a40d-91c9-45a6-940a-c1fcb2efb87c\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"45185e3b-b958-4e9f-9c45-40d8cdf1a3c0","ipConfigurations":[{"name":"ipconfig1468234344900","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/livehelper/providers/Microsoft.Network/networkInterfaces/ubunt-westu-1097441544-nic/ipConfigurations/ipconfig1468234344900","etag":"W/\"cef0a40d-91c9-45a6-940a-c1fcb2efb87c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.1.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/livehelper/providers/Microsoft.Network/publicIPAddresses/ubunt-westu-1097441544-pip"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/livehelper/providers/Microsoft.Network/virtualNetworks/ubunt-westu-1097441544-vnet/subnets/ubunt-westu-1097441544-snet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false},"type":"Microsoft.Network/networkInterfaces"},{"name":"armdemo133168NIC","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/armdemo133168NIC","etag":"W/\"313c7c8e-f3ab-432f-9eef-5aa96923d600\"","location":"westus","tags":{"demo":"deploy_1_33168"},"properties":{"provisioningState":"Succeeded","resourceGuid":"9b4f5373-e950-4fda-b663-da05d116b99c","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/armdemo133168NIC/ipConfigurations/ipconfig1","etag":"W/\"313c7c8e-f3ab-432f-9eef-5aa96923d600\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/publicIPAddresses/armdemo133168PublicIP"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/myVNET/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"pbijbawf3hmeriihr2qocjhd2f.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-EE-10","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/armdemo133168VM"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic01653878289","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic01653878289","etag":"W/\"6f921991-cf48-47ec-8227-d3440e63a366\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"df85022e-68ef-4106-96d9-5244e5093975","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic01653878289/ipConfigurations/primary","etag":"W/\"6f921991-cf48-47ec-8227-d3440e63a366\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.16","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-E1-1D","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-3"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic019673b7dc0","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic019673b7dc0","etag":"W/\"d39e7e78-2991-44d5-a878-4ecfaf0d029a\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"b9e09dba-dfab-4bba-a884-911f6eff7daf","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic019673b7dc0/ipConfigurations/primary","etag":"W/\"d39e7e78-2991-44d5-a878-4ecfaf0d029a\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.11","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-EE-5C","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-19"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic0636470a525","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic0636470a525","etag":"W/\"de4d1cae-005f-495b-b079-26b3fe24f5b3\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"9005b601-9629-42d1-86f7-01452b679aa1","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic0636470a525/ipConfigurations/primary","etag":"W/\"de4d1cae-005f-495b-b079-26b3fe24f5b3\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.15","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-EE-89","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-8"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic150168efa2f","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic150168efa2f","etag":"W/\"c94782dd-afe1-46d7-b592-15b33bc128f2\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"c2b6065c-c641-4d8d-96a3-e74c98227333","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic150168efa2f/ipConfigurations/primary","etag":"W/\"c94782dd-afe1-46d7-b592-15b33bc128f2\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.9","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-E1-C7","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-13"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic170770fac41","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic170770fac41","etag":"W/\"fe26f2a4-c40a-4dfc-a06d-290cf4924d09\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"b5cbe88c-6d68-4f52-a799-5487c819b0bb","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic170770fac41/ipConfigurations/primary","etag":"W/\"fe26f2a4-c40a-4dfc-a06d-290cf4924d09\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.10","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-E3-3F","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-0"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic24432ea21b1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic24432ea21b1","etag":"W/\"0ae19e2e-a2ee-4cda-89de-3eb1828e57ce\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"84e95aa3-4a80-446f-96e6-73776d1b6825","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic24432ea21b1/ipConfigurations/primary","etag":"W/\"0ae19e2e-a2ee-4cda-89de-3eb1828e57ce\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.12","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-E0-31","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-14"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic26097065678","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic26097065678","etag":"W/\"094e49da-e817-4979-a919-9f160d41332b\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"89b53bf4-1e8f-4756-aa4c-30e383c0c4fd","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic26097065678/ipConfigurations/primary","etag":"W/\"094e49da-e817-4979-a919-9f160d41332b\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.13","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-EE-C2","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-17"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic3775129c814","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic3775129c814","etag":"W/\"ba6ecf9c-68bc-4c4d-94dc-8948e1ddf942\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"4ef02f77-0d5d-428b-bbc4-0776cae31b87","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic3775129c814/ipConfigurations/primary","etag":"W/\"ba6ecf9c-68bc-4c4d-94dc-8948e1ddf942\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.20","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-E6-66","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-16"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic38353219b48","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic38353219b48","etag":"W/\"aec2e617-3c16-4d66-bd2b-23ad64e9e7aa\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"ef65061e-b0bb-4752-a12f-3d7b9bd4dbc1","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic38353219b48/ipConfigurations/primary","etag":"W/\"aec2e617-3c16-4d66-bd2b-23ad64e9e7aa\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-EE-46","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-12"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic44894e0b1ae","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic44894e0b1ae","etag":"W/\"5872b87b-95db-4d22-9672-2bfee27947e1\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"e832b386-68a2-4a6c-9d44-e9d83580a328","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic44894e0b1ae/ipConfigurations/primary","etag":"W/\"5872b87b-95db-4d22-9672-2bfee27947e1\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.18","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-EB-DB","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-5"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic50379d47723","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic50379d47723","etag":"W/\"f9049fbe-8132-4124-bfbd-f1f6f1b721bd\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"de2d41a5-657e-4c62-89ca-81beca82e71d","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic50379d47723/ipConfigurations/primary","etag":"W/\"f9049fbe-8132-4124-bfbd-f1f6f1b721bd\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.19","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-EF-68","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-10"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic59728afad3c","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic59728afad3c","etag":"W/\"07a9fe8d-256e-4453-b8e1-9e9ea80e28c1\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"38f00d36-a736-46f5-9cb9-8b3510d41dd1","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic59728afad3c/ipConfigurations/primary","etag":"W/\"07a9fe8d-256e-4453-b8e1-9e9ea80e28c1\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.22","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-EF-4D","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-4"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic6852829e356","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic6852829e356","etag":"W/\"b987ffae-cc50-480b-8bed-ae2ed92d0283\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"5d87ee2c-6ad3-4361-aa01-68b08bb2857d","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic6852829e356/ipConfigurations/primary","etag":"W/\"b987ffae-cc50-480b-8bed-ae2ed92d0283\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.21","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-E6-B6","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-15"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic733897ee67f","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic733897ee67f","etag":"W/\"3be88d5a-af19-428c-ad13-6ea5a8961395\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"3dd330dc-3e21-4820-9f44-a0e63e1df379","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic733897ee67f/ipConfigurations/primary","etag":"W/\"3be88d5a-af19-428c-ad13-6ea5a8961395\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.6","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-E7-A1","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-7"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic75316ebac3c","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic75316ebac3c","etag":"W/\"364ec5fa-c551-49fb-bdd4-53db078e84d0\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"92ca9f5d-1785-471e-b478-8bcc1b212370","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic75316ebac3c/ipConfigurations/primary","etag":"W/\"364ec5fa-c551-49fb-bdd4-53db078e84d0\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.14","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-E1-22","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-6"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic79561772dfc","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic79561772dfc","etag":"W/\"11543a89-63ce-488b-a6e8-dd4a1ba03ac6\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"a0b9aadf-a813-4096-bceb-028302bb4ec9","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic79561772dfc/ipConfigurations/primary","etag":"W/\"11543a89-63ce-488b-a6e8-dd4a1ba03ac6\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.8","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-E4-D8","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-18"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic8214787b869","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic8214787b869","etag":"W/\"8a532095-69f0-4f28-842c-189b426b468b\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"b9230cef-41b7-4711-bcc6-f255554cd03a","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic8214787b869/ipConfigurations/primary","etag":"W/\"8a532095-69f0-4f28-842c-189b426b468b\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.5","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-E3-74","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-9"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic8338895e30f","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic8338895e30f","etag":"W/\"074a2be9-92b8-4632-bef2-92eeffeeca52\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"e99813e4-dc8f-4159-bbf0-94469d73dbe9","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic8338895e30f/ipConfigurations/primary","etag":"W/\"074a2be9-92b8-4632-bef2-92eeffeeca52\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.7","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-EF-DE","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-2"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic9483581c582","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic9483581c582","etag":"W/\"7c224923-73ba-46e1-85a7-072e619838bc\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"f960ab0f-bf1a-418c-9843-4b6b4d59e252","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic9483581c582/ipConfigurations/primary","etag":"W/\"7c224923-73ba-46e1-85a7-072e619838bc\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.23","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-EA-22","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-11"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic97029453209","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic97029453209","etag":"W/\"9f80dda8-99f3-4bf6-9af0-8a3766f906d3\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"6c9201de-a633-4b19-b958-6c1f55664496","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkInterfaces/nic97029453209/ipConfigurations/primary","etag":"W/\"9f80dda8-99f3-4bf6-9af0-8a3766f906d3\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.17","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ylp1l4flryaehmhasdopfloqte.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-EF-40","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Compute/virtualMachines/vm33168-1"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"linvmVMNic","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkInterfaces/linvmVMNic","etag":"W/\"2bb35afe-3f6a-42a6-8b03-99c219f6297e\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"f1e957b7-28eb-4c0c-b6e0-2a821b84a8f9","ipConfigurations":[{"name":"ipconfiglinvm","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkInterfaces/linvmVMNic/ipConfigurations/ipconfiglinvm","etag":"W/\"2bb35afe-3f6a-42a6-8b03-99c219f6297e\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/publicIPAddresses/linvmPublicIP"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/virtualNetworks/linvmVNET/subnets/linvmSubnet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkSecurityGroups/linvmNSG"},"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Compute/virtualMachines/linvm"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"winvmVMNic","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkInterfaces/winvmVMNic","etag":"W/\"8ff069ea-8500-4608-88dc-1096099a4a34\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"f156c647-65c7-4abf-a5e4-1c9c648bf472","ipConfigurations":[{"name":"ipconfigwinvm","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkInterfaces/winvmVMNic/ipConfigurations/ipconfigwinvm","etag":"W/\"8ff069ea-8500-4608-88dc-1096099a4a34\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/publicIPAddresses/winvmPublicIP"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/virtualNetworks/linvmVNET/subnets/linvmSubnet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkSecurityGroups/winvmNSG"},"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Compute/virtualMachines/winvm"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"dcos-master-B90D500F-nic-0","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/dcos-master-B90D500F-nic-0","etag":"W/\"b3f97e12-7488-442f-ba73-ac1d5e1da580\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"cb1dbe3d-9ca9-4d90-b5e5-03238980e320","ipConfigurations":[{"name":"ipConfigNode","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/dcos-master-B90D500F-nic-0/ipConfigurations/ipConfigNode","etag":"W/\"b3f97e12-7488-442f-ba73-ac1d5e1da580\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.16.0.5","privateIPAllocationMethod":"Static","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/virtualNetworks/dcos-vnet-B90D500F/subnets/dcos-masterSubnet"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/loadBalancers/dcos-master-lb-B90D500F/backendAddressPools/dcos-master-pool-B90D500F"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/loadBalancers/dcos-master-lb-B90D500F/inboundNatRules/SSH-dcos-master-B90D500F-0"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/loadBalancers/dcos-master-lb-B90D500F/inboundNatRules/SSHPort22-dcos-master-B90D500F-0"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"efocew30decu1ily4yieqpwzzc.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-2F-F3","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/dcos-master-nsg-B90D500F"},"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Compute/virtualMachines/dcos-master-B90D500F-0"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"dcos-master-B90D500F-nic-1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/dcos-master-B90D500F-nic-1","etag":"W/\"50272d42-18bb-4aff-86f4-773ebcc3a0e3\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"35f53971-fe38-4735-8ffe-70982ac06abf","ipConfigurations":[{"name":"ipConfigNode","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/dcos-master-B90D500F-nic-1/ipConfigurations/ipConfigNode","etag":"W/\"50272d42-18bb-4aff-86f4-773ebcc3a0e3\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.16.0.6","privateIPAllocationMethod":"Static","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/virtualNetworks/dcos-vnet-B90D500F/subnets/dcos-masterSubnet"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/loadBalancers/dcos-master-lb-B90D500F/backendAddressPools/dcos-master-pool-B90D500F"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/loadBalancers/dcos-master-lb-B90D500F/inboundNatRules/SSH-dcos-master-B90D500F-1"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"efocew30decu1ily4yieqpwzzc.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-26-BB","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/dcos-master-nsg-B90D500F"},"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Compute/virtualMachines/dcos-master-B90D500F-1"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"dcos-master-B90D500F-nic-2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/dcos-master-B90D500F-nic-2","etag":"W/\"607cf1c6-1474-4dc5-b2db-16d2f65aa5b1\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"c868210e-51a6-4ea1-8645-43181d172ace","ipConfigurations":[{"name":"ipConfigNode","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/dcos-master-B90D500F-nic-2/ipConfigurations/ipConfigNode","etag":"W/\"607cf1c6-1474-4dc5-b2db-16d2f65aa5b1\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.16.0.7","privateIPAllocationMethod":"Static","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/virtualNetworks/dcos-vnet-B90D500F/subnets/dcos-masterSubnet"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/loadBalancers/dcos-master-lb-B90D500F/backendAddressPools/dcos-master-pool-B90D500F"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/loadBalancers/dcos-master-lb-B90D500F/inboundNatRules/SSH-dcos-master-B90D500F-2"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"efocew30decu1ily4yieqpwzzc.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-36-2E-FF","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/dcos-master-nsg-B90D500F"},"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Compute/virtualMachines/dcos-master-B90D500F-2"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"yugangw-1VMNic","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-1VMNic","etag":"W/\"c5e3578e-49fc-42cd-b5bb-0c7763c28217\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"8d123e5c-d060-428c-af94-50fecfa4c2f0","ipConfigurations":[{"name":"ipconfigyugangw-1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-1VMNic/ipConfigurations/ipconfigyugangw-1","etag":"W/\"c5e3578e-49fc-42cd-b5bb-0c7763c28217\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.1.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-1PublicIP"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/virtualNetworks/yugangw-vnet/subnets/yugangw-subnet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"twx52doja1jezep1dpecbsja0a.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-33-4B-09","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-1NSG"},"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Compute/virtualMachines/yugangw-1"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"yugangw-3VMNic","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-3VMNic","etag":"W/\"a6930746-4d35-447c-829a-a3f5b1b885ef\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"44041eb0-e5c2-4c6f-a8c7-5c28a39ff4d7","ipConfigurations":[{"name":"ipconfigyugangw-3","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-3VMNic/ipConfigurations/ipconfigyugangw-3","etag":"W/\"a6930746-4d35-447c-829a-a3f5b1b885ef\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.16.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-3PublicIP"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/virtualNetworks/dcos-vnet-B90D500F/subnets/dcos-masterSubnet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"efocew30decu1ily4yieqpwzzc.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-31-79-87","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-3NSG"},"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Compute/virtualMachines/yugangw-3"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"yugangw-9VMNic","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-9VMNic","etag":"W/\"26c5aa1e-1893-4aa2-b019-fea27859dc88\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"08d663e4-b6c6-4bc1-a8c2-e987192248a1","ipConfigurations":[{"name":"ipconfigyugangw-9","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-9VMNic/ipConfigurations/ipconfigyugangw-9","etag":"W/\"26c5aa1e-1893-4aa2-b019-fea27859dc88\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.16.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-9PublicIP"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/virtualNetworks/dcos-vnet-B90D500F/subnets/dcos-masterSubnet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"efocew30decu1ily4yieqpwzzc.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-31-3B-85","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-9NSG"},"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Compute/virtualMachines/yugangw-9"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"yugangw-fat1VMNic","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-fat1VMNic","etag":"W/\"54e61f0c-f70c-4472-bf2d-7a9ffb537bd0\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"959f5fa8-b359-4cbf-8ef0-a0ece238dc1c","ipConfigurations":[{"name":"ipconfigyugangw-fat1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-fat1VMNic/ipConfigurations/ipconfigyugangw-fat1","etag":"W/\"54e61f0c-f70c-4472-bf2d-7a9ffb537bd0\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.1.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-fat1PublicIP"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/virtualNetworks/yugangw-vnet/subnets/yugangw-subnet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"macAddress":"00-0D-3A-34-3F-57","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-fat1NSG"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"yugangw-j1VMNic","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-j1VMNic","etag":"W/\"3dc63907-031e-46bf-a56f-cecf80aa946d\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"ba23ba6d-3e7a-44f7-a342-6acbc8044952","ipConfigurations":[{"name":"ipconfigyugangw-j1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-j1VMNic/ipConfigurations/ipconfigyugangw-j1","etag":"W/\"3dc63907-031e-46bf-a56f-cecf80aa946d\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.1.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-j1PublicIP"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/virtualNetworks/yugangw-vnet/subnets/yugangw-subnet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"macAddress":"00-0D-3A-32-7E-55","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-j1NSG"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"yugangw-junkvmVMNic","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-junkvmVMNic","etag":"W/\"cf17b3ad-b448-4464-9b63-c426db232639\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"3f800013-6d84-449f-94cd-b32cc341f187","ipConfigurations":[{"name":"ipconfigyugangw-junkvm","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-junkvmVMNic/ipConfigurations/ipconfigyugangw-junkvm","etag":"W/\"cf17b3ad-b448-4464-9b63-c426db232639\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.1.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-junkvmPublicIP"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/virtualNetworks/yugangw-vnet/subnets/yugangw-subnet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"macAddress":"00-0D-3A-30-F6-1B","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-junkvmNSG"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"yugangw-k1VMNic","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-k1VMNic","etag":"W/\"dbdbfad7-800e-4666-b255-1f48f5cc8994\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"5e4bb34c-bdc5-4987-8f68-e6027a18a30f","ipConfigurations":[{"name":"ipconfigyugangw-k1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-k1VMNic/ipConfigurations/ipconfigyugangw-k1","etag":"W/\"dbdbfad7-800e-4666-b255-1f48f5cc8994\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.1.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-k1PublicIP"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/virtualNetworks/yugangw-vnet/subnets/yugangw-subnet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"macAddress":"00-0D-3A-35-D8-A9","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-k1NSG"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"yugangw-kernelVMNic","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-kernelVMNic","etag":"W/\"8d1d90a9-c16b-4f5b-a629-a020b64d43c1\"","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"005f6afb-359a-45b8-b500-c6e217fbc26d","ipConfigurations":[{"name":"ipconfigyugangw-kernel","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-kernelVMNic/ipConfigurations/ipconfigyugangw-kernel","etag":"W/\"8d1d90a9-c16b-4f5b-a629-a020b64d43c1\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.1.0.9","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-kernelPublicIP"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/virtualNetworks/yugangw-vnet/subnets/yugangw-subnet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"twx52doja1jezep1dpecbsja0a.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-31-E6-57","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-kernelNSG"},"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Compute/virtualMachines/yugangw-kernel"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"yugangw-portal857","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-portal857","etag":"W/\"32ab6e95-3793-4c8a-85cf-4676a7bb0d8e\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"3308ce27-78a3-4d7a-a79d-5d25e7f043dc","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-portal857/ipConfigurations/ipconfig1","etag":"W/\"32ab6e95-3793-4c8a-85cf-4676a7bb0d8e\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.1.0.10","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/publicIPAddresses/yugangw-portal-ip"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/virtualNetworks/yugangw-vnet/subnets/yugangw-subnet"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"twx52doja1jezep1dpecbsja0a.dx.internal.cloudapp.net"},"macAddress":"00-0D-3A-32-CE-5A","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-portal-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Compute/virtualMachines/yugangw-portal"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic805981da395","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMV29c1708752/providers/Microsoft.Network/networkInterfaces/nic805981da395","etag":"W/\"dca5f5cf-b6c4-474d-85bf-7ed92ebb9838\"","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"d89e6634-c07d-4fe8-ba47-bf29eae26d47","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMV29c1708752/providers/Microsoft.Network/networkInterfaces/nic805981da395/ipConfigurations/primary","etag":"W/\"dca5f5cf-b6c4-474d-85bf-7ed92ebb9838\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMV29c1708752/providers/Microsoft.Network/publicIPAddresses/pip95963778"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMV29c1708752/providers/Microsoft.Network/virtualNetworks/vnet63525bf143/subnets/subnet1"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"3x1hjztffnnu3hiwgm223iby1c.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-16-9C-18","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMV29c1708752/providers/Microsoft.Compute/virtualMachines/VM178c1708739"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic45269808de6","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMV8963671476/providers/Microsoft.Network/networkInterfaces/nic45269808de6","etag":"W/\"305676d5-b517-409c-be9e-91cdc557531c\"","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"efe4a08a-a74c-4218-a72c-cdf6f42ea77c","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMV8963671476/providers/Microsoft.Network/networkInterfaces/nic45269808de6/ipConfigurations/primary","etag":"W/\"305676d5-b517-409c-be9e-91cdc557531c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMV8963671476/providers/Microsoft.Network/publicIPAddresses/pip68662aac"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMV8963671476/providers/Microsoft.Network/virtualNetworks/vnet308455accd/subnets/subnet1"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"1sx1penfov4epep0uhxz4czy2c.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-14-C7-4E","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMV8963671476/providers/Microsoft.Compute/virtualMachines/VM1d3a3671463"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic925565cccfd","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMVc857134170/providers/Microsoft.Network/networkInterfaces/nic925565cccfd","etag":"W/\"a459e285-f10f-4350-a695-d6daeeab2e27\"","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"c01c3ba1-0c0c-406a-b377-add9c62c0895","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMVc857134170/providers/Microsoft.Network/networkInterfaces/nic925565cccfd/ipConfigurations/primary","etag":"W/\"a459e285-f10f-4350-a695-d6daeeab2e27\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMVc857134170/providers/Microsoft.Network/publicIPAddresses/pip43883167"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMVc857134170/providers/Microsoft.Network/virtualNetworks/vnet64915f6090/subnets/subnet1"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"konxdqfg111upjswd4kk5mj4lg.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-18-33-74","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMVc857134170/providers/Microsoft.Compute/virtualMachines/VM166e7134158"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic821783025af","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMVe3e3280593/providers/Microsoft.Network/networkInterfaces/nic821783025af","etag":"W/\"027c6ace-f94d-45ba-a5b9-a63d4ab28de4\"","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"73b148dc-ecba-4556-a7a4-dab896a712a6","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMVe3e3280593/providers/Microsoft.Network/networkInterfaces/nic821783025af/ipConfigurations/primary","etag":"W/\"027c6ace-f94d-45ba-a5b9-a63d4ab28de4\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMVe3e3280593/providers/Microsoft.Network/virtualNetworks/vnet822252482e/subnets/subnet1"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"macAddress":"00-0D-3A-15-75-69","enableAcceleratedNetworking":false,"enableIPForwarding":false},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic02223b8537f","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMVef97261861/providers/Microsoft.Network/networkInterfaces/nic02223b8537f","etag":"W/\"6a0d202a-69c4-4f24-813e-7f7cec462825\"","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"4f22e7c1-99df-4ee3-a7cb-ad78fed96809","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMVef97261861/providers/Microsoft.Network/networkInterfaces/nic02223b8537f/ipConfigurations/primary","etag":"W/\"6a0d202a-69c4-4f24-813e-7f7cec462825\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMVef97261861/providers/Microsoft.Network/virtualNetworks/vnet4155548017/subnets/subnet1"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"tlngqfzsdgyujdsvwjud3t1pnc.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-15-E4-15","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgCOMVef97261861/providers/Microsoft.Compute/virtualMachines/wVM07c7261818"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic12ca12786339c8c","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Network/networkInterfaces/nic12ca12786339c8c","etag":"W/\"7dc70912-e151-491a-8626-b854da7488f4\"","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"29dc2377-fb33-4012-94da-e0b153e4d228","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Network/networkInterfaces/nic12ca12786339c8c/ipConfigurations/primary","etag":"W/\"7dc70912-e151-491a-8626-b854da7488f4\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.16.1.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Network/virtualNetworks/vnetb5a61654eea736/subnets/Front-end"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Network/loadBalancers/intlb1-b5756104d/backendAddressPools/intlb1-b5756104d-BAP1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Network/loadBalancers/intlb1-b5756104d/backendAddressPools/intlb1-b5756104d-BAP2"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Network/loadBalancers/intlb1-b5756104d/inboundNatRules/nat5000to22forVM1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Network/loadBalancers/intlb1-b5756104d/inboundNatRules/nat5001to23forVM1"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"3rbsiikfqtkulehoo3xdq4kj0d.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-19-57-49","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Compute/virtualMachines/lvm1a1b0334299c1d7"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic289174924e3ef1a","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Network/networkInterfaces/nic289174924e3ef1a","etag":"W/\"177605ac-c34e-442d-9f26-0f7937718842\"","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"f1079e50-3203-41b4-ad90-0f314b27f647","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Network/networkInterfaces/nic289174924e3ef1a/ipConfigurations/primary","etag":"W/\"177605ac-c34e-442d-9f26-0f7937718842\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.16.1.5","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Network/virtualNetworks/vnetb5a61654eea736/subnets/Front-end"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Network/loadBalancers/intlb1-b5756104d/backendAddressPools/intlb1-b5756104d-BAP1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Network/loadBalancers/intlb1-b5756104d/backendAddressPools/intlb1-b5756104d-BAP2"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Network/loadBalancers/intlb1-b5756104d/inboundNatRules/nat5002to22forVM2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Network/loadBalancers/intlb1-b5756104d/inboundNatRules/nat5003to23forVM2"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"3rbsiikfqtkulehoo3xdq4kj0d.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-19-57-B2","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemla3235156/providers/Microsoft.Compute/virtualMachines/lvm24c966729877280"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic142986528ce1315","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/networkInterfaces/nic142986528ce1315","etag":"W/\"47f20159-b8f1-47d3-9f5d-719aa8cff18a\"","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"d639f702-1fed-4da5-9678-7167121c588f","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/networkInterfaces/nic142986528ce1315/ipConfigurations/primary","etag":"W/\"47f20159-b8f1-47d3-9f5d-719aa8cff18a\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.16.1.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/publicIPAddresses/pip7748c9a6"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/virtualNetworks/vnet7f086527859abf/subnets/Front-end"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"ase355m2vjnuvbg20qdt3tbq4a.bx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":true,"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/networkSecurityGroups/fensg3fa8652774b03"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nic951517fadc0","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv_f442667004ba/providers/Microsoft.Network/networkInterfaces/nic951517fadc0","etag":"W/\"cb100564-bc26-40f3-ab3e-9941e7af5d4b\"","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"f601dab8-23be-47e1-99ae-71535ebf3872","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv_f442667004ba/providers/Microsoft.Network/networkInterfaces/nic951517fadc0/ipConfigurations/primary","etag":"W/\"cb100564-bc26-40f3-ab3e-9941e7af5d4b\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv_f442667004ba/providers/Microsoft.Network/publicIPAddresses/pip34643db7"},"subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv_f442667004ba/providers/Microsoft.Network/virtualNetworks/vnet884626d0e9/subnets/subnet1"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"vke4trr01qkupe1ljnni1ggdie.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-18-1D-ED","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnemv_f442667004ba/providers/Microsoft.Compute/virtualMachines/employeesvm-720959"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nicjavavm5a1330061","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmexttest32530/providers/Microsoft.Network/networkInterfaces/nicjavavm5a1330061","etag":"W/\"8c2ced02-dacc-489e-9661-1ebe1ff108f0\"","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"e2b4cdc0-8361-4144-99bc-80fcc8e0fce1","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmexttest32530/providers/Microsoft.Network/networkInterfaces/nicjavavm5a1330061/ipConfigurations/primary","etag":"W/\"8c2ced02-dacc-489e-9661-1ebe1ff108f0\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmexttest32530/providers/Microsoft.Network/virtualNetworks/vnet395084dbaa/subnets/subnet1"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"zdd1o3hyanee1cp0uq1t1fpusd.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-17-48-56","enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/vmexttest32530/providers/Microsoft.Compute/virtualMachines/javavm"}},"type":"Microsoft.Network/networkInterfaces"},{"name":"nicjavavma8d43895c","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg57927/providers/Microsoft.Network/networkInterfaces/nicjavavma8d43895c","etag":"W/\"f22008c7-f1e9-4f8d-88d7-349dc858d392\"","location":"southcentralus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"b1e1f2a4-4d7b-421b-9944-4bff611dfffc","ipConfigurations":[{"name":"primary","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg57927/providers/Microsoft.Network/networkInterfaces/nicjavavma8d43895c/ipConfigurations/primary","etag":"W/\"f22008c7-f1e9-4f8d-88d7-349dc858d392\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/javacsmrg57927/providers/Microsoft.Network/virtualNetworks/vnet597907e53e/subnets/subnet1"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"itwk5wrj2h0urk0050tnehvaxf.jx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false},"type":"Microsoft.Network/networkInterfaces"}]}'}
     headers:
       Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Length: ['5366']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 28 Sep 2016 20:00:29 GMT']
+      Date: ['Mon, 23 Jan 2017 17:59:52 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
-      x-ms-original-request-ids: [1ca95c4f-f9c0-41e1-a0e5-ebf7de3cd883, 98f2c7b6-cae8-43be-b7e1-fbf88bfc4e49,
-        cc9d0353-111e-44ce-a29f-d4a5bb3ffbf5]
+      content-length: ['78503']
+      x-ms-original-request-ids: [151984ea-5364-432f-8f53-add4944fcb5a, c16a708c-bbd5-434a-80c9-40aede2e1a14,
+        64ee020d-120c-4eda-8b14-62396040bcb5]
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
@@ -158,19 +158,19 @@ class VMShowListSizesListIPAddressesScenarioTest(ResourceGroupVCRTestBase):
                      self.ip_allocation_method))
 
         result = self.cmd('vm show --resource-group {} --name {} -d'.format(self.resource_group, self.vm_name), checks=[
-                JMESPathCheck('type(@)', 'object'),
-                JMESPathCheck('name', self.vm_name),
-                JMESPathCheck('location', self.location),
-                JMESPathCheck('resourceGroup', self.resource_group),
-                JMESPathCheck('powerState', 'VM running')
+            JMESPathCheck('type(@)', 'object'),
+            JMESPathCheck('name', self.vm_name),
+            JMESPathCheck('location', self.location),
+            JMESPathCheck('resourceGroup', self.resource_group),
+            JMESPathCheck('powerState', 'VM running')
         ])
         self.assertEqual(4, len(result['publicIps'].split('.')))
 
         result = self.cmd('vm list --resource-group {} -d'.format(self.resource_group), checks=[
-                JMESPathCheck('[0].name', self.vm_name),
-                JMESPathCheck('[0].location', self.location),
-                JMESPathCheck('[0].resourceGroup', self.resource_group),
-                JMESPathCheck('[0].powerState', 'VM running')
+            JMESPathCheck('[0].name', self.vm_name),
+            JMESPathCheck('[0].location', self.location),
+            JMESPathCheck('[0].resourceGroup', self.resource_group),
+            JMESPathCheck('[0].powerState', 'VM running')
         ])
         self.assertEqual(4, len(result[0]['publicIps'].split('.')))
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_commands.py
@@ -156,13 +156,24 @@ class VMShowListSizesListIPAddressesScenarioTest(ResourceGroupVCRTestBase):
                  '--authentication-type password'.format(
                      self.resource_group, self.location, self.vm_name, self.deployment_name,
                      self.ip_allocation_method))
-        self.cmd('vm show --resource-group {} --name {} --expand instanceView'.format(
-            self.resource_group, self.vm_name), checks=[
+
+        result = self.cmd('vm show --resource-group {} --name {} -d'.format(self.resource_group, self.vm_name), checks=[
                 JMESPathCheck('type(@)', 'object'),
                 JMESPathCheck('name', self.vm_name),
                 JMESPathCheck('location', self.location),
                 JMESPathCheck('resourceGroup', self.resource_group),
+                JMESPathCheck('powerState', 'VM running')
         ])
+        self.assertEqual(4, len(result['publicIps'].split('.')))
+
+        result = self.cmd('vm list --resource-group {} -d'.format(self.resource_group), checks=[
+                JMESPathCheck('[0].name', self.vm_name),
+                JMESPathCheck('[0].location', self.location),
+                JMESPathCheck('[0].resourceGroup', self.resource_group),
+                JMESPathCheck('[0].powerState', 'VM running')
+        ])
+        self.assertEqual(4, len(result[0]['publicIps'].split('.')))
+
         self.cmd('vm list-vm-resize-options --resource-group {} --name {}'.format(
             self.resource_group, self.vm_name), checks=JMESPathCheck('type(@)', 'array'))
 
@@ -312,7 +323,7 @@ class VMCreateAndStateModificationsScenarioTest(ResourceGroupVCRTestBase):  # py
         self.execute()
 
     def _check_vm_power_state(self, expected_power_state):
-        self.cmd('vm show --resource-group {} --name {} --expand instanceView'.format(
+        self.cmd('vm get-instance-view --resource-group {} --name {}'.format(
             self.resource_group, self.vm_name), checks=[
                 JMESPathCheck('type(@)', 'object'),
                 JMESPathCheck('name', self.vm_name),

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_parameters.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_parameters.py
@@ -33,9 +33,9 @@ class Test_ArgumentParser(unittest.TestCase):
         args = mock_echo_args('vm show',
                               '--id /subscriptions/00000000-0000-0000-0000-0123456789abc/resourceGroups/thisisaresourcegroup/providers/Microsoft.Compute/virtualMachines/thisisavmname')  # pylint: disable=line-too-long
         self.assertDictEqual({
-            'expand': None,
             'resource_group_name': 'thisisaresourcegroup',
-            'vm_name': 'thisisavmname'
+            'vm_name': 'thisisavmname',
+            'show_details': False
         }, args.result)
 
         # Invalid resource ID should trigger the missing resource group
@@ -54,6 +54,7 @@ class Test_ArgumentParser(unittest.TestCase):
         args = mock_echo_args('vm list', '')
         self.assertDictEqual({
             'resource_group_name': None,
+            'show_details': False
         }, args.result)
 
         # if resource group name is specified, however,
@@ -61,6 +62,7 @@ class Test_ArgumentParser(unittest.TestCase):
         args = mock_echo_args('vm list', '-g hullo')
         self.assertDictEqual({
             'resource_group_name': 'hullo',
+            'show_details': False
         }, args.result)
 
     consistent_arguments = {


### PR DESCRIPTION
Fix #154, fix #679
1. add flag `--show-details -d  : Show public ip address, FQDN, and power states. command will run slow.`
2. remove `--expand` flag from `vm show`. The functionality is already covered by `get-instance-view` command, also few end users will understand the flag's meaning