### PR TITLE
Fix Docker packaging README formatting

### DIFF
--- a/packaged_releases/docker/README.md
+++ b/packaged_releases/docker/README.md
@@ -9,7 +9,7 @@ Updating the Docker image
 2. In the Dockerfile, modify `CLI_VERSION` and the `CLI_DOWNLOAD_SHA256` hash as appropriate.
 3. Run `docker build` with this Dockerfile.
     When tagging this Docker image, choose an appropriate version number.
-      e.g.: `sudo docker build --no-cache --build-arg BUILD_DATE="`date -u +"%Y-%m-%dT%H:%M:%SZ"`" -f Dockerfile -t azuresdk/azure-cli-python:${CLI_VERSION} .`
+      e.g.: ``sudo docker build --no-cache --build-arg BUILD_DATE="`date -u +"%Y-%m-%dT%H:%M:%SZ"`" -f Dockerfile -t azuresdk/azure-cli-python:${CLI_VERSION} .``
 4. Push the image to the registry,
       e.g.: `sudo docker push azuresdk/azure-cli-python:${CLI_VERSION}`
 5. Create a PR to commit the Dockerfile changes back to the repository.


### PR DESCRIPTION
Need to escape backticks for Markdown format from https://github.com/Azure/azure-cli/pull/2046