### PR TITLE
[Network] DNS Fixes

### DIFF
--- a/azure-cli.pyproj
+++ b/azure-cli.pyproj
@@ -828,27 +828,17 @@
     <Content Include="azure-cli\setup.cfg" />
     <Content Include="command_modules\azure-cli-acr\azure\cli\command_modules\acr\template.json" />
     <Content Include="command_modules\azure-cli-acr\azure\cli\command_modules\acr\tests\recordings\test_acr.yaml" />
-    <Content Include="command_modules\azure-cli-acr\requirements.txt" />
-    <Content Include="command_modules\azure-cli-acs\requirements.txt" />
     <Content Include="command_modules\azure-cli-appservice\azure\cli\command_modules\appservice\tests\sample_web\.gitignore" />
     <Content Include="command_modules\azure-cli-appservice\azure\cli\command_modules\appservice\tests\sample_web\package.json" />
     <Content Include="command_modules\azure-cli-appservice\azure\cli\command_modules\appservice\tests\sample_web\server.js" />
     <Content Include="command_modules\azure-cli-appservice\README.rst" />
-    <Content Include="command_modules\azure-cli-appservice\requirements.txt" />
     <Content Include="command_modules\azure-cli-appservice\setup.cfg" />
-    <Content Include="command_modules\azure-cli-component\requirements.txt" />
-    <Content Include="command_modules\azure-cli-configure\requirements.txt" />
-    <Content Include="command_modules\azure-cli-container\requirements.txt" />
     <Content Include="command_modules\azure-cli-iot\azure\cli\command_modules\iot\mgmt_iot_hub_device\swagger_iot_hub_device_identity.json" />
-    <Content Include="command_modules\azure-cli-iot\requirements.txt" />
-    <Content Include="command_modules\azure-cli-keyvault\requirements.txt" />
-    <Content Include="command_modules\azure-cli-batch\requirements.txt" />
     <Content Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_app_gateway\azuredeploy.json" />
     <Content Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_app_gateway\azuredeploy_tests.md">
       <SubType>Code</SubType>
     </Content>
     <Content Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_app_gateway\swagger_create_app_gateway.json" />
-    <Content Include="command_modules\azure-cli-feedback\requirements.txt" />
     <Content Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_express_route_circuit\azuredeploy.json" />
     <Content Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_express_route_circuit\swagger_create_express_route_circuit.json" />
     <Content Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_lb\azuredeploy_empty.json" />
@@ -882,16 +872,9 @@
     <Content Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_vpn_connection\swagger_create_vpn_connection.json" />
     <Content Include="command_modules\azure-cli-network\azure\cli\command_modules\network\tests\TestCert.pfx" />
     <Content Include="command_modules\azure-cli-network\azure\cli\command_modules\network\tests\zone.txt" />
-    <Content Include="command_modules\azure-cli-network\requirements.txt" />
-    <Content Include="command_modules\azure-cli-profile\requirements.txt" />
-    <Content Include="command_modules\azure-cli-redis\requirements.txt" />
     <Content Include="command_modules\azure-cli-resource\azure\cli\command_modules\resource\tests\sample_policy_rule.json" />
     <Content Include="command_modules\azure-cli-resource\azure\cli\command_modules\resource\tests\simple_deploy.json" />
     <Content Include="command_modules\azure-cli-resource\azure\cli\command_modules\resource\tests\simple_deploy_parameters.json" />
-    <Content Include="command_modules\azure-cli-resource\requirements.txt" />
-    <Content Include="command_modules\azure-cli-role\requirements.txt" />
-    <Content Include="command_modules\azure-cli-storage\requirements.txt" />
-    <Content Include="command_modules\azure-cli-taskhelp\requirements.txt" />
     <Content Include="command_modules\azure-cli-vm\azure\cli\command_modules\vm\mgmt_acs\azuredeploy.json" />
     <Content Include="command_modules\azure-cli-vm\azure\cli\command_modules\vm\mgmt_acs\swagger_create_acs.json" />
     <Content Include="command_modules\azure-cli-vm\azure\cli\command_modules\vm\mgmt_avail_set\azuredeploy.json" />
@@ -926,7 +909,6 @@
     <Content Include="command_modules\azure-cli-vm\azure\cli\command_modules\vm\mgmt_vm\nested_templates\vm_none_sshkey.json" />
     <Content Include="command_modules\azure-cli-vm\azure\cli\command_modules\vm\mgmt_vm\swagger_create_vm.json" />
     <Content Include="command_modules\azure-cli-vm\azure\cli\command_modules\vm\tests\aliases.json" />
-    <Content Include="command_modules\azure-cli-vm\requirements.txt" />
   </ItemGroup>
   <ItemGroup>
     <Interpreter Include="..\env\">

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_format.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_format.py
@@ -23,6 +23,18 @@ def transform_dns_record_set_output(result):
 
     return result
 
+def transform_dns_record_set_table_output(result):
+    table_output = []
+    for item in result:
+        table_row = OrderedDict()
+        table_row['Name'] = item['name']
+        table_row['ResourceGroup'] = item['resourceGroup']
+        table_row['Ttl'] = item['ttl']
+        table_row['Type'] = item['type'].rsplit('/', 1)[1]
+        table_row['Metadata'] = item['metadata'] or ' '
+        table_output.append(table_row)
+    return table_output
+
 def transform_local_gateway_table_output(result):
     final_result = []
     for item in result:

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_format.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_format.py
@@ -25,13 +25,18 @@ def transform_dns_record_set_output(result):
 
 def transform_dns_record_set_table_output(result):
     table_output = []
+
     for item in result:
         table_row = OrderedDict()
         table_row['Name'] = item['name']
         table_row['ResourceGroup'] = item['resourceGroup']
         table_row['Ttl'] = item['ttl']
         table_row['Type'] = item['type'].rsplit('/', 1)[1]
