### PR TITLE
Print parse error before usage statement

### DIFF
--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -3,14 +3,19 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import argparse
+import sys
 
+import argparse
 import argcomplete
 
 import azure.cli.core.telemetry as telemetry
 import azure.cli.core._help as _help
 from azure.cli.core._util import CLIError
 from azure.cli.core._pkg_util import handle_module_not_installed
+
+import azure.cli.core._logging as _logging
+
+logger = _logging.get_az_logger(__name__)
 
 
 class IncorrectUsageError(CLIError):
@@ -142,7 +147,11 @@ class AzCliCommandParser(argparse.ArgumentParser):
     def error(self, message):
         telemetry.set_user_fault('parse error: {}'.format(message))
         self._handle_command_package_error(message)
-        return super(AzCliCommandParser, self).error(message)
+
+        args = {'prog': self.prog, 'message': message}
+        logger.error('%(prog)s: error: %(message)s', args)
+        self.print_usage(sys.stderr)
+        self.exit(2)
 
     def format_help(self):
         is_group = self.is_group()


### PR DESCRIPTION
- Also, parse error now sent to logger instead of stderr directly so it is colorized also.

Closes https://github.com/Azure/azure-cli/issues/1472

BEFORE:
```
$ az vm list sdfsdf
usage: az [-h] [--output {json,tsv,list,table,jsonc}] [--verbose] [--debug]
          [--query JMESPATH]
          {sql,redis,network,batch,iot,account,group,vm,appservice,storage,feature,vmss,cloud,policy,keyvault,logout,acs,acr,container,role,tag,ad,provider,resource,context,component,feedback,taskhelp,login,configure}
          ...
az: error: unrecognized arguments: sdfsdf
```

AFTER:
```
$ az vm list sdfsdf
az: error: unrecognized arguments: sdfsdf
usage: az [-h] [--output {json,tsv,list,table,jsonc}] [--verbose] [--debug]
          [--query JMESPATH]
          {sql,redis,network,batch,iot,account,group,vm,appservice,storage,feature,vmss,cloud,policy,keyvault,logout,acs,acr,container,role,tag,ad,provider,resource,context,component,feedback,taskhelp,login,configure}
          ...
```