### PR TITLE
Added Dockerfile labels from label-schema.org

### DIFF
--- a/packaged_releases/docker/Dockerfile
+++ b/packaged_releases/docker/Dockerfile
@@ -8,6 +8,20 @@ FROM python:3.5.2-alpine
 ENV CLI_VERSION 0.1.9
 ENV CLI_DOWNLOAD_SHA256 4da806cc46acd8e634bc38eb81591b7ecf352703fb84d9b4cfcf4364237ac8b2
 
+# Metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+LABEL org.label-schema.schema-version="1.0" \
+      org.label-schema.vendor="Microsoft" \
+      org.label-schema.name="Azure CLI 2.0" \
+      org.label-schema.version=$CLI_VERSION \
+      org.label-schema.license="MIT" \
+      org.label-schema.description="The Azure CLI 2.0 is the new Azure CLI and is applicable when you use the Resource Manager deployment model." \
+      org.label-schema.url="https://docs.microsoft.com/en-us/cli/azure/overview" \
+      org.label-schema.usage="https://docs.microsoft.com/en-us/cli/azure/install-az-cli2#docker" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vcs-url="https://github.com/Azure/azure-cli.git" \
+      org.label-schema.docker.cmd="docker run -v ${HOME}:/root -it azuresdk/azure-cli-python:<version>"
+
 # INSTALL DEPENDENCIES
 # pip wheel - required for CLI packaging
 # jmespath-terminal - we include jpterm as a useful tool

--- a/packaged_releases/docker/README.md
+++ b/packaged_releases/docker/README.md
@@ -9,7 +9,7 @@ Updating the Docker image
 2. In the Dockerfile, modify `CLI_VERSION` and the `CLI_DOWNLOAD_SHA256` hash as appropriate.
 3. Run `docker build` with this Dockerfile.
     When tagging this Docker image, choose an appropriate version number.
-      e.g.: `sudo docker build --no-cache -f Dockerfile -t azuresdk/azure-cli-python:${CLI_VERSION} .`
+      e.g.: `sudo docker build --no-cache --build-arg BUILD_DATE="`date -u +"%Y-%m-%dT%H:%M:%SZ"`" -f Dockerfile -t azuresdk/azure-cli-python:${CLI_VERSION} .`
 4. Push the image to the registry,
       e.g.: `sudo docker push azuresdk/azure-cli-python:${CLI_VERSION}`
 5. Create a PR to commit the Dockerfile changes back to the repository.


### PR DESCRIPTION
There is a drive from some within the container community towards a standard label schema for container images.

> Label Schema Convention DRAFT (1.0.0-rc.1)
> http://label-schema.org/rc1/
> 
> Docker Inc. express a preference that container labels should be namespaced. Label Schema is a community project to provide a shared namespace for use by multiple tools, specifically org.label-schema.
>
> By providing a shared and community owned namespace we aim to:
> - Avoid duplication in cases where the same information is needed in multiple labels
> - Encourage the use of labels, both by image creators and by tool builders which might consume them
> - Codify good community practice in a way that is easy to consume and keep up-to-date with

There are some blog posts that discuss this:
- [Building agreement around Docker labels](https://puppet.com/blog/building-agreement-around-docker-labels)
- [MicroBadger - helping you manage your containers](http://blog.microscaling.com/2016/06/microbadger-manage-your-containers.html)
- [New for the Image-Conscious Container: Label-Schema.org](https://medium.com/microscaling-systems/new-for-the-image-conscious-container-label-schema-org-78654a270f07#.5nlpzvz0i)

[MicroBadger](http://microbadger.com) provides tooling around these labels to provide badges and docker image details. See the following examples:
- [MicroBadger - Metadata from image puppet/puppetserver](https://microbadger.com/images/puppet/puppetserver)
- [GitHub - puppetlabs/puppet-in-docker](https://github.com/puppetlabs/puppet-in-docker)

In this PR, I've updated the `Dockerfile` in the `packaged_releases/docker` folder to contain the org.label-schema labels. The `docker build` command will now expect two arguments: `BUILD_DATE` and `VCS_REF`.

Running the following command:
```
$ docker build --no-cache --build-arg BUILD_DATE="`date -u +"%Y-%m-%dT%H:%M:%SZ"`" --build-arg VCS_REF="`git rev-parse HEAD`" -f Dockerfile -t azuresdk/azure-cli-python:${CLI_VERSION} .
```
Will result in:
```
$ docker inspect e160c887d71c -f "{{json .Config.Labels}}" | jq .
{
  "org.label-schema.version": "0.1.9",
  "org.label-schema.vendor": "Microsoft",
  "org.label-schema.vcs-url": "https://github.com/Azure/azure-cli.git",
  "org.label-schema.vcs-ref": "27816f4891c85592ad6f06bcc94008fa7d144b69",
  "org.label-schema.build-date": "2017-02-12T03:42:56Z",
  "org.label-schema.description": "The Azure CLI 2.0 is the new Azure CLI and is applicable when you use the Resource Manager deployment model.",
  "org.label-schema.docker.cmd": "docker run -v ${HOME}:/root -it azuresdk/azure-cli-python:<version>",
  "org.label-schema.license": "MIT",
  "org.label-schema.name": "Azure CLI 2.0",
  "org.label-schema.schema-version": "1.0",
  "org.label-schema.url": "https://docs.microsoft.com/en-us/cli/azure/overview",
  "org.label-schema.usage": "https://docs.microsoft.com/en-us/cli/azure/install-az-cli2#docker"
}
```

I also updated the instructions in `packaged_releases/docker/README.md` to ensure that the changes to the `Dockerfile` are committed before building the image. This will ensure that the correct commit hash `VCS_REF` will be embedded in the Docker image.