### PR TITLE
Fix two issues with storage

### DIFF
--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/storage_url_helpers.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/storage_url_helpers.py
@@ -34,7 +34,7 @@ class StorageResourceIdentifier(object):
 
         from azure.cli.core._profile import CLOUD
         self.account_name, type_name = url.netloc[:0 - len(CLOUD.suffixes.storage_endpoint) - 1]\
-            .split('.', maxsplit=2)
+            .split('.', 2)
 
         if type_name == 'blob':
             self.container, self.blob = self._separate_path_l(url.path)

--- a/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/test_storage.py
+++ b/src/command_modules/azure-cli-storage/azure/cli/command_modules/storage/tests/test_storage.py
@@ -792,5 +792,6 @@ class StorageBlobNoCredentialsScenarioTest(VCRTestBase):
         self.execute()
 
     def body(self):
+        self.pop_env('AZURE_STORAGE_CONNECTION_STRING')
         with self.assertRaisesRegexp(CLIError, re.escape(NO_CREDENTIALS_ERROR_MESSAGE)):
             self.cmd('storage blob upload -c foo -n bar -f file_0')


### PR DESCRIPTION
1. The split usage is not python 2.7 compatible; fix it.
2. The environment variable is not popped in the test which expect no credential.