### PR TITLE
Fix ‘null’ output if command doesn’t return

### DIFF
--- a/src/azure-cli-core/azure/cli/core/test_utils/vcr_test_base.py
+++ b/src/azure-cli-core/azure/cli/core/test_utils/vcr_test_base.py
@@ -164,7 +164,7 @@ class NoneCheck(object):  # pylint: disable=too-few-public-methods
         pass
 
     def compare(self, data):  # pylint: disable=no-self-use
-        none_strings = ['[]', '{}', 'null', 'false']
+        none_strings = ['[]', '{}', 'false']
         try:
             assert not data or data in none_strings
         except AssertionError:

--- a/src/azure-cli/azure/cli/main.py
+++ b/src/azure-cli/azure/cli/main.py
@@ -38,7 +38,7 @@ def main(args, file=sys.stdout):  # pylint: disable=redefined-builtin
 
         # Commands can return a dictionary/list of results
         # If they do, we print the results.
-        if cmd_result:
+        if cmd_result and cmd_result.result is not None:
             from azure.cli.core._output import OutputProducer
             formatter = OutputProducer.get_formatter(APPLICATION.configuration.output_format)
             OutputProducer(formatter=formatter, file=file).out(cmd_result)


### PR DESCRIPTION
- This prevents commands from printing ‘null’ in JSON output
- But still keeps ‘[]’, ‘{}’, and ‘false’ as valid JSON results

Closes https://github.com/Azure/azure-cli/issues/1908