### PR TITLE
Batch mgmt test not clearing up test file

### DIFF
--- a/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/tests/test_batch_mgmt_commands.py
+++ b/src/command_modules/azure-cli-batch/azure/cli/command_modules/batch/tests/test_batch_mgmt_commands.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import os
+import tempfile
 
 from azure.cli.core.test_utils.vcr_test_base import (ResourceGroupVCRTestBase, JMESPathCheck,
                                                      NoneCheck)
@@ -126,8 +126,6 @@ class BatchMgmtApplicationScenarioTest(ResourceGroupVCRTestBase):
         name = self.account_name
         self.cmd('storage account delete -g {} -n {} --force'.format(rg, sname))
         self.cmd('batch account delete -g {} -n {}'.format(rg, name))
-        if os.path.exists(self.package_file_name):
-            os.remove(self.package_file_name)
 
     def __init__(self, test_method):
         super(BatchMgmtApplicationScenarioTest, self).__init__(__file__, test_method)
@@ -137,7 +135,7 @@ class BatchMgmtApplicationScenarioTest(ResourceGroupVCRTestBase):
         self.storage_account_name = 'clibatchteststorage7'
         self.application_name = 'testapp'
         self.application_package_name = '1.0'
-        self.package_file_name = os.path.join(os.getcwd(), 'samplepackage.zip')
+        _, self.package_file_name = tempfile.mkstemp()
 
     def test_batch_application_mgmt(self):
         self.execute()


### PR DESCRIPTION
`tear_down` is not called in playback mode so the file was not removed.
Now, like other tests, we use a temp file instead.