### PR TITLE
Add path expansion to file type parameters

### DIFF
--- a/azure-cli.pyproj
+++ b/azure-cli.pyproj
@@ -828,27 +828,17 @@
     <Content Include="azure-cli\setup.cfg" />
     <Content Include="command_modules\azure-cli-acr\azure\cli\command_modules\acr\template.json" />
     <Content Include="command_modules\azure-cli-acr\azure\cli\command_modules\acr\tests\recordings\test_acr.yaml" />
-    <Content Include="command_modules\azure-cli-acr\requirements.txt" />
-    <Content Include="command_modules\azure-cli-acs\requirements.txt" />
     <Content Include="command_modules\azure-cli-appservice\azure\cli\command_modules\appservice\tests\sample_web\.gitignore" />
     <Content Include="command_modules\azure-cli-appservice\azure\cli\command_modules\appservice\tests\sample_web\package.json" />
     <Content Include="command_modules\azure-cli-appservice\azure\cli\command_modules\appservice\tests\sample_web\server.js" />
     <Content Include="command_modules\azure-cli-appservice\README.rst" />
-    <Content Include="command_modules\azure-cli-appservice\requirements.txt" />
     <Content Include="command_modules\azure-cli-appservice\setup.cfg" />
-    <Content Include="command_modules\azure-cli-component\requirements.txt" />
-    <Content Include="command_modules\azure-cli-configure\requirements.txt" />
-    <Content Include="command_modules\azure-cli-container\requirements.txt" />
     <Content Include="command_modules\azure-cli-iot\azure\cli\command_modules\iot\mgmt_iot_hub_device\swagger_iot_hub_device_identity.json" />
-    <Content Include="command_modules\azure-cli-iot\requirements.txt" />
-    <Content Include="command_modules\azure-cli-keyvault\requirements.txt" />
-    <Content Include="command_modules\azure-cli-batch\requirements.txt" />
     <Content Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_app_gateway\azuredeploy.json" />
     <Content Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_app_gateway\azuredeploy_tests.md">
       <SubType>Code</SubType>
     </Content>
     <Content Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_app_gateway\swagger_create_app_gateway.json" />
-    <Content Include="command_modules\azure-cli-feedback\requirements.txt" />
     <Content Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_express_route_circuit\azuredeploy.json" />
     <Content Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_express_route_circuit\swagger_create_express_route_circuit.json" />
     <Content Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_lb\azuredeploy_empty.json" />
@@ -882,16 +872,9 @@
     <Content Include="command_modules\azure-cli-network\azure\cli\command_modules\network\mgmt_vpn_connection\swagger_create_vpn_connection.json" />
     <Content Include="command_modules\azure-cli-network\azure\cli\command_modules\network\tests\TestCert.pfx" />
     <Content Include="command_modules\azure-cli-network\azure\cli\command_modules\network\tests\zone.txt" />
-    <Content Include="command_modules\azure-cli-network\requirements.txt" />
-    <Content Include="command_modules\azure-cli-profile\requirements.txt" />
-    <Content Include="command_modules\azure-cli-redis\requirements.txt" />
     <Content Include="command_modules\azure-cli-resource\azure\cli\command_modules\resource\tests\sample_policy_rule.json" />
     <Content Include="command_modules\azure-cli-resource\azure\cli\command_modules\resource\tests\simple_deploy.json" />
     <Content Include="command_modules\azure-cli-resource\azure\cli\command_modules\resource\tests\simple_deploy_parameters.json" />
-    <Content Include="command_modules\azure-cli-resource\requirements.txt" />
-    <Content Include="command_modules\azure-cli-role\requirements.txt" />
-    <Content Include="command_modules\azure-cli-storage\requirements.txt" />
-    <Content Include="command_modules\azure-cli-taskhelp\requirements.txt" />
     <Content Include="command_modules\azure-cli-vm\azure\cli\command_modules\vm\mgmt_acs\azuredeploy.json" />
     <Content Include="command_modules\azure-cli-vm\azure\cli\command_modules\vm\mgmt_acs\swagger_create_acs.json" />
     <Content Include="command_modules\azure-cli-vm\azure\cli\command_modules\vm\mgmt_avail_set\azuredeploy.json" />
@@ -926,7 +909,6 @@
     <Content Include="command_modules\azure-cli-vm\azure\cli\command_modules\vm\mgmt_vm\nested_templates\vm_none_sshkey.json" />
     <Content Include="command_modules\azure-cli-vm\azure\cli\command_modules\vm\mgmt_vm\swagger_create_vm.json" />
     <Content Include="command_modules\azure-cli-vm\azure\cli\command_modules\vm\tests\aliases.json" />
-    <Content Include="command_modules\azure-cli-vm\requirements.txt" />
   </ItemGroup>
   <ItemGroup>
     <Interpreter Include="..\env\">

--- a/src/azure-cli-core/azure/cli/core/commands/parameters.py
+++ b/src/azure-cli-core/azure/cli/core/commands/parameters.py
@@ -25,6 +25,11 @@ def get_location_completion_list(prefix, **kwargs):  # pylint: disable=unused-ar
     return [l.name for l in result]
 
 
