### PR TITLE
Fixes #1938

### DIFF
--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/custom.py
@@ -51,8 +51,6 @@ def create_resource_group(resource_group_name, location, tags=None):
     '''
     rcf = _resource_client_factory()
 
-    if rcf.resource_groups.check_existence(resource_group_name):
-        raise CLIError('resource group {} already exists'.format(resource_group_name))
     parameters = ResourceGroup(
         location=location,
         tags=tags

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/recordings/test_resource_group.yaml
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/recordings/test_resource_group.yaml
@@ -1,30 +1,5 @@
 interactions:
 - request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          resourcemanagementclient/0.30.2 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b8]
-      accept-language: [en-US]
-      x-ms-client-request-id: [23760b8c-a6c3-11e6-bf2f-64510658e3b3]
-    method: HEAD
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/travistestrg?api-version=2016-09-01
-  response:
-    body: {string: ''}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['104']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Wed, 09 Nov 2016 21:26:12 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-failure-cause: [gateway]
-    status: {code: 404, message: Not Found}
-- request:
     body: !!binary |
       eyJsb2NhdGlvbiI6ICJ3ZXN0dXMiLCAidGFncyI6IHsiYyI6ICIiLCAiYSI6ICJiIn19
     headers:

--- a/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/recordings/test_resource_group_no_wait.yaml
+++ b/src/command_modules/azure-cli-resource/azure/cli/command_modules/resource/tests/recordings/test_resource_group_no_wait.yaml
@@ -1,30 +1,5 @@
 interactions:
 - request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.5.0 (Windows-10.0.14393) requests/2.9.1 msrest/0.4.4 msrest_azure/0.4.3
-          resourcemanagementclient/0.30.2 Azure-SDK-For-Python AZURECLI/TEST/0.1.0b10]
-      accept-language: [en-US]
-      x-ms-client-request-id: [54283862-b5d0-11e6-bfe1-64510658e3b3]
-    method: HEAD
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_rg_nowait_test?api-version=2016-09-01
-  response:
-    body: {string: ''}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['110']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 29 Nov 2016 01:08:25 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      x-ms-failure-cause: [gateway]
-    status: {code: 404, message: Not Found}
-- request:
     body: '{"location": "westus"}'
     headers:
       Accept: [application/json]


### PR DESCRIPTION
Remove the superfluous exists check. Subsequent PUTs will either succeed (if the location is the same) or fail (if you try to change the location). This is consistent with other create commands in the CLI. 