### PR TITLE
Fix #1591: Transform the file and directory list result

### DIFF
--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_format.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/_format.py
@@ -74,16 +74,13 @@ def transform_file_output(result):
     iterable = result if isinstance(result, list) else result.get('items', result)
     for item in iterable:
         new_entry = OrderedDict()
-        item_name = item['name']
-        try:
-            item['properties']['contentLength']  # pylint: disable=pointless-statement
-            is_dir = False
-        except KeyError:
-            item_name = '{}/'.format(item_name)
-            is_dir = True
-        new_entry['Name'] = item_name
+
+        entity_type = item['type']  # type property is added by transform_file_directory_result
+        is_dir = entity_type == 'dir'
+
+        new_entry['Name'] = item['name'] + '/' if is_dir else item['name']
         new_entry['Content Length'] = ' ' if is_dir else item['properties']['contentLength']
-        new_entry['Type'] = 'dir' if is_dir else 'file'
+        new_entry['Type'] = item['type']
         new_entry['Last Modified'] = item['properties']['lastModified'] or ' '
         new_result.append(new_entry)
     return sorted(new_result, key=lambda k: k['Name'])
@@ -121,3 +118,25 @@ def transform_boolean_for_table(result):
     for key in result:
         result[key] = str(result[key])
     return result
+
+
+def transform_file_directory_result(result):
+    """
+    Transform a the result returned from file and directory listing API.
+
+    This transformer add and remove properties from File and Directory objects in the given list
+    in order to align the object's properties so as to offer a better view to the file and dir
+    list.
+    """
+    from azure.storage.file.models import File, Directory
+    return_list = []
+    for each in result:
+        if isinstance(each, File):
+            delattr(each, 'content')
+            setattr(each, 'type', 'file')
+        elif isinstance(each, Directory):
+            setattr(each, 'type', 'dir')
+
+        return_list.append(each)
+
+    return return_list

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/commands.py
@@ -16,7 +16,8 @@ from azure.cli.command_modules.storage._format import \
      transform_file_output,
      transform_entity_show,
      transform_message_show,
-     transform_boolean_for_table)
+     transform_boolean_for_table,
+     transform_file_directory_result)
 from azure.cli.command_modules.storage._validators import \
     (transform_acl_list_output, transform_cors_list_output, transform_entity_query_output,
      transform_logging_list_output, transform_metrics_list_output,
@@ -114,13 +115,13 @@ cli_storage_data_plane_command('storage share policy update', 'azure.cli.command
 cli_storage_data_plane_command('storage directory create', 'azure.storage.file.fileservice#FileService.create_directory', factory, transform=create_boolean_result_output_transformer('created'), table_transformer=transform_boolean_for_table)
 cli_storage_data_plane_command('storage directory delete', 'azure.storage.file.fileservice#FileService.delete_directory', factory, transform=create_boolean_result_output_transformer('deleted'), table_transformer=transform_boolean_for_table)
 cli_storage_data_plane_command('storage directory show', 'azure.storage.file.fileservice#FileService.get_directory_properties', factory, table_transformer=transform_file_output)
-cli_storage_data_plane_command('storage directory list', 'azure.cli.command_modules.storage.custom#list_share_directories', factory, table_transformer=transform_file_output)
+cli_storage_data_plane_command('storage directory list', 'azure.cli.command_modules.storage.custom#list_share_directories', factory, transform=transform_file_directory_result, table_transformer=transform_file_output)
 cli_storage_data_plane_command('storage directory exists', 'azure.storage.file.fileservice#FileService.exists', factory, transform=create_boolean_result_output_transformer('exists'))
 cli_storage_data_plane_command('storage directory metadata show', 'azure.storage.file.fileservice#FileService.get_directory_metadata', factory)
 cli_storage_data_plane_command('storage directory metadata update', 'azure.storage.file.fileservice#FileService.set_directory_metadata', factory)
 
 # file commands
-cli_storage_data_plane_command('storage file list', 'azure.cli.command_modules.storage.custom#list_share_files', factory, table_transformer=transform_file_output)
+cli_storage_data_plane_command('storage file list', 'azure.cli.command_modules.storage.custom#list_share_files', factory, transform=transform_file_directory_result, table_transformer=transform_file_output)
 cli_storage_data_plane_command('storage file delete', 'azure.storage.file.fileservice#FileService.delete_file', factory, transform=create_boolean_result_output_transformer('deleted'), table_transformer=transform_boolean_for_table)
 cli_storage_data_plane_command('storage file resize', 'azure.storage.file.fileservice#FileService.resize_file', factory)
 cli_storage_data_plane_command('storage file url', 'azure.storage.file.fileservice#FileService.make_file_url', factory, transform=transform_url)

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/test_storage.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/test_storage.py
@@ -398,7 +398,7 @@ class StorageFileScenarioTest(StorageAccountVCRTestBase):
         s.cmd('storage file url --share-name {} -p "{}"'.format(share, filename),
               checks=StringCheck(file_url))
 
-        for res in s.cmd('storage file list -s {}'.format(share))['items']:
+        for res in s.cmd('storage file list -s {}'.format(share)):
             assert filename in res['name']
 
         s.cmd('storage file delete --share-name {} -p "{}"'.format(share, filename))
@@ -421,7 +421,7 @@ class StorageFileScenarioTest(StorageAccountVCRTestBase):
         else:
             raise CLIError('\nDownload failed. Test failed!')
 
-        for res in s.cmd('storage file list -s {} -p {}'.format(share, dir))['items']:
+        for res in s.cmd('storage file list -s {} -p {}'.format(share, dir)):
             assert filename in res['name']
 
         s.cmd('storage share stats --name {}'.format(share),


### PR DESCRIPTION
I add a transform method to both `file list` and `directory list`. It adds additional properties to indicate entity type and remove the unused `content` property so that the number of properties are aligned between file and directory. The goal is to ensure the column numbers are the same for file and directory in tsv format.

Outcome:

```
$ az storage directory list -stest01 -otable
Name       Content Length    Type    Last Modified
---------  ----------------  ------  ---------------
python01/                    dir
python02/                    dir
python03/                    dir
python04/                    dir


$ az storage directory list -stest01 -otsv
None    python01                dir
None    python02                dir
None    python03                dir
None    python04                dir


$ az storage directory list -stest01 -otable
Name       Content Length    Type    Last Modified
---------  ----------------  ------  ---------------
python01/                    dir
python02/                    dir
python03/                    dir
python04/                    dir


$ az storage file list -stest01 -otable
Name        Content Length    Type    Last Modified
----------  ----------------  ------  ---------------
python01/                     dir
python02/                     dir
python03/                     dir
python04/                     dir
sample.txt                    file


$ az storage file list -stest01 -otable
Name        Content Length    Type    Last Modified
----------  ----------------  ------  ---------------
chrome.dll  40121176          file
python01/                     dir
python02/                     dir
python03/                     dir
python04/                     dir
sample.txt                    file


$ az storage file list -stest01 -otsv
None    chrome.dll              file
None    sample.txt              file
None    python01                dir
None    python02                dir
None    python03                dir
None    python04                dir


$ az storage file list -stest01 -otsv --exclude-dir
None    chrome.dll              file
None    sample.txt              file


$ az storage directory list -stest01 -otable
Name       Content Length    Type    Last Modified
---------  ----------------  ------  ---------------
python01/                    dir
python02/                    dir
python03/                    dir
python04/                    dir


$ az storage directory list -stest01 -otsv
None    python01                dir
None    python02                dir
None    python03                dir
None    python04                dir
```