### PR TITLE
make ci build run locally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
   - pip install -qqq virtualenv # used by package_verify script
   - python scripts/dev_setup.py
 script: 
-  - ./scripts/build_in_travis.sh
+  - ./scripts/build.sh

--- a/scripts/automation/setup/install_modules.py
+++ b/scripts/automation/setup/install_modules.py
@@ -20,10 +20,7 @@ def install_modules():
 
     for name, path in all_modules:
         try:
-            if os.listdir(path):
-                subprocess.check_call(INSTALL_COMMAND.format(path).split())
-            else:
-                print('{0} is empty... skipping it.'.format(path))
+            subprocess.check_call(INSTALL_COMMAND.format(path).split())
         except subprocess.CalledProcessError as err:
             # exit code is not zero
             failures.append('Failed to install {}. Error message: {}'.format(name, err.output))

--- a/scripts/automation/utilities/path.py
+++ b/scripts/automation/utilities/path.py
@@ -29,8 +29,7 @@ def get_command_modules_paths(include_prefix=False):
     modules_paths = ((name if include_prefix else name[len(COMMAND_MODULE_PREFIX):],
                       os.path.join(root, name))
                      for name in os.listdir(root) if name.startswith(COMMAND_MODULE_PREFIX))
-
-    return list(modules_paths)
+    return list([path for path in modules_paths if os.path.isfile(os.path.join(path[1], 'setup.py'))])
 
 
 def get_command_modules_paths_with_tests():

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,10 +13,18 @@ export PYTHONPATH=$PATHONPATH:./src
 python -m azure.cli -h
 
 # PyLint does not yet support Python 3.6 https://github.com/PyCQA/pylint/issues/1241
-if [ "$TRAVIS_PYTHON_VERSION" != "3.6" ]; then
+
+LOCAL_PYTHON_VERSION=$(python -c 'import sys; print("{0}.{1}".format(sys.version_info[0], sys.version_info[1]))')
+if [[ "$TRAVIS_PYTHON_VERSION" == "3.6" || "$LOCAL_PYTHON_VERSION" == "3.6" ]]; then
+    echo 'Skipping check_style since it is not supported in python 3.6'
+else
     check_style --ci;
 fi
+
 run_tests
-$scripts_root/package_verify.sh
+
+if [[ "$CI" == "true" ]]; then
+    $scripts_root/package_verify.sh
+fi
 
 python $scripts_root/license/verify.py


### PR DESCRIPTION
- move build_in_travis.sh to build.sh
- fix up the grabbing modules locally for style checks so we don't grab empty folders
- ensure we don't run check_style if running py 3.6

To ensure you are receiving the same results as the server, run `./scripts/build.sh`