### PR TITLE
Return empty array '[]' instead of nothing for json output

### DIFF
--- a/src/azure-cli-core/azure/cli/core/test_utils/vcr_test_base.py
+++ b/src/azure-cli-core/azure/cli/core/test_utils/vcr_test_base.py
@@ -157,11 +157,12 @@ class NoneCheck(object):  # pylint: disable=too-few-public-methods
         pass
 
     def compare(self, data):  # pylint: disable=no-self-use
+        none_strings = ['[]', '{}', 'null', 'false']
         try:
-            assert not data
+            assert not data or data in none_strings
         except AssertionError:
-            raise AssertionError("Actual value '{}' != Expected value falsy (None, '', [])".format(
-                data))
+            raise AssertionError("Actual value '{}' != Expected value falsy (None, '', []) or "
+                                 "string in {}".format(data, none_strings))
 
 
 class StringCheck(object):  # pylint: disable=too-few-public-methods

--- a/src/azure-cli/azure/cli/main.py
+++ b/src/azure-cli/azure/cli/main.py
@@ -38,7 +38,7 @@ def main(args, file=sys.stdout):  # pylint: disable=redefined-builtin
 
         # Commands can return a dictionary/list of results
         # If they do, we print the results.
-        if cmd_result and cmd_result.result:
+        if cmd_result:
             from azure.cli.core._output import OutputProducer
             formatter = OutputProducer.get_formatter(APPLICATION.configuration.output_format)
             OutputProducer(formatter=formatter, file=file).out(cmd_result)


### PR DESCRIPTION
- Handle JSON falsy values in NoneCheck

https://docs.python.org/2/library/json.html#json.JSONDecoder

Closes https://github.com/Azure/azure-cli/issues/794