### PR TITLE
commandlint script

### DIFF
--- a/scripts/automation/commandlint/__init__.py
+++ b/scripts/automation/commandlint/__init__.py
@@ -1,0 +1,6 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+"""Command linting automation code"""

--- a/scripts/automation/commandlint/run.py
+++ b/scripts/automation/commandlint/run.py
@@ -18,7 +18,7 @@ from importlib import import_module
 
 def dump_no_help(modules):
     cmd_table = APPLICATION.configuration.get_command_table()
-
+    exit = 0
     for cmd in cmd_table:
         cmd_table[cmd].load_arguments()
 
@@ -34,11 +34,14 @@ def dump_no_help(modules):
     for cmd in cmd_table:
         descrip = cmd_table[cmd].description
         if descrip is None or descrip is "":
+            exit = 1
             print(cmd)
 
         for key in cmd_table[cmd].arguments:
             if cmd_table[cmd].arguments[key].type.settings.get('help') is None:
+                exit = 1
                 print(cmd + " " + str(cmd_table[cmd].arguments[key].name))
+    sys.exit(exit)
 
 if __name__ == '__main__':
     parse = argparse.ArgumentParser('Test tools')

--- a/scripts/automation/commandlint/run.py
+++ b/scripts/automation/commandlint/run.py
@@ -2,11 +2,13 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
+from __future__ import print_function
 import pkgutil
 
 import argparse
 import os
 import sys
+import json
 from importlib import import_module
 
 from automation.utilities.path import filter_user_selected_modules_with_tests
@@ -18,7 +20,8 @@ from azure.cli.core.commands import load_params, _update_command_definitions
 
 def dump_no_help(modules):
     cmd_table = APPLICATION.configuration.get_command_table()
-    exit = 0
+
+    exit_val = 0
     for cmd in cmd_table:
         cmd_table[cmd].load_arguments()
 
@@ -30,17 +33,33 @@ def dump_no_help(modules):
 
     _update_command_definitions(cmd_table)
 
+    command_list = []
+    subgroups_list = []
+    parameters = {}
     for cmd in cmd_table:
-        descrip = cmd_table[cmd].description
-        if not descrip:
-            exit = 1
-            print(cmd)
+        if not cmd_table[cmd].description:
+            command_list.append(cmd)
+            exit_val = 1
+        group_name = " ".join(cmd.split()[:-1])
+        if group_name in cmd_table and not cmd_table[group_name].description:
+            exit_val = 1
+            if group_name not in subgroups_list:
+                subgroups_list.append(group_name)
 
+        param_list = []
         for key in cmd_table[cmd].arguments:
             if cmd_table[cmd].arguments[key].type.settings.get('help') is None:
-                exit = 1
-                print(cmd + " " + str(cmd_table[cmd].arguments[key].name))
-    return exit
+                exit_val = 1
+                param_list.append(cmd_table[cmd].arguments[key].type.settings.get('name'))
+
+        parameters[cmd] = param_list
+    data = {
+        "subgroups" : subgroups_list,
+        "commands" : command_list,
+        "parameters" : parameters
+    }
+    json.dumps(data)
+    return exit_val
 
 if __name__ == '__main__':
     parse = argparse.ArgumentParser('Test tools')
@@ -64,8 +83,8 @@ if __name__ == '__main__':
                                          pkgutil.iter_modules(mods_ns_pkg.__path__)]
         except ImportError:
             pass
-        exit = dump_no_help(installed_command_modules)
+        exit_value = dump_no_help(installed_command_modules)
     else:
-        exit = dump_no_help(selected_modules)
-    sys.exit(exit)
+        exit_value = dump_no_help(selected_modules)
+    sys.exit(exit_value)
 

--- a/scripts/automation/commandlint/run.py
+++ b/scripts/automation/commandlint/run.py
@@ -1,0 +1,71 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+import pkgutil
+
+import argparse
+import os
+import sys
+
+from automation.utilities.path import filter_user_selected_modules_with_tests
+from azure.cli.core.application import APPLICATION, Application
+from azure.cli.core.application import Configuration
+from azure.cli.core.commands import load_params, _update_command_definitions
+
+from importlib import import_module
+
+
+def dump_no_help(modules):
+    cmd_table = APPLICATION.configuration.get_command_table()
+
+    for cmd in cmd_table:
+        cmd_table[cmd].load_arguments()
+
+    for mod in modules:
+        # print('loading params for', mod)
+        try:
+            import_module('azure.cli.command_modules.' + mod).load_params(mod)
+        except Exception as ex:
+            print("EXCPETION: " + ex.message)
+
+    _update_command_definitions(cmd_table)
+
+    for cmd in cmd_table:
+        descrip = cmd_table[cmd].description
+        if descrip is None or descrip is "":
+            print(cmd)
+
+        for key in cmd_table[cmd].arguments:
+            if cmd_table[cmd].arguments[key].type.settings.get('help') is None:
+                print(cmd + " " + str(cmd_table[cmd].arguments[key].name))
+
+if __name__ == '__main__':
+    parse = argparse.ArgumentParser('Test tools')
+    parse.add_argument('--module', dest='modules', action='append',
+                       help='The modules of which the test to be run. Accept short names, except '
+                            'azure-cli, azure-cli-core and azure-cli-nspkg. The modules list can '
+                            'also be set through environment variable AZURE_CLI_TEST_MODULES. The '
+                            'value should be a string of comma separated module names. The '
+                            'environment variable will be overwritten by command line parameters.')
+    parse.add_argument('--non-parallel', action='store_true',
+                       help='Not to run the tests in parallel.')
+    parse.add_argument('--live', action='store_true', help='Run all the tests live.')
+    args = parse.parse_args()
+
+    if not args.modules and os.environ.get('AZURE_CLI_TEST_MODULES', None):
+        print('Test modules list is parsed from environment variable AZURE_CLI_TEST_MODULES.')
+        args.modules = [m.strip() for m in os.environ.get('AZURE_CLI_TEST_MODULES').split(',')]
+
+    selected_modules = filter_user_selected_modules_with_tests(args.modules)
+    if not selected_modules:
+        try:
+            mods_ns_pkg = import_module('azure.cli.command_modules')
+            installed_command_modules = [modname for _, modname, _ in
+                                         pkgutil.iter_modules(mods_ns_pkg.__path__)]
+        except ImportError:
+            pass
+        dump_no_help(installed_command_modules)
+    else:
+        dump_no_help(selected_modules)
+

