### PR TITLE
Add subscription id to ‘az account list’ table format

### DIFF
--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/commands.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/commands.py
@@ -4,13 +4,24 @@
 # --------------------------------------------------------------------------------------------
 
 #pylint: disable=line-too-long
+from collections import OrderedDict
 
 from azure.cli.core.commands import cli_command
 
 cli_command(__name__, 'login', 'azure.cli.command_modules.profile.custom#login')
 cli_command(__name__, 'logout', 'azure.cli.command_modules.profile.custom#logout')
 
-cli_command(__name__, 'account list', 'azure.cli.command_modules.profile.custom#list_subscriptions')
+def transform_account_list(result):
+    transformed = []
+    for r in result:
+        res = OrderedDict([('Name', r['name']), ('CloudName', r['cloudName']), \
+            ('SubscriptionId', r['id']), ('State', r['state']), ('IsDefault', r['isDefault'])])
+        transformed.append(res)
+    return transformed
+
+
+cli_command(__name__, 'account list', 'azure.cli.command_modules.profile.custom#list_subscriptions',
+            table_transformer=transform_account_list)
 cli_command(__name__, 'account set', 'azure.cli.command_modules.profile.custom#set_active_subscription')
 cli_command(__name__, 'account show', 'azure.cli.command_modules.profile.custom#show_subscription')
 cli_command(__name__, 'account clear', 'azure.cli.command_modules.profile.custom#account_clear')


### PR DESCRIPTION
Closes https://github.com/Azure/azure-cli/issues/1257

```
Name                           CloudName    SubscriptionId                        State      IsDefault
-----------------------------  -----------  ------------------------------------  -------  -----------
Graph2                         AzureCloud   00000000-0000-0000-0000-000000000000  Enabled            1
Azure Subscription 1           AzureCloud   00000000-0000-0000-0000-000000000000  Enabled
Visual Studio Subscription     AzureCloud   00000000-0000-0000-0000-000000000000  Enabled
Visual Studio - 1              AzureCloud   00000000-0000-0000-0000-000000000000  Enabled
My Own Subscription            AzureCloud   00000000-0000-0000-0000-000000000000  Enabled
Azure Subscription 2           AzureCloud   00000000-0000-0000-0000-000000000000  Enabled

```