### PR TITLE
Cap logging of ‘Application event’ to 500 chars.

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_util.py
+++ b/src/azure-cli-core/azure/cli/core/_util.py
@@ -43,6 +43,13 @@ def normalize_newlines(str_to_normalize):
     return str_to_normalize.replace('\r\n', '\n')
 
 
+def truncate_text(str_to_shorten, width=70, placeholder=' [...]'):
+    if width <= 0:
+        raise ValueError('width must be greater than 0.')
+    s_len = width - len(placeholder)
+    return str_to_shorten[:s_len] + (str_to_shorten[s_len:] and placeholder)
+
+
 def show_version_info_exit(out_file):
     import platform
     from pip import get_installed_distributions

--- a/src/azure-cli-core/azure/cli/core/application.py
+++ b/src/azure-cli-core/azure/cli/core/application.py
@@ -13,7 +13,7 @@ from azure.cli.core._output import CommandResultItem
 import azure.cli.core.extensions
 import azure.cli.core._help as _help
 import azure.cli.core._logging as _logging
-from azure.cli.core._util import todict, CLIError
+from azure.cli.core._util import todict, truncate_text, CLIError
 from azure.cli.core._config import az_config
 
 import azure.cli.core.telemetry as telemetry
@@ -166,7 +166,8 @@ class Application(object):
     def raise_event(self, name, **kwargs):
         '''Raise the event `name`.
         '''
-        logger.info("Application event '%s' with event data %s", name, kwargs)
+        data = truncate_text(str(kwargs), width=500)
+        logger.debug("Application event '%s' with event data %s", name, data)
         for func in list(self._event_handlers[name]):  # Make copy in case handler modifies the list
             func(**kwargs)
 
@@ -180,7 +181,7 @@ class Application(object):
           event_data: `dict` with event specific data.
         '''
         self._event_handlers[name].append(handler)
-        logger.info("Registered application event handler '%s' at %s", name, handler)
+        logger.debug("Registered application event handler '%s' at %s", name, handler)
 
     def remove(self, name, handler):
         '''Remove a callable that is registered to be called when the
@@ -192,7 +193,7 @@ class Application(object):
           event_data: `dict` with event specific data.
         '''
         self._event_handlers[name].remove(handler)
-        logger.info("Removed application event handler '%s' at %s", name, handler)
+        logger.debug("Removed application event handler '%s' at %s", name, handler)
 
     @staticmethod
     def _register_builtin_arguments(**kwargs):

--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -228,7 +228,7 @@ def get_command_table():
                                      pkgutil.iter_modules(mods_ns_pkg.__path__)]
     except ImportError:
         pass
-    logger.info('Installed command modules %s', installed_command_modules)
+    logger.debug('Installed command modules %s', installed_command_modules)
     cumulative_elapsed_time = 0
     for mod in installed_command_modules:
         try:

--- a/src/azure-cli-core/azure/cli/core/commands/client_factory.py
+++ b/src/azure-cli-core/azure/cli/core/commands/client_factory.py
@@ -45,7 +45,7 @@ def configure_common_settings(client):
 
 def _get_mgmt_service_client(client_type, subscription_bound=True, subscription_id=None,
                              api_version=None):
-    logger.info('Getting management service client client_type=%s', client_type.__name__)
+    logger.debug('Getting management service client client_type=%s', client_type.__name__)
     profile = Profile()
     cred, subscription_id, _ = profile.get_login_credentials(subscription_id=subscription_id)
     client_kwargs = {'base_url': CLOUD.endpoints.resource_manager}
@@ -63,7 +63,7 @@ def _get_mgmt_service_client(client_type, subscription_bound=True, subscription_
 
 def get_data_service_client(service_type, account_name, account_key, connection_string=None,  # pylint: disable=too-many-arguments
                             sas_token=None, endpoint_suffix=None):
-    logger.info('Getting data service client service_type=%s', service_type.__name__)
+    logger.debug('Getting data service client service_type=%s', service_type.__name__)
     try:
         client_kwargs = {'account_name': account_name,
                          'account_key': account_key,

--- a/src/azure-cli-core/azure/cli/core/tests/test_util.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_util.py
@@ -8,7 +8,7 @@ from collections import namedtuple
 import unittest
 import tempfile
 
-from azure.cli.core._util import get_file_json, todict, to_snake_case
+from azure.cli.core._util import get_file_json, todict, to_snake_case, truncate_text
 
 
 class TestUtils(unittest.TestCase):
@@ -88,6 +88,24 @@ class TestUtils(unittest.TestCase):
         expected = 'this_is_snake_cased'
         actual = to_snake_case(the_input)
         self.assertEqual(expected, actual)
+
+    def test_truncate_text(self):
+        expected = 'stri [...]'
+        actual = truncate_text('string to shorten', width=10)
+        self.assertEqual(expected, actual)
+
+    def test_truncate_text_not_needed(self):
+        expected = 'string to shorten'
+        actual = truncate_text('string to shorten', width=100)
+        self.assertEqual(expected, actual)
+
+    def test_truncate_text_zero_width(self):
+        with self.assertRaises(ValueError):
+            truncate_text('string to shorten', width=0)
+
+    def test_truncate_text_negative_width(self):
+        with self.assertRaises(ValueError):
+            truncate_text('string to shorten', width=-1)
 
 
 if __name__ == '__main__':

--- a/src/azure-cli/azure/cli/main.py
+++ b/src/azure-cli/azure/cli/main.py
@@ -18,6 +18,7 @@ logger = _logging.get_az_logger(__name__)
 
 def main(args, file=sys.stdout):  # pylint: disable=redefined-builtin
     _logging.configure_logging(args)
+    logger.debug('Command arguments %s', args)
 
     if len(args) > 0 and args[0] == '--version':
         show_version_info_exit(file)


### PR DESCRIPTION
- This caps the full command table from being printed.
- I did not fully remove this log message as there are other events that are logged that are of value (e.g. CommandParser.loaded, etc.).
- Add truncate_text util method with tests.
- Change some log messages from .info() to .debug() so they only show with the ‘—debug’ flag

Closes https://github.com/Azure/azure-cli/issues/1628
Closes https://github.com/Azure/azure-cli/issues/1010
Closes https://github.com/Azure/azure-cli/issues/1030