### PR TITLE
[Compute] VM Create Fixes

### DIFF
--- a/azure-cli.pyproj
+++ b/azure-cli.pyproj
@@ -839,6 +839,8 @@
     <Content Include="command_modules\azure-cli-vm\azure\cli\command_modules\vm\mgmt_avail_set\azuredeploy_empty.json" />
     <Content Include="command_modules\azure-cli-vm\azure\cli\command_modules\vm\mgmt_avail_set\swagger_create_avail_set.json" />
     <Content Include="command_modules\azure-cli-vm\azure\cli\command_modules\vm\tests\aliases.json" />
+    <Content Include="command_modules\azure-cli-vm\azure\cli\command_modules\vm\tests\vmss_create_test_plan.md" />
+    <Content Include="command_modules\azure-cli-vm\azure\cli\command_modules\vm\tests\vm_create_test_plan.md" />
   </ItemGroup>
   <ItemGroup>
     <Interpreter Include="..\env\">

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -260,7 +260,8 @@ def _validate_vm_create_auth(namespace):
         # prompt for admin username if inadequate
         from azure.cli.core.prompting import prompt, NoTTYException
         try:
-            logger.warning("Cannot use provided admin username: %s. Admin username should be at least 6 characters and cannot be 'root'", namespace.admin_username)
+            logger.warning("Cannot use provided admin username: %s. Admin username should be at "
+                           "least 6 characters and cannot be 'root'", namespace.admin_username)
             namespace.admin_username = prompt('Admin Username: ')
         except NoTTYException:
             raise CLIError('Please specify a valid admin username in non-interactive mode.')

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -260,7 +260,7 @@ def _validate_vm_create_auth(namespace):
         # prompt for admin username if inadequate
         from azure.cli.core.prompting import prompt, NoTTYException
         try:
-            logger.warning("Cannot use provided admin username: %s. Admin username should be at "
+            logger.warning("Cannot use admin username: %s. Admin username should be at "
                            "least 6 characters and cannot be 'root'", namespace.admin_username)
             namespace.admin_username = prompt('Admin Username: ')
         except NoTTYException:

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -256,6 +256,15 @@ def _validate_vm_create_nics(namespace):
 
 def _validate_vm_create_auth(namespace):
 
+    if len(namespace.admin_username) < 6 or namespace.admin_username.lower() == 'root':
+        # prompt for admin username if inadequate
+        from azure.cli.core.prompting import prompt, NoTTYException
+        try:
+            logger.warning("Cannot use provided admin username: %s. Admin username should be at least 6 characters and cannot be 'root'", namespace.admin_username)
+            namespace.admin_username = prompt('Admin Username: ')
+        except NoTTYException:
+            raise CLIError('Please specify a valid admin username in non-interactive mode.')
+
     if not namespace.os_type:
         raise CLIError("Unable to resolve OS type. Specify '--os-type' argument.")
 

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -1244,9 +1244,11 @@ def create_vm(vm_name, resource_group_name, image,
 
     if storage_profile in [StorageProfile.SACustomImage, StorageProfile.SAPirImage]:
         storage_account_name = storage_account.rsplit('/', 1)
-        storage_account_name = storage_account_name[1] if len(storage_account_name) > 1 else storage_account_name[0]
+        storage_account_name = storage_account_name[1] if \
+            len(storage_account_name) > 1 else storage_account_name[0]
         os_vhd_uri = 'https://{}.blob.{}/{}/{}.vhd'.format(
-            storage_account_name, CLOUD.suffixes.storage_endpoint, storage_container_name, os_disk_name)
+            storage_account_name, CLOUD.suffixes.storage_endpoint, storage_container_name,
+            os_disk_name)
 
     vm_resource = build_vm_resource(
         vm_name, location, tags, size, storage_profile, nics, admin_username, availability_set,

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -1243,8 +1243,10 @@ def create_vm(vm_name, resource_group_name, image,
                            'public IP, VNet or subnet.')
 
     if storage_profile in [StorageProfile.SACustomImage, StorageProfile.SAPirImage]:
+        storage_account_name = storage_account.rsplit('/', 1)
+        storage_account_name = storage_account_name[1] if len(storage_account_name) > 1 else storage_account_name[0]
         os_vhd_uri = 'https://{}.blob.{}/{}/{}.vhd'.format(
-            storage_account, CLOUD.suffixes.storage_endpoint, storage_container_name, os_disk_name)
+            storage_account_name, CLOUD.suffixes.storage_endpoint, storage_container_name, os_disk_name)
 
     vm_resource = build_vm_resource(
         vm_name, location, tags, size, storage_profile, nics, admin_username, availability_set,

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/vm_create_test_plan.md
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/vm_create_test_plan.md
@@ -1,0 +1,111 @@
+# VM Create scenarios before merge #
+
+## P0: BASIC ##
+Execute P0s before any change to VM Create ***OR VMSS CREATE*** is merged
+
+**simple VM**
+
+ - delete vm_create_ubuntu.yaml
+ - delete vm_create_state_modifications.yaml
+ - re-record tests
+
+**Linux with existing availability set, existing NSG, existing public IP
+Size Standard_A3, existing storage account, existing storage container name, existing VNET/Subnet**
+
+ - verify VM is in availability set
+ - verify NSG
+ - verify private and public IP are static
+ - verify VHD storage path
+ - verify in correct VNet/Subnet
+ - verify existing IP used
+ - login with SSH
+
+ OR
+
+ - delete test_vm_create_existing_options.yaml
+ - re-record test
+
+**Linux, static private IP, static public IP, DNS name**
+
+ - create
+ - verify private/public IPs are static
+ - verify DNS name
+
+ OR 
+
+ - delete test_vm_create_custom_ip.yaml
+ - re-record test
+
+ **Multi-NIC VM**
+
+ - create vm with multiple nics
+ - verify create succeeds and that nics are added in the correct order
+
+ OR
+
+ - delete test_vm_create_multinic.yaml
+ - re-record test
+
+ **Minimum VM**
+
+ - create vm with no availability set, NSG, public ip or tags
+ - verify create succeeds and that the other resources aren't created
+
+ OR
+
+ - delete test_vm_create_none_options.yaml
+ - re-record test
+
+ **custom Linux image**
+
+ - create VM, add a customization such as "sudo apt-get install emacs23"
+ - generalize, capture and deallocate VM's vhd (https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-capture-image/)
+ - create VM with OS Disk URI pointing to VM's vhd.  Create in a different resource group than
+   the storage account the VHD is in.
+ - SSH into instance
+ - verify emacs is still installed
+
+Commands to verify (Linux):
+ vmname=cusvm0101z
+ rg=myvms2
+ ./az vm create -n $vmname -g $rg --image https://genlinuximg001100.blob.core.windows.net/vhds/linuximage.vhd --authentication-type ssh --custom-disk-os-type linux --storage-account <ID ending in genlinuximg001100> --storage-container-name ${vmname}vhdcopy --os-disk-name osdiskimage
+ then 
+ ssh <IPAddress> (don't specify username or password)
+ verify emacs/application is installed
+
+ **custom Windows image**
+
+ - create VM, add a customization such as installing an application
+ - generalize, capture and deallocate VM's vhd (https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-windows-classic-capture-image/ + https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-capture-image/)
+ - create VM with OS Disk URI pointing to VM's vhd.  Create in a different resource group than
+   the storage account the VHD is in.
+ - RDP into instance
+ - verify application is still installed
+
+Commands to verify (Windows):
+ set vmname=cusvm05123
+ set rg=myvms
+ call az vm create -n %vmname% -g %rg% --image http://genwinimg001100.blob.core.windows.net/vhds/osdiskimage.vhd --authentication-type password --admin-password Test1234@! --storage-account <ID ending in genwinimg001100> --storage-container-name %vmname%mygenimg
+ then
+ RDP <IPAddress>
+ verify WinMerge/application is installed
+
+## P1: LESS COMMON ##
+Execute P1 scenarios if a change is made in these areas
+
+**password Linux**
+
+ - create
+ - login with password
+
+**custom ssh key path**
+ - create
+ - login with SSH
+ - verify SSH key path
+
+## P2: ERROR CASES ##
+Be aware of the P2 behavior, execute P2s occassionally or before an important event/ship cycle
+
+**windows VM with SSH**
+
+**linux VM, no public key generated**

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/vm_create_test_plan.md
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/vm_create_test_plan.md
@@ -106,6 +106,6 @@ Execute P1 scenarios if a change is made in these areas
 ## P2: ERROR CASES ##
 Be aware of the P2 behavior, execute P2s occassionally or before an important event/ship cycle
 
-**windows VM with SSH**
+**Windows VM with SSH**
 
-**linux VM, no public key generated**
+**Linux VM, no public key generated**

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/vmss_create_test_plan.md
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/vmss_create_test_plan.md
@@ -103,6 +103,6 @@ Execute P1 scenarios if a change is made in these areas
 ## P2: ERROR CASES ##
 Be aware of the P2 behavior, execute P2s occassionally or before an important event/ship cycle
 
-**windows VM with SSH**
+**Windows VM with SSH**
 
-**linux VM, no public key generated**
+**Linux VM, no public key generated**

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/vmss_create_test_plan.md
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/vmss_create_test_plan.md
@@ -1,0 +1,108 @@
+# VMSS Create scenarios before merge #
+
+## P0: BASIC ##
+Execute P0s before any change to VMSS Create **OR VM CREATE** is merged
+
+**simple Windows VMSS**
+
+ - create
+ - verify LB and public IP
+
+OR
+
+ - Delete test_vm_scaleset_create_simple.yaml
+ - Re-record the tests
+
+**Windows VMSS with no overprovisioning, instance count 4, ReadWrite caching and Automatic upgrades, static private and static Public IP Addresses**
+
+ - create
+ - verify LB public/private IP is static
+ - verify overprovisioning, instance count (capacity), caching and upgrade policy
+
+ OR
+
+ - Delete test_vm_scaleset_create_options.yaml
+ - Re-record tests
+
+**Linux VMSS with custom OS Disk name and storage container name, existing VNet/subnet, existing IP for LB**
+
+ - verify existing IP is used by LB
+ - verify OS Disk name
+ - verify in correct VNet/Subnet
+ - verify existing IP used
+
+OR
+
+ - Delete test_vm_scaleset_create_existing_options.yaml
+ - Re-record tests
+
+ **Minimum VMSS**
+
+ - create vmss with no load balancer, public ip or tags
+ - verify create succeeds and that the other resources aren't created
+
+ OR
+
+ - delete test_vmss_create_none_options.yaml
+ - re-record test
+
+**custom Linux image**
+
+ - create VM1, add a customization such as "sudo apt-get install emacs23"
+ - generalize, capture and deallocate VM1's vhd (https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-capture-image/)
+ - create VMSS with OS Disk URI pointing to VM1's vhd. Create in a different resource group than
+   the storage account the VHD is in.
+ - SSH into instance 1
+ - verify emacs is still installed
+
+Commands to verify (Linux):
+ vmssname=myvmss16e
+ rg=myvmsss
+ ./az vmss create --image https://genlinuximg001100.blob.core.windows.net/vhds/linuximage.vhd --custom-os-disk-type linux -g $rg --name $vmssname --authentication-type ssh
+ ./az vmss show -n $vmssname -g $rg
+ ./az network public-ip show -n ${vmssname}PublicIP -g $rg --query ipAddress 
+ SSH into the VM, Ssh format for instance 0: ssh <ipAddress> -p 50000
+ Type 'emacs', it should start (exit with Ctrl-X Ctrl-C)
+
+ **custom Windows image**
+
+ - create VM1, add a customization such as installing an application (e.g WinMerge)
+ - generalize, capture and deallocate VM1's vhd (https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-windows-classic-capture-image/ + https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-capture-image/)
+ - create VMSS with OS Disk URI pointing to VM1's vhd. Create in a different resource group than
+   the storage account the VHD is in.
+ - RDP into instance 1
+ - verify application is still installed (e.g. launch WinMerge)
+
+Commands to verify (windows):
+ set vmssname=myvmss16g
+ set rg=myvmsss
+ call az vmss create --image http://genwinimg001100.blob.core.windows.net/vhds/osdiskimage.vhd --custom-os-disk-type windows -g %rg% --name %vmssname% --admin-password Test@1234!
+ call az vmss show -n %vmssname% -g %rg%
+ call az network public-ip show -n %vmssname%PublicIP -g %rg% --query ipAddress 
+ Then RDP in and look for app being installed already
+ mstsc /v:<vmname>:50000, launch application
+
+## P1: LESS COMMON ##
+Execute P1 scenarios if a change is made in these areas
+
+**password Linux**
+
+ - create
+ - login with password
+ - verify SSH key path
+
+**custom ssh key path**
+ - create
+ - login with SSH
+ - verify SSH key path
+
+**no load balancer**
+ - create without LB
+ - verify no LB
+
+## P2: ERROR CASES ##
+Be aware of the P2 behavior, execute P2s occassionally or before an important event/ship cycle
+
+**windows VM with SSH**
+
+**linux VM, no public key generated**


### PR DESCRIPTION
Fixes #1943. 

- If admin_username is < 6 characters or 'root' (either specified or by default), prompts for a valid username. If no TTY available, fails.
- Fixes an issue where the OS disk name would be incorrectly generated when specifying an existing storage account by ID.
- Restores the VM/VMSS create test plans that were deleted when the fat client was removed. Updates the scenarios slightly.