--- a/scripts/automation/commandlint/run.py
+++ b/scripts/automation/commandlint/run.py
@@ -58,20 +58,15 @@ def dump_no_help(modules):
 
     for cmd in helps:
         diction_help = yaml.load(helps[cmd])
-        if "short-summary" in diction_help:
-            if "type" in diction_help:
-                if diction_help["type"] == "command":
-                    if cmd in command_list:
-                        command_list.remove(cmd)
-                elif diction_help["type"] == "group":
-                    if cmd in subgroups_list:
-                        subgroups_list.remove(cmd)
+        if "short-summary" in diction_help and "type" in diction_help:
+            if diction_help["type"] == "command" and cmd in command_list:
+                command_list.remove(cmd)
+            elif diction_help["type"] == "group" and cmd in subgroups_list:
+                subgroups_list.remove(cmd)
         if "parameters" in diction_help:
-            # params = yaml.load(diction_help["parameters"])
             for param in diction_help["parameters"]:
-                if "short-summary" in param:
-                    if param["name"].split()[0] in parameters:
-                        parameters.pop(cmd, None)
+                if "short-summary" in param and param["name"].split()[0] in parameters:
+                    parameters.pop(cmd, None)
 
     data = {
         "subgroups" : subgroups_list,


### PR DESCRIPTION
Dumps the names of all the commands and parameters that don't have descriptions

Example output:
network lb probe create port
appservice web list
vm boot-diagnostics get-boot-log
vm boot-diagnostics get-boot-log vm_name
network application-gateway url-path-map rule create
network application-gateway url-path-map rule create paths
network application-gateway url-path-map rule create item_name
network application-gateway url-path-map rule create no_wait
network application-gateway url-path-map rule create application_gateway_name
network application-gateway url-path-map rule create http_settings
network application-gateway url-path-map rule create address_pool
network application-gateway url-path-map rule create url_path_map_name
network dns record a add
network dns record a add ipv4_address
network dns record a add record_set_name
network dns record a add zone_name
vmss update-instances vm_scale_set_name
vmss update-instances instance_ids
vm diagnostics get-default-config is_windows_os
network traffic-manager profile update
network traffic-manager profile update routing_method
network traffic-manager profile update monitor_protocol
network traffic-manager profile update tags
network traffic-manager profile update monitor_port
network traffic-manager profile update monitor_path
network traffic-manager profile update ttl
network traffic-manager profile update profile_status
vmss list_instance_connection_info
vmss list_instance_connection_info vm_scale_set_name
network application-gateway http-listener create
network application-gateway http-listener create ssl_cert
network application-gateway http-listener create item_name
network application-gateway http-listener create application_gateway_name
network application-gateway http-listener create frontend_ip
network application-gateway http-listener create frontend_port
storage account show-connection-string protocol
storage account show-connection-string queue_endpoint
storage account show-connection-string key_name
storage account show-connection-string table_endpoint
storage account show-connection-string file_endpoint
storage account show-connection-string blob_endpoint
storage account show-connection-string account_name
network lb rule update
network lb rule update frontend_port
network lb rule update frontend_ip_name
network lb rule update floating_ip
network lb rule update backend_address_pool_name
network lb rule update item_name
network lb rule update idle_timeout
network lb rule update protocol
network lb rule update probe_name
network lb rule update load_distribution
network lb rule update backend_port
network dns record update-soa
network dns record update-soa refresh_time
network dns record update-soa minimum_ttl
network dns record update-soa expire_time
network dns record update-soa zone_name
network dns record update-soa retry_time
network dns record update-soa serial_number
network dns record update-soa email
network route-table list
resource update
group deployment export
appservice web deployment slot auto-swap
network lb probe delete
network lb probe delete item_name
network lb probe delete resource_name
network lb probe delete no_wait
ad user create force_change_password_next_login
ad user create password
network application-gateway waf-config show
network application-gateway waf-config show application_gateway_name
vmss diagnostics get-default-config is_windows_os
configure
network application-gateway ssl-cert list
network application-gateway ssl-cert list resource_name
vm get-instance-view
vm get-instance-view vm_name


The first part is the command if it doesn't have a description. If the parameter doesn't have a description, it outputs command name then the parameter name