### PR TITLE
ensure bools are lower case in tsv

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_output.py
+++ b/src/azure-cli-core/azure/cli/core/_output.py
@@ -319,6 +319,8 @@ class TsvOutput(object):  # pylint: disable=too-few-public-methods
                 stream.write(separator)
                 TsvOutput._dump_obj(value, stream)
                 separator = '\t'
+        elif isinstance(data, bool):
+            TsvOutput._dump_obj(str(data).lower(), stream)
         else:
             TsvOutput._dump_obj(data, stream)
         stream.write('\n')

--- a/src/azure-cli-core/azure/cli/core/test_utils/vcr_test_base.py
+++ b/src/azure-cli-core/azure/cli/core/test_utils/vcr_test_base.py
@@ -418,11 +418,14 @@ class VCRTestBase(unittest.TestCase):  # pylint: disable=too-many-instance-attri
             for check in checks:
                 check.compare(result)
 
-        result = result or '{}'
-        try:
-            return json.loads(result)
-        except Exception:  # pylint: disable=broad-except
+        if '-o' in command_list and 'tsv' in command_list:
             return result
+        else:
+            try:
+                result = result or '{}'
+                return json.loads(result)
+            except Exception:  # pylint: disable=broad-except
+                return result
 
     def set_env(self, key, val):  # pylint: disable=no-self-use
         os.environ[key] = val

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_account_scenario.yaml
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/recordings/test_storage_account_scenario.yaml
@@ -30,6 +30,36 @@ interactions:
       content-length: ['23']
     status: {code: 200, message: OK}
 - request:
+    body: '{"name": "teststorageomega", "type": "Microsoft.Storage/storageAccounts"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['73']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [e35b01f8-e32d-11e6-9a99-a0b3ccf7272a]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/checkNameAvailability?api-version=2016-12-01
+  response:
+    body: {string: '{"nameAvailable":true}
+
+        '}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Wed, 25 Jan 2017 18:41:31 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['23']
+    status: {code: 200, message: OK}
+- request:
     body: '{"kind": "Storage", "sku": {"name": "Standard_LRS"}, "location": "westus"}'
     headers:
       Accept: [application/json]
@@ -493,6 +523,36 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/checkNameAvailability?api-version=2016-12-01
   response:
     body: {string: '{"nameAvailable":true}
+
+        '}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json]
+      Date: ['Wed, 25 Jan 2017 18:42:16 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-Azure-Storage-Resource-Provider/1.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['23']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"name": "teststorageomega", "type": "Microsoft.Storage/storageAccounts"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['73']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 storagemanagementclient/0.31.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b2+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [feb6affe-e32d-11e6-9c7c-a0b3ccf7272a]
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/checkNameAvailability?api-version=2016-12-01
+  response:
+    body: {string: '{"nameAvailable":false}
 
         '}
     headers:

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/test_storage.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/test_storage.py
@@ -44,6 +44,8 @@ class StorageAccountScenarioTest(ResourceGroupVCRTestBase):
         rg = self.resource_group
         s = self
         s.cmd('storage account check-name --name teststorageomega', checks=JMESPathCheck('nameAvailable', True))
+        result = s.cmd('storage account check-name --name teststorageomega --query "nameAvailable" -o tsv')
+        assert result == 'true'
         s.cmd('storage account create --sku Standard_LRS -l westus -n {} -g {}'.format(account, rg), checks=[
             JMESPathCheck('location', 'westus'),
             JMESPathCheck('sku.name', 'Standard_LRS')
@@ -90,6 +92,8 @@ class StorageAccountScenarioTest(ResourceGroupVCRTestBase):
               checks=JMESPathCheck('sku.name', 'Standard_GRS'))
         s.cmd('storage account delete -g {} -n {} --force'.format(rg, account))
         s.cmd('storage account check-name --name {}'.format(account), checks=JMESPathCheck('nameAvailable', True))
+        result = s.cmd('storage account check-name --name teststorageomega --query "nameAvailable" -o tsv')
+        assert result == 'false'
 
 
 class StorageBlobScenarioTest(StorageAccountVCRTestBase):


### PR DESCRIPTION
resolves #1906

Return bools as lower case rather than upper case (python bool case) to provide boolean scripting consistency. 