### PR TITLE
Make ACS modules code PEP8 compliant and turn on style check in CI.

### DIFF
--- a/scripts/automation/style/run.py
+++ b/scripts/automation/style/run.py
@@ -70,8 +70,9 @@ if __name__ == '__main__':
 
         # Run flake8 on white-listed modules
         pep8_ready_modules = automation_path.filter_user_selected_modules(
-            ['azure-cli', 'azure-cli-core', 'component', 'cloud', 'feedback', 'profile', 'sql',
-             'storage', 'vm'])
+            ['azure-cli', 'azure-cli-core', 'azure-cli-nspkg', 'acs', 
+             'component', 'cloud', 'feedback', 'profile', 'sql', 'storage',
+             'vm'])
 
         return_code_sum += run_pep8(pep8_ready_modules)
 

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/__init__.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/__init__.py
@@ -4,10 +4,12 @@
 # --------------------------------------------------------------------------------------------
 
 
-import azure.cli.command_modules.acs._help # pylint: disable=unused-import
+import azure.cli.command_modules.acs._help  # pylint: disable=unused-import
+
 
 def load_params(_):
-    import azure.cli.command_modules.acs._params #pylint: disable=redefined-outer-name
+    import azure.cli.command_modules.acs._params  # pylint: disable=redefined-outer-name
+
 
 def load_commands():
-    import azure.cli.command_modules.acs.commands #pylint: disable=redefined-outer-name
+    import azure.cli.command_modules.acs.commands  # pylint: disable=redefined-outer-name

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_params.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_params.py
@@ -25,16 +25,19 @@ def _compute_client_factory(**_):
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
     return get_mgmt_service_client(ComputeManagementClient)
 
+
 def get_vm_sizes(location):
     return list(_compute_client_factory().virtual_machine_sizes.list(location))
 
-def get_vm_size_completion_list(prefix, action, parsed_args, **kwargs):#pylint: disable=unused-argument
+
+def get_vm_size_completion_list(prefix, action, parsed_args, **kwargs):  # pylint: disable=unused-argument
     try:
         location = parsed_args.location
     except AttributeError:
         location = get_one_of_subscription_locations()
     result = get_vm_sizes(location)
     return [r.name for r in result]
+
 
 def _get_default_install_location(exe_name):
     system = platform.system()
@@ -49,13 +52,14 @@ def _get_default_install_location(exe_name):
         install_location = None
     return install_location
 
+
 name_arg_type = CliArgumentType(options_list=('--name', '-n'), metavar='NAME')
 
 register_cli_argument('acs', 'name', arg_type=name_arg_type, help='ACS cluster name', completer=get_resource_name_completion_list('Microsoft.ContainerService/ContainerServices'))
 register_cli_argument('acs', 'resource_group', arg_type=resource_group_name_type)
 
 register_cli_argument('acs', 'orchestrator_type', **enum_choice_list(ContainerServiceOchestratorTypes))
-#some admin names are prohibited in acs, such as root, admin, etc. Because we have no control on the orchestrators, so default to a safe name.
+# some admin names are prohibited in acs, such as root, admin, etc. Because we have no control on the orchestrators, so default to a safe name.
 register_cli_argument('acs', 'admin_username', options_list=('--admin-username',), default='azureuser', required=False)
 register_cli_argument('acs', 'dns_name_prefix', options_list=('--dns-prefix', '-d'))
 register_cli_argument('acs', 'container_service_name', options_list=('--name', '-n'), help='The name of the container service', completer=get_resource_name_completion_list('Microsoft.ContainerService/ContainerServices'))

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/acs_client.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/acs_client.py
@@ -12,6 +12,7 @@ import paramiko
 from sshtunnel import SSHTunnelForwarder
 from scp import SCPClient
 
+
 def SecureCopy(user, host, src, dest,
                key_filename=os.path.join(os.path.expanduser("~"), '.ssh', 'id_rsa')):
     ssh = paramiko.SSHClient()
