### PR TITLE
Fix ‘Cannot record any VCR tests’

### DIFF
--- a/src/azure-cli-core/azure/cli/core/test_utils/vcr_test_base.py
+++ b/src/azure-cli-core/azure/cli/core/test_utils/vcr_test_base.py
@@ -48,7 +48,14 @@ MOCKED_STORAGE_ACCOUNT = 'dummystorage'
 
 # Workaround until https://github.com/kevin1024/vcrpy/issues/293 is fixed.
 vcr_connection_request = vcr.stubs.VCRConnection.request
-vcr.stubs.VCRConnection.request = lambda *args, **kwargs: vcr_connection_request(*args)
+
+
+def patch_vcr_connection_request(*args, **kwargs):
+    kwargs.pop('encode_chunked', None)
+    vcr_connection_request(*args, **kwargs)
+
+
+vcr.stubs.VCRConnection.request = patch_vcr_connection_request
 
 
 def _mock_get_mgmt_service_client(client_type, subscription_bound=True, subscription_id=None,


### PR DESCRIPTION
- Some kwargs are required whilst recording. Before, we ignored all kwargs.
- Now, we only remove the kwarg that was causing the issue in Python 3.6
Closes https://github.com/Azure/azure-cli/issues/1869