### PR TITLE
Catch all exceptions whilst trying to check if PyPI module available.

### DIFF
--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -139,6 +139,8 @@ class AzCliCommandParser(argparse.ArgumentParser):
                 handle_module_not_installed(possible_module)
             except AttributeError:
                 pass
+            except Exception as e:  # pylint: disable=broad-except
+                logger.debug('Unable to handle module not installed: %s', str(e))
 
     def validation_error(self, message):
         telemetry.set_user_fault('validation error')

--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -138,6 +138,7 @@ class AzCliCommandParser(argparse.ArgumentParser):
                                             err_msg).group(1)
                 handle_module_not_installed(possible_module)
             except AttributeError:
+                # regular expression pattern match failed so unable to retrieve module name
                 pass
             except Exception as e:  # pylint: disable=broad-except
                 logger.debug('Unable to handle module not installed: %s', str(e))


### PR DESCRIPTION
If this operation fails, the whole CLI shouldn’t throw another exception.
We should catch it.

On Python 3.6, macOS Sierra and specific versions of OpenSSL on macOS, users may see `[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:749)` whilst running a command of a module that doesn't exist or isn't installed.

Now, we catch the exception and just show the normal usage error as the module was not found.

Thanks for the report @oakeyc!

Related:
- https://bugs.python.org/issue28150
- http://stackoverflow.com/questions/40038246/ssl-sslerror-ssl-certificate-verify-failed-certificate-verify-failed-ssl-c
- http://stackoverflow.com/questions/41691327/ssl-sslerror-ssl-certificate-verify-failed-certificate-verify-failed-ssl-c/41692664
- https://mail.python.org/pipermail/new-bugs-announce/2016-September/026958.html

Full stacktrace:
```
$ az iot
[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:749)
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 1762, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 1971, in _parse_known_args
    stop_index = consume_positionals(start_index)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 1927, in consume_positionals
    take_action(action, args)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 1820, in take_action
    argument_values = self._get_values(action, argument_strings)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 2271, in _get_values
    self._check_value(action, value[0])
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 2314, in _check_value
    raise ArgumentError(action, msg % args)
argparse.ArgumentError: argument _command_package: invalid choice: 'iot' (choose from 'acr', 'acs', 'appservice', 'cloud', 'component', 'configure', 'container', 'context', 'feedback', 'network', 'login', 'logout', 'account', 'group', 'resource', 'provider', 'feature', 'tag', 'policy', 'role', 'ad', 'storage', 'vm', 'vmss')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/parallels/env/lib/python3.6/site-packages/azure/cli/main.py", line 36, in main
    cmd_result = APPLICATION.execute(args)
  File "/Users/parallels/env/lib/python3.6/site-packages/azure/cli/core/application.py", line 123, in execute
    args = self.parser.parse_args(argv)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 1730, in parse_args
    args, argv = self.parse_known_args(args, namespace)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 1769, in parse_known_args
    self.error(str(err))
  File "/Users/parallels/env/lib/python3.6/site-packages/azure/cli/core/parser.py", line 144, in error
    self._handle_command_package_error(message)
  File "/Users/parallels/env/lib/python3.6/site-packages/azure/cli/core/parser.py", line 134, in _handle_command_package_error
    handle_module_not_installed(possible_module)
  File "/Users/parallels/env/lib/python3.6/site-packages/azure/cli/core/_pkg_util.py", line 22, in handle_module_not_installed
    pypi_hits = client.search(query)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/xmlrpc/client.py", line 1112, in __call__
    return self.__send(self.__name, args)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/xmlrpc/client.py", line 1452, in __request
    verbose=self.__verbose
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/xmlrpc/client.py", line 1154, in request
    return self.single_request(host, handler, request_body, verbose)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/xmlrpc/client.py", line 1166, in single_request
    http_conn = self.send_request(host, handler, request_body, verbose)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/xmlrpc/client.py", line 1279, in send_request
    self.send_content(connection, request_body)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/xmlrpc/client.py", line 1309, in send_content
    connection.endheaders(request_body)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/http/client.py", line 1234, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/http/client.py", line 1026, in _send_output
    self.send(msg)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/http/client.py", line 964, in send
    self.connect()
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/http/client.py", line 1400, in connect
    server_hostname=server_hostname)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/ssl.py", line 401, in wrap_socket
    _context=self, _session=session)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/ssl.py", line 808, in __init__
    self.do_handshake()
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/ssl.py", line 1061, in do_handshake
    self._sslobj.do_handshake()
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/ssl.py", line 683, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:749)
```

Now, we get:
```
$ az iot
az: error: argument _command_package: invalid choice: 'iot' (choose from 'acr', 'acs', 'appservice', 'cloud', 'component', 'configure', 'container', 'context', 'feedback', 'network', 'login', 'logout', 'account', 'group', 'resource', 'provider', 'feature', 'tag', 'policy', 'role', 'ad', 'storage', 'vm', 'vmss')

usage: az [-h] [--output {json,tsv,list,table,jsonc}] [--verbose] [--debug]
          [--query JMESPATH]
          {acr,acs,appservice,cloud,component,configure,container,context,feedback,network,login,logout,account,group,resource,provider,feature,tag,policy,role,ad,storage,vm,vmss}
          ...
```