@@ -23,6 +24,7 @@ def SecureCopy(user, host, src, dest,
 
     scp.get(src, dest)
     scp.close()
+
 
 class ACSClient(object):
     def __init__(self, client=None):
@@ -149,11 +151,10 @@ class ACSClient(object):
         if local_port is 0:
             local_port = self.get_available_local_port()
 
-        with SSHTunnelForwarder(
-            (self.host, self.port),
-            ssh_username=self.username,
-            remote_bind_address=(remote_host, remote_port),
-            local_bind_address=('0.0.0.0', local_port)):
+        with SSHTunnelForwarder((self.host, self.port),
+                                ssh_username=self.username,
+                                remote_bind_address=(remote_host, remote_port),
+                                local_bind_address=('0.0.0.0', local_port)):
             try:
                 while True:
                     sleep(1)

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/commands.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/commands.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-#pylint: disable=line-too-long
+# pylint: disable=line-too-long
 
 from azure.cli.core.commands import cli_command
 
@@ -15,4 +15,3 @@ cli_command(__name__, 'acs create', 'azure.cli.command_modules.acs.custom#acs_cr
 cli_command(__name__, 'acs kubernetes browse', 'azure.cli.command_modules.acs.custom#k8s_browse')
 cli_command(__name__, 'acs kubernetes install-cli', 'azure.cli.command_modules.acs.custom#k8s_install_cli')
 cli_command(__name__, 'acs kubernetes get-credentials', 'azure.cli.command_modules.acs.custom#k8s_get_credentials')
-

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -15,8 +15,8 @@ import stat
 import string
 import subprocess
 import sys
-from six.moves.urllib.request import (urlretrieve, urlopen) #pylint: disable=import-error
-from six.moves.urllib.error import URLError #pylint: disable=import-error
+from six.moves.urllib.request import (urlretrieve, urlopen)  # pylint: disable=import-error
+from six.moves.urllib.error import URLError  # pylint: disable=import-error
 import threading
 import time
 import webbrowser
@@ -39,6 +39,7 @@ from azure.cli.core._environment import get_config_dir
 
 logger = azlogging.get_az_logger(__name__)
 
+
 def which(binary):
     pathVar = os.getenv('PATH')
     if platform.system() == 'Windows':
@@ -54,12 +55,15 @@ def which(binary):
 
     return None
 
+
 def _resource_client_factory():
     from azure.mgmt.resource.resources import ResourceManagementClient
     return get_mgmt_service_client(ResourceManagementClient)
 
+
 def cf_providers():
     return _resource_client_factory().providers
+
 
 def register_providers():
     providers = cf_providers()
@@ -67,11 +71,12 @@ def register_providers():
     namespaces = ['Microsoft.Network', 'Microsoft.Compute', 'Microsoft.Storage']
     for namespace in namespaces:
         state = providers.get(resource_provider_namespace=namespace)
-        if state.registration_state != 'Registered': # pylint: disable=no-member
+        if state.registration_state != 'Registered':  # pylint: disable=no-member
             logger.info('registering %s', namespace)
             providers.register(resource_provider_namespace=namespace)
         else:
             logger.info('%s is already registered', namespace)
+
 
 def wait_then_open(url):
     """
@@ -85,10 +90,12 @@ def wait_then_open(url):
         break
     webbrowser.open_new_tab(url)
 
+
 def wait_then_open_async(url):
     t = threading.Thread(target=wait_then_open, args=({url}))
     t.daemon = True
     t.start()
+
 
 def acs_browse(resource_group, name, disable_browser=False,
                ssh_key_file=os.path.join(os.path.expanduser("~"), '.ssh', 'id_rsa')):
@@ -107,15 +114,19 @@ def acs_browse(resource_group, name, disable_browser=False,
     _acs_browse_internal(_get_acs_info(name, resource_group), resource_group, name, disable_browser,
                          ssh_key_file)
 
-def _acs_browse_internal(acs_info, resource_group, name, disable_browser, ssh_key_file):
-    orchestrator_type = acs_info.orchestrator_profile.orchestrator_type # pylint: disable=no-member
 
-    if  orchestrator_type == 'kubernetes' or orchestrator_type == ContainerServiceOchestratorTypes.kubernetes or (acs_info.custom_profile and acs_info.custom_profile.orchestrator == 'kubernetes'): # pylint: disable=no-member
+def _acs_browse_internal(acs_info, resource_group, name, disable_browser, ssh_key_file):
+    orchestrator_type = acs_info.orchestrator_profile.orchestrator_type  # pylint: disable=no-member
+
+    if orchestrator_type == 'kubernetes' or \
+       orchestrator_type == ContainerServiceOchestratorTypes.kubernetes or \
+       (acs_info.custom_profile and acs_info.custom_profile.orchestrator == 'kubernetes'):  # pylint: disable=no-member
         return k8s_browse(name, resource_group, disable_browser, ssh_key_file=ssh_key_file)
     elif orchestrator_type == 'dcos' or orchestrator_type == ContainerServiceOchestratorTypes.dcos:
         return _dcos_browse_internal(acs_info, disable_browser, ssh_key_file)
     else:
         raise CLIError('Unsupported orchestrator type {} for browse'.format(orchestrator_type))
+
 
 def k8s_browse(name, resource_group, disable_browser=False,
                ssh_key_file=os.path.join(os.path.expanduser('~'), '.ssh', 'id_rsa')):
@@ -126,6 +137,7 @@ def k8s_browse(name, resource_group, disable_browser=False,
     """
     acs_info = _get_acs_info(name, resource_group)
     _k8s_browse_internal(name, acs_info, disable_browser, ssh_key_file)
+
 
 def _k8s_browse_internal(name, acs_info, disable_browser, ssh_key_file):
     if not which('kubectl'):
@@ -141,6 +153,7 @@ def _k8s_browse_internal(name, acs_info, disable_browser, ssh_key_file):
     if not disable_browser:
         wait_then_open_async('http://127.0.0.1:8001/ui')
     subprocess.call(["kubectl", "--kubeconfig", browse_path, "proxy"])
+
 
 def dcos_browse(name, resource_group, disable_browser=False,
                 ssh_key_file=os.path.join(os.path.expanduser("~"), '.ssh', 'id_rsa')):
@@ -159,9 +172,11 @@ def dcos_browse(name, resource_group, disable_browser=False,
     acs_info = _get_acs_info(name, resource_group)
     _dcos_browse_internal(acs_info, disable_browser, ssh_key_file)
 
+
 def _dcos_browse_internal(acs_info, disable_browser, ssh_key_file):
     acs = acs_client.ACSClient()
-    if not acs.connect(_get_host_name(acs_info), _get_username(acs_info), key_filename=ssh_key_file):
+    if not acs.connect(_get_host_name(acs_info), _get_username(acs_info),
+                       key_filename=ssh_key_file):
         raise CLIError('Error connecting to ACS: {}'.format(_get_host_name(acs_info)))
 
     octarine_bin = '/opt/mesosphere/bin/octarine'
@@ -194,18 +209,20 @@ def _dcos_browse_internal(acs_info, disable_browser, ssh_key_file):
 
     return
 
+
 def acs_install_cli(resource_group, name, install_location=None, client_version=None):
     acs_info = _get_acs_info(name, resource_group)
     orchestrator_type = acs_info.orchestrator_profile.orchestrator_type  # pylint: disable=no-member
     kwargs = {'install_location': install_location}
     if client_version:
         kwargs['client_version'] = client_version
-    if  orchestrator_type == 'kubernetes':
+    if orchestrator_type == 'kubernetes':
         return k8s_install_cli(**kwargs)
     elif orchestrator_type == 'dcos':
         return dcos_install_cli(**kwargs)
     else:
         raise CLIError('Unsupported orchestrator type {} for install-cli'.format(orchestrator_type))
+
 
 def dcos_install_cli(install_location=None, client_version='1.8'):
     """
@@ -214,7 +231,9 @@ def dcos_install_cli(install_location=None, client_version='1.8'):
     system = platform.system()
 
     if not install_location:
-        raise CLIError("No install location specified and it could not be determined from the current platform '{}'".format(system))
+        raise CLIError(
+            "No install location specified and it could not be determined from the current platform '{}'".format(
+                system))
     base_url = 'https://downloads.dcos.io/binaries/cli/{}/x86-64/dcos-{}/{}'
     if system == 'Windows':
         file_url = base_url.format('windows', client_version, 'dcos.exe')
@@ -229,9 +248,11 @@ def dcos_install_cli(install_location=None, client_version='1.8'):
     logger.info('Downloading client to %s', install_location)
     try:
         urlretrieve(file_url, install_location)
-        os.chmod(install_location, os.stat(install_location).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        os.chmod(install_location,
+                 os.stat(install_location).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
     except IOError as err:
         raise CLIError('Connection error while attempting to download client ({})'.format(err))
+
 
 def k8s_install_cli(client_version="1.5.1", install_location=None):
     """
@@ -253,9 +274,11 @@ def k8s_install_cli(client_version="1.5.1", install_location=None):
     logger.info('Downloading client to %s', install_location)
     try:
         urlretrieve(file_url, install_location)
-        os.chmod(install_location, os.stat(install_location).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        os.chmod(install_location,
+                 os.stat(install_location).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
     except IOError as err:
         raise CLIError('Connection error while attempting to download client ({})'.format(err))
+
 
 def _validate_service_principal(client, sp_id):
     from azure.cli.command_modules.role.custom import (
@@ -264,8 +287,10 @@ def _validate_service_principal(client, sp_id):
     # discard the result, we're trusting this to throw if it can't find something
     try:
         show_service_principal(client.service_principals, sp_id)
-    except: #pylint: disable=bare-except
-        raise CLIError('Failed to validate service principal, if this persists try deleting $HOME/.azure/acsServicePrincipal.json')
+    except:  # pylint: disable=bare-except
+        raise CLIError(
+            'Failed to validate service principal, if this persists try deleting $HOME/.azure/acsServicePrincipal.json')
+
 
 def _build_service_principal(client, name, url, client_secret):
     from azure.cli.command_modules.role.custom import (
@@ -275,17 +300,18 @@ def _build_service_principal(client, name, url, client_secret):
 
     sys.stdout.write('creating service principal')
     result = create_application(client.applications, name, url, [url], password=client_secret)
-    service_principal = result.app_id #pylint: disable=no-member
+    service_principal = result.app_id  # pylint: disable=no-member
     for x in range(0, 10):
         try:
             create_service_principal(service_principal)
         # TODO figure out what exception AAD throws here sometimes.
-        except: #pylint: disable=bare-except
+        except:  # pylint: disable=bare-except
             sys.stdout.write('.')
             sys.stdout.flush()
             time.sleep(2 + 2 * x)
     print('done')
     return service_principal
+
 
 def _add_role_assignment(role, service_principal, delay=2, output=True):
     # AAD can have delays in propagating data, so sleep and retry
@@ -301,7 +327,7 @@ def _add_role_assignment(role, service_principal, delay=2, output=True):
             if ex.message == 'The role assignment already exists.':
                 break
             logger.info('%s', ex.message)
-        except: #pylint: disable=bare-except
+        except:  # pylint: disable=bare-except
             pass
         if output:
             sys.stdout.write('.')
@@ -312,11 +338,18 @@ def _add_role_assignment(role, service_principal, delay=2, output=True):
         print('done')
     return True
 
+
 def _get_subscription_id():
     _, sub_id, _ = Profile().get_login_credentials(subscription_id=None)
     return sub_id
 
-def acs_create(resource_group_name, deployment_name, name, ssh_key_value, dns_name_prefix=None, content_version=None, admin_username="azureuser", agent_count="3", agent_vm_size="Standard_D2_v2", location=None, master_count="3", orchestrator_type="dcos", service_principal=None, client_secret=None, tags=None, custom_headers=None, raw=False, **operation_config): #pylint: disable=too-many-locals
+
+def acs_create(resource_group_name, deployment_name, name, ssh_key_value, dns_name_prefix=None,
+               content_version=None, admin_username="azureuser", agent_count="3",
+               agent_vm_size="Standard_D2_v2", location=None, master_count="3",
+               orchestrator_type="dcos", service_principal=None, client_secret=None, tags=None,
+               custom_headers=None, raw=False,
+               **operation_config):  # pylint: disable=too-many-locals
     """Create a new Acs.
     :param resource_group_name: The name of the resource group. The name
      is case insensitive.
@@ -410,18 +443,32 @@ def acs_create(resource_group_name, deployment_name, name, ssh_key_value, dns_na
                 store_acs_service_principal(subscription_id, client_secret, service_principal)
             # Either way, update the role assignment, this fixes things if we fail part-way through
             if not _add_role_assignment('Owner', service_principal):
-                raise CLIError('Could not create a service principal with the right permissions. Are you an Owner on this project?')
+                raise CLIError(
+                    'Could not create a service principal with the right permissions. Are you an Owner on this project?')
         else:
             # --service-principal specfied, validate --client-secret was too
             if not client_secret:
                 raise CLIError('--client-secret is required if --service-principal is specified')
             _validate_service_principal(client, service_principal)
-        return _create_kubernetes(resource_group_name, deployment_name, dns_name_prefix, name, ssh_key_value, admin_username=admin_username, agent_count=agent_count, agent_vm_size=agent_vm_size, location=location, service_principal=service_principal, client_secret=client_secret)
+        return _create_kubernetes(resource_group_name, deployment_name, dns_name_prefix, name,
+                                  ssh_key_value, admin_username=admin_username,
+                                  agent_count=agent_count, agent_vm_size=agent_vm_size,
+                                  location=location, service_principal=service_principal,
+                                  client_secret=client_secret)
 
     ops = get_mgmt_service_client(ACSClient).acs
-    return ops.create_or_update(resource_group_name, deployment_name, dns_name_prefix, name, ssh_key_value, content_version=content_version, admin_username=admin_username, agent_count=agent_count, agent_vm_size=agent_vm_size, location=location, master_count=master_count, orchestrator_type=orchestrator_type, tags=tags, custom_headers=custom_headers, raw=raw, operation_config=operation_config)
+    return ops.create_or_update(resource_group_name, deployment_name, dns_name_prefix, name,
+                                ssh_key_value, content_version=content_version,
+                                admin_username=admin_username, agent_count=agent_count,
+                                agent_vm_size=agent_vm_size, location=location,
+                                master_count=master_count, orchestrator_type=orchestrator_type,
+                                tags=tags, custom_headers=custom_headers, raw=raw,
+                                operation_config=operation_config)
 
-def store_acs_service_principal(subscription_id, client_secret, service_principal, config_path=os.path.join(get_config_dir(), 'acsServicePrincipal.json')):
+
+def store_acs_service_principal(subscription_id, client_secret, service_principal,
+                                config_path=os.path.join(get_config_dir(),
+                                                         'acsServicePrincipal.json')):
     obj = {}
     if client_secret:
         obj['client_secret'] = client_secret
@@ -433,15 +480,18 @@ def store_acs_service_principal(subscription_id, client_secret, service_principa
         fullConfig = {}
     fullConfig[subscription_id] = obj
 
-    with os.fdopen(os.open(config_path, os.O_RDWR|os.O_CREAT|os.O_TRUNC, 0o600),
+    with os.fdopen(os.open(config_path, os.O_RDWR | os.O_CREAT | os.O_TRUNC, 0o600),
                    'w+') as spFile:
         json.dump(fullConfig, spFile)
 
-def load_acs_service_principal(subscription_id, config_path=os.path.join(get_config_dir(), 'acsServicePrincipal.json')):
+
+def load_acs_service_principal(subscription_id, config_path=os.path.join(get_config_dir(),
+                                                                         'acsServicePrincipal.json')):
     config = load_acs_service_principals(config_path)
     if not config:
         return None
     return config.get(subscription_id)
+
 
 def load_acs_service_principals(config_path):
     if not os.path.exists(config_path):
@@ -450,10 +500,13 @@ def load_acs_service_principals(config_path):
     try:
         with os.fdopen(fd) as f:
             return json.loads(f.read())
-    except: #pylint: disable=bare-except
+    except:  # pylint: disable=bare-except
         return None
 
-def _create_kubernetes(resource_group_name, deployment_name, dns_name_prefix, name, ssh_key_value, admin_username="azureuser", agent_count="3", agent_vm_size="Standard_D2_v2", location=None, service_principal=None, client_secret=None):
+
+def _create_kubernetes(resource_group_name, deployment_name, dns_name_prefix, name, ssh_key_value,
+                       admin_username="azureuser", agent_count="3", agent_vm_size="Standard_D2_v2",
+                       location=None, service_principal=None, client_secret=None):
     from azure.mgmt.resource.resources.models import DeploymentProperties
     if not location:
         location = '[resourceGroup().location]'
@@ -518,6 +571,7 @@ def _create_kubernetes(resource_group_name, deployment_name, dns_name_prefix, na
     smc = _resource_client_factory()
     return smc.deployments.create_or_update(resource_group_name, deployment_name, properties)
 
+
 def k8s_get_credentials(name, resource_group_name,
                         path=os.path.join(os.path.expanduser('~'), '.kube', 'config'),
                         ssh_key_file=os.path.join(os.path.expanduser('~'), '.ssh', 'id_rsa')):
@@ -534,10 +588,11 @@ def k8s_get_credentials(name, resource_group_name,
     acs_info = _get_acs_info(name, resource_group_name)
     _k8s_get_credentials_internal(name, acs_info, path, ssh_key_file)
 
+
 def _k8s_get_credentials_internal(name, acs_info, path, ssh_key_file):
-    dns_prefix = acs_info.master_profile.dns_prefix # pylint: disable=no-member
-    location = acs_info.location # pylint: disable=no-member
-    user = acs_info.linux_profile.admin_username # pylint: disable=no-member
+    dns_prefix = acs_info.master_profile.dns_prefix  # pylint: disable=no-member
+    location = acs_info.location  # pylint: disable=no-member
+    user = acs_info.linux_profile.admin_username  # pylint: disable=no-member
     _mkdir_p(os.path.dirname(path))
 
     path_candidate = path
@@ -559,6 +614,7 @@ def _k8s_get_credentials_internal(name, acs_info, path, ssh_key_file):
             logger.warning('Failed to merge credentials to kube config file: %s', exc)
             logger.warning('The credentials have been saved to %s', path_candidate)
 
+
 def merge_kubernetes_configurations(existing_file, addition_file):
     with open(existing_file) as stream:
         existing = yaml.load(stream)
@@ -575,6 +631,7 @@ def merge_kubernetes_configurations(existing_file, addition_file):
     with open(existing_file, 'w+') as stream:
         yaml.dump(existing, stream, default_flow_style=True)
 
+
 def _get_host_name(acs_info):
     """
     Gets the FQDN from the acs_info object.
@@ -590,6 +647,7 @@ def _get_host_name(acs_info):
         raise CLIError('Missing fqdn')
     return acs_info.master_profile.fqdn
 
+
 def _get_username(acs_info):
     """
     Gets the admin user name from the Linux profile of the ContainerService object.
@@ -600,6 +658,7 @@ def _get_username(acs_info):
     if acs_info.linux_profile is not None:
         return acs_info.linux_profile.admin_username
     return None
+
 
 def _get_acs_info(name, resource_group_name):
     """
@@ -613,12 +672,14 @@ def _get_acs_info(name, resource_group_name):
     mgmt_client = get_mgmt_service_client(ComputeManagementClient)
     return mgmt_client.container_services.get(resource_group_name, name)
 
+
 def _rand_str(n):
     """
     Gets a random string
     """
     choices = string.ascii_lowercase + string.digits
     return ''.join(random.SystemRandom().choice(choices) for _ in range(n))
+
 
 def _mkdir_p(path):
     # http://stackoverflow.com/a/600612

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/proxy.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/proxy.py
@@ -7,11 +7,13 @@ import platform
 import subprocess
 from abc import abstractmethod
 
+
 def disable_http_proxy():
     """
     Disables the HTTP proxy
     """
     _get_proxy_instance().disable_http_proxy()
+
 
 def set_http_proxy(host, port):
     """
@@ -24,6 +26,7 @@ def set_http_proxy(host, port):
         raise ValueError('Missing port')
 
     _get_proxy_instance().set_http_proxy(host, port)
+
 
 def _get_proxy_instance():
     """
@@ -40,10 +43,12 @@ def _get_proxy_instance():
     else:
         raise NotImplementedError('Not implemented yet for {}'.format(os_platform))
 
+
 class Proxy(object):
     """
     Base proxy class
     """
+
     def __init__(self):
         pass
 
@@ -60,6 +65,7 @@ class Proxy(object):
         Disables the HTTP proxy
         """
         pass
+
 
 class LinuxProxy(Proxy):
     def __init__(self):
@@ -80,6 +86,7 @@ class LinuxProxy(Proxy):
         Disables the HTTP proxy
         """
         subprocess.call('sudo gsettings set org.gnome.system.proxy mode \'none\'', shell=True)
+
 
 class MacProxy(Proxy):
     def __init__(self):

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/tests/test_acs_client.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/tests/test_acs_client.py
@@ -3,11 +3,12 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-#pylint: skip-file
+# pylint: skip-file
 import unittest
 import mock
 
 from azure.cli.command_modules.acs.acs_client import ACSClient
+
 
 class AcsClientTest(unittest.TestCase):
     def test_create_acs_client(self):

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/tests/test_custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/tests/test_custom.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-#pylint: skip-file
+# pylint: skip-file
 import mock
 import os
 import requests
@@ -13,16 +13,19 @@ import yaml
 
 from msrestazure.azure_exceptions import CloudError
 
-from azure.cli.command_modules.acs.custom import merge_kubernetes_configurations, _acs_browse_internal, _add_role_assignment
-from azure.mgmt.compute.models import ContainerServiceOchestratorTypes, ContainerService, ContainerServiceOrchestratorProfile
+from azure.cli.command_modules.acs.custom import (merge_kubernetes_configurations,
+                                                  _acs_browse_internal, _add_role_assignment)
+from azure.mgmt.compute.models import (ContainerServiceOchestratorTypes, ContainerService,
+                                       ContainerServiceOrchestratorProfile)
+
 
 class AcsCustomCommandTest(unittest.TestCase):
-    
     def test_add_role_assignment_basic(self):
         role = 'Owner'
         sp = '1234567'
 
-        with mock.patch('azure.cli.command_modules.role.custom.create_role_assignment') as create_role_assignment:
+        with mock.patch(
+                'azure.cli.command_modules.role.custom.create_role_assignment') as create_role_assignment:
             ok = _add_role_assignment(role, sp, delay=0, output=False)
             create_role_assignment.assert_called_with(role, sp)
             self.assertTrue(ok, 'Expected _add_role_assignment to succeed')
@@ -31,7 +34,8 @@ class AcsCustomCommandTest(unittest.TestCase):
         role = 'Owner'
         sp = '1234567'
 
-        with mock.patch('azure.cli.command_modules.role.custom.create_role_assignment') as create_role_assignment:
+        with mock.patch(
+                'azure.cli.command_modules.role.custom.create_role_assignment') as create_role_assignment:
             resp = mock.Mock()
             resp.status_code = 409
             resp.content = 'Conflict'
@@ -47,7 +51,8 @@ class AcsCustomCommandTest(unittest.TestCase):
         role = 'Owner'
         sp = '1234567'
 
-        with mock.patch('azure.cli.command_modules.role.custom.create_role_assignment') as create_role_assignment:
+        with mock.patch(
+                'azure.cli.command_modules.role.custom.create_role_assignment') as create_role_assignment:
             resp = mock.Mock()
             resp.status_code = 500
             resp.content = 'Internal Error'
@@ -55,17 +60,20 @@ class AcsCustomCommandTest(unittest.TestCase):
             err.message = 'Internal Error'
             create_role_assignment.side_effect = err
             ok = _add_role_assignment(role, sp, delay=0, output=False)
-            
+
             create_role_assignment.assert_called_with(role, sp)
             self.assertFalse(ok, 'Expected _add_role_assignment to fail')
 
     @mock.patch('azure.cli.command_modules.acs.custom._get_subscription_id')
     def test_browse_k8s(self, get_subscription_id):
         acs_info = ContainerService("location", {}, {}, {})
-        acs_info.orchestrator_profile = ContainerServiceOrchestratorProfile(ContainerServiceOchestratorTypes.kubernetes)
-        
-        with mock.patch('azure.cli.command_modules.acs.custom._get_acs_info', return_value=acs_info) as get_acs_info:
-            with mock.patch('azure.cli.command_modules.acs.custom._k8s_browse_internal') as k8s_browse:
+        acs_info.orchestrator_profile = ContainerServiceOrchestratorProfile(
+            ContainerServiceOchestratorTypes.kubernetes)
+
+        with mock.patch('azure.cli.command_modules.acs.custom._get_acs_info',
+                        return_value=acs_info) as get_acs_info:
+            with mock.patch(
+                    'azure.cli.command_modules.acs.custom._k8s_browse_internal') as k8s_browse:
                 _acs_browse_internal(acs_info, 'resource-group', 'name', False, 'ssh/key/file')
                 get_acs_info.assert_called_with('name', 'resource-group')
                 k8s_browse.assert_called_with('name', acs_info, False, 'ssh/key/file')
@@ -73,9 +81,11 @@ class AcsCustomCommandTest(unittest.TestCase):
     @mock.patch('azure.cli.command_modules.acs.custom._get_subscription_id')
     def test_browse_dcos(self, get_subscription_id):
         acs_info = ContainerService("location", {}, {}, {})
-        acs_info.orchestrator_profile = ContainerServiceOrchestratorProfile(ContainerServiceOchestratorTypes.dcos)
-        
-        with mock.patch('azure.cli.command_modules.acs.custom._dcos_browse_internal') as dcos_browse:
+        acs_info.orchestrator_profile = ContainerServiceOrchestratorProfile(
+            ContainerServiceOchestratorTypes.dcos)
+
+        with mock.patch(
+                'azure.cli.command_modules.acs.custom._dcos_browse_internal') as dcos_browse:
             _acs_browse_internal(acs_info, 'resource-group', 'name', False, 'ssh/key/file')
             dcos_browse.assert_called_with(acs_info, False, 'ssh/key/file')
 

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/tests/test_service_principals.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/tests/test_service_principals.py
@@ -9,7 +9,9 @@ import tempfile
 import unittest
 
 from azure.cli.core._util import CLIError
-from azure.cli.command_modules.acs.custom import _validate_service_principal, load_acs_service_principal, store_acs_service_principal
+from azure.cli.command_modules.acs.custom import _validate_service_principal, \
+    load_acs_service_principal, store_acs_service_principal
+
 
 class AcsServicePrincipalTest(unittest.TestCase):
     def test_load_non_existent_service_principal(self):

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/win_proxy.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/win_proxy.py
@@ -12,6 +12,7 @@ from azure.cli.command_modules.acs.proxy import Proxy
 LPWSTR = POINTER(WCHAR)
 HINTERNET = LPVOID
 
+
 class WinProxy(Proxy):
     INTERNET_PER_CONN_PROXY_SERVER = 2
     INTERNET_OPTION_REFRESH = 37
@@ -27,7 +28,7 @@ class WinProxy(Proxy):
         """
         Sets the HTTP proxy on Windows
         """
-        setting = create_unicode_buffer(host+':'+str(port))
+        setting = create_unicode_buffer(host + ':' + str(port))
         self._set_internet_options(setting)
 
     def disable_http_proxy(self):
@@ -65,6 +66,7 @@ class WinProxy(Proxy):
         InternetSetOption(None, self.INTERNET_OPTION_SETTINGS_CHANGED, None, 0)
         InternetSetOption(None, self.INTERNET_OPTION_REFRESH, None, 0)
 
+
 # pylint: disable=too-few-public-methods
 class INTERNET_PER_CONN_OPTION(Structure):
     class Value(Union):
@@ -78,6 +80,7 @@ class INTERNET_PER_CONN_OPTION(Structure):
         ('dwOption', DWORD),
         ('Value', Value),
     ]
+
 
 class INTERNET_PER_CONN_OPTION_LIST(Structure):
     _fields_ = [


### PR DESCRIPTION
/cc @brendandburns

All changes are trivial. The goal is to ensure all PEP8 rules are followed. Moving forward the style checker will be run against acs module code in CI.