### PR TITLE
'component update' Check additional component author on PyPI

### DIFF
--- a/src/command_modules/azure-cli-component/azure/cli/command_modules/component/_params.py
+++ b/src/command_modules/azure-cli-component/azure/cli/command_modules/component/_params.py
@@ -11,3 +11,4 @@ register_cli_argument('component', 'link', options_list=('--link', '-l'), help='
 register_cli_argument('component', 'private', help='Include packages from a private server.', action='store_true')
 register_cli_argument('component', 'pre', help='Include pre-release versions', action='store_true')
 register_cli_argument('component', 'additional_components', options_list=('--add',), nargs='+', help='The names of additional components to install (space separated)')
+register_cli_argument('component', 'allow_third_party', options_list=('--allow-third-party',), action='store_true', help='Allow installation of 3rd party command modules. This option is assumed with --private.')

--- a/src/command_modules/azure-cli-component/azure/cli/command_modules/component/custom.py
+++ b/src/command_modules/azure-cli-component/azure/cli/command_modules/component/custom.py
@@ -151,8 +151,9 @@ def _verify_additional_components(components, private, allow_third_party):
         if c not in first_party_component_names:
             third_party.append(c)
     if third_party:
-        raise CLIError("The following components are third party or not available"
-                       " '{}'.".format(', '.join(third_party)))
+        raise CLIError("The following component(s) '{}' are third party or not available. "
+                       "Use --allow-third-party to install "
+                       "third party packages.".format(', '.join(third_party)))
 
 
 def update(private=False,


### PR DESCRIPTION
Added a `--allow-third-party` flag.

```
$ az component update --help

Command
    az component update: Update Azure CLI 2.0 (Preview) and all of the installed components.

Arguments
    --add              : The names of additional components to install (space separated).
    --allow-third-party: Allow installation of 3rd party command modules. This option is assumed
                         with --private.
    --link -l          : If a url or path to an html file, parse for links to archives. If local
                         path or file:// url that's a directory, then look for archives in the
                         directory listing.
    --pre              : Include pre-release versions.
    --private          : Include packages from a private server.
```