### PR TITLE
Fixes KeyError: 'environmentName' after log in

### DIFF
--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+from copy import deepcopy
 import requests
 from adal.adal_error import AdalError
 from azure.cli.core.prompting import prompt_pass, NoTTYException
@@ -84,7 +85,7 @@ def login(username=None, password=None, service_principal=None, tenant=None):
         raise CLIError(err)
     except requests.exceptions.ConnectionError as err:
         raise CLIError('Please ensure you have network connection. Error detail: ' + str(err))
-    all_subscriptions = list(subscriptions)
+    all_subscriptions = deepcopy(subscriptions)
     for sub in all_subscriptions:
         sub['cloudName'] = sub.pop('environmentName', None)
     return all_subscriptions

--- a/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
+++ b/src/command_modules/azure-cli-profile/azure/cli/command_modules/profile/custom.py
@@ -85,6 +85,7 @@ def login(username=None, password=None, service_principal=None, tenant=None):
         raise CLIError(err)
     except requests.exceptions.ConnectionError as err:
         raise CLIError('Please ensure you have network connection. Error detail: ' + str(err))
+    # use deepcopy as we don't want to persist these changes to file.
     all_subscriptions = deepcopy(subscriptions)
     for sub in all_subscriptions:
         sub['cloudName'] = sub.pop('environmentName', None)


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-cli/issues/2031
We modify ‘’environmentName’ to ‘cloudName’ and this changed the object referenced by the file.
So later on, when another change was made, this change was saved to file!