### PR TITLE
[Network] NSG rule help updates and sensible defaults

### DIFF
--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
@@ -1159,10 +1159,38 @@ helps['network nsg'] = """
     type: group
     short-summary: Manage Network Security Groups (NSG)
 """
+
 helps['network nsg rule'] = """
     type: group
     short-summary: Manage NSG rules
 """
+
+helps['network nsg rule create'] = """
+    type: command
+    short-summary: Create a new NSG rule.
+"""
+
+helps['network nsg rule delete'] = """
+    type: command
+    short-summary: Delete an NSG rule.
+"""
+
+helps['network nsg rule list'] = """
+    type: command
+    short-summary: List all rules in an NSG.
+"""
+
+helps['network nsg rule show'] = """
+    type: command
+    short-summary: Show details of an NSG rule.
+"""
+
+helps['network nsg rule update'] = """
+    type: command
+    short-summary: Update an NSG rule.
+"""
+
+
 #endregion
 
 # region Public IP

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -14,7 +14,8 @@ from azure.mgmt.network.models.network_management_client_enums import \
      ApplicationGatewayFirewallMode, ApplicationGatewayProtocol,
      ApplicationGatewayRequestRoutingRuleType, ExpressRouteCircuitSkuFamily,
      ExpressRouteCircuitSkuTier, ExpressRouteCircuitPeeringType, IPVersion, LoadDistribution,
-     ProbeProtocol, TransportProtocol)
+     ProbeProtocol, TransportProtocol, SecurityRuleAccess, SecurityRuleProtocol,
+     SecurityRuleDirection)
 from azure.mgmt.dns.models.dns_management_client_enums import RecordType
 
 from azure.cli.core.commands import \
@@ -339,7 +340,19 @@ register_cli_argument('network nsg create', 'name', name_arg_type)
 # NSG Rule
 register_cli_argument('network nsg rule', 'security_rule_name', name_arg_type, id_part='child_name', help='Name of the network security group rule')
 register_cli_argument('network nsg rule', 'network_security_group_name', options_list=('--nsg-name',), metavar='NSGNAME', help='Name of the network security group', id_part='name')
-register_cli_argument('network nsg rule create', 'priority', default=1000, type=int)
+
+for item in ['create', 'update']:
+    register_cli_argument('network nsg rule {}'.format(item), 'priority', help='Rule priority, between 100 (highest priority) and 4096 (lowest priority). Must be unique for each rule in the collection.', type=int)
+    register_cli_argument('network nsg rule {}'.format(item), 'description', help='Rule description')
+    register_cli_argument('network nsg rule {}'.format(item), 'access', help=None, **enum_choice_list(SecurityRuleAccess))
+    register_cli_argument('network nsg rule {}'.format(item), 'protocol', help='Network protocol this rule applies to.', **enum_choice_list(SecurityRuleProtocol))
+    register_cli_argument('network nsg rule {}'.format(item), 'direction', help=None, **enum_choice_list(SecurityRuleDirection))
+    register_cli_argument('network nsg rule {}'.format(item), 'source_port_range', help="Port or port range between 0-65535. Use '*' to match all ports.", arg_group='Source')
+    register_cli_argument('network nsg rule {}'.format(item), 'source_address_prefix', help="CIDR prefix or IP range. Use '*' to match all IPs. Can also use 'VirtualNetwork', 'AzureLoadBalancer', and 'Internet'.", arg_group='Source')
+    register_cli_argument('network nsg rule {}'.format(item), 'destination_port_range', help="Port or port range between 0-65535. Use '*' to match all ports.", arg_group='Destination')
+    register_cli_argument('network nsg rule {}'.format(item), 'destination_address_prefix', help="CIDR prefix or IP range. Use '*' to match all IPs. Can also use 'VirtualNetwork', 'AzureLoadBalancer', and 'Internet'.", arg_group='Destination')
+
+register_cli_argument('network nsg rule create', 'network_security_group_name', options_list=('--nsg-name',), metavar='NSGNAME', help='Name of the network security group', id_part=None)
 
 # Public IP
 register_cli_argument('network public-ip', 'public_ip_address_name', name_arg_type, completer=get_resource_name_completion_list('Microsoft.Network/publicIPAddresses'), id_part='name', help='The name of the public IP address.')

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/custom.py
@@ -12,7 +12,8 @@ from azure.mgmt.network.models import \
      FrontendIPConfiguration, BackendAddressPool, Probe, LoadBalancingRule,
      NetworkInterfaceIPConfiguration, Route, VpnClientRootCertificate, VpnClientConfiguration,
      AddressSpace, VpnClientRevokedCertificate, SubResource, VirtualNetworkPeering,
-     ApplicationGatewayFirewallMode)
+     ApplicationGatewayFirewallMode, SecurityRuleAccess, SecurityRuleDirection,
+     SecurityRuleProtocol)
 
 from azure.cli.core.commands.arm import parse_resource_id, is_valid_resource_id, resource_id
 from azure.cli.core._util import CLIError
