### PR TITLE
Adding more help docs for az group commands

### DIFF
--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
@@ -157,6 +157,10 @@ helps['group'] = """
     type: group
     short-summary: Commands to manage resource groups
 """
+helps['group update'] = """
+    type: group
+    short-summary: Update a resource group
+"""
 helps['group deployment'] = """
     type: group
     short-summary: Commands to execute or manage ARM deployments
@@ -171,6 +175,14 @@ helps['group deployment create'] = """
         - name: create a deployment from a local template file and use parameter values in string 
           text: >
             az group deployment create -g mygroup --template-file azuredeploy.json --parameters "{\\"location\\": {\\"value\\": \\"westus\\"}}"
+"""
+helps['group deployment export'] = """
+    type: command
+    short-summary: Exports the template used for specified deployment
+"""
+helps['group deployment validate'] = """
+    type: command
+    short-summary: Validates whether the specified template is syntactically correct and will be accepted by Azure Resource Manager
 """
 helps['group deployment operation'] = """
     type: group

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/_help.py
@@ -161,6 +161,10 @@ helps['group update'] = """
     type: group
     short-summary: Update a resource group
 """
+helps['group wait'] = """
+    type: command
+    short-summary: Place the CLI in a waiting state until a condition of the resource group is met.
+"""
 helps['group deployment'] = """
     type: group
     short-summary: Commands to execute or manage ARM deployments
@@ -183,6 +187,10 @@ helps['group deployment export'] = """
 helps['group deployment validate'] = """
     type: command
     short-summary: Validates whether the specified template is syntactically correct and will be accepted by Azure Resource Manager
+"""
+helps['group deployment wait'] = """
+    type: command
+    short-summary: Place the CLI in a waiting state until a condition of the deployment is met.
 """
 helps['group deployment operation'] = """
     type: group


### PR DESCRIPTION
Found minor missing help docs while playing around :)

**Before:**
```
az group -h

Group
    az group: Commands to manage resource groups.

Subgroups:
    deployment: Commands to execute or manage ARM deployments.

Commands:
    create    : Create a new resource group.
    delete    : Delete resource group.
    exists    : Checks whether resource group exists.
    export    : Captures a resource group as a template.
    list      : List resource groups, optionally filtered by a tag.
    show      : Get a resource group.
    update
    wait
```
**After:**
```
az group -h

Group
    az group: Commands to manage resource groups.

Subgroups:
    deployment: Commands to execute or manage ARM deployments.

Commands:
    create    : Create a new resource group.
    delete    : Delete resource group.
    exists    : Checks whether resource group exists.
    export    : Captures a resource group as a template.
    list      : List resource groups, optionally filtered by a tag.
    show      : Get a resource group.
    update    : Update a resource group.
    wait


```

**Before:**
```
az group deployment -h

Group
    az group deployment: Commands to execute or manage ARM deployments.

Subgroups:
    operation: Commands to manage deployment operations.

Commands:
    create   : Start a deployment.
    delete   : Delete deployment.
    export
    list     : Get a list of deployments.
    show     : Get a deployment.
    validate
    wait
```
**After:**
```
az group deployment -h

Group
    az group deployment: Commands to execute or manage ARM deployments.

Subgroups:
    operation: Commands to manage deployment operations.

Commands:
    create   : Start a deployment.
    delete   : Delete deployment.
    export   : Exports the template used for specified deployment.
    list     : Get a list of deployments.
    show     : Get a deployment.
    validate : Validates whether the specified template is syntactically correct and will be
               accepted by Azure Resource Manager.
    wait

```

@tjprescott/@derekbekoe Any idea what should be help doc's short summary for `wait` command and how can I generally apply them across all `wait` command?