### PR TITLE
Only load 1 module when we can

### DIFF
--- a/src/azure-cli-core/azure/cli/core/application.py
+++ b/src/azure-cli-core/azure/cli/core/application.py
@@ -34,6 +34,12 @@ class Configuration(object):  # pylint: disable=too-few-public-methods
 
     def get_command_table(self):  # pylint: disable=no-self-use
         import azure.cli.core.commands as commands
+        # Find the first noun on the command line and only load commands from that
+        # module to improve startup time.
+        for a in self.argv:
+            if not a.startswith('-'):
+                return commands.get_command_table(a)
+        # No noun found, so load all commands.
         return commands.get_command_table()
 
     def load_params(self, command):  # pylint: disable=no-self-use


### PR DESCRIPTION
This means that multiple modules cannot contribute to a top-level command anymore.
A workaround is in place for ‘acs’ as currently, they have commands in both ‘acs’ and ‘vm’ modules.