@@ -737,9 +738,12 @@ def remove_nic_ip_config_inbound_nat_rule(
 #region Network Security Group commands
 
 def create_nsg_rule(resource_group_name, network_security_group_name, security_rule_name,
-                    protocol, source_address_prefix, destination_address_prefix,
-                    access, direction, source_port_range, destination_port_range,
-                    description=None, priority=None):
+                    priority, description=None, protocol=SecurityRuleProtocol.asterisk.value,
+                    access=SecurityRuleAccess.allow.value,
+                    direction=SecurityRuleDirection.inbound.value,
+                    source_port_range='*', source_address_prefix='*',
+                    destination_port_range=80, destination_address_prefix='*',
+                   ):
     settings = SecurityRule(protocol=protocol, source_address_prefix=source_address_prefix,
                             destination_address_prefix=destination_address_prefix, access=access,
                             direction=direction,

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_nsg.yaml
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_nsg.yaml
@@ -1,31 +1,31 @@
 interactions:
 - request:
-    body: '{"properties": {"templateLink": {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateNsg_2016-07-18/azuredeploy.json"},
-      "mode": "Incremental", "parameters": {"name": {"value": "test-nsg1"}}}}'
+    body: '{"properties": {"parameters": {"name": {"value": "test-nsg1"}}, "templateLink":
+      {"uri": "https://azuresdkci.blob.core.windows.net/templatehost/CreateNsg_2016-07-18/azuredeploy.json"},
+      "mode": "Incremental"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['207']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 nsgcreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 nsgcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8a9fb6d1-7611-11e6-a721-a0999b14fe87]
+      x-ms-client-request-id: [6aa432b8-e7e3-11e6-8e94-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_nsg_test1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nsg/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body: {string: !!python/unicode '{"id":"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_nsg_test1/providers/Microsoft.Resources/deployments/azurecli1473372839.3651130","name":"azurecli1473372839.3651130","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateNsg_2016-07-18/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"test-nsg1"},"tags":{"type":"Object","value":{}}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2016-09-08T22:14:00.6443234Z","duration":"PT0.5333115S","correlationId":"d1826f85-d259-42e4-80be-1cafd084a7eb","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[]}}'}
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Resources/deployments/azurecli1485887461.402698345448","name":"azurecli1485887461.402698345448","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateNsg_2016-07-18/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"test-nsg1"},"tags":{"type":"Object","value":{}}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2017-01-31T18:31:03.4038387Z","duration":"PT0.8145119S","correlationId":"254042bc-a644-4448-8f7c-5ff569a0529c","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[]}}'}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_nsg_test1/providers/Microsoft.Resources/deployments/azurecli1473372839.3651130/operationStatuses/08587282340453666077?api-version=2015-11-01']
-      cache-control: [no-cache]
-      content-length: ['819']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:14:00 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/cli_test_nsg/providers/Microsoft.Resources/deployments/azurecli1485887461.402698345448/operationStatuses/08587157194228883177?api-version=2015-11-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['834']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 31 Jan 2017 18:31:03 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
@@ -35,29 +35,23 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 nsgcreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 nsgcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8a9fb6d1-7611-11e6-a721-a0999b14fe87]
+      x-ms-client-request-id: [6aa432b8-e7e3-11e6-8e94-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_nsg_test1/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587282340453666077?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nsg/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08587157194228883177?api-version=2015-11-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR02b
-        tevmo0cfvV5Pp3k+y2cf/ZL/ByCIe+QWAAAA
+    body: {string: '{"status":"Succeeded"}'}
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['141']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:14:30 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 31 Jan 2017 18:31:33 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['22']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -66,87 +60,66 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 nsgcreationclient/2015-11-01 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 nsgcreationclient/2015-11-01 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [8a9fb6d1-7611-11e6-a721-a0999b14fe87]
+      x-ms-client-request-id: [6aa432b8-e7e3-11e6-8e94-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_nsg_test1/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_nsg/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2015-11-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3W3Wk2ZaF6u2qJbN3Z3J7vmn+w92t3cn5zvb+7NZtp3l03vb08nDvQd75zsP7z/cuVvnTbWu
-        p/nndbVeNXenZfH7L5uL37/Nm3b37qquLotZXjd3vyimddVU5+34lb7Q3J3lq7K6XuTLtrmb/WBd
-        5/Ty7v6De/ce7B3cezi+9+n93d17Ox+NPlpmi5zQ29iGulrldVvkzUePfvFHbb5YlVmbPy+Wb/H3
-        ui4IwLxtV82ju9JZM3s7LcaTspqMp1Wdj6+K5ay6asbLvL1rXp9XTXv3pM7p1xc0qL2d3U+3dx5s
-        7x4ICBnA+KebakkYTKtlS2P5SRoukY+62x3v4L+Pfglhl9U0hpa+AjZlNc1AYvzeXq8wttdtXSwv
-        CMplVq7xwRURcN3gXRn9cEuQeptovovGbXbBXWjjLyc/nU9b1/gX/5JfQo0W1Yx+/+hsOa1zkD8r
-        qQUR8LIA5gT9dUsjphav19NpTsOc0fdtsaCOssWKPhdCPNzeOXizt/dod//R7oPxzsP9+w92H/4U
-        NZ2tax3fRy/f7H46fnhw7/6nr+kLInSdE2HpuzMw3Gz3YO/T84P727O9+w+39/fy/e2DnUm+vTvN
-        zmc7B/vZg3xCrzFqYKOPHn3vFzM9mlU2BYKOrV7k7VVVv6XWNLXMYG+IBPKG/wm9RDOMpq/zKbFF
-        ey2cSy+aacFLhv7f/yX0H40oX+XLWb6cMn99jz6p1u1q3dIfhFB+9eL15/htiOoygg3ENRh+vmZB
-        3M8f7Dyc7X26fb6TQ/LuT7cPJvvT7en5/v1sd39n+mC6R281OoJX69KgNcvPs3XZmrGZbwjJDFz0
-        0XFZVlc/SRQ4Wz6p1kv0zT3e/WGIvs7RXeoePw2S+j7eYz4mxdAfxN0I5jlxO+H+3bu/70cP9x/u
-        7k13722fT8+n2/vTg+n2w3w2275/b5Z/+un9g3t7D6e/70f0DuHl6Qn6a+O8zHJLFPqGUUiL5QT9
-        p22dnZ8X0/S8rhZpVpbpT37R0JfpT744fUOvEui2mlYlvfct+lNI9bKq21fZ8gL94FOC3xZL5rru
-        V/LC8WxGZG5e1vl58Y6++cmibtdZqZSkZh6EG9tmNLCGxi0DoQ9WdVGBwh89+vT+zs4OQStIwwIW
-        NTqTcX5EGiNkn2PovudVNnuSldlymtduRv6/xEsbhvH/JsYClmlJaKYTxZNeJ/A/C8zVowi19IB0
-        mwPQDSy1SwBuYKmn+fKaXnbE//8ID/Xw/mEzDRBgvVMIVQ3fUEMC9LPAHvjGeyn2tWUHIEd/+9xA
-        7EDv38ANRFHR8l+uW0PY/48wRAz1HzZPMA4p+SZMWcMRqkmIVWCi2sr++v8ja0VE5zH3uemM3PI6
-        nJb/L3FUBP3/l3KVwZTeJ/g/C+yEb7yXul97/d/AOx2zRKTlkQW8Aw1Gb9N3huz/H+GaPuI/bH4B
-        BswYXZahlgTph88Z+NqyBLCjv32OIJag9+Mc8X0OmWkkFO7Z3AWHVMwP7z1pHwHi/wOG066icREA
-        AA==
+    body: {string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Resources/deployments/azurecli1485887461.402698345448","name":"azurecli1485887461.402698345448","properties":{"templateLink":{"uri":"https://azuresdkci.blob.core.windows.net/templatehost/CreateNsg_2016-07-18/azuredeploy.json","contentVersion":"1.0.0.0"},"parameters":{"location":{"type":"String","value":"westus"},"name":{"type":"String","value":"test-nsg1"},"tags":{"type":"Object","value":{}}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2017-01-31T18:31:21.7991775Z","duration":"PT19.2098507S","correlationId":"254042bc-a644-4448-8f7c-5ff569a0529c","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkSecurityGroups","locations":["westus"]}]}],"dependencies":[],"outputs":{"newNSG":{"type":"Object","value":{"provisioningState":"Succeeded","resourceGuid":"476b2c36-88e8-474b-9594-5f7c304d638c","securityRules":[],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/defaultSecurityRules/AllowVnetInBound","etag":"W/\"1f4b9098-d0df-4792-96a2-9b4f44c7860f\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"1f4b9098-d0df-4792-96a2-9b4f44c7860f\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/defaultSecurityRules/DenyAllInBound","etag":"W/\"1f4b9098-d0df-4792-96a2-9b4f44c7860f\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"1f4b9098-d0df-4792-96a2-9b4f44c7860f\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"1f4b9098-d0df-4792-96a2-9b4f44c7860f\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/defaultSecurityRules/DenyAllOutBound","etag":"W/\"1f4b9098-d0df-4792-96a2-9b4f44c7860f\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}]}}},"outputResources":[{"id":"Microsoft.Network/networkSecurityGroups/test-nsg1"}]}}'}
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['1255']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:14:31 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 31 Jan 2017 18:31:34 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['4512']
     status: {code: 200, message: OK}
 - request:
-    body: '{"properties": {"access": "allow", "priority": 1000, "direction": "inbound",
-      "protocol": "*", "sourceAddressPrefix": "789", "destinationPortRange": "4444",
-      "destinationAddressPrefix": "1234", "sourcePortRange": "*"}, "name": "web"}'
+    body: '{"name": "web", "properties": {"priority": 1000, "destinationAddressPrefix":
+      "1234", "sourceAddressPrefix": "789", "access": "Allow", "sourcePortRange":
+      "*", "direction": "Inbound", "protocol": "*", "destinationPortRange": "4444"}}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['231']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9dd915d4-7611-11e6-8e61-a0999b14fe87]
+      x-ms-client-request-id: [7f2a42d4-e7e3-11e6-beff-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_nsg_test1/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"name\": \"web\",\r\n  \"id\": \"/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_nsg_test1/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web\"\
-        ,\r\n  \"etag\": \"W/\\\"e1b65d40-3b86-4ddd-a385-e7c4310b22eb\\\"\",\r\n \
+    body: {string: "{\r\n  \"name\": \"web\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web\"\
+        ,\r\n  \"etag\": \"W/\\\"45f734c2-4591-4cfd-9a34-6b062207c880\\\"\",\r\n \
         \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
         protocol\": \"*\",\r\n    \"sourcePortRange\": \"*\",\r\n    \"destinationPortRange\"\
         : \"4444\",\r\n    \"sourceAddressPrefix\": \"789\",\r\n    \"destinationAddressPrefix\"\
         : \"1234\",\r\n    \"access\": \"Allow\",\r\n    \"priority\": 1000,\r\n \
         \   \"direction\": \"Inbound\"\r\n  }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/c6809d23-c561-4b9c-88eb-69401192df5b?api-version=2016-09-01']
-      cache-control: [no-cache]
-      content-length: ['551']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:14:31 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/39b622c4-f1c5-4b57-b301-eb50f221c1a5?api-version=2016-09-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['556']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 31 Jan 2017 18:31:36 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -155,29 +128,25 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9dd915d4-7611-11e6-8e61-a0999b14fe87]
+      x-ms-client-request-id: [7f2a42d4-e7e3-11e6-beff-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/c6809d23-c561-4b9c-88eb-69401192df5b?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/39b622c4-f1c5-4b57-b301-eb50f221c1a5?api-version=2016-09-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UdNm7Xr5qNH6Uev19Npns/y2Ue/cfJL/h9PlJBHHQAAAA==
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:14:41 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 31 Jan 2017 18:31:45 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['29']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -186,36 +155,32 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [9dd915d4-7611-11e6-8e61-a0999b14fe87]
+      x-ms-client-request-id: [7f2a42d4-e7e3-11e6-beff-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_nsg_test1/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web?api-version=2016-09-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj96CqffDTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWruTsvi9182F79/mzft7t1VXV0Ws7xu7n5RTOuqqc7b8Yu8
-        varqt3eX8vN1Pl3XRXut7+O9bQKwe7fRL16ty7y561DN2+wCyH737u/70afZw/P9vd3p9oM8m2zv
-        55/e357M8gfb+7sP7+/tHewSitPf9yN9kZBZ5XVb5A29zoSQDy+LhoZbLC9et1nLdHm9nk7zfJbP
-        5E1p1lbTqsS337KfyshfVnX7Klte8KvuyxmNpFhmIGXQYp8e20ggHM9mRMbmZZ2fF+/Q5sHBQ9vE
-        g9Nrt7t3z8HKCOkGY/vouCyrK/v5qi4qEJK+2d3Z2TEfz4o6nwIqff7R2XJSrZezj/DdL/mNk1/y
-        /wAZXtYvKAIAAA==
+    body: {string: "{\r\n  \"name\": \"web\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web\"\
+        ,\r\n  \"etag\": \"W/\\\"708ac300-50d6-494f-a992-9e45b0717074\\\"\",\r\n \
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
+        protocol\": \"*\",\r\n    \"sourcePortRange\": \"*\",\r\n    \"destinationPortRange\"\
+        : \"4444\",\r\n    \"sourceAddressPrefix\": \"789\",\r\n    \"destinationAddressPrefix\"\
+        : \"1234\",\r\n    \"access\": \"Allow\",\r\n    \"priority\": 1000,\r\n \
+        \   \"direction\": \"Inbound\"\r\n  }\r\n}"}
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:14:41 GMT']
-      etag: [W/"6a9f421c-7eab-4e65-bde7-41952281095c"]
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 31 Jan 2017 18:31:46 GMT']
+      ETag: [W/"708ac300-50d6-494f-a992-9e45b0717074"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['557']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -224,153 +189,183 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a48168ca-7611-11e6-9c47-a0999b14fe87]
+      x-ms-client-request-id: [86993b70-e7e3-11e6-be03-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/networkSecurityGroups?api-version=2016-09-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UeXWbnOP3qUfg9/pSl/iOejZbbA5x+1edNuL5uL3Y9G9rtihm/uNutJM62LVVtUy+buzmT3/NP9
-        B7vbu5Pzne392SzbzvLpve3p5OHeg73znYf3H+7crfOmWtfT/PO6Wq+au9Oy+P0J9u+PTnbvrurq
-        spjldXP3i2JaV0113o5f5O1VVb+9u5Sfr/Ppui7aa30f73WRy9vsAuh99+7v+9Gn2cPz/b3d6faD
-        PJts7+ef3t+ezPIH2/u7D+/v7R3sElLT3/cj7+X2esWjviUC3ptlNc1ACLx9RWit/S8JpYa++MW/
-        xH1Eg13ldVvk/IX5WL64LBqCVCwvXrdZy/i8Xk+neT7LZw4oNbXUXMuM7OcPdh7O9j7dPt/JMQX3
-        p9sHk/3p9vR8/362u78zfTDdCwA0OppX65LxUC6Qx0MKj+WIq3ziA8Hz/0KOuBuM7W4M6Q/hFHkw
-        WdFZlAdf33Iu5cELbTWtSrT7VuR7odXLqm5fZcsLBhdrNiMqFEvmx6DtPj2R5gL1eDajyWhe1vl5
-        8Q6tHxw8jDT2YPfe2N27F4Of0YAbUOij47KsriItVnVRYbKoze7Ozk6/wayo8yn6pBYfnS0n1Xo5
-        +yhs9Uv8P70/vu9BI+zPs3XZGq5h5iCQt2J8Rv4nie/Olk+4fw8wnv83SkFsvHdvHMj/CyWD2M7Q
-        FE15CGkhjJC2dXZ+XkzT87papFlZpj/5RUNfpj/54vRNBBZ1/rMpZbG2ArInMD9Z1O06K3U2I+95
-        fbz/y+8ld5/e/2YELwDRmfhQlI5/sK7z51U2e5KV2XKa10Ps+P8pubr1qP6/LWQYZVrSMNOJjjMC
-        jxD4f4mg9WYl8qrXTe/9WFfvLV67/RY/O+L1NF9eE05DnPf/FXm6YRj/7xcgDIDtUSEza2Qo8iZ1
-        9f8SUYk19cDeqr0TDZAg0iCQDBKNfoufHckgdhLX58t1G+eq/68Ix80j+X+/fPAY0mrd8uwa6VAL
-        Q2IDN66t7K8/8uicXDHpIi0CwbrZoyPmYdp/Q5J1tmzzehNP/n9Kum4czf9vJMyMNAKQMPh/iWjF
-        mnpge+03DOq95egm141YhCn84XIEg0lIEcA4z/1/RYJuGsf/+2UHI2Ah6YpP5FXq6/+jUhJr78QD
-        NIg0CKSDxKPf4v2lw/3xffOrfmYEx06xFZbZ5WL3xevPHYbfnHiQLORvv45c9HHyWf3Bg72De9O9
-        ve1P9yd725SX/3T7YO/Th9uz2fmn92dZdv/BwbnP6j9bSxI0rqjs4ItbSk1//WHv4GA6u5dt59MD
-        EuNZdm87O8jy7Qf7ROe9e/fyh5NPAwBBjp4g3CoNq9pmmySzutpumrkPEs//e3igswhxM+Yfwiny
-        YP6iEysPvr7l9MqDF6xmezNdRVoIyW7UVzNiQVVCQdu9YE1KHoV5K2Xlwb1Ve6fcyDzdZPu/odWI
-        AERnUixjC1vQv12U/l/L0ITrAMY/Hxn5YGebTOFO5A0BfCvu9IDfqv37crN1ZOkred6fm90f/x9c
-        WyO2/zARiA1T4sVN+P+/UCCI1Qwp0ZSHQDkWnn/j6oaR4o8SMO8lbggcf2jWg/HpLXMMseP/F8Tp
-        1oP5/7ZsYZQ/WkmjNviWCRVp0ZGqb8KKBSA6U26lCvEv4TTEef8vF6MbsP9/v9xgAGx9CplQIzqR
-        N6mr/5dISKypB/ZW7Z1EgASRBoFAkET0W/zsCASxkzg6lNOJc9X/y2Xi5gH8v18seAy9tKTaE5IW
-        +GqU1Te//shtc+LEpIu0COTpZreNmIdp/w0JlFmqILBxnvz/glDdOIj/3wiWGWkEIGHw/xKJijX1
-        wPbabxjUe4vPTf4ZsQhT+MPFB+aRkCKAcZ77f7ng3IT+//tFBiNg2ehKTeRV6uv/o8IRa++kAjSI
-        NAiEgqSi3+L9hcL9EeTelPVYhs8zwosAbky8/RzIhUOOZeInv3hBTOKj5Q/O/KqfGWVgh2EVAIHK
-        l9P6euUprp+L0Rm5Ni/G0PKleWe6//BTWtvenu0c5ITNp/vb2f6ne9sPD/Z29g6mDw6yLFjz/v/S
-        QuD9fD/Pdu5PtmcP7u1v7z88n2xnD/bvkeKaznbvHew/nN2fBACCZQWCsJF17cyLQsX6A61CxJbT
-        BJu7/69gg87Syc3IfwizyIMpjM6tPPj6ljMsD16w+vtnZQnl58NaoPsj0ODKEIZ/mEsI5K0kgZFH
-        TDuU6fl/lSDERioRxKYh/L9QHIjbDDXRlIdAwTazgPGCwtjhR5H4e0kcQolvQuQCEJ2JD4Wol90e
-        Ysf/j0jUrcfz/23xwih/tIZCbfAtE+qjfotQsG6M0b8xwUJ0RDgNcd7/+yXphgH8v190MAC2QR3p
-        ibxJXf2/REhiTT2wt2rvhAIkiDQIZIKsTb/Fz45MEDuJu0NBf5yr/t8vFjeP4f/9ksFj6KWu1KqQ
-        wMBpo4Sv+fVH/puTKCZdpEUgUjf7b8Q8TPtvSKY4ybSJJ/8/Ilc3juP/N7JlRhoBSBj8v0SoYk09
-        sL32Gwb13hJ0k6NGLMIU/nAJgpEkpAhgnOf+3y87N43g//1SgxGweHQFJ/Iq9fX/UfmItXeCARpE
-        GgRyQYLRb/H+cuH+CLJxyn0sxrxkQQA3puJ+DkTDIeeJxb17D4Lx+gM0v+pnRifYoVg9QOCa9ZIW
-        Ld0k/FwM0Ii2eTGClS/P55N7eyRk0+37swNadbj/cLo9ub9/f/v8IJ99urP/cLo72fHl+f9LKyqT
-        e9N7+w8fPNj+9OHBfSJ0vkdjw5/5wcGnUxpgdm8nABCsNhCEjcxr511U6oZFCcHm7v8buOCDFlTe
-        l1fkwQxGp1YefH3LCZYHL1gF/qMFFX5CHf6NBdzCFvRvF6X/F7M0YTuA889HVj7Y2f6UGCZQc/Io
-        5FsxqAf9Vu3fl6FvctZvw9Duj8AnUQ1nmId5hEDeSrMz8sjVDCUx/98kBbGBSlS8aQT/L5QJYjZD
-        TDTlIVAOiTnAuPVhPPyjBNN7CRzC4x+aCWF8eks3Q+z4/w2BuvVw/r8tXRjlj9YHqQ2+ZUJFWnTk
-        6puwZAGIzpRbuUK0TzgNcd7/6wXpBvz/3y85GABboEKm1AhP5E3q6v8lMhJr6oG9VXsnEyBBpEEg
-        EiQT/RY/OyJB7CTODuWw4lz1wVLxsy0VNw/h//2CwWPoJWLVppC8wGOjFQzz64+cNydQTLpIi0Ci
-        bnbeiHmY9t+QSHHKdBNP/n9DrG4cxv9vRMuMNAKQMPh/iUzFmnpge+03DOq9BegmL41YhCn84QIE
-        E0lIEcA4z/2/XnRuGsD/+4UGI2Dp6MpN5FXq6/+j4hFr7+QCNIg0CMSC5KLf4v3Fwv0R5OGU+ViK
-        efmNAG5Mwv0cSIZDTqXiJ794QWziI+YPz/yqnxmFYAdilcDiuqWZu1zskpS5Wfi5GKGRbX1xADFf
-        pnfO70/3Hk5nlEamVf79e9m97ex893z74Hwvf3Bv9+A8zzNfpn+21gcJJbDMLzZUpo9ovFG9gS9u
-        qTF6S4azg9nOwcNPP91+sHtvur1/cJBtH+ze29uePrh//97s4d4kf3AQAAgWHwjCRp42DKGaFqsU
-        tFYRW3YTbO7+v4Q3OkssN6P/IRwkDyYxOrvy4OtbzrE8eMGq9p+VpZafD6uG7o9AuStDGA5iLiGQ
-        t5IFRh4h71Aq6P9lohAbqwQYmwbx/0KBIH4z9ERTHgJF48wExkUKQ4sfhervJXOINL4JoQtAdCY+
-        FKNeCnyIHf8/I1O3HtH/twUMo/zRUgu1wbdMqEiLjmjdFMR/Y6KF4IlwGuK8/y/I0g1D+H+/8GAA
-        bIcKmVUjP5E3qav/l4hJrKkH9lbtnViABJEGgVSQWPRb/OxIBbGTuDyUFYhz1f8XBOPmUfy/XzZ4
-        DL3slloWEhm4bpQVNr/+yItzMsWki7QIhOpmL46Yh2n/DUkV56E28eT/ZyTrxpH8/0a6zEgjAAmD
-        /5eIVaypB7bXfsOg3luGbnLXiEWYwh8uQzCUhBQB7PEcNfsg6fmhSc9NY/h/v9xgBCwgXdGJvEp9
-        /X9UQmLtnWiABpEGgWSQaPRbvL9kuD+CzJzyHwsyr2wQwI1puZ8D0+KQc4LxDa+87JGguYn4uRik
-        EW99cQAxX6zvPZzcz2b3su1PpxktRZxPd7Yns/uT7ezhp/v5pw939vfvHfhi/f/xlZdJtr+7t7e/
-        s31/lxZd9if3d7azTx8Q+e/f393JPt0/2M0fBACCNQmCsJGtDUOost2wdCHY3P1/CW980MrL+3KQ
-        PJjE6OzKg69vOcfy4AWr3X+08sJPqOBvE5O7PwL9rgxhOIi5hEDeShYYecS+Q2mh/5eJQmysEmZs
-        GsT/CwWC+M3QE015CBSWMxMYLykMMH4Us7+XzCHe+CaELgDRmfhQjHoZ8SF2/P+MTN16RP/fFjCM
-        8kcrL9QG3zKhIi06onVTKP+NiRbiJ8JpiPP+vyBLNwzh//3CgwGwHSpkVo38RN6krv5fIiaxph7Y
-        W7V3YgESRBoEUkFi0W/xsyMVxE7i8lBiIM5V/18QjJtH8f9+2eAx9BJcallIZOC6UW7Y/PojL87J
-        FJMu0iIQqpu9OGIepv03JFWcitrEk/+fkawbR/L/G+kyI40AJAz+XyJWsaYe2F77DYN6bxm6yV0j
-        FmEKf7gMwVASUgQwznP/X5Cem8bw/365wQhYQLqiE3mV+vr/qITE2jvRAA0iDQLJINHot3h/yXB/
-        BJk55T8WZF7cIIAb03I/B8LhkHOC8Q2vvNwjQXMT8XMxSCPe+uIAYr5Yz3b27s2mk3PI8Wx7/2Dn
-        fPvhzu7D7QcP6OPs/MHug4e7vlj/f3zlZbZ/797D/d2d7Wm2TysvB9n+9sOHDyfbn366ezDdneTn
-        5/eCBPv//1dewBvRlZdN6H8IB8mDSYzOrjz4+vJ2cywPXrDa/UcrL/yECv42Mbn7I9Dvys+Gg95L
-        Fhh5xL5DaaH/l4lCbKwSZmwaxP8LBYL4zdATTXkIFJYzExgvKQwwfhSzv5fMId74JoQuANGZ+FCM
-        ehnxIXb8/4xM3XpE/98WMIzyRysv1AbfMqEiLTqidVMo/42JFuInwmmI8/6/IEs3DOH//cKDAbAd
-        KmRWjfxE3qSu/l8iJrGmHthbtXdiARJEGgRSQWLRb/GzIxXETuLyUGIgzlX/XxCMm0fx/37Z4DH0
-        ElxqWUhk4LpRbtj8+iMvzskUky7SIhCqm704Yh6m/TckVZyK2sST/5+RrBtH8v8b6TIjjQAkDP5f
-        Ilaxph7YXvsNg3pvGbrJXSMWYQp/uAzBUBJSBDDOc/9fkJ6bxvD/frnBCFhAuqITeZX6+v+ohMTa
-        O9EADSINAskg0ei3eH/JcH8EmTnlPxZkXtwggBvTcj8HwuGQc4Lxja28XBXLWXXVXC5I1NxU/FwM
-        0wi4vjiImi/a+weT/QfZ3t72wYOcFlWz/YfbkwcH97dn2cP9nfP7D3Z3p/d80f7/+OrLw53Jp1n+
-        INue7O3ube/vPzynNeRPs+37u5ODPH+YTR+cTwIAX2v15dXTlz4QPP+v44fOiksM5Q/hE3kwVdE5
-        lAdf33Im5cELVo//rKyx3Lt38DDSXKDeSjl7kG/V3ilzMsc3+Tk/WmX55gQgNloJKjYN4/+FQkEc
-        ZyiKpjwECsKZDYxPFIYTP4rQ30vqEF18E2IXgOhMfChIvfz3EDv+XErVe0rVrcdkROz/myKGUf5o
-        pYXa4FsmVKRFR7huCt2/MeFCvEQ4DXHe/zek6YZB/L9ffDAAtkWFzKuRoMib1NX/SwQl1tQDe6v2
-        TjBAgkiDQC5IMPotfnbkgthJ3B5KBcS56v8bonHzOP7fLx08hl5SS60LCQ0cOMoHm19/5Ms5qWLS
-        RVoEYnWzL0fMw7T/huSK00+bePL/Q7J141j+fyNfZqQRgITB/0sEK9bUA9trv2FQ7y1FNzltxCJM
-        4Q+XIhhLQooAxnnu/xvyc9Mo/t8vORgBi0hXeCKvUl//H5WRWHsnHKBBpEEgGyQc/RbvLxvujyBL
-        pxzIosyLGgRwY4ru50A8HHK+aHxDay6Xi+1FtrzeXhbThqTNzcbPxUiNjOuLw7j54n1vdn5/Nsv3
-        tyfnD+9t708fTLcf7u1k27t5dn//YX6e35/s+OL9//FVF9JX9x7cm366vftgsru9f29/sn1wbzbb
-        nk0m55NPZ/cmD3bvBwCCtQmCsJG9DVuo0t0mBVVdbTfN3AeJ5/997NFZhLl5BB/CRPJgHqMTLA++
-        vuU0y4MXrKL/WVmS2duLNBaYt9LdHtxbtXe6nqz1TY7QjxZkwLbfkDTEhithx6Zx/L9QJojlDEnR
-        lIdAgTrzgfGZwoDjR1H8e4kd4o9vQu4CEJ2JDyWplycfYsf/L4nVrQf1/20Zwyh/tCRDbfAtEyrS
-        oiNdN0X335h0IaAinIY47/8j4nTDKP7fLz8YAFujQibWiFDkTerq/yWSEmvqgb1VeycZIEGkQSAY
-        JBn9Fj87gkHsJI4PJQviXPX/Edm4eSBx8fh/k3jwGHp5L7UvJDXw4ShpbH79kTvnxIpJF2kRyNXN
-        7hwxD9P+GxIszlBt4sn/LwnXjYP5/42AmZFGABIG/y+RrFhTD2yv/YZBvbcY3eS3EYswhT9cjGAu
-        CSkCGOe5/48I0E3D+H+/6GAELCNd6Ym8Sn39f1RIYu2ddIAGkQaBcJB09Fu8v3C4P26/ZDHPqulP
-        fuEQ/OaEA5Dri68hHHgxQMln9L18fzLd3dvd/nSyc7C9//B8d/tg/zzf3qPk/f6nn97bO/h0z2f0
-        n60FChpWVHLwxS1lprca8TDb/fTT/b1Pt+/Ndj/d3qfBbR9Mz8+3J7O9+/en93by/el5ACBI0hOE
-        W6VfVddsyOULNnd/zlnggxYh3pdR5MH0RedVHnx9y9mVBy9YtfajRQh+Qs12m6jU/fH/wUUI8PKH
-        CEFslOJcb0L//4WiQJxmKImmPASKR3n6jWMQutU/ClbfS9rgZX8T4haA6Ex8KEC9hPAQO/5/QJpu
-        PZb/b4sWRvmjJQdqg2+ZUJEWHaG6KXT9xoQKwQLhNMR5/++WohuQ/3+/2GAAbHsKmU8jOZE3qav/
-        lwhIrKkH9lbtnUCABJEGgTyQQPRb/OzIA7GTuDkU/8a56v/dInEz/v/vlwoeQy+Do9aEhAWOGuU/
-        za8/8tmcNDHpIi0CcbrZZyPmYdp/Q/JkkroENs6T/x+QqRvH8P8buTIjjQAkDP5fIlCxph7YXvsN
-        g3pv6bnJOSMWYQp/uPTAOBJSBDDOc//vlpubsP9/v8RgBCwaXaGJvEp9/ezJRpzhZQp7vB5rSgMb
-        lI1YeycUoEGkQSATJBT9Fu8vE+6PIOumnMcifJ4RXgRwY8rt50AsHHL80uXi/r1gqP7YzK/6mVEF
-        dhRW/C8Xu9vL5sJR/5sbWZPdblxGovW1Pka+EN/fn04/nXxKiwif7mbb+3v3H24f5Nls+9O9yf5s
-        /97DyW4+8YX4/0tLJffu7U0f3HuQbd/LaNFzfzqbbE+y+/e3J/mD7MGD3XvTbPcgABAsJRCEjRxr
-        Zlz16IYVB8Hm7s81B3zQSsn78ok8mL3otMqDr285ufLgBaux35y8jLQQgt3oo3jKNWj7o5USwzzM
-        JQTyVkLAyCOGHUrs/L9FBmKDlGhhE/b/L5QEYjRDSDTlIVBczbNvXJ4wTvhR0P1ewoaw4ZuQtgBE
-        Z+JD+emlsYfY8f/9wnTrofx/W7Iwyh+tk1AbfMuEirToyNRNofg3JlOIgginIc77f7UQ3YD7//ul
-        BgNgy1PIdBrBibxJXf2/RD5iTT2wt2rv5AEkiDQIxIHkod/iZ0cciJ3EyaG4Ps5V/6+WiJvR/3+/
-        UPAYbs7mml9/5LA5YWLSRVoE0nSzw0bMw7T/hsSJU0ibePL//SJ14xD+fyNWZqQRgITB/0vkKdbU
-        A9trv2FQ7y08N3lmxCJM4Q8XHphGQooAxnnu/9VicxPy/+8XGIyAJaMrM5FXqa//j4pGrL2TCdAg
-        0iAQCZKJfov3Fwn3R5BvU9ZjCeZlCAK4Mdn2Q5cKhxok4sH+QTBMf1zmV/3MaAE7Aiv51+sLmvqr
-        7d0Xrz935P/mhqbwbzM6I9Xhm13MfGne2Zmcn2c5LXHeu0cLCg8fnm9P8M+9nWznwcOd8/O9Bzu+
-        NP9sLZYQSmCWX2zITB/ReKMaA1/cUlf01k8mD/bv7+zuzbZ3d6bn2/ufZrvb2d696fb04f70/sMH
-        DyZZfi8AECwwEISN3Gw4QnXshnUIwebu/1uY44PWUd6XheTBLEanVx58fctJlgcvWK3+ZrqKtBDC
-        3airPQUctP3ROorhIOYSIsmthIH8ColyhzI//2+TBeV+04QHK4HFplH8v1AiiJENQdGUh0AROFt3
-        4x6FIcWPwnPnTTG5Ii0Cd+rm8PybTXb10t1D7Pj/HaG69ZD+vy1hGOWP1lWoDb5lQkVadGTrpuj9
-        G5MtRE6E0xDn/X9CmG4Yw//7pQcDYEtUyLQaAYq8SV39v0ROYk09sLdq7+QCJIg0CMSC5KLf4mdH
-        LIidxOmhnECcq/4/IRk3D+P//cLBY+glt9S2kMzAe6OEsPn1R46cEyomXaRFIFU3O3LEPEz7b0is
-        OBG1iSf/vyNaNw7l/zfiZUYaAUgY/L9ErmJNPbC99hsG9d5CdJPHRizCFP5wIYKpJKQIYJzn/j8h
-        PjcN4v/9goMRsIR0ZSfyKvX1/1ERibV3sgEaRBoEokGy0W/x/qLh/vh/ybqL8vhtpMNhZ97a3v3J
-        L14Qq/jI+UM0v+pnRjHYwVhloPDKYrl+x+LmpuMbHyp3cpvxGlGPvN7F0ZfzTx9O93ams0+3s09n
-        97b39x9k2w8/vf9g+zzfnX366ezBdLr/0Jfz/4+vyDyc7Z7v7Wb725ODB/dpuPf2th9OJ/vbe9Pd
-        g4y8socH9x4EAIKlCoKwkc8Ng6j23bCiIdjc/X8fm3zQ2sz7MpM8mM/oRMuDr2853fLgBav5f7Q2
-        w0+o/G8Tsrs/At2vDGHYiLmEQN5KLBh5RMZDWaP/90pFbNgSjmwaz/8LZYNYz5AWTXkIFL8zPxhn
-        KgxEfhTcv5f4IS75JuQvANGZ+FCiesnzIXb8/6J43Xpw/9+WNYzyh71eQ2h9XXnrzUrkVRr9oMjF
-        uupJWa9FR8puiv6/MSlDxEWTN8R5/x8TqxtG8/9+OcIA2DoVMsFGlCJvUlf/L7FQsaYe2Fu1dxIC
-        EkQaBAJCEtJv8bMjIMRO4ghRViHOVf8fk5GbB/T/fjHhMfQSZWpvSHrg21GS2fz6IzfPiReTLtIi
-        kK+b3TxiHqb9NyRgnNHaxJP/XxSyGwf1/xtBMyONACQM/l8iYbGmHthe+w2Dem9xusmfIxZhCn+4
-        OMF8ElIEMM5z/x8TpJuG8/9+EcIIWFa6UhR5lfr6/6iwxNo7KQENIg0CISEp6bd4fyFxfwS5PWVC
-        lmleOSGAGxN7P2dy4lAMXn3fFR78oA9/yf8D4adq42pOAQA=
+    body: {string: '{"value":[{"name":"test-nsg1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1","etag":"W/\"708ac300-50d6-494f-a992-9e45b0717074\"","type":"Microsoft.Network/networkSecurityGroups","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"476b2c36-88e8-474b-9594-5f7c304d638c","securityRules":[{"name":"web","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web","etag":"W/\"708ac300-50d6-494f-a992-9e45b0717074\"","properties":{"provisioningState":"Succeeded","protocol":"*","sourcePortRange":"*","destinationPortRange":"4444","sourceAddressPrefix":"789","destinationAddressPrefix":"1234","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/defaultSecurityRules/AllowVnetInBound","etag":"W/\"708ac300-50d6-494f-a992-9e45b0717074\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"708ac300-50d6-494f-a992-9e45b0717074\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/defaultSecurityRules/DenyAllInBound","etag":"W/\"708ac300-50d6-494f-a992-9e45b0717074\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"708ac300-50d6-494f-a992-9e45b0717074\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"708ac300-50d6-494f-a992-9e45b0717074\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/defaultSecurityRules/DenyAllOutBound","etag":"W/\"708ac300-50d6-494f-a992-9e45b0717074\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}]}},{"name":"basica01NSG","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkSecurityGroups/basica01NSG","etag":"W/\"471d10bc-10e2-4531-8c9f-10f8275d93a1\"","type":"Microsoft.Network/networkSecurityGroups","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"6ec0608f-069b-465c-ab4b-474edeedeae2","securityRules":[{"name":"default-allow-ssh","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkSecurityGroups/basica01NSG/securityRules/default-allow-ssh","etag":"W/\"471d10bc-10e2-4531-8c9f-10f8275d93a1\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"22","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkSecurityGroups/basica01NSG/defaultSecurityRules/AllowVnetInBound","etag":"W/\"471d10bc-10e2-4531-8c9f-10f8275d93a1\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkSecurityGroups/basica01NSG/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"471d10bc-10e2-4531-8c9f-10f8275d93a1\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkSecurityGroups/basica01NSG/defaultSecurityRules/DenyAllInBound","etag":"W/\"471d10bc-10e2-4531-8c9f-10f8275d93a1\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkSecurityGroups/basica01NSG/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"471d10bc-10e2-4531-8c9f-10f8275d93a1\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkSecurityGroups/basica01NSG/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"471d10bc-10e2-4531-8c9f-10f8275d93a1\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkSecurityGroups/basica01NSG/defaultSecurityRules/DenyAllOutBound","etag":"W/\"471d10bc-10e2-4531-8c9f-10f8275d93a1\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkInterfaces/basica01VMNic"}]}},{"name":"basica0NSG","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkSecurityGroups/basica0NSG","etag":"W/\"7b0ac1e6-1006-49ae-8ed2-d000f70e15d8\"","type":"Microsoft.Network/networkSecurityGroups","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"14e729af-2928-4fac-baf4-36d345a5c9eb","securityRules":[{"name":"default-allow-ssh","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkSecurityGroups/basica0NSG/securityRules/default-allow-ssh","etag":"W/\"7b0ac1e6-1006-49ae-8ed2-d000f70e15d8\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"22","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkSecurityGroups/basica0NSG/defaultSecurityRules/AllowVnetInBound","etag":"W/\"7b0ac1e6-1006-49ae-8ed2-d000f70e15d8\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkSecurityGroups/basica0NSG/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"7b0ac1e6-1006-49ae-8ed2-d000f70e15d8\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkSecurityGroups/basica0NSG/defaultSecurityRules/DenyAllInBound","etag":"W/\"7b0ac1e6-1006-49ae-8ed2-d000f70e15d8\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkSecurityGroups/basica0NSG/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"7b0ac1e6-1006-49ae-8ed2-d000f70e15d8\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkSecurityGroups/basica0NSG/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"7b0ac1e6-1006-49ae-8ed2-d000f70e15d8\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkSecurityGroups/basica0NSG/defaultSecurityRules/DenyAllOutBound","etag":"W/\"7b0ac1e6-1006-49ae-8ed2-d000f70e15d8\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkInterfaces/basica0VMNic"}]}},{"name":"myvm2NSG","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkSecurityGroups/myvm2NSG","etag":"W/\"92c28bcd-9fe6-49ca-addc-dff8efed3320\"","type":"Microsoft.Network/networkSecurityGroups","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"f5dc196e-b538-4bcb-b5c8-f2fa4d2ae1e3","securityRules":[{"name":"default-allow-ssh","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkSecurityGroups/myvm2NSG/securityRules/default-allow-ssh","etag":"W/\"92c28bcd-9fe6-49ca-addc-dff8efed3320\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"22","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkSecurityGroups/myvm2NSG/defaultSecurityRules/AllowVnetInBound","etag":"W/\"92c28bcd-9fe6-49ca-addc-dff8efed3320\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkSecurityGroups/myvm2NSG/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"92c28bcd-9fe6-49ca-addc-dff8efed3320\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkSecurityGroups/myvm2NSG/defaultSecurityRules/DenyAllInBound","etag":"W/\"92c28bcd-9fe6-49ca-addc-dff8efed3320\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkSecurityGroups/myvm2NSG/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"92c28bcd-9fe6-49ca-addc-dff8efed3320\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkSecurityGroups/myvm2NSG/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"92c28bcd-9fe6-49ca-addc-dff8efed3320\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkSecurityGroups/myvm2NSG/defaultSecurityRules/DenyAllOutBound","etag":"W/\"92c28bcd-9fe6-49ca-addc-dff8efed3320\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/debekoe-a4/providers/Microsoft.Network/networkInterfaces/myvm2VMNic"}]}},{"name":"network33168","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkSecurityGroups/network33168","etag":"W/\"fde72802-57c3-43ec-88f4-e668b4496cf5\"","type":"Microsoft.Network/networkSecurityGroups","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"2951d365-082a-447b-ba21-db5f3a0a58a5","securityRules":[{"name":"network33168Rule","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkSecurityGroups/network33168/securityRules/network33168Rule","etag":"W/\"fde72802-57c3-43ec-88f4-e668b4496cf5\"","properties":{"provisioningState":"Succeeded","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":100,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkSecurityGroups/network33168/defaultSecurityRules/AllowVnetInBound","etag":"W/\"fde72802-57c3-43ec-88f4-e668b4496cf5\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkSecurityGroups/network33168/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"fde72802-57c3-43ec-88f4-e668b4496cf5\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkSecurityGroups/network33168/defaultSecurityRules/DenyAllInBound","etag":"W/\"fde72802-57c3-43ec-88f4-e668b4496cf5\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkSecurityGroups/network33168/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"fde72802-57c3-43ec-88f4-e668b4496cf5\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkSecurityGroups/network33168/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"fde72802-57c3-43ec-88f4-e668b4496cf5\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/networkSecurityGroups/network33168/defaultSecurityRules/DenyAllOutBound","etag":"W/\"fde72802-57c3-43ec-88f4-e668b4496cf5\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"subnets":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg33168/providers/Microsoft.Network/virtualNetworks/network33168/subnets/subnet33168"}]}},{"name":"nsg1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-nsg/providers/Microsoft.Network/networkSecurityGroups/nsg1","etag":"W/\"c1d01dd8-7bef-42d5-bb0c-067ca05a2471\"","type":"Microsoft.Network/networkSecurityGroups","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"8dd80586-bfa0-455e-90e1-36036e242d54","securityRules":[{"name":"rule1","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-nsg/providers/Microsoft.Network/networkSecurityGroups/nsg1/securityRules/rule1","etag":"W/\"c1d01dd8-7bef-42d5-bb0c-067ca05a2471\"","properties":{"provisioningState":"Succeeded","protocol":"*","sourcePortRange":"*","destinationPortRange":"80","sourceAddressPrefix":"Internet","destinationAddressPrefix":"*","access":"Allow","priority":100,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-nsg/providers/Microsoft.Network/networkSecurityGroups/nsg1/defaultSecurityRules/AllowVnetInBound","etag":"W/\"c1d01dd8-7bef-42d5-bb0c-067ca05a2471\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-nsg/providers/Microsoft.Network/networkSecurityGroups/nsg1/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"c1d01dd8-7bef-42d5-bb0c-067ca05a2471\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-nsg/providers/Microsoft.Network/networkSecurityGroups/nsg1/defaultSecurityRules/DenyAllInBound","etag":"W/\"c1d01dd8-7bef-42d5-bb0c-067ca05a2471\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-nsg/providers/Microsoft.Network/networkSecurityGroups/nsg1/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"c1d01dd8-7bef-42d5-bb0c-067ca05a2471\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-nsg/providers/Microsoft.Network/networkSecurityGroups/nsg1/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"c1d01dd8-7bef-42d5-bb0c-067ca05a2471\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-nsg/providers/Microsoft.Network/networkSecurityGroups/nsg1/defaultSecurityRules/DenyAllOutBound","etag":"W/\"c1d01dd8-7bef-42d5-bb0c-067ca05a2471\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}]}},{"name":"linvmNSG","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkSecurityGroups/linvmNSG","etag":"W/\"ac6c0776-54c3-4af3-b9ac-fed907777eb7\"","type":"Microsoft.Network/networkSecurityGroups","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"aa8d6fb4-5c38-4629-b770-8a751588b64f","securityRules":[{"name":"default-allow-ssh","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkSecurityGroups/linvmNSG/securityRules/default-allow-ssh","etag":"W/\"ac6c0776-54c3-4af3-b9ac-fed907777eb7\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"22","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkSecurityGroups/linvmNSG/defaultSecurityRules/AllowVnetInBound","etag":"W/\"ac6c0776-54c3-4af3-b9ac-fed907777eb7\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkSecurityGroups/linvmNSG/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"ac6c0776-54c3-4af3-b9ac-fed907777eb7\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkSecurityGroups/linvmNSG/defaultSecurityRules/DenyAllInBound","etag":"W/\"ac6c0776-54c3-4af3-b9ac-fed907777eb7\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkSecurityGroups/linvmNSG/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"ac6c0776-54c3-4af3-b9ac-fed907777eb7\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkSecurityGroups/linvmNSG/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"ac6c0776-54c3-4af3-b9ac-fed907777eb7\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkSecurityGroups/linvmNSG/defaultSecurityRules/DenyAllOutBound","etag":"W/\"ac6c0776-54c3-4af3-b9ac-fed907777eb7\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkInterfaces/linvmVMNic"}]}},{"name":"winvmNSG","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkSecurityGroups/winvmNSG","etag":"W/\"8be28083-ab50-4e09-a57b-4174da778409\"","type":"Microsoft.Network/networkSecurityGroups","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"84c4a4b2-a0f0-45bf-a155-c2c8f920d15f","securityRules":[{"name":"rdp","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkSecurityGroups/winvmNSG/securityRules/rdp","etag":"W/\"8be28083-ab50-4e09-a57b-4174da778409\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"3389","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkSecurityGroups/winvmNSG/defaultSecurityRules/AllowVnetInBound","etag":"W/\"8be28083-ab50-4e09-a57b-4174da778409\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkSecurityGroups/winvmNSG/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"8be28083-ab50-4e09-a57b-4174da778409\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkSecurityGroups/winvmNSG/defaultSecurityRules/DenyAllInBound","etag":"W/\"8be28083-ab50-4e09-a57b-4174da778409\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkSecurityGroups/winvmNSG/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"8be28083-ab50-4e09-a57b-4174da778409\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkSecurityGroups/winvmNSG/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"8be28083-ab50-4e09-a57b-4174da778409\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkSecurityGroups/winvmNSG/defaultSecurityRules/DenyAllOutBound","etag":"W/\"8be28083-ab50-4e09-a57b-4174da778409\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tjp-vhd/providers/Microsoft.Network/networkInterfaces/winvmVMNic"}]}},{"name":"dcos-agent-private-nsg-B90D500F","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/dcos-agent-private-nsg-B90D500F","etag":"W/\"9288b63d-92cf-4bbd-8b16-280f51740360\"","type":"Microsoft.Network/networkSecurityGroups","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"5a539ebe-3607-4762-8d7c-0381c0aa385c","securityRules":[],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/dcos-agent-private-nsg-B90D500F/defaultSecurityRules/AllowVnetInBound","etag":"W/\"9288b63d-92cf-4bbd-8b16-280f51740360\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/dcos-agent-private-nsg-B90D500F/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"9288b63d-92cf-4bbd-8b16-280f51740360\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/dcos-agent-private-nsg-B90D500F/defaultSecurityRules/DenyAllInBound","etag":"W/\"9288b63d-92cf-4bbd-8b16-280f51740360\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/dcos-agent-private-nsg-B90D500F/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"9288b63d-92cf-4bbd-8b16-280f51740360\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/dcos-agent-private-nsg-B90D500F/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"9288b63d-92cf-4bbd-8b16-280f51740360\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/dcos-agent-private-nsg-B90D500F/defaultSecurityRules/DenyAllOutBound","etag":"W/\"9288b63d-92cf-4bbd-8b16-280f51740360\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"subnets":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/virtualNetworks/dcos-vnet-B90D500F/subnets/dcos-agentPrivateSubnet"}]}},{"name":"dcos-agent-public-nsg-B90D500F","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/dcos-agent-public-nsg-B90D500F","etag":"W/\"0a4d74e2-aa8e-4621-bbb9-07c627b37c79\"","type":"Microsoft.Network/networkSecurityGroups","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"ace0d1e8-6b0e-4917-927f-dd6b660e3d99","securityRules":[{"name":"Allow_HTTP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/dcos-agent-public-nsg-B90D500F/securityRules/Allow_HTTP","etag":"W/\"0a4d74e2-aa8e-4621-bbb9-07c627b37c79\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        HTTP traffic from the Internet to Public Agents","protocol":"*","sourcePortRange":"*","destinationPortRange":"80","sourceAddressPrefix":"Internet","destinationAddressPrefix":"*","access":"Allow","priority":200,"direction":"Inbound"}},{"name":"Allow_HTTPS","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/dcos-agent-public-nsg-B90D500F/securityRules/Allow_HTTPS","etag":"W/\"0a4d74e2-aa8e-4621-bbb9-07c627b37c79\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        HTTPS traffic from the Internet to Public Agents","protocol":"*","sourcePortRange":"*","destinationPortRange":"443","sourceAddressPrefix":"Internet","destinationAddressPrefix":"*","access":"Allow","priority":300,"direction":"Inbound"}},{"name":"Allow_8080","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/dcos-agent-public-nsg-B90D500F/securityRules/Allow_8080","etag":"W/\"0a4d74e2-aa8e-4621-bbb9-07c627b37c79\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        8080 traffic from the Internet to Public Agents","protocol":"*","sourcePortRange":"*","destinationPortRange":"8080","sourceAddressPrefix":"Internet","destinationAddressPrefix":"*","access":"Allow","priority":400,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/dcos-agent-public-nsg-B90D500F/defaultSecurityRules/AllowVnetInBound","etag":"W/\"0a4d74e2-aa8e-4621-bbb9-07c627b37c79\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/dcos-agent-public-nsg-B90D500F/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"0a4d74e2-aa8e-4621-bbb9-07c627b37c79\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/dcos-agent-public-nsg-B90D500F/defaultSecurityRules/DenyAllInBound","etag":"W/\"0a4d74e2-aa8e-4621-bbb9-07c627b37c79\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/dcos-agent-public-nsg-B90D500F/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"0a4d74e2-aa8e-4621-bbb9-07c627b37c79\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/dcos-agent-public-nsg-B90D500F/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"0a4d74e2-aa8e-4621-bbb9-07c627b37c79\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/dcos-agent-public-nsg-B90D500F/defaultSecurityRules/DenyAllOutBound","etag":"W/\"0a4d74e2-aa8e-4621-bbb9-07c627b37c79\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"subnets":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/virtualNetworks/dcos-vnet-B90D500F/subnets/dcos-agentPublicSubnet"}]}},{"name":"dcos-master-nsg-B90D500F","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/dcos-master-nsg-B90D500F","etag":"W/\"eb452491-524c-490a-b039-4498713d8662\"","type":"Microsoft.Network/networkSecurityGroups","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"4aee1f3e-6980-45d5-a63b-7af838b2d01e","securityRules":[{"name":"ssh","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/dcos-master-nsg-B90D500F/securityRules/ssh","etag":"W/\"eb452491-524c-490a-b039-4498713d8662\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        SSH","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"22","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":200,"direction":"Inbound"}},{"name":"ssh2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/dcos-master-nsg-B90D500F/securityRules/ssh2","etag":"W/\"eb452491-524c-490a-b039-4498713d8662\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        SSH","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"2222","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":201,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/dcos-master-nsg-B90D500F/defaultSecurityRules/AllowVnetInBound","etag":"W/\"eb452491-524c-490a-b039-4498713d8662\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/dcos-master-nsg-B90D500F/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"eb452491-524c-490a-b039-4498713d8662\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/dcos-master-nsg-B90D500F/defaultSecurityRules/DenyAllInBound","etag":"W/\"eb452491-524c-490a-b039-4498713d8662\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/dcos-master-nsg-B90D500F/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"eb452491-524c-490a-b039-4498713d8662\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/dcos-master-nsg-B90D500F/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"eb452491-524c-490a-b039-4498713d8662\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/dcos-master-nsg-B90D500F/defaultSecurityRules/DenyAllOutBound","etag":"W/\"eb452491-524c-490a-b039-4498713d8662\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/dcos-master-B90D500F-nic-1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/dcos-master-B90D500F-nic-2"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/dcos-master-B90D500F-nic-0"}]}},{"name":"yugangw-1NSG","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-1NSG","etag":"W/\"68379a1b-8f4a-4443-b5ce-687b97ff24f4\"","type":"Microsoft.Network/networkSecurityGroups","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"b745012d-10cf-46a1-a23c-c94c5977bae3","securityRules":[{"name":"default-allow-ssh","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-1NSG/securityRules/default-allow-ssh","etag":"W/\"68379a1b-8f4a-4443-b5ce-687b97ff24f4\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"22","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}},{"name":"open-port-cmd","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-1NSG/securityRules/open-port-cmd","etag":"W/\"68379a1b-8f4a-4443-b5ce-687b97ff24f4\"","properties":{"provisioningState":"Succeeded","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":900,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-1NSG/defaultSecurityRules/AllowVnetInBound","etag":"W/\"68379a1b-8f4a-4443-b5ce-687b97ff24f4\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-1NSG/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"68379a1b-8f4a-4443-b5ce-687b97ff24f4\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-1NSG/defaultSecurityRules/DenyAllInBound","etag":"W/\"68379a1b-8f4a-4443-b5ce-687b97ff24f4\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-1NSG/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"68379a1b-8f4a-4443-b5ce-687b97ff24f4\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-1NSG/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"68379a1b-8f4a-4443-b5ce-687b97ff24f4\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-1NSG/defaultSecurityRules/DenyAllOutBound","etag":"W/\"68379a1b-8f4a-4443-b5ce-687b97ff24f4\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-1VMNic"}]}},{"name":"yugangw-3NSG","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-3NSG","etag":"W/\"cfb66a53-06cc-44b1-a615-50da71f9f03d\"","type":"Microsoft.Network/networkSecurityGroups","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"85a4dffc-7a59-40b1-aaad-e20f16b3ccc5","securityRules":[{"name":"default-allow-ssh","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-3NSG/securityRules/default-allow-ssh","etag":"W/\"cfb66a53-06cc-44b1-a615-50da71f9f03d\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"22","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-3NSG/defaultSecurityRules/AllowVnetInBound","etag":"W/\"cfb66a53-06cc-44b1-a615-50da71f9f03d\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-3NSG/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"cfb66a53-06cc-44b1-a615-50da71f9f03d\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-3NSG/defaultSecurityRules/DenyAllInBound","etag":"W/\"cfb66a53-06cc-44b1-a615-50da71f9f03d\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-3NSG/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"cfb66a53-06cc-44b1-a615-50da71f9f03d\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-3NSG/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"cfb66a53-06cc-44b1-a615-50da71f9f03d\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-3NSG/defaultSecurityRules/DenyAllOutBound","etag":"W/\"cfb66a53-06cc-44b1-a615-50da71f9f03d\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-3VMNic"}]}},{"name":"yugangw-9NSG","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-9NSG","etag":"W/\"9fd0eaad-4534-491a-8d36-bd545d10d31d\"","type":"Microsoft.Network/networkSecurityGroups","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"74d0dfd2-183e-4e15-8f12-d9adcc860cfb","securityRules":[{"name":"default-allow-ssh","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-9NSG/securityRules/default-allow-ssh","etag":"W/\"9fd0eaad-4534-491a-8d36-bd545d10d31d\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"22","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-9NSG/defaultSecurityRules/AllowVnetInBound","etag":"W/\"9fd0eaad-4534-491a-8d36-bd545d10d31d\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-9NSG/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"9fd0eaad-4534-491a-8d36-bd545d10d31d\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-9NSG/defaultSecurityRules/DenyAllInBound","etag":"W/\"9fd0eaad-4534-491a-8d36-bd545d10d31d\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-9NSG/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"9fd0eaad-4534-491a-8d36-bd545d10d31d\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-9NSG/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"9fd0eaad-4534-491a-8d36-bd545d10d31d\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-9NSG/defaultSecurityRules/DenyAllOutBound","etag":"W/\"9fd0eaad-4534-491a-8d36-bd545d10d31d\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-9VMNic"}]}},{"name":"yugangw-fat1NSG","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-fat1NSG","etag":"W/\"24ad74bc-34cd-45c9-9ccf-39a5c368f636\"","type":"Microsoft.Network/networkSecurityGroups","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"d942600b-4f83-4247-b9b7-61143d435dbf","securityRules":[{"name":"default-allow-ssh","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-fat1NSG/securityRules/default-allow-ssh","etag":"W/\"24ad74bc-34cd-45c9-9ccf-39a5c368f636\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"22","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-fat1NSG/defaultSecurityRules/AllowVnetInBound","etag":"W/\"24ad74bc-34cd-45c9-9ccf-39a5c368f636\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-fat1NSG/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"24ad74bc-34cd-45c9-9ccf-39a5c368f636\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-fat1NSG/defaultSecurityRules/DenyAllInBound","etag":"W/\"24ad74bc-34cd-45c9-9ccf-39a5c368f636\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-fat1NSG/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"24ad74bc-34cd-45c9-9ccf-39a5c368f636\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-fat1NSG/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"24ad74bc-34cd-45c9-9ccf-39a5c368f636\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-fat1NSG/defaultSecurityRules/DenyAllOutBound","etag":"W/\"24ad74bc-34cd-45c9-9ccf-39a5c368f636\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-fat1VMNic"}]}},{"name":"yugangw-j1NSG","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-j1NSG","etag":"W/\"ed3fbe3e-1542-48b6-bc8e-bae050d2e9d9\"","type":"Microsoft.Network/networkSecurityGroups","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"fcbeb1e6-380d-47c4-836f-85b84d1500f4","securityRules":[{"name":"default-allow-ssh","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-j1NSG/securityRules/default-allow-ssh","etag":"W/\"ed3fbe3e-1542-48b6-bc8e-bae050d2e9d9\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"22","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-j1NSG/defaultSecurityRules/AllowVnetInBound","etag":"W/\"ed3fbe3e-1542-48b6-bc8e-bae050d2e9d9\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-j1NSG/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"ed3fbe3e-1542-48b6-bc8e-bae050d2e9d9\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-j1NSG/defaultSecurityRules/DenyAllInBound","etag":"W/\"ed3fbe3e-1542-48b6-bc8e-bae050d2e9d9\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-j1NSG/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"ed3fbe3e-1542-48b6-bc8e-bae050d2e9d9\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-j1NSG/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"ed3fbe3e-1542-48b6-bc8e-bae050d2e9d9\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-j1NSG/defaultSecurityRules/DenyAllOutBound","etag":"W/\"ed3fbe3e-1542-48b6-bc8e-bae050d2e9d9\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-j1VMNic"}]}},{"name":"yugangw-junkvmNSG","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-junkvmNSG","etag":"W/\"2294e2b5-33c5-4a49-9f03-f8fa383111a2\"","type":"Microsoft.Network/networkSecurityGroups","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"4d62f63c-2373-4b2a-96cb-6b7c2100b3d3","securityRules":[{"name":"default-allow-ssh","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-junkvmNSG/securityRules/default-allow-ssh","etag":"W/\"2294e2b5-33c5-4a49-9f03-f8fa383111a2\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"22","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-junkvmNSG/defaultSecurityRules/AllowVnetInBound","etag":"W/\"2294e2b5-33c5-4a49-9f03-f8fa383111a2\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-junkvmNSG/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"2294e2b5-33c5-4a49-9f03-f8fa383111a2\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-junkvmNSG/defaultSecurityRules/DenyAllInBound","etag":"W/\"2294e2b5-33c5-4a49-9f03-f8fa383111a2\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-junkvmNSG/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"2294e2b5-33c5-4a49-9f03-f8fa383111a2\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-junkvmNSG/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"2294e2b5-33c5-4a49-9f03-f8fa383111a2\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-junkvmNSG/defaultSecurityRules/DenyAllOutBound","etag":"W/\"2294e2b5-33c5-4a49-9f03-f8fa383111a2\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-junkvmVMNic"}]}},{"name":"yugangw-k1NSG","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-k1NSG","etag":"W/\"e03ae39f-303b-46bd-984f-ffd4b43c6280\"","type":"Microsoft.Network/networkSecurityGroups","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"81e6ebbc-74ad-4c9f-a3a8-1e86acc3e131","securityRules":[{"name":"default-allow-ssh","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-k1NSG/securityRules/default-allow-ssh","etag":"W/\"e03ae39f-303b-46bd-984f-ffd4b43c6280\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"22","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-k1NSG/defaultSecurityRules/AllowVnetInBound","etag":"W/\"e03ae39f-303b-46bd-984f-ffd4b43c6280\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-k1NSG/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"e03ae39f-303b-46bd-984f-ffd4b43c6280\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-k1NSG/defaultSecurityRules/DenyAllInBound","etag":"W/\"e03ae39f-303b-46bd-984f-ffd4b43c6280\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-k1NSG/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"e03ae39f-303b-46bd-984f-ffd4b43c6280\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-k1NSG/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"e03ae39f-303b-46bd-984f-ffd4b43c6280\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-k1NSG/defaultSecurityRules/DenyAllOutBound","etag":"W/\"e03ae39f-303b-46bd-984f-ffd4b43c6280\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-k1VMNic"}]}},{"name":"yugangw-kernelNSG","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-kernelNSG","etag":"W/\"fbb754ed-5d0c-42aa-b0ce-da522a46bebb\"","type":"Microsoft.Network/networkSecurityGroups","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"6571ef3e-e6e7-4975-99ce-e5b334cd79bf","securityRules":[{"name":"default-allow-ssh","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-kernelNSG/securityRules/default-allow-ssh","etag":"W/\"fbb754ed-5d0c-42aa-b0ce-da522a46bebb\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"22","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-kernelNSG/defaultSecurityRules/AllowVnetInBound","etag":"W/\"fbb754ed-5d0c-42aa-b0ce-da522a46bebb\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-kernelNSG/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"fbb754ed-5d0c-42aa-b0ce-da522a46bebb\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-kernelNSG/defaultSecurityRules/DenyAllInBound","etag":"W/\"fbb754ed-5d0c-42aa-b0ce-da522a46bebb\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-kernelNSG/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"fbb754ed-5d0c-42aa-b0ce-da522a46bebb\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-kernelNSG/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"fbb754ed-5d0c-42aa-b0ce-da522a46bebb\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-kernelNSG/defaultSecurityRules/DenyAllOutBound","etag":"W/\"fbb754ed-5d0c-42aa-b0ce-da522a46bebb\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-kernelVMNic"}]}},{"name":"yugangw-md2NSG","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-md2NSG","etag":"W/\"4cce29cf-b595-469c-bfea-c2a4547c6b4b\"","type":"Microsoft.Network/networkSecurityGroups","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"46df2e8a-53f9-4cc8-9f45-40e7a3711ba1","securityRules":[{"name":"default-allow-ssh","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-md2NSG/securityRules/default-allow-ssh","etag":"W/\"4cce29cf-b595-469c-bfea-c2a4547c6b4b\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"22","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-md2NSG/defaultSecurityRules/AllowVnetInBound","etag":"W/\"4cce29cf-b595-469c-bfea-c2a4547c6b4b\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-md2NSG/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"4cce29cf-b595-469c-bfea-c2a4547c6b4b\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-md2NSG/defaultSecurityRules/DenyAllInBound","etag":"W/\"4cce29cf-b595-469c-bfea-c2a4547c6b4b\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-md2NSG/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"4cce29cf-b595-469c-bfea-c2a4547c6b4b\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-md2NSG/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"4cce29cf-b595-469c-bfea-c2a4547c6b4b\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-md2NSG/defaultSecurityRules/DenyAllOutBound","etag":"W/\"4cce29cf-b595-469c-bfea-c2a4547c6b4b\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-md2VMNic"}]}},{"name":"yugangw-md3NSG","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-md3NSG","etag":"W/\"26155652-b2d2-4239-a36c-3054f28a2a80\"","type":"Microsoft.Network/networkSecurityGroups","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"930ebb93-6ae0-43da-91e7-ed4b6b7a9804","securityRules":[{"name":"default-allow-ssh","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-md3NSG/securityRules/default-allow-ssh","etag":"W/\"26155652-b2d2-4239-a36c-3054f28a2a80\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"22","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-md3NSG/defaultSecurityRules/AllowVnetInBound","etag":"W/\"26155652-b2d2-4239-a36c-3054f28a2a80\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-md3NSG/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"26155652-b2d2-4239-a36c-3054f28a2a80\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-md3NSG/defaultSecurityRules/DenyAllInBound","etag":"W/\"26155652-b2d2-4239-a36c-3054f28a2a80\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-md3NSG/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"26155652-b2d2-4239-a36c-3054f28a2a80\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-md3NSG/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"26155652-b2d2-4239-a36c-3054f28a2a80\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-md3NSG/defaultSecurityRules/DenyAllOutBound","etag":"W/\"26155652-b2d2-4239-a36c-3054f28a2a80\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-md3VMNic"}]}},{"name":"yugangw-mdmdNSG","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-mdmdNSG","etag":"W/\"44d4487f-bdbd-4e58-9e79-7e4736f3366c\"","type":"Microsoft.Network/networkSecurityGroups","location":"westus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"5dc3678d-ac32-4622-8e65-18885aee57bb","securityRules":[{"name":"default-allow-ssh","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-mdmdNSG/securityRules/default-allow-ssh","etag":"W/\"44d4487f-bdbd-4e58-9e79-7e4736f3366c\"","properties":{"provisioningState":"Succeeded","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"22","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-mdmdNSG/defaultSecurityRules/AllowVnetInBound","etag":"W/\"44d4487f-bdbd-4e58-9e79-7e4736f3366c\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-mdmdNSG/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"44d4487f-bdbd-4e58-9e79-7e4736f3366c\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-mdmdNSG/defaultSecurityRules/DenyAllInBound","etag":"W/\"44d4487f-bdbd-4e58-9e79-7e4736f3366c\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-mdmdNSG/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"44d4487f-bdbd-4e58-9e79-7e4736f3366c\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-mdmdNSG/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"44d4487f-bdbd-4e58-9e79-7e4736f3366c\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-mdmdNSG/defaultSecurityRules/DenyAllOutBound","etag":"W/\"44d4487f-bdbd-4e58-9e79-7e4736f3366c\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-mdmdVMNic"}]}},{"name":"yugangw-portal-nsg","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-portal-nsg","etag":"W/\"7caf1e6a-a11f-4bbd-a53e-24bd63cae044\"","type":"Microsoft.Network/networkSecurityGroups","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"34a9a4b4-0580-4086-8480-9fc34f6fa71b","securityRules":[{"name":"default-allow-ssh","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-portal-nsg/securityRules/default-allow-ssh","etag":"W/\"7caf1e6a-a11f-4bbd-a53e-24bd63cae044\"","properties":{"provisioningState":"Succeeded","protocol":"TCP","sourcePortRange":"*","destinationPortRange":"22","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-portal-nsg/defaultSecurityRules/AllowVnetInBound","etag":"W/\"7caf1e6a-a11f-4bbd-a53e-24bd63cae044\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-portal-nsg/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"7caf1e6a-a11f-4bbd-a53e-24bd63cae044\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-portal-nsg/defaultSecurityRules/DenyAllInBound","etag":"W/\"7caf1e6a-a11f-4bbd-a53e-24bd63cae044\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-portal-nsg/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"7caf1e6a-a11f-4bbd-a53e-24bd63cae044\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-portal-nsg/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"7caf1e6a-a11f-4bbd-a53e-24bd63cae044\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkSecurityGroups/yugangw-portal-nsg/defaultSecurityRules/DenyAllOutBound","etag":"W/\"7caf1e6a-a11f-4bbd-a53e-24bd63cae044\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/yugangw/providers/Microsoft.Network/networkInterfaces/yugangw-portal857"}]}},{"name":"bensg9b0865279be7b","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/networkSecurityGroups/bensg9b0865279be7b","etag":"W/\"e5951041-900c-41b5-8228-4a62b4fb1103\"","type":"Microsoft.Network/networkSecurityGroups","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"a4da8273-fe06-4541-8e07-2c12dd65c892","securityRules":[{"name":"ALLOW-SQL","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/networkSecurityGroups/bensg9b0865279be7b/securityRules/ALLOW-SQL","etag":"W/\"e5951041-900c-41b5-8228-4a62b4fb1103\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        SQL","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"1433","sourceAddressPrefix":"172.16.1.0/24","destinationAddressPrefix":"*","access":"Allow","priority":100,"direction":"Inbound"}},{"name":"DENY-WEB","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/networkSecurityGroups/bensg9b0865279be7b/securityRules/DENY-WEB","etag":"W/\"e5951041-900c-41b5-8228-4a62b4fb1103\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        Web","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":200,"direction":"Outbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/networkSecurityGroups/bensg9b0865279be7b/defaultSecurityRules/AllowVnetInBound","etag":"W/\"e5951041-900c-41b5-8228-4a62b4fb1103\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/networkSecurityGroups/bensg9b0865279be7b/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"e5951041-900c-41b5-8228-4a62b4fb1103\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/networkSecurityGroups/bensg9b0865279be7b/defaultSecurityRules/DenyAllInBound","etag":"W/\"e5951041-900c-41b5-8228-4a62b4fb1103\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/networkSecurityGroups/bensg9b0865279be7b/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"e5951041-900c-41b5-8228-4a62b4fb1103\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/networkSecurityGroups/bensg9b0865279be7b/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"e5951041-900c-41b5-8228-4a62b4fb1103\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/networkSecurityGroups/bensg9b0865279be7b/defaultSecurityRules/DenyAllOutBound","etag":"W/\"e5951041-900c-41b5-8228-4a62b4fb1103\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}]}},{"name":"fensg3fa8652774b03","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/networkSecurityGroups/fensg3fa8652774b03","etag":"W/\"7fb6aa84-77ca-4a85-b0f1-54715ee472ee\"","type":"Microsoft.Network/networkSecurityGroups","location":"eastus","tags":{},"properties":{"provisioningState":"Succeeded","resourceGuid":"bd209213-2ba7-44a0-9ccf-3b2e10136d60","securityRules":[{"name":"ALLOW-HTTP","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/networkSecurityGroups/fensg3fa8652774b03/securityRules/ALLOW-HTTP","etag":"W/\"7fb6aa84-77ca-4a85-b0f1-54715ee472ee\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        HTTP","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"80","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":101,"direction":"Inbound"}},{"name":"ALLOW-SSH","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/networkSecurityGroups/fensg3fa8652774b03/securityRules/ALLOW-SSH","etag":"W/\"7fb6aa84-77ca-4a85-b0f1-54715ee472ee\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        SSH","protocol":"Tcp","sourcePortRange":"*","destinationPortRange":"22","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":100,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/networkSecurityGroups/fensg3fa8652774b03/defaultSecurityRules/AllowVnetInBound","etag":"W/\"7fb6aa84-77ca-4a85-b0f1-54715ee472ee\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/networkSecurityGroups/fensg3fa8652774b03/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"7fb6aa84-77ca-4a85-b0f1-54715ee472ee\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/networkSecurityGroups/fensg3fa8652774b03/defaultSecurityRules/DenyAllInBound","etag":"W/\"7fb6aa84-77ca-4a85-b0f1-54715ee472ee\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/networkSecurityGroups/fensg3fa8652774b03/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"7fb6aa84-77ca-4a85-b0f1-54715ee472ee\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/networkSecurityGroups/fensg3fa8652774b03/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"7fb6aa84-77ca-4a85-b0f1-54715ee472ee\"","properties":{"provisioningState":"Succeeded","description":"Allow
+        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/networkSecurityGroups/fensg3fa8652774b03/defaultSecurityRules/DenyAllOutBound","etag":"W/\"7fb6aa84-77ca-4a85-b0f1-54715ee472ee\"","properties":{"provisioningState":"Succeeded","description":"Deny
+        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}],"networkInterfaces":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rgnems73d86527ff0c2/providers/Microsoft.Network/networkInterfaces/nic142986528ce1315"}]}}]}'}
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:14:42 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 31 Jan 2017 18:31:48 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['115058']
+      x-ms-original-request-ids: [5e234307-ad61-4423-91c9-031f670ab735, 2b419397-3166-44bc-b09d-e0f42376761d]
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -379,44 +374,104 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a4e5cda6-7611-11e6-ae75-a0999b14fe87]
+      x-ms-client-request-id: [877606e4-e7e3-11e6-a168-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_nsg_test1/providers/Microsoft.Network/networkSecurityGroups?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups?api-version=2016-09-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UeXWbnOP3qUfg9/pSl/iOejZbbA5x+1edNuL5uL3Y9G9rtihm/uNutJM62LVVtUy+buzmT3/NP9
-        B7vbu5Pzne392SzbzvLpve3p5OHeg73znYf3H+7crfOmWtfT/PO6Wq+au9Oy+P0J9u+PTnbvrurq
-        spjldXP3i2JaV0113o5f5O1VVb+9u5Sfr/Ppui7aa30f73WRy9vsAuh99+7v+9Gn2cPz/b3d6faD
-        PJts7+ef3t+ezPIH2/u7D+/v7R3sElLT3/cj7+X2esWjviUC3ptlNc1ACLx9RWit/S8JpYa++MW/
-        xH1Eg13ldVvk/IX5WL64LBqCVCwvXrdZy/i8Xk+neT7LZw4oNbXUXMuM7OcPdh7O9j7dPt/JMQX3
-        p9sHk/3p9vR8/362u78zfTDdCwA0OppX65LxUC6Qx0MKj+WIq3ziA8Hz/0KOuBuM7W4M6Q/hFHkw
-        WdFZlAdf33Iu5cELbTWtSrT7VuR7odXLqm5fZcsLBhdrNiMqFEvmx6DtPj2R5gL1eDajyWhe1vl5
-        8Q6tHxw8jDT2YPfe2N27F4Of0YAbUOij47KsriItVnVRYbKoze7Ozk6/wayo8yn6pBYfnS0n1Xo5
-        +yhs9Uv8P70/vu9BI+zPs3XZGq5h5iCQt2J8Rv4nie/Olk+4fw8wnv83SkFsvHdvHMj/CyWD2M7Q
-        FE15CGkhjJC2dXZ+XkzT87papFlZpj/5RUNfpj/54vRNBBZ1/rMpZbG2ArInMD9Z1O06K3U2I+95
-        fbz/y+8ld5/e/2YELwDRmfhQlI5/sK7z51U2e5KV2XKa10Ps+P8pubr1qP6/LWQYZVrSMNOJjjMC
-        jxD4f4mg9WYl8qrXTe/9WFfvLV67/RY/O+L1NF9eE05DnPf/FXm6YRj/7xcgDIDtUSEza2Qo8iZ1
-        9f8SUYk19cDeqr0TDZAg0iCQDBKNfoufHckgdhLX58t1G+eq/68Ix80j+X+/fPAY0mrd8uwa6VAL
-        Q2IDN66t7K8/8uicXDHpIi0CwbrZoyPmYdp/Q5J1tmzzehNP/n9Kum4czf9vJMyMNAKQMPh/iWjF
-        mnpge+03DOq95egm141YhCn84XIEg0lIEcA4z/1/RYJuGsf/+2UHI2Ah6YpP5FXq6/+jUhJr78QD
-        NIg0CKSDxKPf4v2lw/3xffOrfsY/6MNf8v8AQkuCcbQYAAA=
+    body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"test-nsg1\"\
+        ,\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1\"\
+        ,\r\n      \"etag\": \"W/\\\"708ac300-50d6-494f-a992-9e45b0717074\\\"\",\r\
+        \n      \"type\": \"Microsoft.Network/networkSecurityGroups\",\r\n      \"\
+        location\": \"westus\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\
+        \n        \"provisioningState\": \"Succeeded\",\r\n        \"resourceGuid\"\
+        : \"476b2c36-88e8-474b-9594-5f7c304d638c\",\r\n        \"securityRules\":\
+        \ [\r\n          {\r\n            \"name\": \"web\",\r\n            \"id\"\
+        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web\"\
+        ,\r\n            \"etag\": \"W/\\\"708ac300-50d6-494f-a992-9e45b0717074\\\"\
+        \",\r\n            \"properties\": {\r\n              \"provisioningState\"\
+        : \"Succeeded\",\r\n              \"protocol\": \"*\",\r\n              \"\
+        sourcePortRange\": \"*\",\r\n              \"destinationPortRange\": \"4444\"\
+        ,\r\n              \"sourceAddressPrefix\": \"789\",\r\n              \"destinationAddressPrefix\"\
+        : \"1234\",\r\n              \"access\": \"Allow\",\r\n              \"priority\"\
+        : 1000,\r\n              \"direction\": \"Inbound\"\r\n            }\r\n \
+        \         }\r\n        ],\r\n        \"defaultSecurityRules\": [\r\n     \
+        \     {\r\n            \"name\": \"AllowVnetInBound\",\r\n            \"id\"\
+        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/defaultSecurityRules/AllowVnetInBound\"\
+        ,\r\n            \"etag\": \"W/\\\"708ac300-50d6-494f-a992-9e45b0717074\\\"\
+        \",\r\n            \"properties\": {\r\n              \"provisioningState\"\
+        : \"Succeeded\",\r\n              \"description\": \"Allow inbound traffic\
+        \ from all VMs in VNET\",\r\n              \"protocol\": \"*\",\r\n      \
+        \        \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\"\
+        : \"*\",\r\n              \"sourceAddressPrefix\": \"VirtualNetwork\",\r\n\
+        \              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n     \
+        \         \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n\
+        \              \"direction\": \"Inbound\"\r\n            }\r\n          },\r\
+        \n          {\r\n            \"name\": \"AllowAzureLoadBalancerInBound\",\r\
+        \n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/defaultSecurityRules/AllowAzureLoadBalancerInBound\"\
+        ,\r\n            \"etag\": \"W/\\\"708ac300-50d6-494f-a992-9e45b0717074\\\"\
+        \",\r\n            \"properties\": {\r\n              \"provisioningState\"\
+        : \"Succeeded\",\r\n              \"description\": \"Allow inbound traffic\
+        \ from azure load balancer\",\r\n              \"protocol\": \"*\",\r\n  \
+        \            \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\"\
+        : \"*\",\r\n              \"sourceAddressPrefix\": \"AzureLoadBalancer\",\r\
+        \n              \"destinationAddressPrefix\": \"*\",\r\n              \"access\"\
+        : \"Allow\",\r\n              \"priority\": 65001,\r\n              \"direction\"\
+        : \"Inbound\"\r\n            }\r\n          },\r\n          {\r\n        \
+        \    \"name\": \"DenyAllInBound\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/defaultSecurityRules/DenyAllInBound\"\
+        ,\r\n            \"etag\": \"W/\\\"708ac300-50d6-494f-a992-9e45b0717074\\\"\
+        \",\r\n            \"properties\": {\r\n              \"provisioningState\"\
+        : \"Succeeded\",\r\n              \"description\": \"Deny all inbound traffic\"\
+        ,\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\"\
+        : \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n           \
+        \   \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\"\
+        : \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\"\
+        : 65500,\r\n              \"direction\": \"Inbound\"\r\n            }\r\n\
+        \          },\r\n          {\r\n            \"name\": \"AllowVnetOutBound\"\
+        ,\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/defaultSecurityRules/AllowVnetOutBound\"\
+        ,\r\n            \"etag\": \"W/\\\"708ac300-50d6-494f-a992-9e45b0717074\\\"\
+        \",\r\n            \"properties\": {\r\n              \"provisioningState\"\
+        : \"Succeeded\",\r\n              \"description\": \"Allow outbound traffic\
+        \ from all VMs to all VMs in VNET\",\r\n              \"protocol\": \"*\"\
+        ,\r\n              \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\"\
+        : \"*\",\r\n              \"sourceAddressPrefix\": \"VirtualNetwork\",\r\n\
+        \              \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n     \
+        \         \"access\": \"Allow\",\r\n              \"priority\": 65000,\r\n\
+        \              \"direction\": \"Outbound\"\r\n            }\r\n          },\r\
+        \n          {\r\n            \"name\": \"AllowInternetOutBound\",\r\n    \
+        \        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/defaultSecurityRules/AllowInternetOutBound\"\
+        ,\r\n            \"etag\": \"W/\\\"708ac300-50d6-494f-a992-9e45b0717074\\\"\
+        \",\r\n            \"properties\": {\r\n              \"provisioningState\"\
+        : \"Succeeded\",\r\n              \"description\": \"Allow outbound traffic\
+        \ from all VMs to Internet\",\r\n              \"protocol\": \"*\",\r\n  \
+        \            \"sourcePortRange\": \"*\",\r\n              \"destinationPortRange\"\
+        : \"*\",\r\n              \"sourceAddressPrefix\": \"*\",\r\n            \
+        \  \"destinationAddressPrefix\": \"Internet\",\r\n              \"access\"\
+        : \"Allow\",\r\n              \"priority\": 65001,\r\n              \"direction\"\
+        : \"Outbound\"\r\n            }\r\n          },\r\n          {\r\n       \
+        \     \"name\": \"DenyAllOutBound\",\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/defaultSecurityRules/DenyAllOutBound\"\
+        ,\r\n            \"etag\": \"W/\\\"708ac300-50d6-494f-a992-9e45b0717074\\\"\
+        \",\r\n            \"properties\": {\r\n              \"provisioningState\"\
+        : \"Succeeded\",\r\n              \"description\": \"Deny all outbound traffic\"\
+        ,\r\n              \"protocol\": \"*\",\r\n              \"sourcePortRange\"\
+        : \"*\",\r\n              \"destinationPortRange\": \"*\",\r\n           \
+        \   \"sourceAddressPrefix\": \"*\",\r\n              \"destinationAddressPrefix\"\
+        : \"*\",\r\n              \"access\": \"Deny\",\r\n              \"priority\"\
+        : 65500,\r\n              \"direction\": \"Outbound\"\r\n            }\r\n\
+        \          }\r\n        ]\r\n      }\r\n    }\r\n  ]\r\n}"}
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:14:42 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 31 Jan 2017 18:31:49 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['6364']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -425,45 +480,95 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a51cf2ae-7611-11e6-a2b3-a0999b14fe87]
+      x-ms-client-request-id: [8805a870-e7e3-11e6-a66d-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_nsg_test1/providers/Microsoft.Network/networkSecurityGroups/test-nsg1?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1?api-version=2016-09-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj9qM2bdnvZXOx+NOLPixk+vdusJ820LlZtUS2buzuT3fNP9x/sbu9Ozne292ezbDvL
-        p/e2p5OHew/2znce3n+4c7fOm2pdT/PP62q9au5Oy+L3J7i/PzrYvbuqq8tiltfN3S+KaV011Xk7
-        fpG3V1X99u5Sfr7Op+u6aK/1fbznI5a32QVQ++7d3/ejT7OH5/t7u9PtB3k22d7PP72/PZnlD7b3
-        dx/e39s72CWEpr/vR/pie73ikd6yY32rrKYZBo83rwiVtfmC0Gjow1/8S+RPGtgqr9si5w/xkXx4
-        WTT0drG8eN1mLff/ej2d5vksnwkgamYpthaq7+cPdh7O9j7dPt/JQeb70+2Dyf50e3q+fz/b3d+Z
-        Ppju2ZcbxfrVuuS+vyefpwYJPHaWr/KJeRHP/wtn+W4wnrtdhL/u7MuDCenNkjz46hZzJQ8at9W0
-        KtHmW53vhC4vq7p9lS0vGEy3yYxGWyyZr4J2+/R0mgq049mMCN68rPPz4h1aPjh42Gnowey13t27
-        14Wb0cAaUOGj47KsrjrfruqiwiTQ97s7Ozvhl7Oizqfoh7796Gw5qdbL2UeuxS8xv+ov39e3CcPz
-        bF22ZuZ5ggnERoZl5H6SeOZs+YT7UWB4/t/IvbEx3t04iP+XcDSxj6EhmjHKaSGTm7Z1dn5eTNPz
-        ulqkWVmmP/lFQ1+mP/ni9E0HDnX6syEZ3XYCqsfoP1nU7TordbY673iw3+/FW8vKp/e/vrDY17xJ
-        DMXg+AfrOn9eZbMnWZktp3kdY6f/T8nErUb0/z0BwajSkoaVTnRcHVjU8c+hkPSo3nnNA997t9vF
-        e4nGbvjtNyMaT/PlNfUd45z/r8jChiH8v5P5gTDbgUJmzfB/5y3q4ueQzbvNPHA3tnVsjaF2vgy4
-        mtg6/Pab4WpiB3EZvly3fa74/wpjbx7F/zt5m3FOq3XLM2c4WzU7sTxcn7ayv/7IC+KHRuwJxWYv
-        iJiBafs1peJs2eb1EE/9f0oyNo7k/9PSYUbWAUY9/xyKRbeZB67XdmAA7yUDm9wdmnKm4PvLAAwS
-        dU4A+jzz/xXu3zSG/3fyPTBmBu+yfuc16uP/IxzebetYG2PtfBlwNrF2+O3tOVt++T5+0O+/5P8B
-        +ypgU4MWAAA=
+    body: {string: "{\r\n  \"name\": \"test-nsg1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1\"\
+        ,\r\n  \"etag\": \"W/\\\"708ac300-50d6-494f-a992-9e45b0717074\\\"\",\r\n \
+        \ \"type\": \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\"\
+        : \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\"\
+        : \"Succeeded\",\r\n    \"resourceGuid\": \"476b2c36-88e8-474b-9594-5f7c304d638c\"\
+        ,\r\n    \"securityRules\": [\r\n      {\r\n        \"name\": \"web\",\r\n\
+        \        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web\"\
+        ,\r\n        \"etag\": \"W/\\\"708ac300-50d6-494f-a992-9e45b0717074\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\"\
+        ,\r\n          \"destinationPortRange\": \"4444\",\r\n          \"sourceAddressPrefix\"\
+        : \"789\",\r\n          \"destinationAddressPrefix\": \"1234\",\r\n      \
+        \    \"access\": \"Allow\",\r\n          \"priority\": 1000,\r\n         \
+        \ \"direction\": \"Inbound\"\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\"\
+        : [\r\n      {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\"\
+        : \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/defaultSecurityRules/AllowVnetInBound\"\
+        ,\r\n        \"etag\": \"W/\\\"708ac300-50d6-494f-a992-9e45b0717074\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"description\": \"Allow inbound traffic from all VMs in VNET\"\
+        ,\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\"\
+        ,\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\"\
+        : \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\"\
+        ,\r\n          \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n\
+        \          \"direction\": \"Inbound\"\r\n        }\r\n      },\r\n      {\r\
+        \n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n        \"id\":\
+        \ \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/defaultSecurityRules/AllowAzureLoadBalancerInBound\"\
+        ,\r\n        \"etag\": \"W/\\\"708ac300-50d6-494f-a992-9e45b0717074\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"description\": \"Allow inbound traffic from azure load balancer\"\
+        ,\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\"\
+        ,\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\"\
+        : \"AzureLoadBalancer\",\r\n          \"destinationAddressPrefix\": \"*\"\
+        ,\r\n          \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n\
+        \          \"direction\": \"Inbound\"\r\n        }\r\n      },\r\n      {\r\
+        \n        \"name\": \"DenyAllInBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/defaultSecurityRules/DenyAllInBound\"\
+        ,\r\n        \"etag\": \"W/\\\"708ac300-50d6-494f-a992-9e45b0717074\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"description\": \"Deny all inbound traffic\",\r\n        \
+        \  \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n     \
+        \     \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\"\
+        : \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"\
+        access\": \"Deny\",\r\n          \"priority\": 65500,\r\n          \"direction\"\
+        : \"Inbound\"\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"\
+        AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/defaultSecurityRules/AllowVnetOutBound\"\
+        ,\r\n        \"etag\": \"W/\\\"708ac300-50d6-494f-a992-9e45b0717074\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"description\": \"Allow outbound traffic from all VMs to all\
+        \ VMs in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\"\
+        : \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\"\
+        : \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\"\
+        ,\r\n          \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n\
+        \          \"direction\": \"Outbound\"\r\n        }\r\n      },\r\n      {\r\
+        \n        \"name\": \"AllowInternetOutBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/defaultSecurityRules/AllowInternetOutBound\"\
+        ,\r\n        \"etag\": \"W/\\\"708ac300-50d6-494f-a992-9e45b0717074\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"description\": \"Allow outbound traffic from all VMs to Internet\"\
+        ,\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\"\
+        ,\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\"\
+        : \"*\",\r\n          \"destinationAddressPrefix\": \"Internet\",\r\n    \
+        \      \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n      \
+        \    \"direction\": \"Outbound\"\r\n        }\r\n      },\r\n      {\r\n \
+        \       \"name\": \"DenyAllOutBound\",\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/defaultSecurityRules/DenyAllOutBound\"\
+        ,\r\n        \"etag\": \"W/\\\"708ac300-50d6-494f-a992-9e45b0717074\\\"\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"description\": \"Deny all outbound traffic\",\r\n       \
+        \   \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n    \
+        \      \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\"\
+        : \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"\
+        access\": \"Deny\",\r\n          \"priority\": 65500,\r\n          \"direction\"\
+        : \"Outbound\"\r\n        }\r\n      }\r\n    ]\r\n  }\r\n}"}
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:14:43 GMT']
-      etag: [W/"6a9f421c-7eab-4e65-bde7-41952281095c"]
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 31 Jan 2017 18:31:50 GMT']
+      ETag: [W/"708ac300-50d6-494f-a992-9e45b0717074"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['5803']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -472,35 +577,33 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a54fa597-7611-11e6-824f-a0999b14fe87]
+      x-ms-client-request-id: [889d7c9c-e7e3-11e6-b930-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_nsg_test1/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules?api-version=2016-09-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UeXWbnOP3qUfg9/pSl/iOejZbbA5x9d5ZOPRvbTYobP7jbrSTOti1VbVMvm7s5k9/zT/Qe727uT
-        853t/dks287y6b3t6eTh3oO9852H9x/u3K3zplrX0/zzulqvmrvTsvj9l83F79/mTbt7d1VXl8Us
-        r5u7XxTTumqq83b8Im+vqvrt3aX8fJ1P13XRXuv7eG+bAOzebfSLV+syb+6G6OZtdgGEv3v39/3o
-        0+zh+f7e7nT7QZ5NtvfzT+9vT2b5g+393Yf39/YOdgnN6e/7kfcyIbXK67bIGwJhCSNfXBYNDb1Y
-        Xrxus5bp9Ho9neb5LJ85CNK0raZViRbfCr4Rarys6vZVtrxgEGGDGY2wWGYgcdBqn56goUA6ns2I
-        xM3LOj8v3qHdg4OHQTMPXq/t7t69EGZGg2kw7o+Oy7K6Cr5b1UUFgtO3uzs7O/5Xs6LOp+iBvvvo
-        bDmp1svZR+b7XyK/8I/v/8bJL/l/AFatTl+BAgAA
+    body: {string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"web\",\r\n \
+        \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web\"\
+        ,\r\n      \"etag\": \"W/\\\"708ac300-50d6-494f-a992-9e45b0717074\\\"\",\r\
+        \n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\
+        ,\r\n        \"protocol\": \"*\",\r\n        \"sourcePortRange\": \"*\",\r\
+        \n        \"destinationPortRange\": \"4444\",\r\n        \"sourceAddressPrefix\"\
+        : \"789\",\r\n        \"destinationAddressPrefix\": \"1234\",\r\n        \"\
+        access\": \"Allow\",\r\n        \"priority\": 1000,\r\n        \"direction\"\
+        : \"Inbound\"\r\n      }\r\n    }\r\n  ]\r\n}"}
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:14:43 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 31 Jan 2017 18:31:51 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['646']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -509,36 +612,32 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a587c64a-7611-11e6-9a1c-a0999b14fe87]
+      x-ms-client-request-id: [892eba24-e7e3-11e6-9ed8-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_nsg_test1/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web?api-version=2016-09-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj96CqffDTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWruTsvi9182F79/mzft7t1VXV0Ws7xu7n5RTOuqqc7b8Yu8
-        varqt3eX8vN1Pl3XRXut7+O9bQKwe7fRL16ty7y561DN2+wCyH737u/70afZw/P9vd3p9oM8m2zv
-        55/e357M8gfb+7sP7+/tHewSitPf9yN9kZBZ5XVb5A29zoSQDy+LhoZbLC9et1nLdHm9nk7zfJbP
-        5E1p1lbTqsS337KfyshfVnX7Klte8KvuyxmNpFhmIGXQYp8e20ggHM9mRMbmZZ2fF+/Q5sHBQ9vE
-        g9Nrt7t3z8HKCOkGY/vouCyrK/v5qi4qEJK+2d3Z2TEfz4o6nwIqff7R2XJSrZezj/DdL/mNk1/y
-        /wAZXtYvKAIAAA==
+    body: {string: "{\r\n  \"name\": \"web\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web\"\
+        ,\r\n  \"etag\": \"W/\\\"708ac300-50d6-494f-a992-9e45b0717074\\\"\",\r\n \
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
+        protocol\": \"*\",\r\n    \"sourcePortRange\": \"*\",\r\n    \"destinationPortRange\"\
+        : \"4444\",\r\n    \"sourceAddressPrefix\": \"789\",\r\n    \"destinationAddressPrefix\"\
+        : \"1234\",\r\n    \"access\": \"Allow\",\r\n    \"priority\": 1000,\r\n \
+        \   \"direction\": \"Inbound\"\r\n  }\r\n}"}
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:14:44 GMT']
-      etag: [W/"6a9f421c-7eab-4e65-bde7-41952281095c"]
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 31 Jan 2017 18:31:52 GMT']
+      ETag: [W/"708ac300-50d6-494f-a992-9e45b0717074"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['557']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -547,232 +646,212 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a5c03373-7611-11e6-97a5-a0999b14fe87]
+      x-ms-client-request-id: [89c288d8-e7e3-11e6-95d8-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_nsg_test1/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web?api-version=2016-09-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj96CqffDTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWruTsvi9182F79/mzft7t1VXV0Ws7xu7n5RTOuqqc7b8Yu8
-        varqt3eX8vN1Pl3XRXut7+O9bQKwe7fRL16ty7y561DN2+wCyH737u/70afZw/P9vd3p9oM8m2zv
-        55/e357M8gfb+7sP7+/tHewSitPf9yN9kZBZ5XVb5A29zoSQDy+LhoZbLC9et1nLdHm9nk7zfJbP
-        5E1p1lbTqsS337KfyshfVnX7Klte8KvuyxmNpFhmIGXQYp8e20ggHM9mRMbmZZ2fF+/Q5sHBQ9vE
-        g9Nrt7t3z8HKCOkGY/vouCyrK/v5qi4qEJK+2d3Z2TEfz4o6nwIqff7R2XJSrZezj/DdL/mNk1/y
-        /wAZXtYvKAIAAA==
+    body: {string: "{\r\n  \"name\": \"web\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web\"\
+        ,\r\n  \"etag\": \"W/\\\"708ac300-50d6-494f-a992-9e45b0717074\\\"\",\r\n \
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
+        protocol\": \"*\",\r\n    \"sourcePortRange\": \"*\",\r\n    \"destinationPortRange\"\
+        : \"4444\",\r\n    \"sourceAddressPrefix\": \"789\",\r\n    \"destinationAddressPrefix\"\
+        : \"1234\",\r\n    \"access\": \"Allow\",\r\n    \"priority\": 1000,\r\n \
+        \   \"direction\": \"Inbound\"\r\n  }\r\n}"}
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:14:44 GMT']
-      etag: [W/"6a9f421c-7eab-4e65-bde7-41952281095c"]
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 31 Jan 2017 18:31:53 GMT']
+      ETag: [W/"708ac300-50d6-494f-a992-9e45b0717074"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['557']
     status: {code: 200, message: OK}
 - request:
-    body: '{"etag": "W/\"6a9f421c-7eab-4e65-bde7-41952281095c\"", "properties": {"access":
-      "DENY", "priority": 888, "direction": "Outbound", "protocol": "tcp", "description":
-      "greatrule", "destinationPortRange": "1234-1235", "sourceAddressPrefix": "111",
-      "destinationAddressPrefix": "111", "sourcePortRange": "1234-1235", "provisioningState":
-      "Succeeded"}, "name": "web", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_nsg_test1/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web"}'
+    body: '{"name": "web", "etag": "W/\"708ac300-50d6-494f-a992-9e45b0717074\"", "properties":
+      {"priority": 888, "description": "greatrule", "destinationAddressPrefix": "111",
+      "sourceAddressPrefix": "111", "access": "Deny", "sourcePortRange": "1234-1235",
+      "direction": "Outbound", "destinationPortRange": "1234-1235", "protocol": "Tcp",
+      "provisioningState": "Succeeded"}, "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['533']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [8a093ac6-e7e3-11e6-a762-a0b3ccf7272a]
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"name\": \"web\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web\"\
+        ,\r\n  \"etag\": \"W/\\\"71c77fbd-f59a-49ce-8cbc-bad3dec96026\\\"\",\r\n \
+        \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
+        description\": \"greatrule\",\r\n    \"protocol\": \"Tcp\",\r\n    \"sourcePortRange\"\
+        : \"1234-1235\",\r\n    \"destinationPortRange\": \"1234-1235\",\r\n    \"\
+        sourceAddressPrefix\": \"111\",\r\n    \"destinationAddressPrefix\": \"111\"\
+        ,\r\n    \"access\": \"Deny\",\r\n    \"priority\": 888,\r\n    \"direction\"\
+        : \"Outbound\"\r\n  }\r\n}"}
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/6fabfd5a-11ac-4af4-9bb0-41b320ea6f95?api-version=2016-09-01']
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 31 Jan 2017 18:31:54 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['602']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [8a093ac6-e7e3-11e6-a762-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/6fabfd5a-11ac-4af4-9bb0-41b320ea6f95?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 31 Jan 2017 18:32:04 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['29']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [8a093ac6-e7e3-11e6-a762-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"name\": \"web\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web\"\
+        ,\r\n  \"etag\": \"W/\\\"0d66f562-c042-4478-af4c-22231f4beade\\\"\",\r\n \
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
+        description\": \"greatrule\",\r\n    \"protocol\": \"Tcp\",\r\n    \"sourcePortRange\"\
+        : \"1234-1235\",\r\n    \"destinationPortRange\": \"1234-1235\",\r\n    \"\
+        sourceAddressPrefix\": \"111\",\r\n    \"destinationAddressPrefix\": \"111\"\
+        ,\r\n    \"access\": \"Deny\",\r\n    \"priority\": 888,\r\n    \"direction\"\
+        : \"Outbound\"\r\n  }\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 31 Jan 2017 18:32:05 GMT']
+      ETag: [W/"0d66f562-c042-4478-af4c-22231f4beade"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['603']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [911ed7ec-e7e3-11e6-911f-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"name\": \"web\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web\"\
+        ,\r\n  \"etag\": \"W/\\\"0d66f562-c042-4478-af4c-22231f4beade\\\"\",\r\n \
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
+        description\": \"greatrule\",\r\n    \"protocol\": \"Tcp\",\r\n    \"sourcePortRange\"\
+        : \"1234-1235\",\r\n    \"destinationPortRange\": \"1234-1235\",\r\n    \"\
+        sourceAddressPrefix\": \"111\",\r\n    \"destinationAddressPrefix\": \"111\"\
+        ,\r\n    \"access\": \"Deny\",\r\n    \"priority\": 888,\r\n    \"direction\"\
+        : \"Outbound\"\r\n  }\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 31 Jan 2017 18:32:07 GMT']
+      ETag: [W/"0d66f562-c042-4478-af4c-22231f4beade"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['603']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"name": "web", "etag": "W/\"0d66f562-c042-4478-af4c-22231f4beade\"", "properties":
+      {"priority": 888, "description": "cool", "destinationAddressPrefix": "111",
+      "sourceAddressPrefix": "111", "access": "Deny", "sourcePortRange": "1234-1235",
+      "direction": "Outbound", "destinationPortRange": "1234-1235", "protocol": "Tcp",
+      "provisioningState": "Succeeded"}, "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Length: ['528']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a5dd8a28-7611-11e6-8f8e-a0999b14fe87]
+      x-ms-client-request-id: [920b7940-e7e3-11e6-8132-a0b3ccf7272a]
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_nsg_test1/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web?api-version=2016-09-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj96CqffDTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWruTsvi9182F79/mzft7t1VXV0Ws7xu7n5RTOuqqc7b8Yu8
-        varqt3eX8vN1Pl3XRXut7+O9bQKwe7fRL16ty7y561DN2+wCyH737u/70eT+ZO/hw53Z9uR8+un2
-        /v2dyfbBwb297Wya7dx7cJDv39ud/b4f6YuEzCqv2yJv6HUmhHx4WTQ03GJ58brNWqbLV6tZ1tIH
-        8iK1muWWLPj+os6ztia8bAMC01bTqsS37XRlPxfavKzq9lW2vGDgu3v39rfpn/u2EUGn3qjHanlD
-        SwF3PJsR1ZuXdX5evOOGu7u2iQdsY7tsOqXv8OnTfHltP17VRQWq0xcHBwfm01lR51OApI8/+nLd
-        Tqr1cvYRvvwlv3HyS/4fUFtaulUCAAA=
+    body: {string: "{\r\n  \"name\": \"web\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web\"\
+        ,\r\n  \"etag\": \"W/\\\"98d38f85-62e9-402e-8059-c94f365da1f5\\\"\",\r\n \
+        \ \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n    \"\
+        description\": \"cool\",\r\n    \"protocol\": \"Tcp\",\r\n    \"sourcePortRange\"\
+        : \"1234-1235\",\r\n    \"destinationPortRange\": \"1234-1235\",\r\n    \"\
+        sourceAddressPrefix\": \"111\",\r\n    \"destinationAddressPrefix\": \"111\"\
+        ,\r\n    \"access\": \"Deny\",\r\n    \"priority\": 888,\r\n    \"direction\"\
+        : \"Outbound\"\r\n  }\r\n}"}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/4a5cb166-98c8-4f1e-9159-97f2987b520e?api-version=2016-09-01']
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:14:44 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/178a7860-b8e4-40c1-a908-b164c2dcd7b2?api-version=2016-09-01']
+      Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [a5dd8a28-7611-11e6-8f8e-a0999b14fe87]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/4a5cb166-98c8-4f1e-9159-97f2987b520e?api-version=2016-09-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UdNm7Xr5qNH6Uev19Npns/y2Ue/cfJL/h9PlJBHHQAAAA==
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:14:54 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [a5dd8a28-7611-11e6-8f8e-a0999b14fe87]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_nsg_test1/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web?api-version=2016-09-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj96CqffDTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWruTsvi9182F79/mzft7t1VXV0Ws7xu7n5RTOuqqc7b8Yu8
-        varqt3eX8vN1Pl3XRXut7+O9bQKwe7fRL16ty7y561DN2+wCyH737u/70e6D/ezeQXawPc0mhOH+
-        9OH2wcHuw+3d851Pd/am9/Y+3cl/34/0RUJmlddtkTf0OhNCPrwsGhpusbx43WYt0+X1ejrN81k+
-        kzep2Sy3dEGDizrP2poQsw0ITltNqxLfttOV/VyI87Kq21fZ8oKh7+7d29+mf+7bRgS9LZYZoN/Q
-        UsAdz2ZE9uZlnZ8X77jh7q5t4gHb2C6jMTYgxUdP8+W1/XhVFxXITl8cHByYT2dFnU8Bkj7+6Mt1
-        O6nWy9lH+PKX/MbJL/l/AOSpLxFWAgAA
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:14:54 GMT']
-      etag: [W/"174a38a8-cab0-44c9-8819-1f0602c3260e"]
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [ac450080-7611-11e6-9c6c-a0999b14fe87]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_nsg_test1/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web?api-version=2016-09-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj96CqffDTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWruTsvi9182F79/mzft7t1VXV0Ws7xu7n5RTOuqqc7b8Yu8
-        varqt3eX8vN1Pl3XRXut7+O9bQKwe7fRL16ty7y561DN2+wCyH737u/70e6D/ezeQXawPc0mhOH+
-        9OH2wcHuw+3d851Pd/am9/Y+3cl/34/0RUJmlddtkTf0OhNCPrwsGhpusbx43WYt0+X1ejrN81k+
-        kzep2Sy3dEGDizrP2poQsw0ITltNqxLfttOV/VyI87Kq21fZ8oKh7+7d29+mf+7bRgS9LZYZoN/Q
-        UsAdz2ZE9uZlnZ8X77jh7q5t4gHb2C6jMTYgxUdP8+W1/XhVFxXITl8cHByYT2dFnU8Bkj7+6Mt1
-        O6nWy9lH+PKX/MbJL/l/AOSpLxFWAgAA
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:14:55 GMT']
-      etag: [W/"174a38a8-cab0-44c9-8819-1f0602c3260e"]
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: '{"etag": "W/\"174a38a8-cab0-44c9-8819-1f0602c3260e\"", "properties": {"access":
-      "Deny", "priority": 888, "direction": "Outbound", "protocol": "tcp", "description":
-      "cool", "destinationPortRange": "1234-1235", "sourceAddressPrefix": "111", "destinationAddressPrefix":
-      "111", "sourcePortRange": "1234-1235", "provisioningState": "Succeeded"}, "name":
-      "web", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_nsg_test1/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web"}'
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['523']
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [ac594e33-7611-11e6-93f2-a0999b14fe87]
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_nsg_test1/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web?api-version=2016-09-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj96CqffDTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWruTsvi9182F79/mzft7t1VXV0Ws7xu7n5RTOuqqc7b8Yu8
-        varqt3eX8vN1Pl3XRXut7+O9bQKwe7fRL16ty7y561DN2+wCyH737u/70Xn2YDLZ2/t0+8H93b3t
-        /f3759sH9ye729NP72eTycPppwcP9n/fj/RFQmaV122RN/Q6E0I+vCwaGm6xvHjdZi3T5avVLGvp
-        A3mRWs1ySxZ8P62q0n5HENpqSh/QF+10ZT8Xsrys6vZVtrxguLt79/a36Z/7thEBpo6os2p5Q0sB
-        dzybEcGbl3V+Xrzjhru7tokHbGO7bDql7/Dp03x5bT9e1UUFgtMXBwcH5tNZUedTgKSPP/py3U6q
-        9XL2Eb78Jb9x8kv+H15cumZQAgAA
-    headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/978455ec-d90d-46c1-a722-d55f36aed00c?api-version=2016-09-01']
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:14:55 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Date: ['Tue, 31 Jan 2017 18:32:08 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['597']
       x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
@@ -782,29 +861,25 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ac594e33-7611-11e6-93f2-a0999b14fe87]
+      x-ms-client-request-id: [920b7940-e7e3-11e6-8132-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/978455ec-d90d-46c1-a722-d55f36aed00c?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/178a7860-b8e4-40c1-a908-b164c2dcd7b2?api-version=2016-09-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UdNm7Xr5qNH6Uev19Npns/y2Ue/cfJL/h9PlJBHHQAAAA==
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:15:06 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 31 Jan 2017 18:32:18 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['29']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -813,97 +888,33 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ac594e33-7611-11e6-93f2-a0999b14fe87]
+      x-ms-client-request-id: [920b7940-e7e3-11e6-8132-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_nsg_test1/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web?api-version=2016-09-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UfLbJF/9Cj96CqffDTiT4oZ/r7brCfNtC5WbVEtm7s7k93zT/cf7G7vTs53tvdns2w7y6f3tqeT
-        h3sP9s53Ht5/uHO3zptqXU/zz+tqvWruTsvi9182F79/mzft7t1VXV0Ws7xu7n5RTOuqqc7b8Yu8
-        varqt3eX8vN1Pl3XRXut7+O9bQKwe7fRL16ty7y561DN2+wCyH737u/70acPD/anBw/y7Qe72e72
-        /uTBp9sP8/3pdvbpdHe2t3cwOz/Pft+P9EVCZpXXbZE39DoTQj68LBoabrG8eN1mLdPl9Xo6zfNZ
-        PpM3qdkst3RBg2lVlfY7AtFWU/qAvminK/u50OVlVbevsuUFA97du7e/Tf/ct40IcFssMwC+oaWA
-        O57NiOLNyzo/L95xw91d28QDtrFdRsNrQIWPnubLa/vxqi4qUJy+ODg4MJ/OijqfAiR9/NGX63ZS
-        rZezj/DlL/mNk1/y/wAbGHgkUQIAAA==
+    body: {string: "{\r\n  \"name\": \"web\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web\"\
+        ,\r\n  \"etag\": \"W/\\\"5847e5db-1543-4e0b-8a07-70ff5e502473\\\"\",\r\n \
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"\
+        description\": \"cool\",\r\n    \"protocol\": \"Tcp\",\r\n    \"sourcePortRange\"\
+        : \"1234-1235\",\r\n    \"destinationPortRange\": \"1234-1235\",\r\n    \"\
+        sourceAddressPrefix\": \"111\",\r\n    \"destinationAddressPrefix\": \"111\"\
+        ,\r\n    \"access\": \"Deny\",\r\n    \"priority\": 888,\r\n    \"direction\"\
+        : \"Outbound\"\r\n  }\r\n}"}
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:15:06 GMT']
-      etag: [W/"6984c87e-71a1-4b76-9e4c-a6c1d228dffa"]
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
+      Cache-Control: [no-cache]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [b3282cba-7611-11e6-9f28-a0999b14fe87]
-    method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_nsg_test1/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web?api-version=2016-09-01
-  response:
-    body: {string: !!python/unicode ''}
-    headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/5cf3c019-0717-4199-9a12-033b97d5f197?api-version=2016-09-01']
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Thu, 08 Sep 2016 22:15:06 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/5cf3c019-0717-4199-9a12-033b97d5f197?api-version=2016-09-01']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1198']
-    status: {code: 202, message: Accepted}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
-      accept-language: [en-US]
-      x-ms-client-request-id: [b3282cba-7611-11e6-9f28-a0999b14fe87]
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/5cf3c019-0717-4199-9a12-033b97d5f197?api-version=2016-09-01
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UdNm7Xr5qNH6Uev19Npns/y2Ue/cfJL/h9PlJBHHQAAAA==
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:15:16 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Date: ['Tue, 31 Jan 2017 18:32:19 GMT']
+      ETag: [W/"5847e5db-1543-4e0b-8a07-70ff5e502473"]
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['598']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -913,27 +924,26 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b9cfe1a3-7611-11e6-abc5-a0999b14fe87]
+      x-ms-client-request-id: [99ab26f4-e7e3-11e6-adcb-a0b3ccf7272a]
     method: DELETE
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_nsg_test1/providers/Microsoft.Network/networkSecurityGroups/test-nsg1?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1/securityRules/web?api-version=2016-09-01
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      azure-asyncoperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/8be85e02-0a38-48ea-9b6a-aabbc1acd4f8?api-version=2016-09-01']
-      cache-control: [no-cache]
-      content-length: ['0']
-      date: ['Thu, 08 Sep 2016 22:15:18 GMT']
-      expires: ['-1']
-      location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/8be85e02-0a38-48ea-9b6a-aabbc1acd4f8?api-version=2016-09-01']
-      pragma: [no-cache]
-      retry-after: ['10']
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-ms-ratelimit-remaining-subscription-writes: ['1195']
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/b07fccbc-f450-4292-8b9b-2a908ae54199?api-version=2016-09-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Tue, 31 Jan 2017 18:32:20 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/b07fccbc-f450-4292-8b9b-2a908ae54199?api-version=2016-09-01']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
     status: {code: 202, message: Accepted}
 - request:
     body: null
@@ -942,29 +952,81 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b9cfe1a3-7611-11e6-abc5-a0999b14fe87]
+      x-ms-client-request-id: [99ab26f4-e7e3-11e6-adcb-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/8be85e02-0a38-48ea-9b6a-aabbc1acd4f8?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/b07fccbc-f450-4292-8b9b-2a908ae54199?api-version=2016-09-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UdNm7Xr5qNH6Uev19Npns/y2Ue/cfJL/h9PlJBHHQAAAA==
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:15:28 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 31 Jan 2017 18:32:30 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['29']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [a11abd14-e7e3-11e6-b07f-a0b3ccf7272a]
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups/test-nsg1?api-version=2016-09-01
+  response:
+    body: {string: ''}
+    headers:
+      Azure-AsyncOperation: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operations/9975d16d-8ccd-4481-a686-9ae5c6a6f984?api-version=2016-09-01']
+      Cache-Control: [no-cache]
+      Content-Length: ['0']
+      Date: ['Tue, 31 Jan 2017 18:32:32 GMT']
+      Expires: ['-1']
+      Location: ['https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/providers/Microsoft.Network/locations/westus/operationResults/9975d16d-8ccd-4481-a686-9ae5c6a6f984?api-version=2016-09-01']
+      Pragma: [no-cache]
+      Retry-After: ['10']
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+    status: {code: 202, message: Accepted}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
+      accept-language: [en-US]
+      x-ms-client-request-id: [a11abd14-e7e3-11e6-b07f-a0b3ccf7272a]
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/operations/9975d16d-8ccd-4481-a686-9ae5c6a6f984?api-version=2016-09-01
+  response:
+    body: {string: "{\r\n  \"status\": \"Succeeded\"\r\n}"}
+    headers:
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 31 Jan 2017 18:32:43 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      Vary: [Accept-Encoding]
+      content-length: ['29']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -973,28 +1035,22 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-15.5.0-x86_64-i386-64bit) requests/2.9.1
-          msrest/0.4.3 msrest_azure/0.4.2 networkmanagementclient/0.30.0rc6 Azure-SDK-For-Python
-          AZURECLI/TEST/0.0.1.dev0]
+      User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
+          msrest_azure/0.4.6 networkmanagementclient/0.30.0 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c077188f-7611-11e6-a7e0-a0999b14fe87]
+      x-ms-client-request-id: [a883b2f8-e7e3-11e6-8450-a0b3ccf7272a]
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_nsg_test1/providers/Microsoft.Network/networkSecurityGroups?api-version=2016-09-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_nsg/providers/Microsoft.Network/networkSecurityGroups?api-version=2016-09-01
   response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk
-        6UeXWbnOP3qUfu/7v3HyS/4fW9IxlRMAAAA=
+    body: {string: '{"value":[]}'}
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 08 Sep 2016 22:15:29 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
+      Cache-Control: [no-cache]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 31 Jan 2017 18:32:44 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      content-length: ['12']
     status: {code: 200, message: OK}
 version: 1

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/test_network_commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/test_network_commands.py
@@ -798,7 +798,7 @@ class NetworkNicConvenienceCommandsScenarioTest(ResourceGroupVCRTestBase):
 class NetworkSecurityGroupScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(NetworkSecurityGroupScenarioTest, self).__init__(__file__, test_method, resource_group='cli_nsg_test1')
+        super(NetworkSecurityGroupScenarioTest, self).__init__(__file__, test_method, resource_group='cli_test_nsg')
         self.nsg_name = 'test-nsg1'
         self.nsg_rule_name = 'web'
         self.resource_type = 'Microsoft.Network/networkSecurityGroups'
@@ -813,7 +813,7 @@ class NetworkSecurityGroupScenarioTest(ResourceGroupVCRTestBase):
         rt = self.resource_type
 
         self.cmd('network nsg create --name {} -g {}'.format(nsg, rg))
-        self.cmd('network nsg rule create --access allow --destination-address-prefix 1234 --direction inbound --nsg-name {} --protocol * -g {} --source-address-prefix 789 -n {} --source-port-range * --destination-port-range 4444'.format(nsg, rg, nrn))
+        self.cmd('network nsg rule create --access allow --destination-address-prefix 1234 --direction inbound --nsg-name {} --protocol * -g {} --source-address-prefix 789 -n {} --source-port-range * --destination-port-range 4444 --priority 1000'.format(nsg, rg, nrn))
 
         self.cmd('network nsg list', checks=[
             JMESPathCheck('type(@)', 'array'),
@@ -846,7 +846,7 @@ class NetworkSecurityGroupScenarioTest(ResourceGroupVCRTestBase):
         new_access = 'DENY'
         new_addr_prefix = '111'
         new_direction = 'Outbound'
-        new_protocol = 'tcp'
+        new_protocol = 'Tcp'
         new_port_range = '1234-1235'
         description = 'greatrule'
         priority = 888


### PR DESCRIPTION
Closes #1678.

- **Breaking Change**: Removes the default value of 1000 from `--priority`. This is now a required parameter.
- Reduces the number of required parameters from 11 to 4. Defaults are borrowed from Xplat CLI except for source/dest-address-prefix, which default to '*'. This would result in a default rule allowing inbound traffic to port 80 from any IP range.
- Updates the help text for NSG rule commands
- Fixes issue where `--ids` parameter was exposed for `nsg rule create`. 