-        table_row['Metadata'] = item['metadata'] or ' '
+        metadata = item['metadata']
+        if metadata:
+            table_row['Metadata'] = ' '.join(['{}="{}"'.format(x, metadata[x]) for x in sorted(metadata)])
+        else:
+            table_row['Metadata'] = ' '
         table_output.append(table_row)
     return table_output
 

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -551,8 +551,6 @@ register_cli_argument('network dns zone import', 'file_name', help='Path to the 
 register_cli_argument('network dns zone export', 'file_name', help='Path to the DNS zone file to save')
 register_cli_argument('network dns zone update', 'if_none_match', ignore_type)
 
-register_cli_argument('network dns record', 'record_set_name', options_list=('--record-set-name',))
-
 register_cli_argument('network dns record txt add', 'value', nargs='+')
 register_cli_argument('network dns record txt remove', 'value', nargs='+')
 
@@ -562,3 +560,6 @@ register_cli_argument('network dns record-set create', 'if_none_match', help='Cr
 
 for item in ['list', 'show']:
     register_cli_argument('network dns record-set {}'.format(item), 'record_type', options_list=('--type', '-t'), **enum_choice_list(RecordType))
+
+for item in ['a', 'aaaa', 'cname', 'mx', 'ns', 'ptr', 'srv', 'txt']:
+    register_cli_argument('network dns record {} add'.format(item), 'record_set_name', options_list=('--record-set-name',), help='The name of the record set relative to the zone. Creates a new record set if one does not exist.')

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -563,3 +563,4 @@ for item in ['list', 'show']:
 
 for item in ['a', 'aaaa', 'cname', 'mx', 'ns', 'ptr', 'srv', 'txt']:
     register_cli_argument('network dns record {} add'.format(item), 'record_set_name', options_list=('--record-set-name',), help='The name of the record set relative to the zone. Creates a new record set if one does not exist.')
+    register_cli_argument('network dns record {} remove'.format(item), 'record_set_name', options_list=('--record-set-name',), help='The name of the record set relative to the zone.')

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
@@ -13,7 +13,8 @@ from ._util import (list_network_resource_property,
                     get_network_resource_property_entry,
                     delete_network_resource_property_entry)
 from ._format import \
-    (transform_local_gateway_table_output, transform_dns_record_set_output)
+    (transform_local_gateway_table_output, transform_dns_record_set_output,
+     transform_dns_record_set_table_output)
 
 custom_path = 'azure.cli.command_modules.network.custom#{}'
 
@@ -415,7 +416,7 @@ cli_command(__name__, 'network dns zone create', custom_path.format('create_dns_
 # DNS RecordSetsOperations
 cli_command(__name__, 'network dns record-set show', 'azure.mgmt.dns.operations.record_sets_operations#RecordSetsOperations.get', cf_dns_mgmt_record_sets, transform=transform_dns_record_set_output)
 cli_command(__name__, 'network dns record-set delete', 'azure.mgmt.dns.operations.record_sets_operations#RecordSetsOperations.delete', cf_dns_mgmt_record_sets)
-cli_command(__name__, 'network dns record-set list', 'azure.mgmt.dns.operations.record_sets_operations#RecordSetsOperations.list_all_in_resource_group', cf_dns_mgmt_record_sets, transform=transform_dns_record_set_output)
+cli_command(__name__, 'network dns record-set list', custom_path.format('list_dns_record_set'), cf_dns_mgmt_record_sets, transform=transform_dns_record_set_output, table_transformer=transform_dns_record_set_table_output)
 cli_command(__name__, 'network dns record-set create', custom_path.format('create_dns_record_set'), transform=transform_dns_record_set_output)
 cli_generic_update_command(__name__, 'network dns record-set update',
                            'azure.mgmt.dns.operations.record_sets_operations#RecordSetsOperations.get',

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -1584,7 +1584,10 @@ def _add_record(record_set, record, record_type, property_name=None, is_list=Fal
 def _add_save_record(record, record_type, record_set_name, resource_group_name, zone_name,
                      property_name=None, is_list=True):
     ncf = get_mgmt_service_client(DnsManagementClient).record_sets
-    record_set = ncf.get(resource_group_name, zone_name, record_set_name, record_type)
+    try:
+        record_set = ncf.get(resource_group_name, zone_name, record_set_name, record_type)
+    except CloudError:
+        record_set = RecordSet(name=record_set_name, type=record_type, ttl=3600)
 
     _add_record(record_set, record, record_type, property_name, is_list)
 

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -1587,7 +1587,7 @@ def _add_save_record(record, record_type, record_set_name, resource_group_name, 
     try:
         record_set = ncf.get(resource_group_name, zone_name, record_set_name, record_type)
     except CloudError:
-        record_set = RecordSet(name=record_set_name, type=record_type, ttl=3600)
+        record_set = RecordSet(name=record_set_name, type=record_type, ttl=3600)  # pylint: disable=redefined-variable-type
 
     _add_record(record_set, record, record_type, property_name, is_list)
 

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -1324,6 +1324,12 @@ def create_dns_record_set(resource_group_name, zone_name, record_set_name, recor
                                 if_none_match='*' if if_none_match else None)
 create_dns_record_set.__doc__ = RecordSetsOperations.create_or_update.__doc__
 
+def list_dns_record_set(client, resource_group_name, zone_name, record_type=None):
+    if record_type:
+        return client.list_by_type(resource_group_name, zone_name, record_type)
+    else:
+        return client.list_all_in_resource_group(resource_group_name, zone_name)
+
 def update_dns_record_set(instance, metadata=None):
     if metadata is not None:
         instance.metadata = metadata

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_dns.yaml
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_dns.yaml
@@ -1,27 +1,26 @@
 interactions:
 - request:
-    body: !!binary |
-      eyJsb2NhdGlvbiI6ICJnbG9iYWwifQ==
+    body: '{"location": "global"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['22']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9f372b06-a792-11e6-b228-3c15c2cf0610]
+      x-ms-client-request-id: [8a81270c-e1b9-11e6-8471-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/00977cdb-163f-435f-9c32-39ec8ae61f4d\/resourceGroups\/cli_dns_test1\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-8fa5-87619f3bd201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-08.azure-dns.com.","ns2-08.azure-dns.net.","ns3-08.azure-dns.org.","ns4-08.azure-dns.info."],"numberOfRecordSets":2}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-c2f0-7a4cc675d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-02.azure-dns.com.","ns2-02.azure-dns.net.","ns3-02.azure-dns.org.","ns4-02.azure-dns.info."],"numberOfRecordSets":2}}'}
     headers:
       Cache-Control: [private]
-      Content-Length: ['458']
+      Content-Length: ['463']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:11:27 GMT']
-      ETag: [00000002-0000-0000-8fa5-87619f3bd201]
+      Date: ['Mon, 23 Jan 2017 22:16:09 GMT']
+      ETag: [00000002-0000-0000-c2f0-7a4cc675d201]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
@@ -36,67 +35,57 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a11f9c62-a792-11e6-9982-3c15c2cf0610]
+      x-ms-client-request-id: [8bc19a28-e1b9-11e6-a029-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com?api-version=2016-04-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf/b53m/WkmdbFqi2qZfP73t3ZefjgwXQ22d799N759v69++fbD6f39rbvPcynB1n+6e75/uz3
-        vVvnTbWup/nndbVe0VvTsvj9Z8vm92/zpt39fe+u6uqymOU1ffNFMa2rpjpvxy/y9qqq3/6+d6nh
-        D6plTl8urvHLeFotPhp9tMwWOWEUfNZer/DZBiDUKG+zC2q0I8/eNv2zI/8cnGf3tw8efLr78Pze
-        ZLa3s0uty2qaYaz0xkVZTbKSPiMAzUePfvEvGX1EmK/yui0I8KNf/NEie/divZjk9Zfnr/JpVc9e
-        5y19cZ9gC76v8/qShvnRo+99tGx2t3cOxtkP1nW+TdhhBGOCvWwII//zZd7K5/fCz6v6Qj7fDz8v
-        lufV+KPv0zcRVPZ+yS/5fwBMy4ONygEAAA==
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-c2f0-7a4cc675d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-02.azure-dns.com.","ns2-02.azure-dns.net.","ns3-02.azure-dns.org.","ns4-02.azure-dns.info."],"numberOfRecordSets":2}}'}
     headers:
       Cache-Control: [private]
-      Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:11:28 GMT']
-      ETag: [00000002-0000-0000-8fa5-87619f3bd201]
+      Date: ['Mon, 23 Jan 2017 22:16:11 GMT']
+      ETag: [00000002-0000-0000-c2f0-7a4cc675d201]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
+      content-length: ['463']
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: !!binary |
-      eyJuYW1lIjogIm15cnNhIiwgInR5cGUiOiAiQSIsICJwcm9wZXJ0aWVzIjogeyJUVEwiOiAzNjAw
-      fX0=
+    body: '{"properties": {"TTL": 3600}, "type": "A", "name": "myrsa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['59']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a2207b2e-a792-11e6-9959-3c15c2cf0610]
+      x-ms-client-request-id: [8c5e6ba6-e1b9-11e6-aaa5-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/00977cdb-163f-435f-9c32-39ec8ae61f4d\/resourceGroups\/cli_dns_test1\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"8494b27a-5dca-4039-993e-e6ea0e40aab1","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"4ab3ef98-0c03-4811-b69e-520e9c6617f8","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
     headers:
       Cache-Control: [private]
-      Content-Length: ['323']
+      Content-Length: ['328']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:11:31 GMT']
-      ETag: [8494b27a-5dca-4039-993e-e6ea0e40aab1]
+      Date: ['Mon, 23 Jan 2017 22:16:12 GMT']
+      ETag: [4ab3ef98-0c03-4811-b69e-520e9c6617f8]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -105,95 +94,142 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a3a1c44c-a792-11e6-aa65-3c15c2cf0610]
+      x-ms-client-request-id: [8d5cb8f4-e1b9-11e6-9573-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf/b53m/WkmdbFqi2qZfP73t3ZefjgwXQ22d799N759v69++fbD6f39rbvPcynB1n+6e75/uz3
-        vVvnTbWup/nndbVe0VvTsvj9Z8vm92/zpt39fe+u6uqymOU1ffNFMa2rpjpvxy/y9qqq3/6+d6nh
-        D6plTl8urvHLeFotft+7x/izbrKPRh8ts0VOuJk/2+sV/twI6Zja5W12Qe0O9h/uT/YeZNv3Z9Ns
-        e3/n3sPthw/v5dv5p3m2k+/vZNlkl1oTjqu8bou8+ejRL/7o/BfNlvQudzl2aI2p4Zs3zz96dO/T
-        nZ3RR8ev8mlVz+iN733/l/yS/wdeIkZcQwEAAA==
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"4ab3ef98-0c03-4811-b69e-520e9c6617f8","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
     headers:
       Cache-Control: [private]
-      Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:11:36 GMT']
-      ETag: [8494b27a-5dca-4039-993e-e6ea0e40aab1]
+      Date: ['Mon, 23 Jan 2017 22:16:14 GMT']
+      ETag: [4ab3ef98-0c03-4811-b69e-520e9c6617f8]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      content-length: ['328']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 200, message: OK}
 - request:
-    body: !!binary |
-      eyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wMDk3N2NkYi0xNjNmLTQzNWYtOWMzMi0zOWVjOGFlNjFm
-      NGQvcmVzb3VyY2VHcm91cHMvY2xpX2Ruc190ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdv
-      cmsvZG5zem9uZXMvbXl6b25lLmNvbS9BL215cnNhIiwgInByb3BlcnRpZXMiOiB7IlRUTCI6IDM2
-      MDAsICJBUmVjb3JkcyI6IFt7ImlwdjRBZGRyZXNzIjogIjEwLjAuMC4xMCJ9XX0sICJuYW1lIjog
-      Im15cnNhIiwgInR5cGUiOiAiTWljcm9zb2Z0Lk5ldHdvcmsvZG5zem9uZXMvQSIsICJldGFnIjog
-      Ijg0OTRiMjdhLTVkY2EtNDAzOS05OTNlLWU2ZWEwZTQwYWFiMSJ9
+    body: '{"type": "Microsoft.Network/dnszones/A", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa",
+      "properties": {"TTL": 3600, "ARecords": [{"ipv4Address": "10.0.0.10"}]}, "etag":
+      "4ab3ef98-0c03-4811-b69e-520e9c6617f8", "name": "myrsa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['324']
+      Content-Length: ['329']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a62707d8-a792-11e6-a81b-3c15c2cf0610]
+      x-ms-client-request-id: [8dd2da3a-e1b9-11e6-a8ef-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/00977cdb-163f-435f-9c32-39ec8ae61f4d\/resourceGroups\/cli_dns_test1\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"d105017e-4168-4a9c-b361-ec38bb178e1c","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"69b5e7ad-42b5-4481-8bd3-66d6ca299c2f","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
     headers:
       Cache-Control: [private]
-      Content-Length: ['350']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:11:41 GMT']
-      ETag: [d105017e-4168-4a9c-b361-ec38bb178e1c]
+      Date: ['Mon, 23 Jan 2017 22:16:15 GMT']
+      ETag: [69b5e7ad-42b5-4481-8bd3-66d6ca299c2f]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['355']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [8eb538fa-e1b9-11e6-b789-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsaalt?api-version=2016-04-01
+  response:
+    body: {string: '{"code":"NotFound","message":"The resource record ''myrsaalt''
+        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['172']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:16:16 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-    status: {code: 200, message: OK}
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11996']
+    status: {code: 404, message: Not Found}
 - request:
-    body: !!binary |
-      eyJuYW1lIjogIm15cnNhYWFhIiwgInR5cGUiOiAiQUFBQSIsICJwcm9wZXJ0aWVzIjogeyJUVEwi
-      OiAzNjAwfX0=
+    body: '{"properties": {"TTL": 3600, "ARecords": [{"ipv4Address": "10.0.0.10"}]},
+      "type": "a", "name": "myrsaalt"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['106']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [8f336e64-e1b9-11e6-bbc2-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsaalt?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsaalt","name":"myrsaalt","type":"Microsoft.Network\/dnszones\/A","etag":"ad689281-89d1-40a1-941b-b40f6887c312","properties":{"fqdn":"myrsaalt.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['364']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:16:18 GMT']
+      ETag: [ad689281-89d1-40a1-941b-b40f6887c312]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
+    status: {code: 201, message: Created}
+- request:
+    body: '{"properties": {"TTL": 3600}, "type": "AAAA", "name": "myrsaaaa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['65']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a94f3670-a792-11e6-a654-3c15c2cf0610]
+      x-ms-client-request-id: [90566876-e1b9-11e6-bc35-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/00977cdb-163f-435f-9c32-39ec8ae61f4d\/resourceGroups\/cli_dns_test1\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"65869e87-8652-4bbe-b62c-3a5f4559e6e6","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"3deb27e2-aef3-4d34-88a3-9e5a5a2760e2","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[]}}'}
     headers:
       Cache-Control: [private]
-      Content-Length: ['341']
+      Content-Length: ['346']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:11:46 GMT']
-      ETag: [65869e87-8652-4bbe-b62c-3a5f4559e6e6]
+      Date: ['Mon, 23 Jan 2017 22:16:19 GMT']
+      ETag: [3deb27e2-aef3-4d34-88a3-9e5a5a2760e2]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
@@ -208,106 +244,142 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ad3fa12c-a792-11e6-9411-3c15c2cf0610]
+      x-ms-client-request-id: [915e61dc-e1b9-11e6-a0d5-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf/b53m/WkmdbFqi2qZfP73t3ZefjgwXQ22d799N759v69++fbD6f39rbvPcynB1n+6e75/uz3
-        vVvnTbWup/nndbVe0VvTsvj9Z8vm92/zpt39fe+u6uqymOU1ffNFMa2rpjpvxy/y9qqq3/6+d6nh
-        D6plTl8urvHLeFotft+7x/Tgk7rJ6Plo9NEyW+SEofdJe73CJxtBEpRjapq32QU1/fT+wacP84MH
-        2wef3t/b3p9M8u3Jp3vT7XvZ/fP9+/cf5p/mn1JrwneV122RNx89+sUfnf+i2ZLeNR2PHZZjavvm
-        zfOPHt37dGdn9BF1dfwqn1b1jN773vd/yS/5fwC9uoh8VQEAAA==
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"3deb27e2-aef3-4d34-88a3-9e5a5a2760e2","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[]}}'}
     headers:
       Cache-Control: [private]
-      Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:11:52 GMT']
-      ETag: [65869e87-8652-4bbe-b62c-3a5f4559e6e6]
+      Date: ['Mon, 23 Jan 2017 22:16:20 GMT']
+      ETag: [3deb27e2-aef3-4d34-88a3-9e5a5a2760e2]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
+      content-length: ['346']
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: !!binary |
-      eyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wMDk3N2NkYi0xNjNmLTQzNWYtOWMzMi0zOWVjOGFlNjFm
-      NGQvcmVzb3VyY2VHcm91cHMvY2xpX2Ruc190ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdv
-      cmsvZG5zem9uZXMvbXl6b25lLmNvbS9BQUFBL215cnNhYWFhIiwgImV0YWciOiAiNjU4NjllODct
-      ODY1Mi00YmJlLWI2MmMtM2E1ZjQ1NTllNmU2IiwgIm5hbWUiOiAibXlyc2FhYWEiLCAidHlwZSI6
-      ICJNaWNyb3NvZnQuTmV0d29yay9kbnN6b25lcy9BQUFBIiwgInByb3BlcnRpZXMiOiB7IkFBQUFS
-      ZWNvcmRzIjogW3siaXB2NkFkZHJlc3MiOiAiMjAwMTpkYjg6MDoxOjE6MToxOjEifV0sICJUVEwi
-      OiAzNjAwfX0=
+    body: '{"type": "Microsoft.Network/dnszones/AAAA", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa",
+      "properties": {"AAAARecords": [{"ipv6Address": "2001:db8:0:1:1:1:1:1"}], "TTL":
+      3600}, "etag": "3deb27e2-aef3-4d34-88a3-9e5a5a2760e2", "name": "myrsaaaa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['350']
+      Content-Length: ['355']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b0056f92-a792-11e6-892f-3c15c2cf0610]
+      x-ms-client-request-id: [91d95a58-e1b9-11e6-aaa4-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf/b53m/WkmdbFqi2qZfP73t3ZefjgwXQ22d799N759v69++fbD6f39rbvPcynB1n+6e75/uz3
-        vVvnTbWup/nndbVe0VvTsvj9Z8vm92/zpt39fe+u6uqymOU1ffNFMa2rpjpvxy/y9qqq3/6+d6nh
-        D6plTl8urvHLeFotft+7x/Tgk7rJ6Plo9NEyW+SEofdJe73CJxtBEpRjapq32QU1zR9+urd3nu9t
-        T6Z7k+39h+cPtw/yg0+3Hzy4v3cwOc927h/sUmvCd5XXbZE3Hz36xR+d/6LZkt41HY8dlmNq++bN
-        848e3ft0Z2f0EXV1/CqfVvWM3vseUXR1+enxbEbEob8/2tvZ2X00mxw82nm0a/776Jd8/5f8kv8H
-        5wXTIXsBAAA=
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"72495495-8e86-4754-991e-9ccdee711977","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
     headers:
       Cache-Control: [private]
-      Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:11:55 GMT']
-      ETag: [e9622fe2-bc2b-49f9-8e86-77528bfa0581]
+      Date: ['Mon, 23 Jan 2017 22:16:21 GMT']
+      ETag: [72495495-8e86-4754-991e-9ccdee711977]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
+      content-length: ['384']
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: !!binary |
-      eyJuYW1lIjogIm15cnNjbmFtZSIsICJ0eXBlIjogIkNOQU1FIiwgInByb3BlcnRpZXMiOiB7IlRU
-      TCI6IDM2MDB9fQ==
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [92de670c-e1b9-11e6-82db-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaaalt?api-version=2016-04-01
+  response:
+    body: {string: '{"code":"NotFound","message":"The resource record ''myrsaaaaalt''
+        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['175']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:16:23 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 404, message: Not Found}
+- request:
+    body: '{"properties": {"AAAARecords": [{"ipv6Address": "2001:db8:0:1:1:1:1:1"}],
+      "TTL": 3600}, "type": "aaaa", "name": "myrsaaaaalt"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['126']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9339b024-e1b9-11e6-8560-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaaalt?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaaalt","name":"myrsaaaaalt","type":"Microsoft.Network\/dnszones\/AAAA","etag":"21f33888-2207-42e2-a4ad-e7792bcc84f7","properties":{"fqdn":"myrsaaaaalt.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['393']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:16:24 GMT']
+      ETag: [21f33888-2207-42e2-a4ad-e7792bcc84f7]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+    status: {code: 201, message: Created}
+- request:
+    body: '{"properties": {"TTL": 3600}, "type": "CNAME", "name": "myrscname"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['67']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b35a6600-a792-11e6-9168-3c15c2cf0610]
+      x-ms-client-request-id: [9439701c-e1b9-11e6-a9c4-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/00977cdb-163f-435f-9c32-39ec8ae61f4d\/resourceGroups\/cli_dns_test1\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"c9a3d52d-cf75-48dd-aed6-c937f5654a6c","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"a855e325-2740-4493-a327-2e63d001716b","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600}}'}
     headers:
       Cache-Control: [private]
-      Content-Length: ['329']
+      Content-Length: ['334']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:12:00 GMT']
-      ETag: [c9a3d52d-cf75-48dd-aed6-c937f5654a6c]
+      Date: ['Mon, 23 Jan 2017 22:16:26 GMT']
+      ETag: [a855e325-2740-4493-a327-2e63d001716b]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
@@ -322,101 +394,148 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b486972e-a792-11e6-b11a-3c15c2cf0610]
+      x-ms-client-request-id: [95494506-e1b9-11e6-9594-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/00977cdb-163f-435f-9c32-39ec8ae61f4d\/resourceGroups\/cli_dns_test1\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"c9a3d52d-cf75-48dd-aed6-c937f5654a6c","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"a855e325-2740-4493-a327-2e63d001716b","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600}}'}
     headers:
       Cache-Control: [private]
-      Content-Length: ['329']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:12:02 GMT']
-      ETag: [c9a3d52d-cf75-48dd-aed6-c937f5654a6c]
+      Date: ['Mon, 23 Jan 2017 22:16:27 GMT']
+      ETag: [a855e325-2740-4493-a327-2e63d001716b]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wMDk3N2NkYi0xNjNmLTQzNWYtOWMzMi0zOWVjOGFlNjFm
-      NGQvcmVzb3VyY2VHcm91cHMvY2xpX2Ruc190ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdv
-      cmsvZG5zem9uZXMvbXl6b25lLmNvbS9DTkFNRS9teXJzY25hbWUiLCAicHJvcGVydGllcyI6IHsi
-      VFRMIjogMzYwMCwgIkNOQU1FUmVjb3JkIjogeyJjbmFtZSI6ICJteWNuYW1lIn19LCAibmFtZSI6
-      ICJteXJzY25hbWUiLCAidHlwZSI6ICJNaWNyb3NvZnQuTmV0d29yay9kbnN6b25lcy9DTkFNRSIs
-      ICJldGFnIjogImM5YTNkNTJkLWNmNzUtNDhkZC1hZWQ2LWM5MzdmNTY1NGE2YyJ9
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['333']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [b525e28c-a792-11e6-b0ba-3c15c2cf0610]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname?api-version=2016-04-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf/b53m/WkmdbFqi2qZfP73t3ZefjgwXQ22d799N759v69++fbD6f39rbvPcynB1n+6e75/uz3
-        vVvnTbWup/nndbVe0VvTsvj9Z8vm92/zpt39fe+u6uqymOU1ffNFMa2rpjpvxy/y9qqq3/6+d6nh
-        D6plTl8urvHLeFotft+7Jy+OvzjFR3UzXWaL/KPRR/zj0Uf+R+31Ch9thMqQqG3eZhfUdu/Bw0/P
-        s/v729mnk73t/d0H+9sHkwf3tif72cPZ3iQ/nx3sU2vCeZXXbZE3Hz36xR+d/6LZkt61XY8dqmNq
-        /ObN848e3ft0Z2f0Eff2Kp9WNdHzF3/ErflN+e2X/JJf8v8AZojix2sBAAA=
-    headers:
-      Cache-Control: [private]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:12:03 GMT']
-      ETag: [2796fa54-a6b2-4174-8b73-b4a9d2befd84]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
+      content-length: ['334']
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: !!binary |
-      eyJuYW1lIjogIm15cnNteCIsICJ0eXBlIjogIk1YIiwgInByb3BlcnRpZXMiOiB7IlRUTCI6IDM2
-      MDB9fQ==
+    body: '{"type": "Microsoft.Network/dnszones/CNAME", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname",
+      "properties": {"CNAMERecord": {"cname": "mycname"}, "TTL": 3600}, "etag": "a855e325-2740-4493-a327-2e63d001716b",
+      "name": "myrscname"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['338']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [95a40cf4-e1b9-11e6-92ad-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"d871c6bd-bcfa-42e6-b603-69ab5ad68473","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:16:27 GMT']
+      ETag: [d871c6bd-bcfa-42e6-b603-69ab5ad68473]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['368']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [967e9b08-e1b9-11e6-8111-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscnamealt?api-version=2016-04-01
+  response:
+    body: {string: '{"code":"NotFound","message":"The resource record ''myrscnamealt''
+        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['176']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:16:29 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+    status: {code: 404, message: Not Found}
+- request:
+    body: '{"properties": {"CNAMERecord": {"cname": "mycname"}, "TTL": 3600}, "type":
+      "cname", "name": "myrscnamealt"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['107']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [96be1626-e1b9-11e6-b0bc-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscnamealt?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscnamealt","name":"myrscnamealt","type":"Microsoft.Network\/dnszones\/CNAME","etag":"7658182f-01ef-4712-bf2e-4fae29f5cb95","properties":{"fqdn":"myrscnamealt.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['377']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:16:29 GMT']
+      ETag: [7658182f-01ef-4712-bf2e-4fae29f5cb95]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 201, message: Created}
+- request:
+    body: '{"properties": {"TTL": 3600}, "type": "MX", "name": "myrsmx"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['61']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b665bd90-a792-11e6-91ab-3c15c2cf0610]
+      x-ms-client-request-id: [97892ca2-e1b9-11e6-b4d6-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/00977cdb-163f-435f-9c32-39ec8ae61f4d\/resourceGroups\/cli_dns_test1\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"6f529cfb-01d8-4785-83c5-4ea7b7efcf38","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"956a4cb3-680c-46b7-8497-9903b0838f32","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
     headers:
       Cache-Control: [private]
-      Content-Length: ['329']
+      Content-Length: ['334']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:12:05 GMT']
-      ETag: [6f529cfb-01d8-4785-83c5-4ea7b7efcf38]
+      Date: ['Mon, 23 Jan 2017 22:16:31 GMT']
+      ETag: [956a4cb3-680c-46b7-8497-9903b0838f32]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -425,799 +544,358 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b83a7ce6-a792-11e6-abb5-3c15c2cf0610]
+      x-ms-client-request-id: [9864d026-e1b9-11e6-880e-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/00977cdb-163f-435f-9c32-39ec8ae61f4d\/resourceGroups\/cli_dns_test1\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"6f529cfb-01d8-4785-83c5-4ea7b7efcf38","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"956a4cb3-680c-46b7-8497-9903b0838f32","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
     headers:
       Cache-Control: [private]
-      Content-Length: ['329']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:12:07 GMT']
-      ETag: [6f529cfb-01d8-4785-83c5-4ea7b7efcf38]
+      Date: ['Mon, 23 Jan 2017 22:16:32 GMT']
+      ETag: [956a4cb3-680c-46b7-8497-9903b0838f32]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['334']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"type": "Microsoft.Network/dnszones/MX", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx",
+      "properties": {"TTL": 3600, "MXRecords": [{"preference": 13, "exchange": "12"}]},
+      "etag": "956a4cb3-680c-46b7-8497-9903b0838f32", "name": "myrsmx"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['342']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [98d1398a-e1b9-11e6-a1c1-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"b5642c85-2454-41bc-9e17-e25d4d670036","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:16:33 GMT']
+      ETag: [b5642c85-2454-41bc-9e17-e25d4d670036]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['367']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [999acb76-e1b9-11e6-95b0-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmxalt?api-version=2016-04-01
+  response:
+    body: {string: '{"code":"NotFound","message":"The resource record ''myrsmxalt''
+        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['173']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:16:34 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 404, message: Not Found}
+- request:
+    body: '{"properties": {"TTL": 3600, "MXRecords": [{"preference": 13, "exchange":
+      "12"}]}, "type": "mx", "name": "myrsmxalt"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['117']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [99f30b48-e1b9-11e6-a316-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmxalt?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmxalt","name":"myrsmxalt","type":"Microsoft.Network\/dnszones\/MX","etag":"4c03d5db-bd5e-46a4-8da3-8998e2faab78","properties":{"fqdn":"myrsmxalt.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['376']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:16:36 GMT']
+      ETag: [4c03d5db-bd5e-46a4-8da3-8998e2faab78]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+    status: {code: 201, message: Created}
+- request:
+    body: '{"properties": {"TTL": 3600}, "type": "NS", "name": "myrsns"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['61']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9aff8410-e1b9-11e6-8b86-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"5dc0cafc-40d8-4f28-b6cd-98286fe62c5d","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['334']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:16:36 GMT']
+      ETag: [5dc0cafc-40d8-4f28-b6cd-98286fe62c5d]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9babcb38-e1b9-11e6-ab6e-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"5dc0cafc-40d8-4f28-b6cd-98286fe62c5d","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:16:37 GMT']
+      ETag: [5dc0cafc-40d8-4f28-b6cd-98286fe62c5d]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['334']
     status: {code: 200, message: OK}
 - request:
-    body: !!binary |
-      eyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wMDk3N2NkYi0xNjNmLTQzNWYtOWMzMi0zOWVjOGFlNjFm
-      NGQvcmVzb3VyY2VHcm91cHMvY2xpX2Ruc190ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdv
-      cmsvZG5zem9uZXMvbXl6b25lLmNvbS9NWC9teXJzbXgiLCAicHJvcGVydGllcyI6IHsiTVhSZWNv
-      cmRzIjogW3siZXhjaGFuZ2UiOiAiMTIiLCAicHJlZmVyZW5jZSI6IDEzfV0sICJUVEwiOiAzNjAw
-      fSwgIm5hbWUiOiAibXlyc214IiwgInR5cGUiOiAiTWljcm9zb2Z0Lk5ldHdvcmsvZG5zem9uZXMv
-      TVgiLCAiZXRhZyI6ICI2ZjUyOWNmYi0wMWQ4LTQ3ODUtODNjNS00ZWE3YjdlZmNmMzgifQ==
+    body: '{"type": "Microsoft.Network/dnszones/NS", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns",
+      "properties": {"TTL": 3600, "NSRecords": [{"nsdname": "foobar.com"}]}, "etag":
+      "5dc0cafc-40d8-4f28-b6cd-98286fe62c5d", "name": "myrsns"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['331']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9c113c26-e1b9-11e6-8ab9-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"ff950952-88ba-46af-b20b-dad5d4f81dcd","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:16:38 GMT']
+      ETag: [ff950952-88ba-46af-b20b-dad5d4f81dcd]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['358']
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9cd5f89c-e1b9-11e6-836c-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsnsalt?api-version=2016-04-01
+  response:
+    body: {string: '{"code":"NotFound","message":"The resource record ''myrsnsalt''
+        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['173']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:16:40 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+    status: {code: 404, message: Not Found}
+- request:
+    body: '{"properties": {"TTL": 3600, "NSRecords": [{"nsdname": "foobar.com"}]},
+      "type": "ns", "name": "myrsnsalt"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['106']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9d0e769a-e1b9-11e6-878f-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsnsalt?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsnsalt","name":"myrsnsalt","type":"Microsoft.Network\/dnszones\/NS","etag":"c2307410-b445-491c-9fca-f019f525ddd6","properties":{"fqdn":"myrsnsalt.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['367']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:16:40 GMT']
+      ETag: [c2307410-b445-491c-9fca-f019f525ddd6]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+    status: {code: 201, message: Created}
+- request:
+    body: '{"properties": {"TTL": 3600}, "type": "PTR", "name": "myrsptr"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['63']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9dd6b264-e1b9-11e6-8628-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"bd8d6024-8af7-4a42-b44b-62b9e1246144","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['340']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:16:41 GMT']
+      ETag: [bd8d6024-8af7-4a42-b44b-62b9e1246144]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [9ecc6d90-e1b9-11e6-b186-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"bd8d6024-8af7-4a42-b44b-62b9e1246144","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:16:43 GMT']
+      ETag: [bd8d6024-8af7-4a42-b44b-62b9e1246144]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['340']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"type": "Microsoft.Network/dnszones/PTR", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr",
+      "properties": {"PTRRecords": [{"ptrdname": "foobar.com"}], "TTL": 3600}, "etag":
+      "bd8d6024-8af7-4a42-b44b-62b9e1246144", "name": "myrsptr"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['337']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b8831d0a-a792-11e6-b991-3c15c2cf0610]
+      x-ms-client-request-id: [9f4d53f4-e1b9-11e6-bf7f-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr?api-version=2016-04-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf/b53m/WkmdbFqi2qZfP73t3ZefjgwXQ22d799N759v69++fbD6f39rbvPcynB1n+6e75/uz3
-        vVvnTbWup/nndbVe0VvTsvj9Z8vm92/zpt39fe+u6uqymOU1ffNFMa2rpjpvxy/y9qqq3/6+d6nh
-        D6plTl8urvHLeFotqOHvjb/rZvHuo9FHy2yRE3b27/Z6hb83Avvi96aGeZtdUMO9fO/+9Hx3tv1g
-        9ul0ez+7t789Od+lUUw/nc32ZgfT3U8fUmvCc5XXbZE3Hz36xR+d/6LZkt6VTscOtzG1fPPm+UeP
-        7n26szP66Ivf+1U+reoZvfO9X/xR/m46z5YXwG53jxqu6vw8r/PllD7ZvfdLvv9Lfsn/Axh6UShq
-        AQAA
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"1f58e3ac-8147-44fc-b01d-2cd35b080240","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
     headers:
       Cache-Control: [private]
-      Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:12:08 GMT']
-      ETag: [2e25cf1d-7d6c-4a34-bf12-3c6dd2d8c169]
+      Date: ['Mon, 23 Jan 2017 22:16:44 GMT']
+      ETag: [1f58e3ac-8147-44fc-b01d-2cd35b080240]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJuYW1lIjogIm15cnNucyIsICJ0eXBlIjogIk5TIiwgInByb3BlcnRpZXMiOiB7IlRUTCI6IDM2
-      MDB9fQ==
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['61']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [b9b7ff30-a792-11e6-8366-3c15c2cf0610]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/00977cdb-163f-435f-9c32-39ec8ae61f4d\/resourceGroups\/cli_dns_test1\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"1ede392a-b683-4eff-bd9a-53d2135eed77","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[]}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Length: ['329']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:12:11 GMT']
-      ETag: [1ede392a-b683-4eff-bd9a-53d2135eed77]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 201, message: Created}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [bb718aba-a792-11e6-86c1-3c15c2cf0610]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns?api-version=2016-04-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf/b53m/WkmdbFqi2qZfP73t3ZefjgwXQ22d799N759v69++fbD6f39rbvPcynB1n+6e75/uz3
-        vVvnTbWup/nndbVe0VvTsvj9Z8vm92/zpt39fe+u6uqymOU1ffNFMa2rpjpvxy/y9qqq3/6+d6nh
-        D6plTl8urvHLeFotft+7L17j77pZNh+NPlpmi5yws3+31yv8vRHYi9fUMG+zC2q4m8/yew/3su3J
-        pwf3tvfz8/Ptyexhtn3/3mxv9979PJ89eECtCc9VXrdF3nz06Bd/dP6LZkt6VzodO9zG1PLNm+cf
-        Pbr36c7O6KMXr1/l06qe0Tvf+/4v+SX/D0u1t9FJAQAA
-    headers:
-      Cache-Control: [private]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:12:13 GMT']
-      ETag: [1ede392a-b683-4eff-bd9a-53d2135eed77]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wMDk3N2NkYi0xNjNmLTQzNWYtOWMzMi0zOWVjOGFlNjFm
-      NGQvcmVzb3VyY2VHcm91cHMvY2xpX2Ruc190ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdv
-      cmsvZG5zem9uZXMvbXl6b25lLmNvbS9OUy9teXJzbnMiLCAicHJvcGVydGllcyI6IHsiVFRMIjog
-      MzYwMCwgIk5TUmVjb3JkcyI6IFt7Im5zZG5hbWUiOiAiZm9vYmFyLmNvbSJ9XX0sICJuYW1lIjog
-      Im15cnNucyIsICJ0eXBlIjogIk1pY3Jvc29mdC5OZXR3b3JrL2Ruc3pvbmVzL05TIiwgImV0YWci
-      OiAiMWVkZTM5MmEtYjY4My00ZWZmLWJkOWEtNTNkMjEzNWVlZDc3In0=
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['326']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [bba3063e-a792-11e6-9ebd-3c15c2cf0610]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns?api-version=2016-04-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf/b53m/WkmdbFqi2qZfP73t3ZefjgwXQ22d799N759v69++fbD6f39rbvPcynB1n+6e75/uz3
-        vVvnTbWup/nndbVe0VvTsvj9Z8vm92/zpt39fe+u6uqymOU1ffNFMa2rpjpvxy/y9qqq3/6+d6nh
-        D6plTl8urvHLeFotft+7L17j77pZNh+NPlpmi5yws3+31yv8vRHYi9fUMG+zC2p4f2c3v5/t5Nuz
-        LKdR7GX3tg92aVCf7uUPD6bTBwfZzg61JjxXed0WefPRo1/80fkvmi3pXel07HAbU8s3b55/9Oje
-        pzs7o49evH6VT6t6Ru987xd/tGxmiux5VU2yGi989Eu+/0t+yf8DD1/DpWEBAAA=
-    headers:
-      Cache-Control: [private]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:12:17 GMT']
-      ETag: [501e5a0e-daef-42a3-81db-62e98cc78a00]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJuYW1lIjogIm15cnNwdHIiLCAidHlwZSI6ICJQVFIiLCAicHJvcGVydGllcyI6IHsiVFRMIjog
-      MzYwMH19
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['63']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [bf949a80-a792-11e6-8f89-3c15c2cf0610]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/00977cdb-163f-435f-9c32-39ec8ae61f4d\/resourceGroups\/cli_dns_test1\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"869cff2a-a101-4693-bce3-9e48659a19f9","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[]}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Length: ['335']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:12:21 GMT']
-      ETag: [869cff2a-a101-4693-bce3-9e48659a19f9]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-    status: {code: 201, message: Created}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [c113bcda-a792-11e6-adb2-3c15c2cf0610]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/00977cdb-163f-435f-9c32-39ec8ae61f4d\/resourceGroups\/cli_dns_test1\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"869cff2a-a101-4693-bce3-9e48659a19f9","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[]}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Length: ['335']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:12:22 GMT']
-      ETag: [869cff2a-a101-4693-bce3-9e48659a19f9]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wMDk3N2NkYi0xNjNmLTQzNWYtOWMzMi0zOWVjOGFlNjFm
-      NGQvcmVzb3VyY2VHcm91cHMvY2xpX2Ruc190ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdv
-      cmsvZG5zem9uZXMvbXl6b25lLmNvbS9QVFIvbXlyc3B0ciIsICJldGFnIjogIjg2OWNmZjJhLWEx
-      MDEtNDY5My1iY2UzLTllNDg2NTlhMTlmOSIsICJuYW1lIjogIm15cnNwdHIiLCAidHlwZSI6ICJN
-      aWNyb3NvZnQuTmV0d29yay9kbnN6b25lcy9QVFIiLCAicHJvcGVydGllcyI6IHsiUFRSUmVjb3Jk
-      cyI6IFt7InB0cmRuYW1lIjogImZvb2Jhci5jb20ifV0sICJUVEwiOiAzNjAwfX0=
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['332']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [c167af3e-a792-11e6-9eb9-3c15c2cf0610]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/00977cdb-163f-435f-9c32-39ec8ae61f4d\/resourceGroups\/cli_dns_test1\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"640d90ca-22a0-4539-b190-a926be583f5f","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Length: ['360']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:12:23 GMT']
-      ETag: [640d90ca-22a0-4539-b190-a926be583f5f]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJuYW1lIjogIm15cnNzcnYiLCAidHlwZSI6ICJTUlYiLCAicHJvcGVydGllcyI6IHsiVFRMIjog
-      MzYwMH19
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['63']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [c32df202-a792-11e6-9bfa-3c15c2cf0610]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/00977cdb-163f-435f-9c32-39ec8ae61f4d\/resourceGroups\/cli_dns_test1\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"4efca5e0-9e31-43be-9c02-39fdb542bc48","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[]}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Length: ['335']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:12:26 GMT']
-      ETag: [4efca5e0-9e31-43be-9c02-39fdb542bc48]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-    status: {code: 201, message: Created}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [c47ac55e-a792-11e6-b8dc-3c15c2cf0610]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/00977cdb-163f-435f-9c32-39ec8ae61f4d\/resourceGroups\/cli_dns_test1\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"4efca5e0-9e31-43be-9c02-39fdb542bc48","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[]}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Length: ['335']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:12:28 GMT']
-      ETag: [4efca5e0-9e31-43be-9c02-39fdb542bc48]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wMDk3N2NkYi0xNjNmLTQzNWYtOWMzMi0zOWVjOGFlNjFm
-      NGQvcmVzb3VyY2VHcm91cHMvY2xpX2Ruc190ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdv
-      cmsvZG5zem9uZXMvbXl6b25lLmNvbS9TUlYvbXlyc3NydiIsICJldGFnIjogIjRlZmNhNWUwLTll
-      MzEtNDNiZS05YzAyLTM5ZmRiNTQyYmM0OCIsICJuYW1lIjogIm15cnNzcnYiLCAidHlwZSI6ICJN
-      aWNyb3NvZnQuTmV0d29yay9kbnN6b25lcy9TUlYiLCAicHJvcGVydGllcyI6IHsiU1JWUmVjb3Jk
-      cyI6IFt7IndlaWdodCI6IDUwLCAicHJpb3JpdHkiOiAxLCAidGFyZ2V0IjogInRhcmdldC5jb20i
-      LCAicG9ydCI6IDEyMzR9XSwgIlRUTCI6IDM2MDB9fQ==
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['373']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [c4c5f74c-a792-11e6-9c93-3c15c2cf0610]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv?api-version=2016-04-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf/b53m/WkmdbFqi2qZfP73t3ZefjgwXQ22d799N759v69++fbD6f39rbvPcynB1n+6e75/uz3
-        vVvnTbWup/nndbVe0VvTsvj9Z8vm92/zpt39fe+u6uqymOU1ffNFMa2rpjpvxy/y9qqq3/6+d6nh
-        D6plTl8urvHLeFotft+7r1/9JD6om6a+/Gj00TJb5ISf+6C9XuGDjfAIBrXM2+yCWj7YP9jfe3B+
-        b3vv3t6D7f1ZPqGRzLLtg3v7e+f38+lsNptQa8J1lddtkTcfPfrFH53/otmS3tVuxw7BMTV98+b5
-        R4/ufbqzM/qIenqVT6t6Rm997xd/tKrq9qNHu3v39gGwqOqivaa/CeusvsjpK/0FkAjQVV5czOnT
-        +zu/5Pu/5Jf8PzcnYIGLAQAA
-    headers:
-      Cache-Control: [private]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:12:29 GMT']
-      ETag: [748427f3-2327-4deb-9cda-8342f5ecdddb]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJuYW1lIjogIm15cnN0eHQiLCAidHlwZSI6ICJUWFQiLCAicHJvcGVydGllcyI6IHsiVFRMIjog
-      MzYwMH19
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['63']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [c6a98c18-a792-11e6-9a80-3c15c2cf0610]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/00977cdb-163f-435f-9c32-39ec8ae61f4d\/resourceGroups\/cli_dns_test1\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"c29f2961-02b5-4f5d-a08d-873cfee37758","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Length: ['335']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:12:35 GMT']
-      ETag: [c29f2961-02b5-4f5d-a08d-873cfee37758]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-    status: {code: 201, message: Created}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [ca05a7d4-a792-11e6-8827-3c15c2cf0610]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/00977cdb-163f-435f-9c32-39ec8ae61f4d\/resourceGroups\/cli_dns_test1\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"c29f2961-02b5-4f5d-a08d-873cfee37758","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Length: ['335']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:12:38 GMT']
-      ETag: [c29f2961-02b5-4f5d-a08d-873cfee37758]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wMDk3N2NkYi0xNjNmLTQzNWYtOWMzMi0zOWVjOGFlNjFm
-      NGQvcmVzb3VyY2VHcm91cHMvY2xpX2Ruc190ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdv
-      cmsvZG5zem9uZXMvbXl6b25lLmNvbS9UWFQvbXlyc3R4dCIsICJwcm9wZXJ0aWVzIjogeyJUWFRS
-      ZWNvcmRzIjogW3sidmFsdWUiOiBbInNvbWVfdGV4dCJdfV0sICJUVEwiOiAzNjAwfSwgIm5hbWUi
-      OiAibXlyc3R4dCIsICJ0eXBlIjogIk1pY3Jvc29mdC5OZXR3b3JrL2Ruc3pvbmVzL1RYVCIsICJl
-      dGFnIjogImMyOWYyOTYxLTAyYjUtNGY1ZC1hMDhkLTg3M2NmZWUzNzc1OCJ9
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['330']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [ca968664-a792-11e6-9aa9-3c15c2cf0610]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt?api-version=2016-04-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf/b53m/WkmdbFqi2qZfP73t3ZefjgwXQ22d799N759v69++fbD6f39rbvPcynB1n+6e75/uz3
-        vVvnTbWup/nndbVe0VvTsvj9Z8vm92/zpt39fe+u6uqymOU1ffNFMa2rpjpvxy/y9qqq3/6+d6nh
-        D6plTl8urvHLeFotft+7b37vN/igbtp37Uejj5bZIif83Aft9QofbIRHMKhl3mYX1HL26U4+Pf90
-        ur1z/8GD7f29/fvb2d50tn0we7i/P5vs7x5MH1JrwnWV122RNx89+sUfnf+i2ZLe1W7HDsExNX3z
-        5vlHj+59urNDv/7eb17l06qe0Vvf+8UfXWblmrD73kdNtciJCoTx93/J93/JL/l/AAAV1HtmAQAA
-    headers:
-      Cache-Control: [private]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:12:39 GMT']
-      ETag: [d60ecf6c-0577-4245-a2cd-8d944db418c9]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [cc0162f8-a792-11e6-b6c1-3c15c2cf0610]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/00977cdb-163f-435f-9c32-39ec8ae61f4d\/resourceGroups\/cli_dns_test1\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"d105017e-4168-4a9c-b361-ec38bb178e1c","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Length: ['350']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:12:41 GMT']
-      ETag: [d105017e-4168-4a9c-b361-ec38bb178e1c]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wMDk3N2NkYi0xNjNmLTQzNWYtOWMzMi0zOWVjOGFlNjFm
-      NGQvcmVzb3VyY2VHcm91cHMvY2xpX2Ruc190ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdv
-      cmsvZG5zem9uZXMvbXl6b25lLmNvbS9BL215cnNhIiwgInByb3BlcnRpZXMiOiB7IlRUTCI6IDM2
-      MDAsICJBUmVjb3JkcyI6IFt7ImlwdjRBZGRyZXNzIjogIjEwLjAuMC4xMCJ9LCB7ImlwdjRBZGRy
-      ZXNzIjogIjEwLjAuMC4xMSJ9XX0sICJuYW1lIjogIm15cnNhIiwgInR5cGUiOiAiTWljcm9zb2Z0
-      Lk5ldHdvcmsvZG5zem9uZXMvQSIsICJldGFnIjogImQxMDUwMTdlLTQxNjgtNGE5Yy1iMzYxLWVj
-      MzhiYjE3OGUxYyJ9
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['354']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [cc684036-a792-11e6-b31e-3c15c2cf0610]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/00977cdb-163f-435f-9c32-39ec8ae61f4d\/resourceGroups\/cli_dns_test1\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"565434a7-1057-4cc6-8e4a-db3305698173","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Length: ['378']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:12:41 GMT']
-      ETag: [565434a7-1057-4cc6-8e4a-db3305698173]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [cdab29b8-a792-11e6-848b-3c15c2cf0610]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/SOA/@?api-version=2016-04-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf/b53m/WkmdbFqi2qZfP73t3ZefjgwXQ22d799N759v69++fbD6f39rbvPcynB1n+6e75/uz3
-        vVvnTbWup/nndbVe0VvTsvj9Z8vm92/zpt39fe+u6uqymOU1ffNFMa2rpjpvxy/y9qqq3/6+d6nh
-        D6plTl8urvHLeFotft+7r788/n3v/p4fjT5aZoucMMOv7fUKv26EQe9Ry7zNLqjl/d1Z/nC6c397
-        fz8/2N6fHtzbzh7cy7Yn9yYPJvnudJZlO9Sa8FvldVvkzUePfvFH579otqR3HTJjavLmzfOPHt37
-        dGdn9BH18CqfVjXR6xd/lC+yoqTW2Q/WdU5YbM+rpl1kTZvX44XFk4AQjPzdqqjzNwXGs7e/+3AP
-        0NCe3l82u9s7B2MGs01w8Ar6XRTLYrFeSPdoX+fnRO25QBGE6rytr/UD/N3kdZGVL9aLSV5/9Gj3
-        l/ySX/L/ADgIeoLeAQAA
-    headers:
-      Cache-Control: [private]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:12:43 GMT']
-      ETag: [51de9c05-44e8-4c83-a73a-b3b7be1cdaa0]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [cdded3da-a792-11e6-bf56-3c15c2cf0610]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/SOA/@?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/00977cdb-163f-435f-9c32-39ec8ae61f4d\/resourceGroups\/cli_dns_test1\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"51de9c05-44e8-4c83-a73a-b3b7be1cdaa0","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"azuredns-hostmaster.microsoft.com","expireTime":2419200,"host":"ns1-08.azure-dns.com.","minimumTTL":300,"refreshTime":3600,"retryTime":300,"serialNumber":1}}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Length: ['478']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:12:44 GMT']
-      ETag: [51de9c05-44e8-4c83-a73a-b3b7be1cdaa0]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wMDk3N2NkYi0xNjNmLTQzNWYtOWMzMi0zOWVjOGFlNjFm
-      NGQvcmVzb3VyY2VHcm91cHMvY2xpX2Ruc190ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdv
-      cmsvZG5zem9uZXMvbXl6b25lLmNvbS9TT0EvQCIsICJwcm9wZXJ0aWVzIjogeyJUVEwiOiAzNjAw
-      LCAiU09BUmVjb3JkIjogeyJtaW5pbXVtVFRMIjogMjAsICJob3N0IjogIm5zMS0wOC5henVyZS1k
-      bnMuY29tLiIsICJleHBpcmVUaW1lIjogMzAsICJlbWFpbCI6ICJmb28uY29tIiwgInJldHJ5VGlt
-      ZSI6IDkwLCAicmVmcmVzaFRpbWUiOiA2MCwgInNlcmlhbE51bWJlciI6IDEyM319LCAibmFtZSI6
-      ICJAIiwgInR5cGUiOiAiTWljcm9zb2Z0Lk5ldHdvcmsvZG5zem9uZXMvU09BIiwgImV0YWciOiAi
-      NTFkZTljMDUtNDRlOC00YzgzLWE3M2EtYjNiN2JlMWNkYWEwIn0=
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['437']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [ce27252c-a792-11e6-9d69-3c15c2cf0610]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/SOA/@?api-version=2016-04-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf/b53m/WkmdbFqi2qZfP73t3ZefjgwXQ22d799N759v69++fbD6f39rbvPcynB1n+6e75/uz3
-        vVvnTbWup/nndbVe0VvTsvj9Z8vm92/zpt39fe+u6uqymOU1ffNFMa2rpjpvxy/y9qqq3/6+d6nh
-        D6plTl8urvHLeFotft+7r788/n3v/p4fjT5aZoucMMOv7fUKv26EQe9Ry7zNLqjl7N7Og+nu/t52
-        fvBgtr3/6f697Yf3ZtPt89l9+mInezjZP6fWhN8qr9sibz569Is/Ov9FsyW965AZU5M3b55/9Oje
-        pzs7o4+oh1f5tKqJXr/4o3yRFSW1Pq8qNKWW+btVUedvCmB9j5rPq6alBstmd3vnYJz9YF3n24Qu
-        WgPwolgWi/WC4e9R8zo/J2rO5f1P+YO2vpY/H9KfTV4XWflivZjk9UePdvfu/ZJf8kv+H1faANe9
-        AQAA
-    headers:
-      Cache-Control: [private]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:12:45 GMT']
-      ETag: [d307c142-e87d-4643-93dc-fd507c0a9b4f]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [cfa414a2-a792-11e6-a579-3c15c2cf0610]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com?api-version=2016-04-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf/b53m/WkmdbFqi2qZfP73t3ZefjgwXQ22d799N759v69++fbD6f39rbvPcynB1n+6e75/uz3
-        vVvnTbWup/nndbVe0VvTsvj9Z8vm92/zpt39fe+u6uqymOU1ffNFMa2rpjpvxy/y9qqq3/6+d6nh
-        D6plTl8urvHLeFotPhp9tMwWOWEUfNZer/DZBiDUKG+zC2q0I8/eNv2zI/8cnGf3tw8efLr78Pze
-        ZLa3s0uty2qaYaz0xkVZTbKSPiMAzUePfvEvGX1EmK/yui0I8KNf/NEie/divZjk9Zfnr/JpVc9e
-        5y19cZ9gC76v8/qShvnRo+99tGx2t3cOxtkP1nW+TdhhBGOCvWwII//zZd7K5/fCz6v6Qj7fDz8v
-        lufV+KPv0zcRVHZ3fskv+X8AAd2m6csBAAA=
-    headers:
-      Cache-Control: [private]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:12:47 GMT']
-      ETag: [00000002-0000-0000-8fa5-87619f3bd201]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [d0ec6270-a792-11e6-8678-3c15c2cf0610]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/00977cdb-163f-435f-9c32-39ec8ae61f4d\/resourceGroups\/cli_dns_test1\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"565434a7-1057-4cc6-8e4a-db3305698173","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Length: ['378']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:12:49 GMT']
-      ETag: [565434a7-1057-4cc6-8e4a-db3305698173]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [d1dc26ae-a792-11e6-8316-3c15c2cf0610]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf/b53m/WkmdbFqi2qZfP73t3ZefjgwXQ22d799N759v69++fbD6f39rbvPcynB1n+6e75/uz3
-        vVvnTbWup/nndbVe0VvTsvj9Z8vm92/zpt39fe+u6uqymOU1ffNFMa2rpjpvxy/y9qqq3/6+d6nh
-        D6plTl8urvHLeFotft+7x/izbrKPRh8ts0VOuJk/2+sV/twI6Zja5W12Qe3uf3p//95+9mB7d+f+
-        g+396fTT7YN8P9ueTe7d27n/6cOD3Qf3qDXhuMrrtsibjx794o/Of9FsSe9yl2OH1pgavnnz/KNH
-        9z7d2Rl9dPwqn1b1jN74HtFvdbl/PJsRKejvj3Z3xvhvd+ejXzIa+m73o1/y/V/yS/4fKaGLvXoB
-        AAA=
-    headers:
-      Cache-Control: [private]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:12:51 GMT']
-      ETag: [565434a7-1057-4cc6-8e4a-db3305698173]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wMDk3N2NkYi0xNjNmLTQzNWYtOWMzMi0zOWVjOGFlNjFm
-      NGQvcmVzb3VyY2VHcm91cHMvY2xpX2Ruc190ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdv
-      cmsvZG5zem9uZXMvbXl6b25lLmNvbS9BL215cnNhIiwgInByb3BlcnRpZXMiOiB7IlRUTCI6IDM2
-      MDAsICJBUmVjb3JkcyI6IFt7ImlwdjRBZGRyZXNzIjogIjEwLjAuMC4xMSJ9XX0sICJuYW1lIjog
-      Im15cnNhIiwgInR5cGUiOiAiTWljcm9zb2Z0Lk5ldHdvcmsvZG5zem9uZXMvQSIsICJldGFnIjog
-      IjU2NTQzNGE3LTEwNTctNGNjNi04ZTRhLWRiMzMwNTY5ODE3MyJ9
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['324']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [d2313c0c-a792-11e6-a57f-3c15c2cf0610]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/00977cdb-163f-435f-9c32-39ec8ae61f4d\/resourceGroups\/cli_dns_test1\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"2cb3b350-0c7e-46c2-a3b0-65d769e3dcf0","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Length: ['350']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:12:51 GMT']
-      ETag: [2cb3b350-0c7e-46c2-a3b0-65d769e3dcf0]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      content-length: ['365']
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 200, message: OK}
 - request:
@@ -1227,141 +905,949 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d34231a2-a792-11e6-b7a2-3c15c2cf0610]
+      x-ms-client-request-id: [a03c8964-e1b9-11e6-8fbe-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptralt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/00977cdb-163f-435f-9c32-39ec8ae61f4d\/resourceGroups\/cli_dns_test1\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"e9622fe2-bc2b-49f9-8e86-77528bfa0581","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
+    body: {string: '{"code":"NotFound","message":"The resource record ''myrsptralt''
+        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
     headers:
       Cache-Control: [private]
-      Content-Length: ['379']
+      Content-Length: ['174']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:12:52 GMT']
-      ETag: [e9622fe2-bc2b-49f9-8e86-77528bfa0581]
+      Date: ['Mon, 23 Jan 2017 22:16:45 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 404, message: Not Found}
+- request:
+    body: '{"properties": {"PTRRecords": [{"ptrdname": "foobar.com"}], "TTL": 3600},
+      "type": "ptr", "name": "myrsptralt"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['110']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [a08d606e-e1b9-11e6-aaa0-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptralt?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptralt","name":"myrsptralt","type":"Microsoft.Network\/dnszones\/PTR","etag":"4427d7d8-27fe-4c6f-9f80-d7e6cb7e3695","properties":{"fqdn":"myrsptralt.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['374']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:16:46 GMT']
+      ETag: [4427d7d8-27fe-4c6f-9f80-d7e6cb7e3695]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 201, message: Created}
+- request:
+    body: '{"properties": {"TTL": 3600}, "type": "SRV", "name": "myrssrv"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['63']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [a1655048-e1b9-11e6-8790-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"8487c180-18a9-461b-a083-73f7d338083e","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['340']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:16:47 GMT']
+      ETag: [8487c180-18a9-461b-a083-73f7d338083e]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [a23f0fd4-e1b9-11e6-8f4d-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"8487c180-18a9-461b-a083-73f7d338083e","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:16:49 GMT']
+      ETag: [8487c180-18a9-461b-a083-73f7d338083e]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['340']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 200, message: OK}
 - request:
-    body: !!binary |
-      eyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wMDk3N2NkYi0xNjNmLTQzNWYtOWMzMi0zOWVjOGFlNjFm
-      NGQvcmVzb3VyY2VHcm91cHMvY2xpX2Ruc190ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdv
-      cmsvZG5zem9uZXMvbXl6b25lLmNvbS9BQUFBL215cnNhYWFhIiwgImV0YWciOiAiZTk2MjJmZTIt
-      YmMyYi00OWY5LThlODYtNzc1MjhiZmEwNTgxIiwgIm5hbWUiOiAibXlyc2FhYWEiLCAidHlwZSI6
-      ICJNaWNyb3NvZnQuTmV0d29yay9kbnN6b25lcy9BQUFBIiwgInByb3BlcnRpZXMiOiB7IkFBQUFS
-      ZWNvcmRzIjogW10sICJUVEwiOiAzNjAwfX0=
+    body: '{"type": "Microsoft.Network/dnszones/SRV", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv",
+      "properties": {"TTL": 3600, "SRVRecords": [{"priority": 1, "target": "target.com",
+      "weight": 50, "port": 1234}]}, "etag": "8487c180-18a9-461b-a083-73f7d338083e",
+      "name": "myrssrv"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['378']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [a2b19ad2-e1b9-11e6-ad31-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"15cc800b-b075-4433-a1ae-b955d9239240","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:16:50 GMT']
+      ETag: [15cc800b-b075-4433-a1ae-b955d9239240]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['400']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [a381aeb4-e1b9-11e6-b3f3-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrvalt?api-version=2016-04-01
+  response:
+    body: {string: '{"code":"NotFound","message":"The resource record ''myrssrvalt''
+        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['174']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:16:51 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+    status: {code: 404, message: Not Found}
+- request:
+    body: '{"properties": {"TTL": 3600, "SRVRecords": [{"priority": 1, "target": "target.com",
+      "weight": 50, "port": 1234}]}, "type": "srv", "name": "myrssrvalt"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['151']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [a406f3d2-e1b9-11e6-a94f-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrvalt?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrvalt","name":"myrssrvalt","type":"Microsoft.Network\/dnszones\/SRV","etag":"cedfc12d-3509-470a-ab5a-c60c8e17ccbb","properties":{"fqdn":"myrssrvalt.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['409']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:16:54 GMT']
+      ETag: [cedfc12d-3509-470a-ab5a-c60c8e17ccbb]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+    status: {code: 201, message: Created}
+- request:
+    body: '{"properties": {"TTL": 3600}, "type": "TXT", "name": "myrstxt"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['63']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [a5efdeca-e1b9-11e6-bd84-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"57010733-4c19-46e9-933c-0b65ba218ab1","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['340']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:16:56 GMT']
+      ETag: [57010733-4c19-46e9-933c-0b65ba218ab1]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [a6e7db6e-e1b9-11e6-8d04-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"57010733-4c19-46e9-933c-0b65ba218ab1","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:16:57 GMT']
+      ETag: [57010733-4c19-46e9-933c-0b65ba218ab1]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['340']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"type": "Microsoft.Network/dnszones/TXT", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt",
+      "properties": {"TTL": 3600, "TXTRecords": [{"value": ["some_text"]}]}, "etag":
+      "57010733-4c19-46e9-933c-0b65ba218ab1", "name": "myrstxt"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['335']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [a752e5d0-e1b9-11e6-b5e0-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"136519d0-2f77-4771-a3d6-a6506412e688","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:16:57 GMT']
+      ETag: [136519d0-2f77-4771-a3d6-a6506412e688]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['363']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [a83b0498-e1b9-11e6-b772-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxtalt?api-version=2016-04-01
+  response:
+    body: {string: '{"code":"NotFound","message":"The resource record ''myrstxtalt''
+        does not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['174']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:16:59 GMT']
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+    status: {code: 404, message: Not Found}
+- request:
+    body: '{"properties": {"TTL": 3600, "TXTRecords": [{"value": ["some_text"]}]},
+      "type": "txt", "name": "myrstxtalt"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['108']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [a8a4a6dc-e1b9-11e6-83f0-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxtalt?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxtalt","name":"myrstxtalt","type":"Microsoft.Network\/dnszones\/TXT","etag":"929750d6-71cb-47da-b70c-61b7d4725326","properties":{"fqdn":"myrstxtalt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Length: ['372']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:16:59 GMT']
+      ETag: [929750d6-71cb-47da-b70c-61b7d4725326]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [a97f9bda-e1b9-11e6-823a-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"69b5e7ad-42b5-4481-8bd3-66d6ca299c2f","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:17:00 GMT']
+      ETag: [69b5e7ad-42b5-4481-8bd3-66d6ca299c2f]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['355']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"type": "Microsoft.Network/dnszones/A", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa",
+      "properties": {"TTL": 3600, "ARecords": [{"ipv4Address": "10.0.0.10"}, {"ipv4Address":
+      "10.0.0.11"}]}, "etag": "69b5e7ad-42b5-4481-8bd3-66d6ca299c2f", "name": "myrsa"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['359']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [a9cc3c94-e1b9-11e6-a996-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"fb407006-9d3b-4743-a09f-a4541b4cbd2d","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:17:04 GMT']
+      ETag: [fb407006-9d3b-4743-a09f-a4541b4cbd2d]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['383']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [ac20b24a-e1b9-11e6-842c-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SOA/@?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"6fcae9a7-ecd3-46ea-8319-3aa7592430f4","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"azuredns-hostmaster.microsoft.com","expireTime":2419200,"host":"ns1-02.azure-dns.com.","minimumTTL":300,"refreshTime":3600,"retryTime":300,"serialNumber":1}}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:17:05 GMT']
+      ETag: [6fcae9a7-ecd3-46ea-8319-3aa7592430f4]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['483']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [ac5b7bbe-e1b9-11e6-b72a-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SOA/@?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"6fcae9a7-ecd3-46ea-8319-3aa7592430f4","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"azuredns-hostmaster.microsoft.com","expireTime":2419200,"host":"ns1-02.azure-dns.com.","minimumTTL":300,"refreshTime":3600,"retryTime":300,"serialNumber":1}}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:17:05 GMT']
+      ETag: [6fcae9a7-ecd3-46ea-8319-3aa7592430f4]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['483']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"type": "Microsoft.Network/dnszones/SOA", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SOA/@",
+      "properties": {"SOARecord": {"host": "ns1-02.azure-dns.com.", "expireTime":
+      30, "minimumTTL": 20, "refreshTime": 60, "retryTime": 90, "email": "foo.com",
+      "serialNumber": 123}, "TTL": 3600}, "etag": "6fcae9a7-ecd3-46ea-8319-3aa7592430f4",
+      "name": "@"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['442']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [acb25d80-e1b9-11e6-a5c9-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SOA/@?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"ac48e315-49ac-429d-b3f6-794c9cf009a1","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"foo.com","expireTime":30,"host":"ns1-02.azure-dns.com.","minimumTTL":20,"refreshTime":60,"retryTime":90,"serialNumber":123}}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:17:06 GMT']
+      ETag: [ac48e315-49ac-429d-b3f6-794c9cf009a1]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['450']
+      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [ad60e4b0-e1b9-11e6-aee0-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-c2f0-7a4cc675d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-02.azure-dns.com.","ns2-02.azure-dns.net.","ns3-02.azure-dns.org.","ns4-02.azure-dns.info."],"numberOfRecordSets":18}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:17:07 GMT']
+      ETag: [00000002-0000-0000-c2f0-7a4cc675d201]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['464']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [adf5e38c-e1b9-11e6-8def-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"fb407006-9d3b-4743-a09f-a4541b4cbd2d","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:17:08 GMT']
+      ETag: [fb407006-9d3b-4743-a09f-a4541b4cbd2d]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['383']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [ae987be6-e1b9-11e6-b739-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"fb407006-9d3b-4743-a09f-a4541b4cbd2d","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:17:09 GMT']
+      ETag: [fb407006-9d3b-4743-a09f-a4541b4cbd2d]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['383']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"type": "Microsoft.Network/dnszones/A", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa",
+      "properties": {"TTL": 3600, "ARecords": [{"ipv4Address": "10.0.0.11"}]}, "etag":
+      "fb407006-9d3b-4743-a09f-a4541b4cbd2d", "name": "myrsa"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['329']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [aef2a04c-e1b9-11e6-a1f5-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"fe1de1a2-d382-4361-abcd-f4ce173c5ce9","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:17:10 GMT']
+      ETag: [fe1de1a2-d382-4361-abcd-f4ce173c5ce9]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['355']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [afda98e4-e1b9-11e6-b74a-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"72495495-8e86-4754-991e-9ccdee711977","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:17:12 GMT']
+      ETag: [72495495-8e86-4754-991e-9ccdee711977]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['384']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"type": "Microsoft.Network/dnszones/AAAA", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa",
+      "properties": {"AAAARecords": [], "TTL": 3600}, "etag": "72495495-8e86-4754-991e-9ccdee711977",
+      "name": "myrsaaaa"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['316']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b02d1ec8-e1b9-11e6-8c33-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"0ed321fb-62e8-462f-9f73-47b09faccbb3","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:17:13 GMT']
+      ETag: [0ed321fb-62e8-462f-9f73-47b09faccbb3]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['346']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b11620da-e1b9-11e6-93fe-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"d871c6bd-bcfa-42e6-b603-69ab5ad68473","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:17:13 GMT']
+      ETag: [d871c6bd-bcfa-42e6-b603-69ab5ad68473]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['368']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"type": "Microsoft.Network/dnszones/CNAME", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname",
+      "properties": {"TTL": 3600}, "etag": "d871c6bd-bcfa-42e6-b603-69ab5ad68473",
+      "name": "myrscname"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['301']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b1711df4-e1b9-11e6-ab81-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"9ee971fc-a8ca-4341-8bc4-4a95289d0d79","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:17:14 GMT']
+      ETag: [9ee971fc-a8ca-4341-8bc4-4a95289d0d79]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['334']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b266a2b6-e1b9-11e6-ae44-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"b5642c85-2454-41bc-9e17-e25d4d670036","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:17:15 GMT']
+      ETag: [b5642c85-2454-41bc-9e17-e25d4d670036]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['367']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"type": "Microsoft.Network/dnszones/MX", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx",
+      "properties": {"TTL": 3600, "MXRecords": []}, "etag": "b5642c85-2454-41bc-9e17-e25d4d670036",
+      "name": "myrsmx"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['306']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b2b4cc1e-e1b9-11e6-a866-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"17fd1f52-afee-49a9-b3b6-23ea9a2c0e2d","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:17:17 GMT']
+      ETag: [17fd1f52-afee-49a9-b3b6-23ea9a2c0e2d]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['334']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b3865342-e1b9-11e6-8358-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"ff950952-88ba-46af-b20b-dad5d4f81dcd","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:17:17 GMT']
+      ETag: [ff950952-88ba-46af-b20b-dad5d4f81dcd]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['358']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"type": "Microsoft.Network/dnszones/NS", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns",
+      "properties": {"TTL": 3600, "NSRecords": []}, "etag": "ff950952-88ba-46af-b20b-dad5d4f81dcd",
+      "name": "myrsns"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['306']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b3bbf39e-e1b9-11e6-8c75-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"b9b3d37e-b2cf-41ad-9ca6-5cef2e204a9e","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:17:18 GMT']
+      ETag: [b9b3d37e-b2cf-41ad-9ca6-5cef2e204a9e]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['334']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b4959f4a-e1b9-11e6-870f-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"1f58e3ac-8147-44fc-b01d-2cd35b080240","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:17:19 GMT']
+      ETag: [1f58e3ac-8147-44fc-b01d-2cd35b080240]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['365']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"type": "Microsoft.Network/dnszones/PTR", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr",
+      "properties": {"PTRRecords": [], "TTL": 3600}, "etag": "1f58e3ac-8147-44fc-b01d-2cd35b080240",
+      "name": "myrsptr"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['311']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d39af93e-a792-11e6-ae74-3c15c2cf0610]
+      x-ms-client-request-id: [b4cbcbfe-e1b9-11e6-a01a-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr?api-version=2016-04-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf/b53m/WkmdbFqi2qZfP73t3ZefjgwXQ22d799N759v69++fbD6f39rbvPcynB1n+6e75/uz3
-        vVvnTbWup/nndbVe0VvTsvj9Z8vm92/zpt39fe+u6uqymOU1ffNFMa2rpjpvxy/y9qqq3/6+d6nh
-        D6plTl8urvHLeFotft+7x/Tgk7rJ6Plo9NEyW+SEofdJe73CJxtBEpRjapq32QU1/XRv+umD2YOD
-        7Z1Jlm3v7+5gNPcPtu9PH+7t7H6aP3gw2aXWhO8qr9sibz569Is/Ov9FsyW9azoeOyzH1PbNm+cf
-        Pbr36c7O6CPq6vhVPq3qGb33ve//kl/y/wBYvcSpVQEAAA==
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"b52f0442-e0d6-4314-8d9a-b03a5f94b953","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[]}}'}
     headers:
       Cache-Control: [private]
-      Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:12:54 GMT']
-      ETag: [62c67d78-0baa-410f-9c58-5c92016e77b1]
+      Date: ['Mon, 23 Jan 2017 22:17:19 GMT']
+      ETag: [b52f0442-e0d6-4314-8d9a-b03a5f94b953]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [d56f785c-a792-11e6-b246-3c15c2cf0610]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/00977cdb-163f-435f-9c32-39ec8ae61f4d\/resourceGroups\/cli_dns_test1\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"2796fa54-a6b2-4174-8b73-b4a9d2befd84","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Length: ['363']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:12:56 GMT']
-      ETag: [2796fa54-a6b2-4174-8b73-b4a9d2befd84]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wMDk3N2NkYi0xNjNmLTQzNWYtOWMzMi0zOWVjOGFlNjFm
-      NGQvcmVzb3VyY2VHcm91cHMvY2xpX2Ruc190ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdv
-      cmsvZG5zem9uZXMvbXl6b25lLmNvbS9DTkFNRS9teXJzY25hbWUiLCAicHJvcGVydGllcyI6IHsi
-      VFRMIjogMzYwMH0sICJuYW1lIjogIm15cnNjbmFtZSIsICJ0eXBlIjogIk1pY3Jvc29mdC5OZXR3
-      b3JrL2Ruc3pvbmVzL0NOQU1FIiwgImV0YWciOiAiMjc5NmZhNTQtYTZiMi00MTc0LThiNzMtYjRh
-      OWQyYmVmZDg0In0=
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['296']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [d5a8396e-a792-11e6-a29e-3c15c2cf0610]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname?api-version=2016-04-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf/b53m/WkmdbFqi2qZfP73t3ZefjgwXQ22d799N759v69++fbD6f39rbvPcynB1n+6e75/uz3
-        vVvnTbWup/nndbVe0VvTsvj9Z8vm92/zpt39fe+u6uqymOU1ffNFMa2rpjpvxy/y9qqq3/6+d6nh
-        D6plTl8urvHLeFotft+7Jy+OvzjFR3UzXWaL/KPRR/zj0Uf+R+31Ch9thMqQqG3eZhfUNp88fJDt
-        3bu/PZuc727v39872H44eZBtzz6dZnsH+5MH9yb3qTXhvMrrtsibjx794o/Of9FsSe/arscO1TE1
-        fvPm+UeP7n26s/NLfsn/A+lXFXFJAQAA
-    headers:
-      Cache-Control: [private]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:12:57 GMT']
-      ETag: [eb97a235-dbf1-4528-9b7a-d6ca284b73b5]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      content-length: ['340']
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 200, message: OK}
 - request:
@@ -1371,285 +1857,216 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d6c795ae-a792-11e6-813b-3c15c2cf0610]
+      x-ms-client-request-id: [b59a0d34-e1b9-11e6-8c80-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv?api-version=2016-04-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf/b53m/WkmdbFqi2qZfP73t3ZefjgwXQ22d799N759v69++fbD6f39rbvPcynB1n+6e75/uz3
-        vVvnTbWup/nndbVe0VvTsvj9Z8vm92/zpt39fe+u6uqymOU1ffNFMa2rpjpvxy/y9qqq3/6+d6nh
-        D6plTl8urvHLeFotqOHvjb/rZvHuo9FHy2yRE3b27/Z6hb83Avvi96aGeZtdUMO9fO/+9Hx3tv1g
-        9ul0ez+7t789Od+lUUw/nc32ZgfT3U8fUmvCc5XXbZE3Hz36xR+d/6LZkt6VTscOtzG1fPPm+UeP
-        7n26szP66Ivf+1U+reoZvfO9X/xR/m46z5YXwG53jxqu6vw8r/PllD7ZvfdLvv9Lfsn/Axh6UShq
-        AQAA
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"15cc800b-b075-4433-a1ae-b955d9239240","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
     headers:
       Cache-Control: [private]
-      Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:12:59 GMT']
-      ETag: [2e25cf1d-7d6c-4a34-bf12-3c6dd2d8c169]
+      Date: ['Mon, 23 Jan 2017 22:17:21 GMT']
+      ETag: [15cc800b-b075-4433-a1ae-b955d9239240]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
+      content-length: ['400']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"type": "Microsoft.Network/dnszones/SRV", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv",
+      "properties": {"TTL": 3600, "SRVRecords": []}, "etag": "15cc800b-b075-4433-a1ae-b955d9239240",
+      "name": "myrssrv"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['311']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b6002dc0-e1b9-11e6-b359-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"0c490578-cda9-4757-8b32-0eb2f0dfbaaa","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:17:22 GMT']
+      ETag: [0c490578-cda9-4757-8b32-0eb2f0dfbaaa]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['340']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b6ddbaae-e1b9-11e6-ba83-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"136519d0-2f77-4771-a3d6-a6506412e688","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:17:23 GMT']
+      ETag: [136519d0-2f77-4771-a3d6-a6506412e688]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['363']
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: !!binary |
-      eyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wMDk3N2NkYi0xNjNmLTQzNWYtOWMzMi0zOWVjOGFlNjFm
-      NGQvcmVzb3VyY2VHcm91cHMvY2xpX2Ruc190ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdv
-      cmsvZG5zem9uZXMvbXl6b25lLmNvbS9NWC9teXJzbXgiLCAicHJvcGVydGllcyI6IHsiTVhSZWNv
-      cmRzIjogW10sICJUVEwiOiAzNjAwfSwgIm5hbWUiOiAibXlyc214IiwgInR5cGUiOiAiTWljcm9z
-      b2Z0Lk5ldHdvcmsvZG5zem9uZXMvTVgiLCAiZXRhZyI6ICIyZTI1Y2YxZC03ZDZjLTRhMzQtYmYx
-      Mi0zYzZkZDJkOGMxNjkifQ==
+    body: '{"type": "Microsoft.Network/dnszones/TXT", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt",
+      "properties": {"TTL": 3600, "TXTRecords": []}, "etag": "136519d0-2f77-4771-a3d6-a6506412e688",
+      "name": "myrstxt"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['311']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b733db62-e1b9-11e6-9485-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"6b10faac-37a5-4b00-8b49-4d5f6f3b9abb","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:17:24 GMT']
+      ETag: [6b10faac-37a5-4b00-8b49-4d5f6f3b9abb]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['340']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b805d05c-e1b9-11e6-ba3e-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"fe1de1a2-d382-4361-abcd-f4ce173c5ce9","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:17:25 GMT']
+      ETag: [fe1de1a2-d382-4361-abcd-f4ce173c5ce9]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['355']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [b8bd5e70-e1b9-11e6-8475-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"fe1de1a2-d382-4361-abcd-f4ce173c5ce9","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 22:17:26 GMT']
+      ETag: [fe1de1a2-d382-4361-abcd-f4ce173c5ce9]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['355']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"type": "Microsoft.Network/dnszones/A", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa",
+      "properties": {"TTL": 3600, "ARecords": []}, "etag": "fe1de1a2-d382-4361-abcd-f4ce173c5ce9",
+      "name": "myrsa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['301']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [d71672fa-a792-11e6-98d3-3c15c2cf0610]
+      x-ms-client-request-id: [b923dba8-e1b9-11e6-9b15-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/00977cdb-163f-435f-9c32-39ec8ae61f4d\/resourceGroups\/cli_dns_test1\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"1044a873-158b-4708-85a1-02b3e9ab48c1","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"be74daa9-5621-4912-a50d-23c7b3249eca","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
     headers:
       Cache-Control: [private]
-      Content-Length: ['329']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:13:00 GMT']
-      ETag: [1044a873-158b-4708-85a1-02b3e9ab48c1]
+      Date: ['Mon, 23 Jan 2017 22:17:27 GMT']
+      ETag: [be74daa9-5621-4912-a50d-23c7b3249eca]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [d882f924-a792-11e6-8f35-3c15c2cf0610]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns?api-version=2016-04-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf/b53m/WkmdbFqi2qZfP73t3ZefjgwXQ22d799N759v69++fbD6f39rbvPcynB1n+6e75/uz3
-        vVvnTbWup/nndbVe0VvTsvj9Z8vm92/zpt39fe+u6uqymOU1ffNFMa2rpjpvxy/y9qqq3/6+d6nh
-        D6plTl8urvHLeFotft+7L17j77pZNh+NPlpmi5yws3+31yv8vRHYi9fUMG+zC2p4f2c3v5/t5Nuz
-        LKdR7GX3tg92aVCf7uUPD6bTBwfZzg61JjxXed0WefPRo1/80fkvmi3pXel07HAbU8s3b55/9Oje
-        pzs7o49evH6VT6t6Ru987xd/tGxmiux5VU2yGi989Eu+/0t+yf8DD1/DpWEBAAA=
-    headers:
-      Cache-Control: [private]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:13:02 GMT']
-      ETag: [501e5a0e-daef-42a3-81db-62e98cc78a00]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wMDk3N2NkYi0xNjNmLTQzNWYtOWMzMi0zOWVjOGFlNjFm
-      NGQvcmVzb3VyY2VHcm91cHMvY2xpX2Ruc190ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdv
-      cmsvZG5zem9uZXMvbXl6b25lLmNvbS9OUy9teXJzbnMiLCAicHJvcGVydGllcyI6IHsiVFRMIjog
-      MzYwMCwgIk5TUmVjb3JkcyI6IFtdfSwgIm5hbWUiOiAibXlyc25zIiwgInR5cGUiOiAiTWljcm9z
-      b2Z0Lk5ldHdvcmsvZG5zem9uZXMvTlMiLCAiZXRhZyI6ICI1MDFlNWEwZS1kYWVmLTQyYTMtODFk
-      Yi02MmU5OGNjNzhhMDAifQ==
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['301']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [d8d4eb26-a792-11e6-a37f-3c15c2cf0610]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/00977cdb-163f-435f-9c32-39ec8ae61f4d\/resourceGroups\/cli_dns_test1\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"7e45dd35-227c-40ad-9bdd-646a09e963f8","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[]}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Length: ['329']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:13:03 GMT']
-      ETag: [7e45dd35-227c-40ad-9bdd-646a09e963f8]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [da28b518-a792-11e6-bd10-3c15c2cf0610]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/00977cdb-163f-435f-9c32-39ec8ae61f4d\/resourceGroups\/cli_dns_test1\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"640d90ca-22a0-4539-b190-a926be583f5f","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Length: ['360']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:13:04 GMT']
-      ETag: [640d90ca-22a0-4539-b190-a926be583f5f]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wMDk3N2NkYi0xNjNmLTQzNWYtOWMzMi0zOWVjOGFlNjFm
-      NGQvcmVzb3VyY2VHcm91cHMvY2xpX2Ruc190ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdv
-      cmsvZG5zem9uZXMvbXl6b25lLmNvbS9QVFIvbXlyc3B0ciIsICJldGFnIjogIjY0MGQ5MGNhLTIy
-      YTAtNDUzOS1iMTkwLWE5MjZiZTU4M2Y1ZiIsICJuYW1lIjogIm15cnNwdHIiLCAidHlwZSI6ICJN
-      aWNyb3NvZnQuTmV0d29yay9kbnN6b25lcy9QVFIiLCAicHJvcGVydGllcyI6IHsiUFRSUmVjb3Jk
-      cyI6IFtdLCAiVFRMIjogMzYwMH19
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['306']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [da6f36da-a792-11e6-9f4b-3c15c2cf0610]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr?api-version=2016-04-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf/b53m/WkmdbFqi2qZfP73t3ZefjgwXQ22d799N759v69++fbD6f39rbvPcynB1n+6e75/uz3
-        vVvnTbWup/nndbVe0VvTsvj9Z8vm92/zpt39fe+u6uqymOU1ffNFMa2rpjpvxy/y9qqq3/6+d6nh
-        D6plTl8urvHLeFotft+7L9+8wgd1s2rrj0YfLbNFTvi5D9rrFT7YCI9gUMu8zS6o5f0HDx/u7s0+
-        3T7fn9zf3t+7d7Cd7eW72/uTnb3J3nT34N5sn1oTrqu8bou8+ejRL/7o/BfNlvSudjt2CI6p6Zs3
-        zz96dO/TnZ3RR9TTq3xa1TN663vf/yW/5P8BWtfN0U8BAAA=
-    headers:
-      Cache-Control: [private]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:13:05 GMT']
-      ETag: [579912d6-f4b5-4238-a2e1-4b02b2c183d4]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [dbcdbea2-a792-11e6-ba19-3c15c2cf0610]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/00977cdb-163f-435f-9c32-39ec8ae61f4d\/resourceGroups\/cli_dns_test1\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"748427f3-2327-4deb-9cda-8342f5ecdddb","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Length: ['395']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:13:07 GMT']
-      ETag: [748427f3-2327-4deb-9cda-8342f5ecdddb]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wMDk3N2NkYi0xNjNmLTQzNWYtOWMzMi0zOWVjOGFlNjFm
-      NGQvcmVzb3VyY2VHcm91cHMvY2xpX2Ruc190ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdv
-      cmsvZG5zem9uZXMvbXl6b25lLmNvbS9TUlYvbXlyc3NydiIsICJldGFnIjogIjc0ODQyN2YzLTIz
-      MjctNGRlYi05Y2RhLTgzNDJmNWVjZGRkYiIsICJuYW1lIjogIm15cnNzcnYiLCAidHlwZSI6ICJN
-      aWNyb3NvZnQuTmV0d29yay9kbnN6b25lcy9TUlYiLCAicHJvcGVydGllcyI6IHsiU1JWUmVjb3Jk
-      cyI6IFtdLCAiVFRMIjogMzYwMH19
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['306']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [dc1a358c-a792-11e6-a610-3c15c2cf0610]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv?api-version=2016-04-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf/b53m/WkmdbFqi2qZfP73t3ZefjgwXQ22d799N759v69++fbD6f39rbvPcynB1n+6e75/uz3
-        vVvnTbWup/nndbVe0VvTsvj9Z8vm92/zpt39fe+u6uqymOU1ffNFMa2rpjpvxy/y9qqq3/6+d6nh
-        D6plTl8urvHLeFotft+7r1/9JD6om6a+/Gj00TJb5ISf+6C9XuGDjfAIBrXM2+yCWk53HuT39u7l
-        25NPdw+296f7e9sPzyfT7YPJvYOdnfvZwf39B9SacF3ldVvkzUePfvFH579otqR3tduxQ3BMTd+8
-        ef7Ro3uf7uyMPqKeXuXTqp7RW9/7/i/5Jf8P3qQgpk8BAAA=
-    headers:
-      Cache-Control: [private]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:13:07 GMT']
-      ETag: [c07e323e-b618-4c42-9fbc-8b38005a8547]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      content-length: ['328']
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 200, message: OK}
 - request:
@@ -1659,207 +2076,28 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [dd3599f4-a792-11e6-bcf6-3c15c2cf0610]
+      x-ms-client-request-id: [ba1e6766-e1b9-11e6-9d79-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf/b53m/WkmdbFqi2qZfP73t3ZefjgwXQ22d799N759v69++fbD6f39rbvPcynB1n+6e75/uz3
-        vVvnTbWup/nndbVe0VvTsvj9Z8vm92/zpt39fe+u6uqymOU1ffNFMa2rpjpvxy/y9qqq3/6+d6nh
-        D6plTl8urvHLeFotft+7b37vN/igbtp37Uejj5bZIif83Aft9QofbIRHMKhl3mYX1HL26U4+Pf90
-        ur1z/8GD7f29/fvb2d50tn0we7i/P5vs7x5MH1JrwnWV122RNx89+sUfnf+i2ZLe1W7HDsExNX3z
-        5vlHj+59urNDv/7eb17l06qe0Vvf+8UfXWblmrD73kdNtciJCoTx93/J93/JL/l/AAAV1HtmAQAA
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"be74daa9-5621-4912-a50d-23c7b3249eca","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
     headers:
       Cache-Control: [private]
-      Content-Encoding: [gzip]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:13:09 GMT']
-      ETag: [d60ecf6c-0577-4245-a2cd-8d944db418c9]
+      Date: ['Mon, 23 Jan 2017 22:17:28 GMT']
+      ETag: [be74daa9-5621-4912-a50d-23c7b3249eca]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
       Vary: [Accept-Encoding]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wMDk3N2NkYi0xNjNmLTQzNWYtOWMzMi0zOWVjOGFlNjFm
-      NGQvcmVzb3VyY2VHcm91cHMvY2xpX2Ruc190ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdv
-      cmsvZG5zem9uZXMvbXl6b25lLmNvbS9UWFQvbXlyc3R4dCIsICJwcm9wZXJ0aWVzIjogeyJUWFRS
-      ZWNvcmRzIjogW10sICJUVEwiOiAzNjAwfSwgIm5hbWUiOiAibXlyc3R4dCIsICJ0eXBlIjogIk1p
-      Y3Jvc29mdC5OZXR3b3JrL2Ruc3pvbmVzL1RYVCIsICJldGFnIjogImQ2MGVjZjZjLTA1NzctNDI0
-      NS1hMmNkLThkOTQ0ZGI0MThjOSJ9
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['306']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [dd7d4d8a-a792-11e6-8a38-3c15c2cf0610]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/00977cdb-163f-435f-9c32-39ec8ae61f4d\/resourceGroups\/cli_dns_test1\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"71edff5a-4e8c-40d5-8e55-be2aca5027c9","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Length: ['335']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:13:10 GMT']
-      ETag: [71edff5a-4e8c-40d5-8e55-be2aca5027c9]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [dec19248-a792-11e6-b724-3c15c2cf0610]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf/b53m/WkmdbFqi2qZfP73t3ZefjgwXQ22d799N759v69++fbD6f39rbvPcynB1n+6e75/uz3
-        vVvnTbWup/nndbVe0VvTsvj9Z8vm92/zpt39fe+u6uqymOU1ffNFMa2rpjpvxy/y9qqq3/6+d6nh
-        D6plTl8urvHLeFotft+7x/izbrKPRh8ts0VOuJk/2+sV/twI6Zja5W12Qe32ppN7k3v3d7Z3pg/y
-        7f1Pp3vb2b3Jzvan92cPPn2Y35tNz3eoNeG4yuu2yJuPHv3ij85/0WxJ73KXY4fWmBq+efP8o0f3
-        Pt3ZGX10/CqfVvWM3vge0W91uX88mxEp6O+PdnfG+G9396Nf8v1f8kv+HyBCRKpeAQAA
-    headers:
-      Cache-Control: [private]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:13:12 GMT']
-      ETag: [2cb3b350-0c7e-46c2-a3b0-65d769e3dcf0]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
+      content-length: ['328']
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [dfa7004a-a792-11e6-81c1-3c15c2cf0610]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/00977cdb-163f-435f-9c32-39ec8ae61f4d\/resourceGroups\/cli_dns_test1\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"2cb3b350-0c7e-46c2-a3b0-65d769e3dcf0","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Length: ['350']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:13:14 GMT']
-      ETag: [2cb3b350-0c7e-46c2-a3b0-65d769e3dcf0]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
-    status: {code: 200, message: OK}
-- request:
-    body: !!binary |
-      eyJpZCI6ICIvc3Vic2NyaXB0aW9ucy8wMDk3N2NkYi0xNjNmLTQzNWYtOWMzMi0zOWVjOGFlNjFm
-      NGQvcmVzb3VyY2VHcm91cHMvY2xpX2Ruc190ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdv
-      cmsvZG5zem9uZXMvbXl6b25lLmNvbS9BL215cnNhIiwgInByb3BlcnRpZXMiOiB7IlRUTCI6IDM2
-      MDAsICJBUmVjb3JkcyI6IFtdfSwgIm5hbWUiOiAibXlyc2EiLCAidHlwZSI6ICJNaWNyb3NvZnQu
-      TmV0d29yay9kbnN6b25lcy9BIiwgImV0YWciOiAiMmNiM2IzNTAtMGM3ZS00NmMyLWEzYjAtNjVk
-      NzY5ZTNkY2YwIn0=
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['296']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [dfce8fd4-a792-11e6-acbf-3c15c2cf0610]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/00977cdb-163f-435f-9c32-39ec8ae61f4d\/resourceGroups\/cli_dns_test1\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"fe8b13a8-8cfa-4ac5-8973-da9368acdf6f","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Length: ['323']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:13:14 GMT']
-      ETag: [fe8b13a8-8cfa-4ac5-8973-da9368acdf6f]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [e13ead36-a792-11e6-8ca6-3c15c2cf0610]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf/b53m/WkmdbFqi2qZfP73t3ZefjgwXQ22d799N759v69++fbD6f39rbvPcynB1n+6e75/uz3
-        vVvnTbWup/nndbVe0VvTsvj9Z8vm92/zpt39fe+u6uqymOU1ffNFMa2rpjpvxy/y9qqq3/6+d6nh
-        D6plTl8urvHLeFotft+7x/izbrKPRh8ts0VOuJk/2+sV/twI6Zja5W12Qe3O84PJ7r3sYPtgep5t
-        72fT+9sHDx/c255lD+99epBNZ+efnlNrwnGV122RNx89+sUfnf+i2ZLe5S7HDq0xNXzz5vlHj+59
-        urMz+uj4VT6t6hm98b3v/5Jf8v8AMyKJbUMBAAA=
-    headers:
-      Cache-Control: [private]
-      Content-Encoding: [gzip]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:13:16 GMT']
-      ETag: [fe8b13a8-8cfa-4ac5-8973-da9368acdf6f]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1869,18 +2107,18 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e283cdfe-a792-11e6-aebc-3c15c2cf0610]
+      x-ms-client-request-id: [baa2bf98-e1b9-11e6-a1d1-a0b3ccf7272a]
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
     body: {string: ''}
     headers:
       Cache-Control: [private]
       Content-Length: ['0']
-      Date: ['Thu, 10 Nov 2016 22:13:19 GMT']
+      Date: ['Mon, 23 Jan 2017 22:17:30 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
@@ -1895,25 +2133,25 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.2 (Darwin-16.1.0-x86_64-i386-64bit) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.3 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [e3a92eb8-a792-11e6-b226-3c15c2cf0610]
+      x-ms-client-request-id: [bb62091c-e1b9-11e6-b85d-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_dns_test1/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
     body: {string: '{"code":"NotFound","message":"The resource record ''myrsa'' does
-        not exist in resource group ''cli_dns_test1'' of subscription ''00977cdb-163f-435f-9c32-39ec8ae61f4d''."}'}
+        not exist in resource group ''cli_test_dns'' of subscription ''0b1f6471-1bf0-4dda-aec3-cb9272f09590''."}'}
     headers:
       Cache-Control: [private]
-      Content-Length: ['164']
+      Content-Length: ['169']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 10 Nov 2016 22:13:20 GMT']
+      Date: ['Mon, 23 Jan 2017 22:17:30 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 404, message: Not Found}
 version: 1

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_dns.yaml
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_dns.yaml
@@ -10,17 +10,17 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8a81270c-e1b9-11e6-8471-a0b3ccf7272a]
+      x-ms-client-request-id: [cfac8c90-e1bf-11e6-9a29-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-c2f0-7a4cc675d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-02.azure-dns.com.","ns2-02.azure-dns.net.","ns3-02.azure-dns.org.","ns4-02.azure-dns.info."],"numberOfRecordSets":2}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-a3c3-ff91cc75d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-01.azure-dns.com.","ns2-01.azure-dns.net.","ns3-01.azure-dns.org.","ns4-01.azure-dns.info."],"numberOfRecordSets":2}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['463']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:09 GMT']
-      ETag: [00000002-0000-0000-c2f0-7a4cc675d201]
+      Date: ['Mon, 23 Jan 2017 23:01:03 GMT']
+      ETag: [00000002-0000-0000-a3c3-ff91cc75d201]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
@@ -38,16 +38,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8bc19a28-e1b9-11e6-a029-a0b3ccf7272a]
+      x-ms-client-request-id: [d126b07e-e1bf-11e6-b207-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-c2f0-7a4cc675d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-02.azure-dns.com.","ns2-02.azure-dns.net.","ns3-02.azure-dns.org.","ns4-02.azure-dns.info."],"numberOfRecordSets":2}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-a3c3-ff91cc75d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-01.azure-dns.com.","ns2-01.azure-dns.net.","ns3-01.azure-dns.org.","ns4-01.azure-dns.info."],"numberOfRecordSets":2}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:11 GMT']
-      ETag: [00000002-0000-0000-c2f0-7a4cc675d201]
+      Date: ['Mon, 23 Jan 2017 23:01:04 GMT']
+      ETag: [00000002-0000-0000-a3c3-ff91cc75d201]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -59,7 +59,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"TTL": 3600}, "type": "A", "name": "myrsa"}'
+    body: '{"type": "A", "properties": {"TTL": 3600}, "name": "myrsa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -69,23 +69,23 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8c5e6ba6-e1b9-11e6-aaa5-a0b3ccf7272a]
+      x-ms-client-request-id: [d1ae0b3a-e1bf-11e6-9cf4-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"4ab3ef98-0c03-4811-b69e-520e9c6617f8","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"cfce35aa-6494-4372-b826-f0d9d2118483","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['328']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:12 GMT']
-      ETag: [4ab3ef98-0c03-4811-b69e-520e9c6617f8]
+      Date: ['Mon, 23 Jan 2017 23:01:05 GMT']
+      ETag: [cfce35aa-6494-4372-b826-f0d9d2118483]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -97,16 +97,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8d5cb8f4-e1b9-11e6-9573-a0b3ccf7272a]
+      x-ms-client-request-id: [d2817f94-e1bf-11e6-aad4-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"4ab3ef98-0c03-4811-b69e-520e9c6617f8","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"cfce35aa-6494-4372-b826-f0d9d2118483","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:14 GMT']
-      ETag: [4ab3ef98-0c03-4811-b69e-520e9c6617f8]
+      Date: ['Mon, 23 Jan 2017 23:01:06 GMT']
+      ETag: [cfce35aa-6494-4372-b826-f0d9d2118483]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -118,9 +118,9 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "Microsoft.Network/dnszones/A", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa",
-      "properties": {"TTL": 3600, "ARecords": [{"ipv4Address": "10.0.0.10"}]}, "etag":
-      "4ab3ef98-0c03-4811-b69e-520e9c6617f8", "name": "myrsa"}'
+    body: '{"etag": "cfce35aa-6494-4372-b826-f0d9d2118483", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa",
+      "properties": {"TTL": 3600, "ARecords": [{"ipv4Address": "10.0.0.10"}]}, "type":
+      "Microsoft.Network/dnszones/A", "name": "myrsa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -130,16 +130,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8dd2da3a-e1b9-11e6-a8ef-a0b3ccf7272a]
+      x-ms-client-request-id: [d2d1d06c-e1bf-11e6-a6cc-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"69b5e7ad-42b5-4481-8bd3-66d6ca299c2f","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"ad939425-21e0-4423-9cce-97e0cedb8a2a","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:15 GMT']
-      ETag: [69b5e7ad-42b5-4481-8bd3-66d6ca299c2f]
+      Date: ['Mon, 23 Jan 2017 23:01:07 GMT']
+      ETag: [ad939425-21e0-4423-9cce-97e0cedb8a2a]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -148,7 +148,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['355']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -160,7 +160,7 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8eb538fa-e1b9-11e6-b789-a0b3ccf7272a]
+      x-ms-client-request-id: [d3c16e46-e1bf-11e6-b2da-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsaalt?api-version=2016-04-01
   response:
@@ -170,17 +170,17 @@ interactions:
       Cache-Control: [private]
       Content-Length: ['172']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:16 GMT']
+      Date: ['Mon, 23 Jan 2017 23:01:08 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11996']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"properties": {"TTL": 3600, "ARecords": [{"ipv4Address": "10.0.0.10"}]},
-      "type": "a", "name": "myrsaalt"}'
+    body: '{"type": "a", "properties": {"TTL": 3600, "ARecords": [{"ipv4Address":
+      "10.0.0.10"}]}, "name": "myrsaalt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -190,26 +190,26 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8f336e64-e1b9-11e6-bbc2-a0b3ccf7272a]
+      x-ms-client-request-id: [d43058de-e1bf-11e6-9dc3-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsaalt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsaalt","name":"myrsaalt","type":"Microsoft.Network\/dnszones\/A","etag":"ad689281-89d1-40a1-941b-b40f6887c312","properties":{"fqdn":"myrsaalt.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsaalt","name":"myrsaalt","type":"Microsoft.Network\/dnszones\/A","etag":"c9a653fe-0bd6-42fa-a738-04aa1a199d47","properties":{"fqdn":"myrsaalt.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['364']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:18 GMT']
-      ETag: [ad689281-89d1-40a1-941b-b40f6887c312]
+      Date: ['Mon, 23 Jan 2017 23:01:10 GMT']
+      ETag: [c9a653fe-0bd6-42fa-a738-04aa1a199d47]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 201, message: Created}
 - request:
-    body: '{"properties": {"TTL": 3600}, "type": "AAAA", "name": "myrsaaaa"}'
+    body: '{"type": "AAAA", "properties": {"TTL": 3600}, "name": "myrsaaaa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -219,17 +219,17 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [90566876-e1b9-11e6-bc35-a0b3ccf7272a]
+      x-ms-client-request-id: [d5417a3a-e1bf-11e6-9fe7-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"3deb27e2-aef3-4d34-88a3-9e5a5a2760e2","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"3aefd4c1-a066-497e-9618-78c7ae8512e5","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['346']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:19 GMT']
-      ETag: [3deb27e2-aef3-4d34-88a3-9e5a5a2760e2]
+      Date: ['Mon, 23 Jan 2017 23:01:12 GMT']
+      ETag: [3aefd4c1-a066-497e-9618-78c7ae8512e5]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
@@ -247,16 +247,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [915e61dc-e1b9-11e6-a0d5-a0b3ccf7272a]
+      x-ms-client-request-id: [d6209a50-e1bf-11e6-885e-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"3deb27e2-aef3-4d34-88a3-9e5a5a2760e2","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"3aefd4c1-a066-497e-9618-78c7ae8512e5","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:20 GMT']
-      ETag: [3deb27e2-aef3-4d34-88a3-9e5a5a2760e2]
+      Date: ['Mon, 23 Jan 2017 23:01:12 GMT']
+      ETag: [3aefd4c1-a066-497e-9618-78c7ae8512e5]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -265,12 +265,12 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['346']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "Microsoft.Network/dnszones/AAAA", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa",
-      "properties": {"AAAARecords": [{"ipv6Address": "2001:db8:0:1:1:1:1:1"}], "TTL":
-      3600}, "etag": "3deb27e2-aef3-4d34-88a3-9e5a5a2760e2", "name": "myrsaaaa"}'
+    body: '{"etag": "3aefd4c1-a066-497e-9618-78c7ae8512e5", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa",
+      "properties": {"TTL": 3600, "AAAARecords": [{"ipv6Address": "2001:db8:0:1:1:1:1:1"}]},
+      "type": "Microsoft.Network/dnszones/AAAA", "name": "myrsaaaa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -280,16 +280,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [91d95a58-e1b9-11e6-aaa4-a0b3ccf7272a]
+      x-ms-client-request-id: [d6765f36-e1bf-11e6-b3bd-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"72495495-8e86-4754-991e-9ccdee711977","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"23e5ebac-9a35-4184-a9f8-101f40d6775d","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:21 GMT']
-      ETag: [72495495-8e86-4754-991e-9ccdee711977]
+      Date: ['Mon, 23 Jan 2017 23:01:13 GMT']
+      ETag: [23e5ebac-9a35-4184-a9f8-101f40d6775d]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -298,7 +298,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['384']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -310,7 +310,7 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [92de670c-e1b9-11e6-82db-a0b3ccf7272a]
+      x-ms-client-request-id: [d74395fa-e1bf-11e6-8c3a-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaaalt?api-version=2016-04-01
   response:
@@ -320,7 +320,7 @@ interactions:
       Cache-Control: [private]
       Content-Length: ['175']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:23 GMT']
+      Date: ['Mon, 23 Jan 2017 23:01:14 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
@@ -329,8 +329,8 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"properties": {"AAAARecords": [{"ipv6Address": "2001:db8:0:1:1:1:1:1"}],
-      "TTL": 3600}, "type": "aaaa", "name": "myrsaaaaalt"}'
+    body: '{"type": "aaaa", "properties": {"TTL": 3600, "AAAARecords": [{"ipv6Address":
+      "2001:db8:0:1:1:1:1:1"}]}, "name": "myrsaaaaalt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -340,26 +340,26 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9339b024-e1b9-11e6-8560-a0b3ccf7272a]
+      x-ms-client-request-id: [d78f389c-e1bf-11e6-a9f8-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaaalt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaaalt","name":"myrsaaaaalt","type":"Microsoft.Network\/dnszones\/AAAA","etag":"21f33888-2207-42e2-a4ad-e7792bcc84f7","properties":{"fqdn":"myrsaaaaalt.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaaalt","name":"myrsaaaaalt","type":"Microsoft.Network\/dnszones\/AAAA","etag":"d0b62fc4-17b1-434c-b146-1eee6dd4eee1","properties":{"fqdn":"myrsaaaaalt.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['393']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:24 GMT']
-      ETag: [21f33888-2207-42e2-a4ad-e7792bcc84f7]
+      Date: ['Mon, 23 Jan 2017 23:01:16 GMT']
+      ETag: [d0b62fc4-17b1-434c-b146-1eee6dd4eee1]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 201, message: Created}
 - request:
-    body: '{"properties": {"TTL": 3600}, "type": "CNAME", "name": "myrscname"}'
+    body: '{"type": "CNAME", "properties": {"TTL": 3600}, "name": "myrscname"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -369,23 +369,23 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9439701c-e1b9-11e6-a9c4-a0b3ccf7272a]
+      x-ms-client-request-id: [d8778b5c-e1bf-11e6-a701-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"a855e325-2740-4493-a327-2e63d001716b","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"206e4255-0247-48f4-a342-54bc202d1244","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['334']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:26 GMT']
-      ETag: [a855e325-2740-4493-a327-2e63d001716b]
+      Date: ['Mon, 23 Jan 2017 23:01:17 GMT']
+      ETag: [206e4255-0247-48f4-a342-54bc202d1244]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -397,16 +397,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [95494506-e1b9-11e6-9594-a0b3ccf7272a]
+      x-ms-client-request-id: [d9656370-e1bf-11e6-8859-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"a855e325-2740-4493-a327-2e63d001716b","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"206e4255-0247-48f4-a342-54bc202d1244","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:27 GMT']
-      ETag: [a855e325-2740-4493-a327-2e63d001716b]
+      Date: ['Mon, 23 Jan 2017 23:01:18 GMT']
+      ETag: [206e4255-0247-48f4-a342-54bc202d1244]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -418,8 +418,8 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "Microsoft.Network/dnszones/CNAME", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname",
-      "properties": {"CNAMERecord": {"cname": "mycname"}, "TTL": 3600}, "etag": "a855e325-2740-4493-a327-2e63d001716b",
+    body: '{"etag": "206e4255-0247-48f4-a342-54bc202d1244", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname",
+      "properties": {"TTL": 3600, "CNAMERecord": {"cname": "mycname"}}, "type": "Microsoft.Network/dnszones/CNAME",
       "name": "myrscname"}'
     headers:
       Accept: [application/json]
@@ -430,16 +430,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [95a40cf4-e1b9-11e6-92ad-a0b3ccf7272a]
+      x-ms-client-request-id: [d9b96fb6-e1bf-11e6-ba43-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"d871c6bd-bcfa-42e6-b603-69ab5ad68473","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"05e1c8fb-8647-4a51-8d64-6131017be2fe","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:27 GMT']
-      ETag: [d871c6bd-bcfa-42e6-b603-69ab5ad68473]
+      Date: ['Mon, 23 Jan 2017 23:01:19 GMT']
+      ETag: [05e1c8fb-8647-4a51-8d64-6131017be2fe]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -460,7 +460,7 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [967e9b08-e1b9-11e6-8111-a0b3ccf7272a]
+      x-ms-client-request-id: [da8a2b0c-e1bf-11e6-815d-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscnamealt?api-version=2016-04-01
   response:
@@ -470,17 +470,17 @@ interactions:
       Cache-Control: [private]
       Content-Length: ['176']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:29 GMT']
+      Date: ['Mon, 23 Jan 2017 23:01:20 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"properties": {"CNAMERecord": {"cname": "mycname"}, "TTL": 3600}, "type":
-      "cname", "name": "myrscnamealt"}'
+    body: '{"type": "cname", "properties": {"TTL": 3600, "CNAMERecord": {"cname":
+      "mycname"}}, "name": "myrscnamealt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -490,17 +490,17 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [96be1626-e1b9-11e6-b0bc-a0b3ccf7272a]
+      x-ms-client-request-id: [dac0c94c-e1bf-11e6-8ad4-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscnamealt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscnamealt","name":"myrscnamealt","type":"Microsoft.Network\/dnszones\/CNAME","etag":"7658182f-01ef-4712-bf2e-4fae29f5cb95","properties":{"fqdn":"myrscnamealt.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscnamealt","name":"myrscnamealt","type":"Microsoft.Network\/dnszones\/CNAME","etag":"d589932d-e49c-4537-836d-57b563f26e92","properties":{"fqdn":"myrscnamealt.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['377']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:29 GMT']
-      ETag: [7658182f-01ef-4712-bf2e-4fae29f5cb95]
+      Date: ['Mon, 23 Jan 2017 23:01:20 GMT']
+      ETag: [d589932d-e49c-4537-836d-57b563f26e92]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
@@ -509,7 +509,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 201, message: Created}
 - request:
-    body: '{"properties": {"TTL": 3600}, "type": "MX", "name": "myrsmx"}'
+    body: '{"type": "MX", "properties": {"TTL": 3600}, "name": "myrsmx"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -519,23 +519,23 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [97892ca2-e1b9-11e6-b4d6-a0b3ccf7272a]
+      x-ms-client-request-id: [dbab3cd2-e1bf-11e6-9e50-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"956a4cb3-680c-46b7-8497-9903b0838f32","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"edb89c6d-8692-450c-afeb-f3a938b7d2bf","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['334']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:31 GMT']
-      ETag: [956a4cb3-680c-46b7-8497-9903b0838f32]
+      Date: ['Mon, 23 Jan 2017 23:01:22 GMT']
+      ETag: [edb89c6d-8692-450c-afeb-f3a938b7d2bf]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -547,16 +547,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9864d026-e1b9-11e6-880e-a0b3ccf7272a]
+      x-ms-client-request-id: [dc64a83a-e1bf-11e6-8d9a-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"956a4cb3-680c-46b7-8497-9903b0838f32","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"edb89c6d-8692-450c-afeb-f3a938b7d2bf","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:32 GMT']
-      ETag: [956a4cb3-680c-46b7-8497-9903b0838f32]
+      Date: ['Mon, 23 Jan 2017 23:01:23 GMT']
+      ETag: [edb89c6d-8692-450c-afeb-f3a938b7d2bf]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -568,9 +568,9 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "Microsoft.Network/dnszones/MX", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx",
+    body: '{"etag": "edb89c6d-8692-450c-afeb-f3a938b7d2bf", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx",
       "properties": {"TTL": 3600, "MXRecords": [{"preference": 13, "exchange": "12"}]},
-      "etag": "956a4cb3-680c-46b7-8497-9903b0838f32", "name": "myrsmx"}'
+      "type": "Microsoft.Network/dnszones/MX", "name": "myrsmx"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -580,16 +580,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [98d1398a-e1b9-11e6-a1c1-a0b3ccf7272a]
+      x-ms-client-request-id: [dcb0dc9a-e1bf-11e6-b121-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"b5642c85-2454-41bc-9e17-e25d4d670036","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"98959c0d-d8ee-48b9-90ea-6177bb044269","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:33 GMT']
-      ETag: [b5642c85-2454-41bc-9e17-e25d4d670036]
+      Date: ['Mon, 23 Jan 2017 23:01:23 GMT']
+      ETag: [98959c0d-d8ee-48b9-90ea-6177bb044269]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -598,7 +598,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['367']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -610,7 +610,7 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [999acb76-e1b9-11e6-95b0-a0b3ccf7272a]
+      x-ms-client-request-id: [dd7c7098-e1bf-11e6-b615-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmxalt?api-version=2016-04-01
   response:
@@ -620,7 +620,7 @@ interactions:
       Cache-Control: [private]
       Content-Length: ['173']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:34 GMT']
+      Date: ['Mon, 23 Jan 2017 23:01:25 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
@@ -629,8 +629,8 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"properties": {"TTL": 3600, "MXRecords": [{"preference": 13, "exchange":
-      "12"}]}, "type": "mx", "name": "myrsmxalt"}'
+    body: '{"type": "mx", "properties": {"TTL": 3600, "MXRecords": [{"preference":
+      13, "exchange": "12"}]}, "name": "myrsmxalt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -640,26 +640,26 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [99f30b48-e1b9-11e6-a316-a0b3ccf7272a]
+      x-ms-client-request-id: [ddc2c482-e1bf-11e6-9189-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmxalt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmxalt","name":"myrsmxalt","type":"Microsoft.Network\/dnszones\/MX","etag":"4c03d5db-bd5e-46a4-8da3-8998e2faab78","properties":{"fqdn":"myrsmxalt.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmxalt","name":"myrsmxalt","type":"Microsoft.Network\/dnszones\/MX","etag":"a0e11058-9acf-4fb3-b0eb-2ecd9690a0d0","properties":{"fqdn":"myrsmxalt.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['376']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:36 GMT']
-      ETag: [4c03d5db-bd5e-46a4-8da3-8998e2faab78]
+      Date: ['Mon, 23 Jan 2017 23:01:25 GMT']
+      ETag: [a0e11058-9acf-4fb3-b0eb-2ecd9690a0d0]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 201, message: Created}
 - request:
-    body: '{"properties": {"TTL": 3600}, "type": "NS", "name": "myrsns"}'
+    body: '{"type": "NS", "properties": {"TTL": 3600}, "name": "myrsns"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -669,23 +669,23 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9aff8410-e1b9-11e6-8b86-a0b3ccf7272a]
+      x-ms-client-request-id: [dea03386-e1bf-11e6-a24a-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"5dc0cafc-40d8-4f28-b6cd-98286fe62c5d","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"5e813b0c-6d48-4309-a933-bf57e9671a25","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['334']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:36 GMT']
-      ETag: [5dc0cafc-40d8-4f28-b6cd-98286fe62c5d]
+      Date: ['Mon, 23 Jan 2017 23:01:27 GMT']
+      ETag: [5e813b0c-6d48-4309-a933-bf57e9671a25]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -697,16 +697,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9babcb38-e1b9-11e6-ab6e-a0b3ccf7272a]
+      x-ms-client-request-id: [df4f1e68-e1bf-11e6-afc6-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"5dc0cafc-40d8-4f28-b6cd-98286fe62c5d","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"5e813b0c-6d48-4309-a933-bf57e9671a25","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:37 GMT']
-      ETag: [5dc0cafc-40d8-4f28-b6cd-98286fe62c5d]
+      Date: ['Mon, 23 Jan 2017 23:01:27 GMT']
+      ETag: [5e813b0c-6d48-4309-a933-bf57e9671a25]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -717,9 +717,9 @@ interactions:
       content-length: ['334']
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "Microsoft.Network/dnszones/NS", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns",
-      "properties": {"TTL": 3600, "NSRecords": [{"nsdname": "foobar.com"}]}, "etag":
-      "5dc0cafc-40d8-4f28-b6cd-98286fe62c5d", "name": "myrsns"}'
+    body: '{"etag": "5e813b0c-6d48-4309-a933-bf57e9671a25", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns",
+      "properties": {"TTL": 3600, "NSRecords": [{"nsdname": "foobar.com"}]}, "type":
+      "Microsoft.Network/dnszones/NS", "name": "myrsns"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -729,16 +729,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9c113c26-e1b9-11e6-8ab9-a0b3ccf7272a]
+      x-ms-client-request-id: [df874cdc-e1bf-11e6-a0d8-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"ff950952-88ba-46af-b20b-dad5d4f81dcd","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"f75047f6-9769-4f87-83db-47c9f5380306","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:38 GMT']
-      ETag: [ff950952-88ba-46af-b20b-dad5d4f81dcd]
+      Date: ['Mon, 23 Jan 2017 23:01:29 GMT']
+      ETag: [f75047f6-9769-4f87-83db-47c9f5380306]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -747,7 +747,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['358']
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -759,7 +759,7 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9cd5f89c-e1b9-11e6-836c-a0b3ccf7272a]
+      x-ms-client-request-id: [e054e092-e1bf-11e6-af8b-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsnsalt?api-version=2016-04-01
   response:
@@ -769,7 +769,7 @@ interactions:
       Cache-Control: [private]
       Content-Length: ['173']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:40 GMT']
+      Date: ['Mon, 23 Jan 2017 23:01:29 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
@@ -777,8 +777,8 @@ interactions:
       X-Powered-By: [ASP.NET]
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"properties": {"TTL": 3600, "NSRecords": [{"nsdname": "foobar.com"}]},
-      "type": "ns", "name": "myrsnsalt"}'
+    body: '{"type": "ns", "properties": {"TTL": 3600, "NSRecords": [{"nsdname": "foobar.com"}]},
+      "name": "myrsnsalt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -788,26 +788,26 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9d0e769a-e1b9-11e6-878f-a0b3ccf7272a]
+      x-ms-client-request-id: [e0940f6c-e1bf-11e6-ab74-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsnsalt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsnsalt","name":"myrsnsalt","type":"Microsoft.Network\/dnszones\/NS","etag":"c2307410-b445-491c-9fca-f019f525ddd6","properties":{"fqdn":"myrsnsalt.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsnsalt","name":"myrsnsalt","type":"Microsoft.Network\/dnszones\/NS","etag":"ae0402ec-c862-461b-8421-bb75ff3a0031","properties":{"fqdn":"myrsnsalt.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['367']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:40 GMT']
-      ETag: [c2307410-b445-491c-9fca-f019f525ddd6]
+      Date: ['Mon, 23 Jan 2017 23:01:30 GMT']
+      ETag: [ae0402ec-c862-461b-8421-bb75ff3a0031]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 201, message: Created}
 - request:
-    body: '{"properties": {"TTL": 3600}, "type": "PTR", "name": "myrsptr"}'
+    body: '{"type": "PTR", "properties": {"TTL": 3600}, "name": "myrsptr"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -817,23 +817,23 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9dd6b264-e1b9-11e6-8628-a0b3ccf7272a]
+      x-ms-client-request-id: [e1417d42-e1bf-11e6-92cb-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"bd8d6024-8af7-4a42-b44b-62b9e1246144","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"26e16695-d71f-4543-aacd-cbaf52670206","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['340']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:41 GMT']
-      ETag: [bd8d6024-8af7-4a42-b44b-62b9e1246144]
+      Date: ['Mon, 23 Jan 2017 23:01:32 GMT']
+      ETag: [26e16695-d71f-4543-aacd-cbaf52670206]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -845,16 +845,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9ecc6d90-e1b9-11e6-b186-a0b3ccf7272a]
+      x-ms-client-request-id: [e218a31e-e1bf-11e6-8696-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"bd8d6024-8af7-4a42-b44b-62b9e1246144","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"26e16695-d71f-4543-aacd-cbaf52670206","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:43 GMT']
-      ETag: [bd8d6024-8af7-4a42-b44b-62b9e1246144]
+      Date: ['Mon, 23 Jan 2017 23:01:32 GMT']
+      ETag: [26e16695-d71f-4543-aacd-cbaf52670206]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -866,9 +866,9 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "Microsoft.Network/dnszones/PTR", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr",
-      "properties": {"PTRRecords": [{"ptrdname": "foobar.com"}], "TTL": 3600}, "etag":
-      "bd8d6024-8af7-4a42-b44b-62b9e1246144", "name": "myrsptr"}'
+    body: '{"etag": "26e16695-d71f-4543-aacd-cbaf52670206", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr",
+      "properties": {"PTRRecords": [{"ptrdname": "foobar.com"}], "TTL": 3600}, "type":
+      "Microsoft.Network/dnszones/PTR", "name": "myrsptr"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -878,16 +878,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9f4d53f4-e1b9-11e6-bf7f-a0b3ccf7272a]
+      x-ms-client-request-id: [e2604000-e1bf-11e6-b652-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"1f58e3ac-8147-44fc-b01d-2cd35b080240","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"69ef284a-f0c8-4680-bbaf-5f11dfe5e93f","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:44 GMT']
-      ETag: [1f58e3ac-8147-44fc-b01d-2cd35b080240]
+      Date: ['Mon, 23 Jan 2017 23:01:34 GMT']
+      ETag: [69ef284a-f0c8-4680-bbaf-5f11dfe5e93f]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -896,7 +896,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['365']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -908,7 +908,7 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a03c8964-e1b9-11e6-8fbe-a0b3ccf7272a]
+      x-ms-client-request-id: [e32eecac-e1bf-11e6-a045-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptralt?api-version=2016-04-01
   response:
@@ -918,7 +918,7 @@ interactions:
       Cache-Control: [private]
       Content-Length: ['174']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:45 GMT']
+      Date: ['Mon, 23 Jan 2017 23:01:34 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
@@ -927,8 +927,8 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"properties": {"PTRRecords": [{"ptrdname": "foobar.com"}], "TTL": 3600},
-      "type": "ptr", "name": "myrsptralt"}'
+    body: '{"type": "ptr", "properties": {"PTRRecords": [{"ptrdname": "foobar.com"}],
+      "TTL": 3600}, "name": "myrsptralt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -938,17 +938,17 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a08d606e-e1b9-11e6-aaa0-a0b3ccf7272a]
+      x-ms-client-request-id: [e37a102c-e1bf-11e6-ae2b-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptralt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptralt","name":"myrsptralt","type":"Microsoft.Network\/dnszones\/PTR","etag":"4427d7d8-27fe-4c6f-9f80-d7e6cb7e3695","properties":{"fqdn":"myrsptralt.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptralt","name":"myrsptralt","type":"Microsoft.Network\/dnszones\/PTR","etag":"88e2d449-4ba5-4cc2-a314-90b8e4d51d8b","properties":{"fqdn":"myrsptralt.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['374']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:46 GMT']
-      ETag: [4427d7d8-27fe-4c6f-9f80-d7e6cb7e3695]
+      Date: ['Mon, 23 Jan 2017 23:01:36 GMT']
+      ETag: [88e2d449-4ba5-4cc2-a314-90b8e4d51d8b]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
@@ -957,7 +957,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 201, message: Created}
 - request:
-    body: '{"properties": {"TTL": 3600}, "type": "SRV", "name": "myrssrv"}'
+    body: '{"type": "SRV", "properties": {"TTL": 3600}, "name": "myrssrv"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -967,17 +967,17 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a1655048-e1b9-11e6-8790-a0b3ccf7272a]
+      x-ms-client-request-id: [e455934a-e1bf-11e6-851a-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"8487c180-18a9-461b-a083-73f7d338083e","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"4881293d-7aaf-4c11-afa1-a5f5e58079b6","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['340']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:47 GMT']
-      ETag: [8487c180-18a9-461b-a083-73f7d338083e]
+      Date: ['Mon, 23 Jan 2017 23:01:37 GMT']
+      ETag: [4881293d-7aaf-4c11-afa1-a5f5e58079b6]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
@@ -995,16 +995,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a23f0fd4-e1b9-11e6-8f4d-a0b3ccf7272a]
+      x-ms-client-request-id: [e53945da-e1bf-11e6-b32b-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"8487c180-18a9-461b-a083-73f7d338083e","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"4881293d-7aaf-4c11-afa1-a5f5e58079b6","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:49 GMT']
-      ETag: [8487c180-18a9-461b-a083-73f7d338083e]
+      Date: ['Mon, 23 Jan 2017 23:01:37 GMT']
+      ETag: [4881293d-7aaf-4c11-afa1-a5f5e58079b6]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1013,13 +1013,13 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['340']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "Microsoft.Network/dnszones/SRV", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv",
-      "properties": {"TTL": 3600, "SRVRecords": [{"priority": 1, "target": "target.com",
-      "weight": 50, "port": 1234}]}, "etag": "8487c180-18a9-461b-a083-73f7d338083e",
-      "name": "myrssrv"}'
+    body: '{"etag": "4881293d-7aaf-4c11-afa1-a5f5e58079b6", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv",
+      "properties": {"TTL": 3600, "SRVRecords": [{"port": 1234, "priority": 1, "target":
+      "target.com", "weight": 50}]}, "type": "Microsoft.Network/dnszones/SRV", "name":
+      "myrssrv"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1029,16 +1029,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a2b19ad2-e1b9-11e6-ad31-a0b3ccf7272a]
+      x-ms-client-request-id: [e5926740-e1bf-11e6-b573-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"15cc800b-b075-4433-a1ae-b955d9239240","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"df31bfc2-3fc2-4114-8baf-3686089e7f68","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:50 GMT']
-      ETag: [15cc800b-b075-4433-a1ae-b955d9239240]
+      Date: ['Mon, 23 Jan 2017 23:01:39 GMT']
+      ETag: [df31bfc2-3fc2-4114-8baf-3686089e7f68]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1047,7 +1047,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['400']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1059,7 +1059,7 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a381aeb4-e1b9-11e6-b3f3-a0b3ccf7272a]
+      x-ms-client-request-id: [e66e2cd0-e1bf-11e6-9716-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrvalt?api-version=2016-04-01
   response:
@@ -1069,17 +1069,17 @@ interactions:
       Cache-Control: [private]
       Content-Length: ['174']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:51 GMT']
+      Date: ['Mon, 23 Jan 2017 23:01:40 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"properties": {"TTL": 3600, "SRVRecords": [{"priority": 1, "target": "target.com",
-      "weight": 50, "port": 1234}]}, "type": "srv", "name": "myrssrvalt"}'
+    body: '{"type": "srv", "properties": {"TTL": 3600, "SRVRecords": [{"port": 1234,
+      "priority": 1, "target": "target.com", "weight": 50}]}, "name": "myrssrvalt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1089,26 +1089,26 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a406f3d2-e1b9-11e6-a94f-a0b3ccf7272a]
+      x-ms-client-request-id: [e6c5c206-e1bf-11e6-a718-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrvalt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrvalt","name":"myrssrvalt","type":"Microsoft.Network\/dnszones\/SRV","etag":"cedfc12d-3509-470a-ab5a-c60c8e17ccbb","properties":{"fqdn":"myrssrvalt.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrvalt","name":"myrssrvalt","type":"Microsoft.Network\/dnszones\/SRV","etag":"2e2e36b4-927c-4309-920e-cd8c762a34b0","properties":{"fqdn":"myrssrvalt.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['409']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:54 GMT']
-      ETag: [cedfc12d-3509-470a-ab5a-c60c8e17ccbb]
+      Date: ['Mon, 23 Jan 2017 23:01:41 GMT']
+      ETag: [2e2e36b4-927c-4309-920e-cd8c762a34b0]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 201, message: Created}
 - request:
-    body: '{"properties": {"TTL": 3600}, "type": "TXT", "name": "myrstxt"}'
+    body: '{"type": "TXT", "properties": {"TTL": 3600}, "name": "myrstxt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1118,23 +1118,23 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a5efdeca-e1b9-11e6-bd84-a0b3ccf7272a]
+      x-ms-client-request-id: [e79f9c7a-e1bf-11e6-94ee-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"57010733-4c19-46e9-933c-0b65ba218ab1","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"66abd873-3763-488a-b33c-fedf54e9e911","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['340']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:56 GMT']
-      ETag: [57010733-4c19-46e9-933c-0b65ba218ab1]
+      Date: ['Mon, 23 Jan 2017 23:01:42 GMT']
+      ETag: [66abd873-3763-488a-b33c-fedf54e9e911]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -1146,16 +1146,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a6e7db6e-e1b9-11e6-8d04-a0b3ccf7272a]
+      x-ms-client-request-id: [e87f01b8-e1bf-11e6-afdb-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"57010733-4c19-46e9-933c-0b65ba218ab1","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"66abd873-3763-488a-b33c-fedf54e9e911","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:57 GMT']
-      ETag: [57010733-4c19-46e9-933c-0b65ba218ab1]
+      Date: ['Mon, 23 Jan 2017 23:01:43 GMT']
+      ETag: [66abd873-3763-488a-b33c-fedf54e9e911]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1164,12 +1164,12 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['340']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "Microsoft.Network/dnszones/TXT", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt",
-      "properties": {"TTL": 3600, "TXTRecords": [{"value": ["some_text"]}]}, "etag":
-      "57010733-4c19-46e9-933c-0b65ba218ab1", "name": "myrstxt"}'
+    body: '{"etag": "66abd873-3763-488a-b33c-fedf54e9e911", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt",
+      "properties": {"TTL": 3600, "TXTRecords": [{"value": ["some_text"]}]}, "type":
+      "Microsoft.Network/dnszones/TXT", "name": "myrstxt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1179,16 +1179,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a752e5d0-e1b9-11e6-b5e0-a0b3ccf7272a]
+      x-ms-client-request-id: [e8c4844a-e1bf-11e6-8e0f-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"136519d0-2f77-4771-a3d6-a6506412e688","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"481339bc-0f47-4025-83f6-78f417426333","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:57 GMT']
-      ETag: [136519d0-2f77-4771-a3d6-a6506412e688]
+      Date: ['Mon, 23 Jan 2017 23:01:44 GMT']
+      ETag: [481339bc-0f47-4025-83f6-78f417426333]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1197,7 +1197,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['363']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1209,7 +1209,7 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a83b0498-e1b9-11e6-b772-a0b3ccf7272a]
+      x-ms-client-request-id: [e97bee66-e1bf-11e6-8b0e-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxtalt?api-version=2016-04-01
   response:
@@ -1219,17 +1219,17 @@ interactions:
       Cache-Control: [private]
       Content-Length: ['174']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:59 GMT']
+      Date: ['Mon, 23 Jan 2017 23:01:45 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"properties": {"TTL": 3600, "TXTRecords": [{"value": ["some_text"]}]},
-      "type": "txt", "name": "myrstxtalt"}'
+    body: '{"type": "txt", "properties": {"TTL": 3600, "TXTRecords": [{"value": ["some_text"]}]},
+      "name": "myrstxtalt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1239,23 +1239,23 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a8a4a6dc-e1b9-11e6-83f0-a0b3ccf7272a]
+      x-ms-client-request-id: [e9bf3406-e1bf-11e6-ac42-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxtalt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxtalt","name":"myrstxtalt","type":"Microsoft.Network\/dnszones\/TXT","etag":"929750d6-71cb-47da-b70c-61b7d4725326","properties":{"fqdn":"myrstxtalt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxtalt","name":"myrstxtalt","type":"Microsoft.Network\/dnszones\/TXT","etag":"0f4de694-250f-4efd-ab44-7e196bb09fe9","properties":{"fqdn":"myrstxtalt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['372']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:16:59 GMT']
-      ETag: [929750d6-71cb-47da-b70c-61b7d4725326]
+      Date: ['Mon, 23 Jan 2017 23:01:46 GMT']
+      ETag: [0f4de694-250f-4efd-ab44-7e196bb09fe9]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -1267,16 +1267,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a97f9bda-e1b9-11e6-823a-a0b3ccf7272a]
+      x-ms-client-request-id: [ea71968a-e1bf-11e6-8bce-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"69b5e7ad-42b5-4481-8bd3-66d6ca299c2f","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"ad939425-21e0-4423-9cce-97e0cedb8a2a","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:17:00 GMT']
-      ETag: [69b5e7ad-42b5-4481-8bd3-66d6ca299c2f]
+      Date: ['Mon, 23 Jan 2017 23:01:46 GMT']
+      ETag: [ad939425-21e0-4423-9cce-97e0cedb8a2a]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1285,12 +1285,12 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['355']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "Microsoft.Network/dnszones/A", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa",
+    body: '{"etag": "ad939425-21e0-4423-9cce-97e0cedb8a2a", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa",
       "properties": {"TTL": 3600, "ARecords": [{"ipv4Address": "10.0.0.10"}, {"ipv4Address":
-      "10.0.0.11"}]}, "etag": "69b5e7ad-42b5-4481-8bd3-66d6ca299c2f", "name": "myrsa"}'
+      "10.0.0.11"}]}, "type": "Microsoft.Network/dnszones/A", "name": "myrsa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1300,16 +1300,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a9cc3c94-e1b9-11e6-a996-a0b3ccf7272a]
+      x-ms-client-request-id: [eab3325e-e1bf-11e6-bd8f-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"fb407006-9d3b-4743-a09f-a4541b4cbd2d","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"7ee8c180-e2a1-4255-a980-42688924eac7","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:17:04 GMT']
-      ETag: [fb407006-9d3b-4743-a09f-a4541b4cbd2d]
+      Date: ['Mon, 23 Jan 2017 23:01:47 GMT']
+      ETag: [7ee8c180-e2a1-4255-a980-42688924eac7]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1318,7 +1318,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['383']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1330,16 +1330,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ac20b24a-e1b9-11e6-842c-a0b3ccf7272a]
+      x-ms-client-request-id: [eb613174-e1bf-11e6-a83d-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SOA/@?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"6fcae9a7-ecd3-46ea-8319-3aa7592430f4","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"azuredns-hostmaster.microsoft.com","expireTime":2419200,"host":"ns1-02.azure-dns.com.","minimumTTL":300,"refreshTime":3600,"retryTime":300,"serialNumber":1}}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"1afbcb94-00b9-42c9-abe0-1463f6e4269f","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"azuredns-hostmaster.microsoft.com","expireTime":2419200,"host":"ns1-01.azure-dns.com.","minimumTTL":300,"refreshTime":3600,"retryTime":300,"serialNumber":1}}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:17:05 GMT']
-      ETag: [6fcae9a7-ecd3-46ea-8319-3aa7592430f4]
+      Date: ['Mon, 23 Jan 2017 23:01:48 GMT']
+      ETag: [1afbcb94-00b9-42c9-abe0-1463f6e4269f]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1359,16 +1359,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ac5b7bbe-e1b9-11e6-b72a-a0b3ccf7272a]
+      x-ms-client-request-id: [eb8d7dee-e1bf-11e6-bec6-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SOA/@?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"6fcae9a7-ecd3-46ea-8319-3aa7592430f4","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"azuredns-hostmaster.microsoft.com","expireTime":2419200,"host":"ns1-02.azure-dns.com.","minimumTTL":300,"refreshTime":3600,"retryTime":300,"serialNumber":1}}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"1afbcb94-00b9-42c9-abe0-1463f6e4269f","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"azuredns-hostmaster.microsoft.com","expireTime":2419200,"host":"ns1-01.azure-dns.com.","minimumTTL":300,"refreshTime":3600,"retryTime":300,"serialNumber":1}}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:17:05 GMT']
-      ETag: [6fcae9a7-ecd3-46ea-8319-3aa7592430f4]
+      Date: ['Mon, 23 Jan 2017 23:01:49 GMT']
+      ETag: [1afbcb94-00b9-42c9-abe0-1463f6e4269f]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1379,11 +1379,10 @@ interactions:
       content-length: ['483']
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "Microsoft.Network/dnszones/SOA", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SOA/@",
-      "properties": {"SOARecord": {"host": "ns1-02.azure-dns.com.", "expireTime":
-      30, "minimumTTL": 20, "refreshTime": 60, "retryTime": 90, "email": "foo.com",
-      "serialNumber": 123}, "TTL": 3600}, "etag": "6fcae9a7-ecd3-46ea-8319-3aa7592430f4",
-      "name": "@"}'
+    body: '{"etag": "1afbcb94-00b9-42c9-abe0-1463f6e4269f", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SOA/@",
+      "properties": {"TTL": 3600, "SOARecord": {"host": "ns1-01.azure-dns.com.", "refreshTime":
+      60, "expireTime": 30, "serialNumber": 123, "retryTime": 90, "email": "foo.com",
+      "minimumTTL": 20}}, "type": "Microsoft.Network/dnszones/SOA", "name": "@"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1393,16 +1392,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [acb25d80-e1b9-11e6-a5c9-a0b3ccf7272a]
+      x-ms-client-request-id: [ebd130d8-e1bf-11e6-8ccb-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SOA/@?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"ac48e315-49ac-429d-b3f6-794c9cf009a1","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"foo.com","expireTime":30,"host":"ns1-02.azure-dns.com.","minimumTTL":20,"refreshTime":60,"retryTime":90,"serialNumber":123}}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"e42528cf-b9f4-40c8-a9dc-93dc013e9d08","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"foo.com","expireTime":30,"host":"ns1-01.azure-dns.com.","minimumTTL":20,"refreshTime":60,"retryTime":90,"serialNumber":123}}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:17:06 GMT']
-      ETag: [ac48e315-49ac-429d-b3f6-794c9cf009a1]
+      Date: ['Mon, 23 Jan 2017 23:01:49 GMT']
+      ETag: [e42528cf-b9f4-40c8-a9dc-93dc013e9d08]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1411,7 +1410,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['450']
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1423,16 +1422,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ad60e4b0-e1b9-11e6-aee0-a0b3ccf7272a]
+      x-ms-client-request-id: [ec8ef2f4-e1bf-11e6-a97d-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-c2f0-7a4cc675d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-02.azure-dns.com.","ns2-02.azure-dns.net.","ns3-02.azure-dns.org.","ns4-02.azure-dns.info."],"numberOfRecordSets":18}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-a3c3-ff91cc75d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-01.azure-dns.com.","ns2-01.azure-dns.net.","ns3-01.azure-dns.org.","ns4-01.azure-dns.info."],"numberOfRecordSets":18}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:17:07 GMT']
-      ETag: [00000002-0000-0000-c2f0-7a4cc675d201]
+      Date: ['Mon, 23 Jan 2017 23:01:50 GMT']
+      ETag: [00000002-0000-0000-a3c3-ff91cc75d201]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1453,16 +1452,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [adf5e38c-e1b9-11e6-8def-a0b3ccf7272a]
+      x-ms-client-request-id: [ed232cee-e1bf-11e6-a99d-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"fb407006-9d3b-4743-a09f-a4541b4cbd2d","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"7ee8c180-e2a1-4255-a980-42688924eac7","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:17:08 GMT']
-      ETag: [fb407006-9d3b-4743-a09f-a4541b4cbd2d]
+      Date: ['Mon, 23 Jan 2017 23:01:51 GMT']
+      ETag: [7ee8c180-e2a1-4255-a980-42688924eac7]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1483,16 +1482,15 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ae987be6-e1b9-11e6-b739-a0b3ccf7272a]
+      x-ms-client-request-id: [eda2fff0-e1bf-11e6-93b8-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/recordsets?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"fb407006-9d3b-4743-a09f-a4541b4cbd2d","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
+    body: {string: '{"value":[{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/@","name":"@","type":"Microsoft.Network\/dnszones\/NS","etag":"5c914a8b-0e58-4512-ab99-b3e2323118e2","properties":{"fqdn":"myzone.com.","TTL":172800,"NSRecords":[{"nsdname":"ns1-01.azure-dns.com."},{"nsdname":"ns2-01.azure-dns.net."},{"nsdname":"ns3-01.azure-dns.org."},{"nsdname":"ns4-01.azure-dns.info."}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"e42528cf-b9f4-40c8-a9dc-93dc013e9d08","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"foo.com","expireTime":30,"host":"ns1-01.azure-dns.com.","minimumTTL":20,"refreshTime":60,"retryTime":90,"serialNumber":123}}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"7ee8c180-e2a1-4255-a980-42688924eac7","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"23e5ebac-9a35-4184-a9f8-101f40d6775d","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaaalt","name":"myrsaaaaalt","type":"Microsoft.Network\/dnszones\/AAAA","etag":"d0b62fc4-17b1-434c-b146-1eee6dd4eee1","properties":{"fqdn":"myrsaaaaalt.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsaalt","name":"myrsaalt","type":"Microsoft.Network\/dnszones\/A","etag":"c9a653fe-0bd6-42fa-a738-04aa1a199d47","properties":{"fqdn":"myrsaalt.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"05e1c8fb-8647-4a51-8d64-6131017be2fe","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscnamealt","name":"myrscnamealt","type":"Microsoft.Network\/dnszones\/CNAME","etag":"d589932d-e49c-4537-836d-57b563f26e92","properties":{"fqdn":"myrscnamealt.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"98959c0d-d8ee-48b9-90ea-6177bb044269","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmxalt","name":"myrsmxalt","type":"Microsoft.Network\/dnszones\/MX","etag":"a0e11058-9acf-4fb3-b0eb-2ecd9690a0d0","properties":{"fqdn":"myrsmxalt.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"f75047f6-9769-4f87-83db-47c9f5380306","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsnsalt","name":"myrsnsalt","type":"Microsoft.Network\/dnszones\/NS","etag":"ae0402ec-c862-461b-8421-bb75ff3a0031","properties":{"fqdn":"myrsnsalt.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"69ef284a-f0c8-4680-bbaf-5f11dfe5e93f","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptralt","name":"myrsptralt","type":"Microsoft.Network\/dnszones\/PTR","etag":"88e2d449-4ba5-4cc2-a314-90b8e4d51d8b","properties":{"fqdn":"myrsptralt.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"df31bfc2-3fc2-4114-8baf-3686089e7f68","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrvalt","name":"myrssrvalt","type":"Microsoft.Network\/dnszones\/SRV","etag":"2e2e36b4-927c-4309-920e-cd8c762a34b0","properties":{"fqdn":"myrssrvalt.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"481339bc-0f47-4025-83f6-78f417426333","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxtalt","name":"myrstxtalt","type":"Microsoft.Network\/dnszones\/TXT","etag":"0f4de694-250f-4efd-ab44-7e196bb09fe9","properties":{"fqdn":"myrstxtalt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}]}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:17:09 GMT']
-      ETag: [fb407006-9d3b-4743-a09f-a4541b4cbd2d]
+      Date: ['Mon, 23 Jan 2017 23:01:51 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1500,32 +1498,27 @@ interactions:
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      content-length: ['383']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      content-length: ['6962']
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "Microsoft.Network/dnszones/A", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa",
-      "properties": {"TTL": 3600, "ARecords": [{"ipv4Address": "10.0.0.11"}]}, "etag":
-      "fb407006-9d3b-4743-a09f-a4541b4cbd2d", "name": "myrsa"}'
+    body: null
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['329']
       Content-Type: [application/json; charset=utf-8]
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [aef2a04c-e1b9-11e6-a1f5-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
+      x-ms-client-request-id: [ee10fe40-e1bf-11e6-a349-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"fe1de1a2-d382-4361-abcd-f4ce173c5ce9","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
+    body: {string: '{"value":[{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"481339bc-0f47-4025-83f6-78f417426333","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxtalt","name":"myrstxtalt","type":"Microsoft.Network\/dnszones\/TXT","etag":"0f4de694-250f-4efd-ab44-7e196bb09fe9","properties":{"fqdn":"myrstxtalt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}]}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:17:10 GMT']
-      ETag: [fe1de1a2-d382-4361-abcd-f4ce173c5ce9]
+      Date: ['Mon, 23 Jan 2017 23:01:52 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1533,7 +1526,7 @@ interactions:
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      content-length: ['355']
+      content-length: ['748']
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 200, message: OK}
 - request:
@@ -1546,16 +1539,79 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [afda98e4-e1b9-11e6-b74a-a0b3ccf7272a]
+      x-ms-client-request-id: [ee7f89e8-e1bf-11e6-b88c-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"72495495-8e86-4754-991e-9ccdee711977","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"7ee8c180-e2a1-4255-a980-42688924eac7","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:17:12 GMT']
-      ETag: [72495495-8e86-4754-991e-9ccdee711977]
+      Date: ['Mon, 23 Jan 2017 23:01:53 GMT']
+      ETag: [7ee8c180-e2a1-4255-a980-42688924eac7]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['383']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"etag": "7ee8c180-e2a1-4255-a980-42688924eac7", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa",
+      "properties": {"TTL": 3600, "ARecords": [{"ipv4Address": "10.0.0.11"}]}, "type":
+      "Microsoft.Network/dnszones/A", "name": "myrsa"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['329']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [eec8df5c-e1bf-11e6-8881-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"22ddacf2-faa2-485b-a38d-05bddd488a7a","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 23:01:54 GMT']
+      ETag: [22ddacf2-faa2-485b-a38d-05bddd488a7a]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['355']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [efaa6d38-e1bf-11e6-b265-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"23e5ebac-9a35-4184-a9f8-101f40d6775d","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 23:01:55 GMT']
+      ETag: [23e5ebac-9a35-4184-a9f8-101f40d6775d]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1564,11 +1620,11 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['384']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "Microsoft.Network/dnszones/AAAA", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa",
-      "properties": {"AAAARecords": [], "TTL": 3600}, "etag": "72495495-8e86-4754-991e-9ccdee711977",
+    body: '{"etag": "23e5ebac-9a35-4184-a9f8-101f40d6775d", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa",
+      "properties": {"TTL": 3600, "AAAARecords": []}, "type": "Microsoft.Network/dnszones/AAAA",
       "name": "myrsaaaa"}'
     headers:
       Accept: [application/json]
@@ -1579,16 +1635,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b02d1ec8-e1b9-11e6-8c33-a0b3ccf7272a]
+      x-ms-client-request-id: [eff7084a-e1bf-11e6-90a2-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"0ed321fb-62e8-462f-9f73-47b09faccbb3","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"5e3ac85a-a607-4369-a6d6-a28cea08e2fa","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:17:13 GMT']
-      ETag: [0ed321fb-62e8-462f-9f73-47b09faccbb3]
+      Date: ['Mon, 23 Jan 2017 23:01:56 GMT']
+      ETag: [5e3ac85a-a607-4369-a6d6-a28cea08e2fa]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1609,16 +1665,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b11620da-e1b9-11e6-93fe-a0b3ccf7272a]
+      x-ms-client-request-id: [f0d475c0-e1bf-11e6-9f0b-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"d871c6bd-bcfa-42e6-b603-69ab5ad68473","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"05e1c8fb-8647-4a51-8d64-6131017be2fe","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:17:13 GMT']
-      ETag: [d871c6bd-bcfa-42e6-b603-69ab5ad68473]
+      Date: ['Mon, 23 Jan 2017 23:01:57 GMT']
+      ETag: [05e1c8fb-8647-4a51-8d64-6131017be2fe]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1627,12 +1683,12 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['368']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "Microsoft.Network/dnszones/CNAME", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname",
-      "properties": {"TTL": 3600}, "etag": "d871c6bd-bcfa-42e6-b603-69ab5ad68473",
-      "name": "myrscname"}'
+    body: '{"etag": "05e1c8fb-8647-4a51-8d64-6131017be2fe", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname",
+      "properties": {"TTL": 3600}, "type": "Microsoft.Network/dnszones/CNAME", "name":
+      "myrscname"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1642,79 +1698,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b1711df4-e1b9-11e6-ab81-a0b3ccf7272a]
+      x-ms-client-request-id: [f10042b4-e1bf-11e6-827c-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"9ee971fc-a8ca-4341-8bc4-4a95289d0d79","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"3c4e403e-c86c-4e6b-9ffe-32524d363737","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:17:14 GMT']
-      ETag: [9ee971fc-a8ca-4341-8bc4-4a95289d0d79]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      content-length: ['334']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [b266a2b6-e1b9-11e6-ae44-a0b3ccf7272a]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"b5642c85-2454-41bc-9e17-e25d4d670036","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:17:15 GMT']
-      ETag: [b5642c85-2454-41bc-9e17-e25d4d670036]
-      Server: [Microsoft-IIS/8.5]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Transfer-Encoding: [chunked]
-      Vary: [Accept-Encoding]
-      X-AspNet-Version: [4.0.30319]
-      X-Content-Type-Options: [nosniff]
-      X-Powered-By: [ASP.NET]
-      content-length: ['367']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"type": "Microsoft.Network/dnszones/MX", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx",
-      "properties": {"TTL": 3600, "MXRecords": []}, "etag": "b5642c85-2454-41bc-9e17-e25d4d670036",
-      "name": "myrsmx"}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['306']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
-          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
-      accept-language: [en-US]
-      x-ms-client-request-id: [b2b4cc1e-e1b9-11e6-a866-a0b3ccf7272a]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx?api-version=2016-04-01
-  response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"17fd1f52-afee-49a9-b3b6-23ea9a2c0e2d","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
-    headers:
-      Cache-Control: [private]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:17:17 GMT']
-      ETag: [17fd1f52-afee-49a9-b3b6-23ea9a2c0e2d]
+      Date: ['Mon, 23 Jan 2017 23:01:58 GMT']
+      ETag: [3c4e403e-c86c-4e6b-9ffe-32524d363737]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1735,16 +1728,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b3865342-e1b9-11e6-8358-a0b3ccf7272a]
+      x-ms-client-request-id: [f1ba09d2-e1bf-11e6-a28b-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"ff950952-88ba-46af-b20b-dad5d4f81dcd","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"98959c0d-d8ee-48b9-90ea-6177bb044269","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:17:17 GMT']
-      ETag: [ff950952-88ba-46af-b20b-dad5d4f81dcd]
+      Date: ['Mon, 23 Jan 2017 23:01:59 GMT']
+      ETag: [98959c0d-d8ee-48b9-90ea-6177bb044269]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1752,12 +1745,13 @@ interactions:
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      content-length: ['358']
+      content-length: ['367']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "Microsoft.Network/dnszones/NS", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns",
-      "properties": {"TTL": 3600, "NSRecords": []}, "etag": "ff950952-88ba-46af-b20b-dad5d4f81dcd",
-      "name": "myrsns"}'
+    body: '{"etag": "98959c0d-d8ee-48b9-90ea-6177bb044269", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx",
+      "properties": {"TTL": 3600, "MXRecords": []}, "type": "Microsoft.Network/dnszones/MX",
+      "name": "myrsmx"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1767,16 +1761,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b3bbf39e-e1b9-11e6-8c75-a0b3ccf7272a]
+      x-ms-client-request-id: [f202e222-e1bf-11e6-8eec-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"b9b3d37e-b2cf-41ad-9ca6-5cef2e204a9e","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"2b4fb052-6093-4b3e-804c-3974993e8af5","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:17:18 GMT']
-      ETag: [b9b3d37e-b2cf-41ad-9ca6-5cef2e204a9e]
+      Date: ['Mon, 23 Jan 2017 23:01:59 GMT']
+      ETag: [2b4fb052-6093-4b3e-804c-3974993e8af5]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1785,7 +1779,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['334']
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1797,16 +1791,78 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b4959f4a-e1b9-11e6-870f-a0b3ccf7272a]
+      x-ms-client-request-id: [f2be651e-e1bf-11e6-a91b-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr?api-version=2016-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"1f58e3ac-8147-44fc-b01d-2cd35b080240","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"f75047f6-9769-4f87-83db-47c9f5380306","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:17:19 GMT']
-      ETag: [1f58e3ac-8147-44fc-b01d-2cd35b080240]
+      Date: ['Mon, 23 Jan 2017 23:02:00 GMT']
+      ETag: [f75047f6-9769-4f87-83db-47c9f5380306]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['358']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"etag": "f75047f6-9769-4f87-83db-47c9f5380306", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns",
+      "properties": {"TTL": 3600, "NSRecords": []}, "type": "Microsoft.Network/dnszones/NS",
+      "name": "myrsns"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['306']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [f2fc26e4-e1bf-11e6-a0ed-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"a5a98583-7edd-4bec-89ea-1560d5d61b27","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 23:02:01 GMT']
+      ETag: [a5a98583-7edd-4bec-89ea-1560d5d61b27]
+      Server: [Microsoft-IIS/8.5]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      X-AspNet-Version: [4.0.30319]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      content-length: ['334']
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [f3968f92-e1bf-11e6-a58a-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr?api-version=2016-04-01
+  response:
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"69ef284a-f0c8-4680-bbaf-5f11dfe5e93f","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
+    headers:
+      Cache-Control: [private]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 23 Jan 2017 23:02:01 GMT']
+      ETag: [69ef284a-f0c8-4680-bbaf-5f11dfe5e93f]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1818,8 +1874,8 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "Microsoft.Network/dnszones/PTR", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr",
-      "properties": {"PTRRecords": [], "TTL": 3600}, "etag": "1f58e3ac-8147-44fc-b01d-2cd35b080240",
+    body: '{"etag": "69ef284a-f0c8-4680-bbaf-5f11dfe5e93f", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr",
+      "properties": {"PTRRecords": [], "TTL": 3600}, "type": "Microsoft.Network/dnszones/PTR",
       "name": "myrsptr"}'
     headers:
       Accept: [application/json]
@@ -1830,16 +1886,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b4cbcbfe-e1b9-11e6-a01a-a0b3ccf7272a]
+      x-ms-client-request-id: [f3d2649a-e1bf-11e6-97cf-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"b52f0442-e0d6-4314-8d9a-b03a5f94b953","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"3ad0a5ee-55c2-45f7-b2a2-f8c33d1ddb31","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:17:19 GMT']
-      ETag: [b52f0442-e0d6-4314-8d9a-b03a5f94b953]
+      Date: ['Mon, 23 Jan 2017 23:02:02 GMT']
+      ETag: [3ad0a5ee-55c2-45f7-b2a2-f8c33d1ddb31]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1848,7 +1904,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['340']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1860,16 +1916,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b59a0d34-e1b9-11e6-8c80-a0b3ccf7272a]
+      x-ms-client-request-id: [f49cb610-e1bf-11e6-b433-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"15cc800b-b075-4433-a1ae-b955d9239240","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"df31bfc2-3fc2-4114-8baf-3686089e7f68","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:17:21 GMT']
-      ETag: [15cc800b-b075-4433-a1ae-b955d9239240]
+      Date: ['Mon, 23 Jan 2017 23:02:03 GMT']
+      ETag: [df31bfc2-3fc2-4114-8baf-3686089e7f68]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1878,11 +1934,11 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['400']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "Microsoft.Network/dnszones/SRV", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv",
-      "properties": {"TTL": 3600, "SRVRecords": []}, "etag": "15cc800b-b075-4433-a1ae-b955d9239240",
+    body: '{"etag": "df31bfc2-3fc2-4114-8baf-3686089e7f68", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv",
+      "properties": {"TTL": 3600, "SRVRecords": []}, "type": "Microsoft.Network/dnszones/SRV",
       "name": "myrssrv"}'
     headers:
       Accept: [application/json]
@@ -1893,16 +1949,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b6002dc0-e1b9-11e6-b359-a0b3ccf7272a]
+      x-ms-client-request-id: [f4f576c6-e1bf-11e6-924d-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"0c490578-cda9-4757-8b32-0eb2f0dfbaaa","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"eadce3ab-3228-472c-984f-985b7e68d2e2","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:17:22 GMT']
-      ETag: [0c490578-cda9-4757-8b32-0eb2f0dfbaaa]
+      Date: ['Mon, 23 Jan 2017 23:02:04 GMT']
+      ETag: [eadce3ab-3228-472c-984f-985b7e68d2e2]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1911,7 +1967,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['340']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1923,16 +1979,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b6ddbaae-e1b9-11e6-ba83-a0b3ccf7272a]
+      x-ms-client-request-id: [f5a3e1fa-e1bf-11e6-9bae-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"136519d0-2f77-4771-a3d6-a6506412e688","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"481339bc-0f47-4025-83f6-78f417426333","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:17:23 GMT']
-      ETag: [136519d0-2f77-4771-a3d6-a6506412e688]
+      Date: ['Mon, 23 Jan 2017 23:02:05 GMT']
+      ETag: [481339bc-0f47-4025-83f6-78f417426333]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1944,8 +2000,8 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "Microsoft.Network/dnszones/TXT", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt",
-      "properties": {"TTL": 3600, "TXTRecords": []}, "etag": "136519d0-2f77-4771-a3d6-a6506412e688",
+    body: '{"etag": "481339bc-0f47-4025-83f6-78f417426333", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt",
+      "properties": {"TTL": 3600, "TXTRecords": []}, "type": "Microsoft.Network/dnszones/TXT",
       "name": "myrstxt"}'
     headers:
       Accept: [application/json]
@@ -1956,16 +2012,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b733db62-e1b9-11e6-9485-a0b3ccf7272a]
+      x-ms-client-request-id: [f5f4a31e-e1bf-11e6-a2c7-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"6b10faac-37a5-4b00-8b49-4d5f6f3b9abb","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"56c5370b-6cb7-4692-9c5f-f2813edae0e6","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:17:24 GMT']
-      ETag: [6b10faac-37a5-4b00-8b49-4d5f6f3b9abb]
+      Date: ['Mon, 23 Jan 2017 23:02:06 GMT']
+      ETag: [56c5370b-6cb7-4692-9c5f-f2813edae0e6]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1986,16 +2042,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b805d05c-e1b9-11e6-ba3e-a0b3ccf7272a]
+      x-ms-client-request-id: [f6aafe4c-e1bf-11e6-8049-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"fe1de1a2-d382-4361-abcd-f4ce173c5ce9","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"22ddacf2-faa2-485b-a38d-05bddd488a7a","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:17:25 GMT']
-      ETag: [fe1de1a2-d382-4361-abcd-f4ce173c5ce9]
+      Date: ['Mon, 23 Jan 2017 23:02:07 GMT']
+      ETag: [22ddacf2-faa2-485b-a38d-05bddd488a7a]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -2016,16 +2072,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b8bd5e70-e1b9-11e6-8475-a0b3ccf7272a]
+      x-ms-client-request-id: [f74178e6-e1bf-11e6-86bb-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"fe1de1a2-d382-4361-abcd-f4ce173c5ce9","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"22ddacf2-faa2-485b-a38d-05bddd488a7a","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:17:26 GMT']
-      ETag: [fe1de1a2-d382-4361-abcd-f4ce173c5ce9]
+      Date: ['Mon, 23 Jan 2017 23:02:08 GMT']
+      ETag: [22ddacf2-faa2-485b-a38d-05bddd488a7a]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -2034,11 +2090,11 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['355']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "Microsoft.Network/dnszones/A", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa",
-      "properties": {"TTL": 3600, "ARecords": []}, "etag": "fe1de1a2-d382-4361-abcd-f4ce173c5ce9",
+    body: '{"etag": "22ddacf2-faa2-485b-a38d-05bddd488a7a", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa",
+      "properties": {"TTL": 3600, "ARecords": []}, "type": "Microsoft.Network/dnszones/A",
       "name": "myrsa"}'
     headers:
       Accept: [application/json]
@@ -2049,16 +2105,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b923dba8-e1b9-11e6-9b15-a0b3ccf7272a]
+      x-ms-client-request-id: [f7998be6-e1bf-11e6-8727-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"be74daa9-5621-4912-a50d-23c7b3249eca","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"5bd327a3-00ca-414c-9e78-b45765db9dc6","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:17:27 GMT']
-      ETag: [be74daa9-5621-4912-a50d-23c7b3249eca]
+      Date: ['Mon, 23 Jan 2017 23:02:09 GMT']
+      ETag: [5bd327a3-00ca-414c-9e78-b45765db9dc6]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -2067,7 +2123,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['328']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2079,16 +2135,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ba1e6766-e1b9-11e6-9d79-a0b3ccf7272a]
+      x-ms-client-request-id: [f862bc9e-e1bf-11e6-932f-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"be74daa9-5621-4912-a50d-23c7b3249eca","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"5bd327a3-00ca-414c-9e78-b45765db9dc6","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:17:28 GMT']
-      ETag: [be74daa9-5621-4912-a50d-23c7b3249eca]
+      Date: ['Mon, 23 Jan 2017 23:02:10 GMT']
+      ETag: [5bd327a3-00ca-414c-9e78-b45765db9dc6]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -2097,7 +2153,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['328']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2110,7 +2166,7 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [baa2bf98-e1b9-11e6-a1d1-a0b3ccf7272a]
+      x-ms-client-request-id: [f8f2cbec-e1bf-11e6-9d42-a0b3ccf7272a]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
@@ -2118,7 +2174,7 @@ interactions:
     headers:
       Cache-Control: [private]
       Content-Length: ['0']
-      Date: ['Mon, 23 Jan 2017 22:17:30 GMT']
+      Date: ['Mon, 23 Jan 2017 23:02:11 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
@@ -2136,7 +2192,7 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.6 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [bb62091c-e1b9-11e6-b85d-a0b3ccf7272a]
+      x-ms-client-request-id: [f9b13f74-e1bf-11e6-94ef-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
@@ -2146,12 +2202,12 @@ interactions:
       Cache-Control: [private]
       Content-Length: ['169']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 23 Jan 2017 22:17:30 GMT']
+      Date: ['Mon, 23 Jan 2017 23:02:12 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
     status: {code: 404, message: Not Found}
 version: 1

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/test_network_commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/test_network_commands.py
@@ -90,7 +90,7 @@ class NetworkAppGatewayDefaultScenarioTest(ResourceGroupVCRTestBase):
 class NetworkAppGatewayExistingSubnetScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(NetworkAppGatewayExistingSubnetScenarioTest, self).__init__(__file__, test_method, resource_group='cli_test_ag_existing_subnet', debug=True)
+        super(NetworkAppGatewayExistingSubnetScenarioTest, self).__init__(__file__, test_method, resource_group='cli_test_ag_existing_subnet')
 
     def test_network_app_gateway_with_existing_subnet(self):
         self.execute()
@@ -1178,7 +1178,7 @@ class NetworkTrafficManagerScenarioTest(ResourceGroupVCRTestBase):
 class NetworkDnsScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(NetworkDnsScenarioTest, self).__init__(__file__, test_method, resource_group='cli_dns_test1')
+        super(NetworkDnsScenarioTest, self).__init__(__file__, test_method, resource_group='cli_test_dns')
 
     def test_network_dns(self):
         self.execute()
@@ -1209,16 +1209,21 @@ class NetworkDnsScenarioTest(ResourceGroupVCRTestBase):
         record_types = ['a', 'aaaa', 'cname', 'mx', 'ns', 'ptr', 'srv', 'txt']
 
         for t in record_types:
+            # test creating the record set and then adding records
             self.cmd('network dns record-set create -n myrs{0} -g {1} --zone-name {2} --type {0}'
                      .format(t, rg, zone_name))
             self.cmd('network dns record {0} add -g {1} --zone-name {2} --record-set-name myrs{0} {3}'
                      .format(t, rg, zone_name, args[t]))
+            # test creating the record set at the same time you add records
+            self.cmd('network dns record {0} add -g {1} --zone-name {2} --record-set-name myrs{0}alt {3}'
+                     .format(t, rg, zone_name, args[t]))
+
         self.cmd('network dns record {0} add -g {1} --zone-name {2} --record-set-name myrs{0} {3}'
                  .format('a', rg, zone_name, '--ipv4-address 10.0.0.11'))
         self.cmd('network dns record update-soa -g {0} --zone-name {1} {2}'
                      .format(rg, zone_name, args['soa']))
 
-        typed_record_sets = len(record_types)
+        typed_record_sets = 2 * len(record_types)
         self.cmd('network dns zone show -n {} -g {}'.format(zone_name, rg), checks=[
             JMESPathCheck('numberOfRecordSets', base_record_sets + typed_record_sets)
             ])

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/test_network_commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/test_network_commands.py
@@ -1232,6 +1232,13 @@ class NetworkDnsScenarioTest(ResourceGroupVCRTestBase):
                      JMESPathCheck('length(arecords)', 2)
                      ])
 
+        # test list vs. list type
+        self.cmd('network dns record-set list -g {} -z {}'.format(rg, zone_name),
+            checks=JMESPathCheck('length(@)', base_record_sets + typed_record_sets))
+
+        self.cmd('network dns record-set list -g {} -z {} --type txt'.format(rg, zone_name),
+            checks=JMESPathCheck('length(@)', 2))
+
         for t in record_types:
             self.cmd('network dns record {0} remove -g {1} --zone-name {2} --record-set-name myrs{0} {3}'
                      .format(t, rg, zone_name, args[t]))


### PR DESCRIPTION
Fixes #1718. Fixes #1719. Addresses parts of #1131.

- Automatically creates a record set when using `az record _ add` if the set does not already exist. (#1719)
- Adds the ability to filter `dns record-set list` by `--type`. (#1131)
- **BC**: Removes the `--top` parameter from `dns record-set list`. (#1131)
- Adjusts the table format of `dns record-set list` (#1131) (#1718)