+def file_type(path):
+    import os
+    return os.path.expanduser(path)
+
+
 def location_name_type(name):
     if ' ' in name:
         # if display name is provided, attempt to convert to short form name

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_params.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_params.py
@@ -12,6 +12,7 @@ from argcomplete.completers import FilesCompleter
 from azure.cli.core.commands import register_cli_argument, CliArgumentType, register_extra_cli_argument
 from azure.cli.core.commands.parameters import (
     enum_choice_list,
+    file_type,
     resource_group_name_type,
     get_one_of_subscription_locations,
     get_resource_name_completion_list)
@@ -57,7 +58,7 @@ register_cli_argument('acs', 'admin_username', options_list=('--admin-username',
 register_cli_argument('acs', 'dns_name_prefix', options_list=('--dns-prefix', '-d'))
 register_cli_argument('acs', 'container_service_name', options_list=('--name', '-n'), help='The name of the container service', completer=get_resource_name_completion_list('Microsoft.ContainerService/ContainerServices'))
 
-register_cli_argument('acs', 'ssh_key_value', required=False, help='SSH key file value or key file path.', default=os.path.join(os.path.expanduser('~'), '.ssh', 'id_rsa.pub'), completer=FilesCompleter())
+register_cli_argument('acs', 'ssh_key_value', required=False, help='SSH key file value or key file path.', type=file_type, default=os.path.join('~', '.ssh', 'id_rsa.pub'), completer=FilesCompleter())
 
 register_extra_cli_argument('acs create', 'generate_ssh_keys', action='store_true', help='Generate SSH public and private key files if missing')
 register_cli_argument('acs create', 'agent_vm_size', completer=get_vm_size_completion_list)
@@ -82,4 +83,5 @@ register_cli_argument('acs kubernetes get-credentials', 'location')
 register_cli_argument('acs kubernetes get-credentials', 'path',
                       options_list=('--file', '-f',),
                       default=os.path.join(os.path.expanduser('~'), '.kube', 'config'),
+                      type=file_type,
                       completer=FilesCompleter())

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
@@ -2,6 +2,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
+
+from argcomplete.completers import FilesCompleter
+
 from azure.cli.core.commands import register_cli_argument
 
 from azure.cli.core.commands.parameters import (resource_group_name_type, location_type,
@@ -77,7 +80,7 @@ server_log_switch_options = ['off', 'storage', 'filesystem']
 register_cli_argument('appservice web log config', 'web_server_logging', help='configure Web server logging', **enum_choice_list(server_log_switch_options))
 
 register_cli_argument('appservice web log tail', 'provider', help="scope the live traces to certain providers/folders, for example:'application', 'http' for server log, 'kudu/trace', etc")
-register_cli_argument('appservice web log download', 'log_file', default='webapp_logs.zip', type=file_type, help='the downloaded zipped log file path')
+register_cli_argument('appservice web log download', 'log_file', default='webapp_logs.zip', type=file_type, completer=FilesCompleter(), help='the downloaded zipped log file path')
 
 register_cli_argument('appservice web config appsettings', 'settings', nargs='+', help="space separated app settings in a format of <name>=<value>")
 register_cli_argument('appservice web config appsettings', 'setting_names', nargs='+', help="space separated app setting names")

--- a/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
+++ b/src/command_modules/azure-cli-appservice/azure/cli/command_modules/appservice/_params.py
@@ -5,7 +5,7 @@
 from azure.cli.core.commands import register_cli_argument
 
 from azure.cli.core.commands.parameters import (resource_group_name_type, location_type,
-                                                get_resource_name_completion_list,
+                                                get_resource_name_completion_list, file_type,
                                                 CliArgumentType, ignore_type, enum_choice_list)
 
 from ._client_factory import web_client_factory
@@ -77,7 +77,7 @@ server_log_switch_options = ['off', 'storage', 'filesystem']
 register_cli_argument('appservice web log config', 'web_server_logging', help='configure Web server logging', **enum_choice_list(server_log_switch_options))
 
 register_cli_argument('appservice web log tail', 'provider', help="scope the live traces to certain providers/folders, for example:'application', 'http' for server log, 'kudu/trace', etc")
-register_cli_argument('appservice web log download', 'log_file', default='webapp_logs.zip', help='the downloaded zipped log file path')
+register_cli_argument('appservice web log download', 'log_file', default='webapp_logs.zip', type=file_type, help='the downloaded zipped log file path')
 
 register_cli_argument('appservice web config appsettings', 'settings', nargs='+', help="space separated app settings in a format of <name>=<value>")
 register_cli_argument('appservice web config appsettings', 'setting_names', nargs='+', help="space separated app setting names")

--- a/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/_params.py
+++ b/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/_params.py
@@ -11,7 +11,7 @@ from azure.cli.core.commands import \
     (register_cli_argument, CliArgumentType)
 from azure.cli.core.commands.parameters import \
     (tags_type, location_type, resource_group_name_type,
-     get_resource_name_completion_list, enum_choice_list)
+     get_resource_name_completion_list, enum_choice_list, file_type)
 
 from ._validators import \
     (application_enabled)
@@ -31,5 +31,5 @@ register_cli_argument('batch account create', 'tags', tags_type)
 register_cli_argument('batch account set', 'tags', tags_type)
 register_cli_argument('batch account keys renew', 'key_name', **enum_choice_list(AccountKeyType))
 register_cli_argument('batch application', 'account_name', batch_name_type, options_list=('--name', '-n'), validator=application_enabled)
-register_cli_argument('batch application package create', 'package_file', help='The path of the application package in zip format', completer=FilesCompleter())
+register_cli_argument('batch application package create', 'package_file', type=file_type, help='The path of the application package in zip format', completer=FilesCompleter())
 register_cli_argument('batch location quotas show', 'location_name', location_type)

--- a/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
+++ b/src/command_modules/azure-cli-keyvault/azure/cli/command_modules/keyvault/_params.py
@@ -13,7 +13,7 @@ from azure.cli.core.commands import \
 import azure.cli.core.commands.arm # pylint: disable=unused-import
 from azure.cli.core.commands.parameters import (
     get_resource_name_completion_list, resource_group_name_type,
-    tags_type, ignore_type, enum_choice_list)
+    tags_type, ignore_type, enum_choice_list, file_type)
 from azure.cli.core._profile import Profile
 from azure.cli.core._util import get_json_object
 from azure.keyvault import KeyVaultClient, KeyVaultAuthentication
@@ -125,13 +125,13 @@ for item in ['create', 'import']:
     register_cli_argument('keyvault key {}'.format(item), 'expires', default=None, help='Expiration UTC datetime  (Y-m-d\'T\'H:M\'Z\').', type=datetime_type)
     register_cli_argument('keyvault key {}'.format(item), 'not_before', default=None, help='Key not usable before the provided UTC datetime  (Y-m-d\'T\'H:M\'Z\').', type=datetime_type)
 
-register_cli_argument('keyvault key import', 'pem_file', help='PEM file containing the key to be imported.', arg_group='Key Source', completer=FilesCompleter(), validator=validate_key_import_source)
+register_cli_argument('keyvault key import', 'pem_file', type=file_type, help='PEM file containing the key to be imported.', arg_group='Key Source', completer=FilesCompleter(), validator=validate_key_import_source)
 register_cli_argument('keyvault key import', 'pem_password', help='Password of PEM file.', arg_group='Key Source')
-register_cli_argument('keyvault key import', 'byok_file', help='BYOK file containing the key to be imported. Must not be password protected.', completer=FilesCompleter(), arg_group='Key Source')
+register_cli_argument('keyvault key import', 'byok_file', type=file_type, help='BYOK file containing the key to be imported. Must not be password protected.', completer=FilesCompleter(), arg_group='Key Source')
 
-register_cli_argument('keyvault key backup', 'file_path', options_list=('--file', '-f'), completer=FilesCompleter(), help='Local file path in which to store key backup.')
+register_cli_argument('keyvault key backup', 'file_path', options_list=('--file', '-f'), type=file_type, completer=FilesCompleter(), help='Local file path in which to store key backup.')
 
-register_cli_argument('keyvault key restore', 'file_path', options_list=('--file', '-f'), completer=FilesCompleter(), help='Local key backup from which to restore key.')
+register_cli_argument('keyvault key restore', 'file_path', options_list=('--file', '-f'), type=file_type, completer=FilesCompleter(), help='Local key backup from which to restore key.')
 
 register_attributes_argument('keyvault key set-attributes', 'key', KeyAttributes)
 
@@ -140,12 +140,12 @@ register_cli_argument('keyvault secret', 'secret_version', options_list=('--vers
 register_cli_argument('keyvault secret set', 'content_type', options_list=('--description',), help='Description of the secret contents (e.g. password, connection string, etc)')
 register_attributes_argument('keyvault secret set', 'secret', SecretAttributes, create=True)
 register_cli_argument('keyvault secret set', 'value', options_list=('--value',), help="Plain text secret value. Cannot be used with '--file' or '--encoding'", required=False, arg_group='Content Source')
-register_extra_cli_argument('keyvault secret set', 'file_path', options_list=('--file', '-f'), help="Source file for secret. Use in conjunction with '--encoding'", completer=FilesCompleter(), arg_group='Content Source')
+register_extra_cli_argument('keyvault secret set', 'file_path', options_list=('--file', '-f'), type=file_type, help="Source file for secret. Use in conjunction with '--encoding'", completer=FilesCompleter(), arg_group='Content Source')
 register_extra_cli_argument('keyvault secret set', 'encoding', options_list=('--encoding', '-e'), help='Source file encoding. The value is saved as a tag (file-encoding=<val>) and used during download to automtically encode the resulting file.', default='utf-8', validator=process_secret_set_namespace, arg_group='Content Source', **enum_choice_list(secret_encoding_values))
 
 register_attributes_argument('keyvault secret set-attributes', 'secret', SecretAttributes)
 
-register_cli_argument('keyvault secret download', 'file_path', options_list=('--file', '-f'), completer=FilesCompleter(), help='File to receive the secret contents.')
+register_cli_argument('keyvault secret download', 'file_path', options_list=('--file', '-f'), type=file_type, completer=FilesCompleter(), help='File to receive the secret contents.')
 register_cli_argument('keyvault secret download', 'encoding', options_list=('--encoding', '-e'), help="Encoding of the destination file. By default, will look for the 'file-encoding' tag on the secret. Otherwise will assume 'utf-8'.", default=None, **enum_choice_list(secret_encoding_values))
 
 register_cli_argument('keyvault certificate', 'certificate_version', options_list=('--version', '-v'), help='The certificate version. If omitted, uses the latest version.', default='', required=False, completer=get_keyvault_version_completion_list('certificate'))
@@ -157,10 +157,10 @@ for item in ['create', 'set-attributes', 'import']:
 
 register_cli_argument('keyvault certificate import', 'base64_encoded_certificate', options_list=('--file', '-f'), completer=FilesCompleter(), help='PKCS12 file or PEM file containing the certificate and private key.', type=base64_encoded_certificate_type)
 
-register_cli_argument('keyvault certificate download', 'file_path', options_list=('--file', '-f'), completer=FilesCompleter(), help='File to receive the binary certificate contents.')
+register_cli_argument('keyvault certificate download', 'file_path', options_list=('--file', '-f'), type=file_type, completer=FilesCompleter(), help='File to receive the binary certificate contents.')
 register_cli_argument('keyvault certificate download', 'encoding', options_list=('--encoding', '-e'), help='How to store base64 certificate contents in file.', **enum_choice_list(certificate_file_encoding_values))
 
-register_cli_argument('keyvault certificate pending merge', 'x509_certificates', options_list=('--file', '-f'), completer=FilesCompleter(), help='File containing the certificate or certificate chain to merge.', validator=validate_x509_certificate_chain)
+register_cli_argument('keyvault certificate pending merge', 'x509_certificates', options_list=('--file', '-f'), type=file_type, completer=FilesCompleter(), help='File containing the certificate or certificate chain to merge.', validator=validate_x509_certificate_chain)
 register_attributes_argument('keyvault certificate pending merge', 'certificate', CertificateAttributes, True)
 
 register_cli_argument('keyvault certificate pending cancel', 'cancellation_requested', ignore_type, validator=process_certificate_cancel_namespace)

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -20,7 +20,7 @@ from azure.cli.core.commands import \
     (CliArgumentType, register_cli_argument, register_extra_cli_argument)
 from azure.cli.core.commands.parameters import (location_type, get_resource_name_completion_list,
                                                 enum_choice_list, tags_type, ignore_type,
-                                                get_generic_completion_list)
+                                                get_generic_completion_list, file_type)
 from azure.cli.core.commands.validators import MarkSpecifiedAction
 from azure.cli.core.commands.template_create import get_folded_parameter_help_string
 from azure.cli.command_modules.network._client_factory import _network_client_factory
@@ -147,7 +147,7 @@ register_cli_argument('network application-gateway', 'virtual_network_type', ign
 register_cli_argument('network application-gateway', 'private_ip_address_allocation', ignore_type)
 
 register_cli_argument('network application-gateway create', 'routing_rule_type', validator=process_ag_create_namespace, **enum_choice_list(ApplicationGatewayRequestRoutingRuleType))
-register_cli_argument('network application-gateway create', 'cert_data', options_list=('--cert-file',), help='The path to the PFX certificate file.')
+register_cli_argument('network application-gateway create', 'cert_data', options_list=('--cert-file',), type=file_type, help='The path to the PFX certificate file.')
 register_cli_argument('network application-gateway create', 'frontend_type', ignore_type)
 register_cli_argument('network application-gateway create', 'http_listener_protocol', ignore_type)
 
@@ -178,7 +178,7 @@ for item in ag_subresources:
     register_cli_argument('network application-gateway {}'.format(item['name']), 'application_gateway_name', options_list=('--gateway-name',), help='The name of the application gateway.')
     register_cli_argument('network application-gateway {} list'.format(item['name']), 'resource_name', options_list=('--gateway-name',))
 
-register_cli_argument('network application-gateway auth-cert', 'cert_data', options_list=('--cert-file',), validator=validate_auth_cert)
+register_cli_argument('network application-gateway auth-cert', 'cert_data', options_list=('--cert-file',), type=file_type, validator=validate_auth_cert)
 
 register_cli_argument('network application-gateway frontend-ip', 'subnet', validator=get_subnet_validator())
 register_cli_argument('network application-gateway frontend-ip', 'public_ip_address', validator=get_public_ip_validator(), help='The name or ID of the public IP address.', completer=get_resource_name_completion_list('Microsoft.Network/publicIPAddresses'))
@@ -211,7 +211,7 @@ register_cli_argument('network application-gateway rule', 'http_settings', help=
 register_cli_argument('network application-gateway rule', 'rule_type', help='The rule type (Basic, PathBasedRouting).')
 register_cli_argument('network application-gateway rule', 'url_path_map', help='The name or ID of the URL path map.', completer=get_ag_subresource_completion_list('url_path_maps'))
 
-register_cli_argument('network application-gateway ssl-cert', 'cert_data', options_list=('--cert-file',), help='The path to the PFX certificate file.', validator=validate_cert)
+register_cli_argument('network application-gateway ssl-cert', 'cert_data', options_list=('--cert-file',), type=file_type, help='The path to the PFX certificate file.', validator=validate_cert)
 
 register_cli_argument('network application-gateway ssl-policy', 'clear', action='store_true', help='Clear SSL policy.', validator=process_ag_ssl_policy_set_namespace)
 register_cli_argument('network application-gateway ssl-policy', 'disabled_ssl_protocols', nargs='+', help='Space separated list of protocols to disable.', **enum_choice_list(ApplicationGatewaySslProtocol))
@@ -478,7 +478,7 @@ vnet_help = "Name or ID of an existing virtual network which has a subnet named 
 register_cli_argument('network vnet-gateway create', 'virtual_network', options_list=('--vnet',), help=vnet_help, validator=get_virtual_network_validator(has_type_field=True))
 register_cli_argument('network vnet-gateway create', 'virtual_network_type', ignore_type)
 
-register_cli_argument('network vnet-gateway root-cert create', 'public_cert_data', help='Base64 contents of the root certificate file or file path.', validator=load_cert_file('public_cert_data'))
+register_cli_argument('network vnet-gateway root-cert create', 'public_cert_data', help='Base64 contents of the root certificate file or file path.', type=file_type, validator=load_cert_file('public_cert_data'))
 register_cli_argument('network vnet-gateway root-cert create', 'cert_name', help='Root certificate name', options_list=('--name', '-n'))
 register_cli_argument('network vnet-gateway root-cert create', 'gateway_name', help='Virtual network gateway name')
 
@@ -489,7 +489,7 @@ register_extra_cli_argument('network vnet-gateway update', 'address_prefixes', o
 
 # VPN connection
 register_cli_argument('network vpn-connection', 'virtual_network_gateway_connection_name', options_list=('--name', '-n'), metavar='NAME', id_part='name')
-register_cli_argument('network vpn-connection', 'shared_key', validator=load_cert_file('shared_key'), help='Shared IPSec key, base64 contents of the certificate file or file path.')
+register_cli_argument('network vpn-connection', 'shared_key', validator=load_cert_file('shared_key'), type=file_type, help='Shared IPSec key, base64 contents of the certificate file or file path.')
 
 register_cli_argument('network vpn-connection create', 'vnet_gateway1_id', options_list=('--vnet-gateway1',), validator=process_vpn_connection_create_namespace)
 register_cli_argument('network vpn-connection create', 'vnet_gateway2_id', options_list=('--vnet-gateway2',))
@@ -547,8 +547,8 @@ register_cli_argument('network dns', 'location', help=argparse.SUPPRESS, default
 
 register_cli_argument('network dns zone', 'zone_name', name_arg_type)
 
-register_cli_argument('network dns zone import', 'file_name', help='Path to the DNS zone file to import')
-register_cli_argument('network dns zone export', 'file_name', help='Path to the DNS zone file to save')
+register_cli_argument('network dns zone import', 'file_name', type=file_type, help='Path to the DNS zone file to import')
+register_cli_argument('network dns zone export', 'file_name', type=file_type, help='Path to the DNS zone file to save')
 register_cli_argument('network dns zone update', 'if_none_match', ignore_type)
 
 register_cli_argument('network dns record', 'record_set_name', options_list=('--record-set-name',))

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -5,6 +5,7 @@
 
 # pylint: disable=line-too-long
 import argparse
+from argcomplete.completers import FilesCompleter
 
 from azure.mgmt.network.models import \
     (IPAllocationMethod, RouteNextHopType)
@@ -147,7 +148,7 @@ register_cli_argument('network application-gateway', 'virtual_network_type', ign
 register_cli_argument('network application-gateway', 'private_ip_address_allocation', ignore_type)
 
 register_cli_argument('network application-gateway create', 'routing_rule_type', validator=process_ag_create_namespace, **enum_choice_list(ApplicationGatewayRequestRoutingRuleType))
-register_cli_argument('network application-gateway create', 'cert_data', options_list=('--cert-file',), type=file_type, help='The path to the PFX certificate file.')
+register_cli_argument('network application-gateway create', 'cert_data', options_list=('--cert-file',), type=file_type, completer=FilesCompleter(), help='The path to the PFX certificate file.')
 register_cli_argument('network application-gateway create', 'frontend_type', ignore_type)
 register_cli_argument('network application-gateway create', 'http_listener_protocol', ignore_type)
 
@@ -178,7 +179,7 @@ for item in ag_subresources:
     register_cli_argument('network application-gateway {}'.format(item['name']), 'application_gateway_name', options_list=('--gateway-name',), help='The name of the application gateway.')
     register_cli_argument('network application-gateway {} list'.format(item['name']), 'resource_name', options_list=('--gateway-name',))
 
-register_cli_argument('network application-gateway auth-cert', 'cert_data', options_list=('--cert-file',), type=file_type, validator=validate_auth_cert)
+register_cli_argument('network application-gateway auth-cert', 'cert_data', options_list=('--cert-file',), type=file_type, completer=FilesCompleter(), validator=validate_auth_cert)
 
 register_cli_argument('network application-gateway frontend-ip', 'subnet', validator=get_subnet_validator())
 register_cli_argument('network application-gateway frontend-ip', 'public_ip_address', validator=get_public_ip_validator(), help='The name or ID of the public IP address.', completer=get_resource_name_completion_list('Microsoft.Network/publicIPAddresses'))
@@ -211,7 +212,7 @@ register_cli_argument('network application-gateway rule', 'http_settings', help=
 register_cli_argument('network application-gateway rule', 'rule_type', help='The rule type (Basic, PathBasedRouting).')
 register_cli_argument('network application-gateway rule', 'url_path_map', help='The name or ID of the URL path map.', completer=get_ag_subresource_completion_list('url_path_maps'))
 
-register_cli_argument('network application-gateway ssl-cert', 'cert_data', options_list=('--cert-file',), type=file_type, help='The path to the PFX certificate file.', validator=validate_cert)
+register_cli_argument('network application-gateway ssl-cert', 'cert_data', options_list=('--cert-file',), type=file_type, completer=FilesCompleter(), help='The path to the PFX certificate file.', validator=validate_cert)
 
 register_cli_argument('network application-gateway ssl-policy', 'clear', action='store_true', help='Clear SSL policy.', validator=process_ag_ssl_policy_set_namespace)
 register_cli_argument('network application-gateway ssl-policy', 'disabled_ssl_protocols', nargs='+', help='Space separated list of protocols to disable.', **enum_choice_list(ApplicationGatewaySslProtocol))
@@ -478,7 +479,7 @@ vnet_help = "Name or ID of an existing virtual network which has a subnet named 
 register_cli_argument('network vnet-gateway create', 'virtual_network', options_list=('--vnet',), help=vnet_help, validator=get_virtual_network_validator(has_type_field=True))
 register_cli_argument('network vnet-gateway create', 'virtual_network_type', ignore_type)
 
-register_cli_argument('network vnet-gateway root-cert create', 'public_cert_data', help='Base64 contents of the root certificate file or file path.', type=file_type, validator=load_cert_file('public_cert_data'))
+register_cli_argument('network vnet-gateway root-cert create', 'public_cert_data', help='Base64 contents of the root certificate file or file path.', type=file_type, completer=FilesCompleter(), validator=load_cert_file('public_cert_data'))
 register_cli_argument('network vnet-gateway root-cert create', 'cert_name', help='Root certificate name', options_list=('--name', '-n'))
 register_cli_argument('network vnet-gateway root-cert create', 'gateway_name', help='Virtual network gateway name')
 
@@ -489,7 +490,7 @@ register_extra_cli_argument('network vnet-gateway update', 'address_prefixes', o
 
 # VPN connection
 register_cli_argument('network vpn-connection', 'virtual_network_gateway_connection_name', options_list=('--name', '-n'), metavar='NAME', id_part='name')
-register_cli_argument('network vpn-connection', 'shared_key', validator=load_cert_file('shared_key'), type=file_type, help='Shared IPSec key, base64 contents of the certificate file or file path.')
+register_cli_argument('network vpn-connection', 'shared_key', validator=load_cert_file('shared_key'), type=file_type, completer=FilesCompleter(), help='Shared IPSec key, base64 contents of the certificate file or file path.')
 
 register_cli_argument('network vpn-connection create', 'vnet_gateway1_id', options_list=('--vnet-gateway1',), validator=process_vpn_connection_create_namespace)
 register_cli_argument('network vpn-connection create', 'vnet_gateway2_id', options_list=('--vnet-gateway2',))
@@ -547,8 +548,8 @@ register_cli_argument('network dns', 'location', help=argparse.SUPPRESS, default
 
 register_cli_argument('network dns zone', 'zone_name', name_arg_type)
 
-register_cli_argument('network dns zone import', 'file_name', type=file_type, help='Path to the DNS zone file to import')
-register_cli_argument('network dns zone export', 'file_name', type=file_type, help='Path to the DNS zone file to save')
+register_cli_argument('network dns zone import', 'file_name', type=file_type, completer=FilesCompleter(), help='Path to the DNS zone file to import')
+register_cli_argument('network dns zone export', 'file_name', type=file_type, completer=FilesCompleter(), help='Path to the DNS zone file to save')
 register_cli_argument('network dns zone update', 'if_none_match', ignore_type)
 
 register_cli_argument('network dns record', 'record_set_name', options_list=('--record-set-name',))

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
@@ -10,7 +10,7 @@ from azure.mgmt.resource.resources.models import DeploymentMode
 from azure.cli.core.commands import register_cli_argument, CliArgumentType
 from azure.cli.core.commands.parameters import (ignore_type, resource_group_name_type, tag_type,
                                                 tags_type, get_resource_group_completion_list,
-                                                enum_choice_list, no_wait_type)
+                                                enum_choice_list, no_wait_type, file_type)
 from .custom import (get_policy_completion_list, get_policy_assignment_completion_list,
                      get_resource_types_completion_list, get_providers_completion_list)
 from ._validators import validate_deployment_name
@@ -47,7 +47,7 @@ existing_policy_definition_name_type = CliArgumentType(options_list=('--name', '
 register_cli_argument('policy', 'resource_group_name', arg_type=resource_group_name_type, help='the resource group where the policy will be applied')
 register_cli_argument('policy definition', 'policy_definition_name', arg_type=existing_policy_definition_name_type)
 register_cli_argument('policy definition create', 'name', options_list=('--name', '-n'), help='name of the new policy definition')
-register_cli_argument('policy definition', 'rules', help='JSON formatted string or a path to a file with such content')
+register_cli_argument('policy definition', 'rules', help='JSON formatted string or a path to a file with such content', type=file_type)
 register_cli_argument('policy definition', 'display_name', help='display name of policy definition')
 register_cli_argument('policy definition', 'description', help='description of policy definition')
 register_cli_argument('policy assignment', 'name', options_list=('--name', '-n'), completer=get_policy_assignment_completion_list, help='name of the assignment')
@@ -63,8 +63,8 @@ register_cli_argument('group', 'resource_group_name', resource_group_name_type, 
 register_cli_argument('group deployment', 'resource_group_name', arg_type=resource_group_name_type, completer=get_resource_group_completion_list)
 register_cli_argument('group deployment', 'deployment_name', options_list=('--name', '-n'), required=True, help='The deployment name.')
 register_cli_argument('group deployment', 'parameters', completer=FilesCompleter(), help="provide deployment parameter values, either json string, or use '@<file path>' to load from a file")
-register_cli_argument('group deployment', 'template_file', completer=FilesCompleter(), help="a template file path in the file system")
-register_cli_argument('group deployment', 'template_uri', completer=FilesCompleter(), help='a uri to a remote template file')
+register_cli_argument('group deployment', 'template_file', completer=FilesCompleter(), type=file_type, help="a template file path in the file system")
+register_cli_argument('group deployment', 'template_uri', help='a uri to a remote template file')
 register_cli_argument('group deployment', 'mode', help='Incremental (only add resources to resource group) or Complete (remove extra resources from resource group)', **enum_choice_list(DeploymentMode))
 register_cli_argument('group deployment create', 'deployment_name', options_list=('--name', '-n'), required=False,
                       validator=validate_deployment_name, help='The deployment name. Default to template file base name')

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_params.py
@@ -47,7 +47,7 @@ existing_policy_definition_name_type = CliArgumentType(options_list=('--name', '
 register_cli_argument('policy', 'resource_group_name', arg_type=resource_group_name_type, help='the resource group where the policy will be applied')
 register_cli_argument('policy definition', 'policy_definition_name', arg_type=existing_policy_definition_name_type)
 register_cli_argument('policy definition create', 'name', options_list=('--name', '-n'), help='name of the new policy definition')
-register_cli_argument('policy definition', 'rules', help='JSON formatted string or a path to a file with such content', type=file_type)
+register_cli_argument('policy definition', 'rules', help='JSON formatted string or a path to a file with such content', type=file_type, completer=FilesCompleter())
 register_cli_argument('policy definition', 'display_name', help='display name of policy definition')
 register_cli_argument('policy definition', 'description', help='description of policy definition')
 register_cli_argument('policy assignment', 'name', options_list=('--name', '-n'), completer=get_policy_assignment_completion_list, help='name of the assignment')

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_params.py
@@ -10,7 +10,7 @@ from six import u as unicode_string
 
 from azure.cli.core._config import az_config
 from azure.cli.core.commands.parameters import \
-    (ignore_type, tags_type, get_resource_name_completion_list, enum_choice_list)
+    (ignore_type, tags_type, file_type, get_resource_name_completion_list, enum_choice_list)
 import azure.cli.core.commands.arm  # pylint: disable=unused-import
 from azure.cli.core.commands import register_cli_argument, register_extra_cli_argument, CliArgumentType
 
@@ -287,7 +287,7 @@ register_cli_argument('storage blob exists', 'blob_name', required=True)
 register_cli_argument('storage blob list', 'include', help='Specifies additional datasets to include: (c)opy-info, (m)etadata, (s)napshots. Can be combined.', validator=validate_included_datasets)
 
 for item in ['download', 'upload']:
-    register_cli_argument('storage blob {}'.format(item), 'file_path', options_list=('--file', '-f'), completer=FilesCompleter())
+    register_cli_argument('storage blob {}'.format(item), 'file_path', options_list=('--file', '-f'), type=file_type, completer=FilesCompleter())
     register_cli_argument('storage blob {}'.format(item), 'max_connections', type=int)
     register_cli_argument('storage blob {}'.format(item), 'validate_content', action='store_true')
 
@@ -418,7 +418,7 @@ register_path_argument('storage file copy cancel', options_list=('--destination-
 
 register_path_argument('storage file delete')
 
-register_cli_argument('storage file download', 'file_path', options_list=('--dest',), help='Path of the file to write to. The source filename will be used if not specified.', required=False, validator=process_file_download_namespace, completer=FilesCompleter())
+register_cli_argument('storage file download', 'file_path', options_list=('--dest',), type=file_type, help='Path of the file to write to. The source filename will be used if not specified.', required=False, validator=process_file_download_namespace, completer=FilesCompleter())
 register_cli_argument('storage file download', 'path', validator=None)  # validator called manually from process_file_download_namespace so remove the automatic one
 register_cli_argument('storage file download', 'progress_callback', ignore_type)
 register_path_argument('storage file download')
@@ -444,7 +444,7 @@ for item in ['update', 'upload']:
 register_path_argument('storage file update')
 
 register_cli_argument('storage file upload', 'progress_callback', ignore_type)
-register_cli_argument('storage file upload', 'local_file_path', options_list=('--source',), completer=FilesCompleter())
+register_cli_argument('storage file upload', 'local_file_path', options_list=('--source',), type=file_type, completer=FilesCompleter())
 register_path_argument('storage file upload', default_file_param='local_file_path')
 
 register_path_argument('storage file url')

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -19,7 +19,7 @@ from azure.cli.core.commands.arm import is_valid_resource_id
 from azure.cli.core.commands.template_create import register_folded_cli_argument
 from azure.cli.core.commands.parameters import \
     (location_type, get_location_completion_list, get_one_of_subscription_locations,
-     get_resource_name_completion_list, tags_type, enum_choice_list, ignore_type)
+     get_resource_name_completion_list, tags_type, file_type, enum_choice_list, ignore_type)
 from azure.cli.command_modules.vm._actions import \
     (VMImageFieldAction, VMSSHFieldAction, VMDNSNameAction, load_images_from_aliases_doc,
      get_vm_sizes, PrivateIpAction, _resource_not_exists)
@@ -128,8 +128,8 @@ register_cli_argument('vmss extension image', 'version', help='Extension version
 
 for scope in ['vm diagnostics', 'vmss diagnostics']:
     register_cli_argument(scope, 'version', help='version of the diagnostics extension. Will use the latest if not specfied')
-    register_cli_argument(scope, 'settings', help='json string or a file path, which defines data to be collected.')
-    register_cli_argument(scope, 'protected_settings', help='json string or a file path containing private configurations such as storage account keys, etc.')
+    register_cli_argument(scope, 'settings', help='json string or a file path, which defines data to be collected.', type=file_type)
+    register_cli_argument(scope, 'protected_settings', help='json string or a file path containing private configurations such as storage account keys, etc.', type=file_type)
 
 for scope in ['vm', 'vmss']:
     register_cli_argument(scope, 'no_auto_upgrade', action='store_true', help='by doing this, extension system will not pick the highest minor version for the specified version number, and will not auto update to the latest build/revision number on any scale set updates in future.')
@@ -194,7 +194,7 @@ for scope in ['vm create', 'vmss create']:
     register_cli_argument(scope, 'subnet_name', help='The subnet name.  Creates if creating a new VNet, references if referencing an existing VNet.')
     register_cli_argument(scope, 'admin_password', help='Password for the Virtual Machine if Authentication Type is Password.')
     register_cli_argument(scope, 'ssh_key_value', action=VMSSHFieldAction)
-    register_cli_argument(scope, 'ssh_dest_key_path', completer=FilesCompleter())
+    register_cli_argument(scope, 'ssh_dest_key_path', completer=FilesCompleter(), type=file_type)
     register_cli_argument(scope, 'dns_name_for_public_ip', action=VMDNSNameAction, options_list=('--public-ip-address-dns-name',), help='Globally unique DNS Name for the Public IP.')
     register_cli_argument(scope, 'authentication_type', authentication_type)
     register_folded_cli_argument(scope, 'availability_set', 'Microsoft.Compute/availabilitySets', new_flag_value=None, default_value_flag='none')

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -128,8 +128,8 @@ register_cli_argument('vmss extension image', 'version', help='Extension version
 
 for scope in ['vm diagnostics', 'vmss diagnostics']:
     register_cli_argument(scope, 'version', help='version of the diagnostics extension. Will use the latest if not specfied')
-    register_cli_argument(scope, 'settings', help='json string or a file path, which defines data to be collected.', type=file_type)
-    register_cli_argument(scope, 'protected_settings', help='json string or a file path containing private configurations such as storage account keys, etc.', type=file_type)
+    register_cli_argument(scope, 'settings', help='json string or a file path, which defines data to be collected.', type=file_type, completer=FilesCompleter())
+    register_cli_argument(scope, 'protected_settings', help='json string or a file path containing private configurations such as storage account keys, etc.', type=file_type, completer=FilesCompleter())
 
 for scope in ['vm', 'vmss']:
     register_cli_argument(scope, 'no_auto_upgrade', action='store_true', help='by doing this, extension system will not pick the highest minor version for the specified version number, and will not auto update to the latest build/revision number on any scale set updates in future.')
@@ -194,7 +194,6 @@ for scope in ['vm create', 'vmss create']:
     register_cli_argument(scope, 'subnet_name', help='The subnet name.  Creates if creating a new VNet, references if referencing an existing VNet.')
     register_cli_argument(scope, 'admin_password', help='Password for the Virtual Machine if Authentication Type is Password.')
     register_cli_argument(scope, 'ssh_key_value', action=VMSSHFieldAction)
-    register_cli_argument(scope, 'ssh_dest_key_path', completer=FilesCompleter(), type=file_type)
     register_cli_argument(scope, 'dns_name_for_public_ip', action=VMDNSNameAction, options_list=('--public-ip-address-dns-name',), help='Globally unique DNS Name for the Public IP.')
     register_cli_argument(scope, 'authentication_type', authentication_type)
     register_folded_cli_argument(scope, 'availability_set', 'Microsoft.Compute/availabilitySets', new_flag_value=None, default_value_flag='none')


### PR DESCRIPTION
Fixes #1614 and fixes #1307.

Creates a "file_type" in core which simply calls the os.path.expanduser method and assigns this type to parameters which could accept a local path with ~. This is fine for parameters which are of the "JSON object or path" type since the expanduser method only expands a leading ~, so JSON would not be modified.