### PR TITLE
Decouple azure-cli-acs and azure-cli-role module

### DIFF
--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_client_factory.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/_client_factory.py
@@ -1,0 +1,30 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+
+def _auth_client_factory(scope=None):
+    import re
+    from azure.cli.core.commands.client_factory import get_mgmt_service_client
+    from azure.mgmt.authorization import AuthorizationManagementClient
+    subscription_id = None
+    if scope:
+        matched = re.match('/subscriptions/(?P<subscription>[^/]*)/', scope)
+        if matched:
+            subscription_id = matched.groupdict()['subscription']
+    return get_mgmt_service_client(AuthorizationManagementClient, subscription_id=subscription_id)
+
+
+def _graph_client_factory(**_):
+    from azure.cli.core._profile import Profile, CLOUD
+    from azure.cli.core.commands.client_factory import configure_common_settings
+    from azure.graphrbac import GraphRbacManagementClient
+    profile = Profile()
+    cred, _, tenant_id = profile.get_login_credentials(
+        resource=CLOUD.endpoints.active_directory_graph_resource_id)
+    client = GraphRbacManagementClient(cred,
+                                       tenant_id,
+                                       base_url=CLOUD.endpoints.active_directory_graph_resource_id)
+    configure_common_settings(client)
+    return client

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/commands.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/commands.py
@@ -7,6 +7,7 @@
 
 from azure.cli.core.commands import cli_command
 
+
 cli_command(__name__, 'acs browse', 'azure.cli.command_modules.acs.custom#acs_browse')
 cli_command(__name__, 'acs install-cli', 'azure.cli.command_modules.acs.custom#acs_install_cli')
 cli_command(__name__, 'acs dcos browse', 'azure.cli.command_modules.acs.custom#dcos_browse')

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -9,18 +9,22 @@ import errno
 import json
 import os
 import os.path
+import uuid
+import datetime
 import platform
 import random
 import stat
 import string
 import subprocess
 import sys
-from six.moves.urllib.request import (urlretrieve, urlopen)  # pylint: disable=import-error
-from six.moves.urllib.error import URLError  # pylint: disable=import-error
 import threading
 import time
 import webbrowser
 import yaml
+import dateutil.parser
+from dateutil.relativedelta import relativedelta
+from six.moves.urllib.request import (urlretrieve, urlopen)  # pylint: disable=import-error
+from six.moves.urllib.error import URLError  # pylint: disable=import-error
 
 from msrestazure.azure_exceptions import CloudError
 
@@ -33,9 +37,16 @@ from azure.cli.command_modules.vm.mgmt_acs.lib import \
 from azure.cli.core._util import CLIError
 from azure.cli.core._profile import Profile
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
+from azure.cli.core._environment import get_config_dir
 from azure.mgmt.compute import ComputeManagementClient
 from azure.mgmt.compute.models import ContainerServiceOchestratorTypes
-from azure.cli.core._environment import get_config_dir
+from azure.graphrbac.models import (ApplicationCreateParameters,
+                                    PasswordCredential,
+                                    KeyCredential,
+                                    ServicePrincipalCreateParameters,
+                                    GetObjectsParameters)
+from azure.mgmt.authorization.models import RoleAssignmentProperties
+from ._client_factory import (_auth_client_factory, _graph_client_factory)
 
 logger = azlogging.get_az_logger(__name__)
 
@@ -281,9 +292,6 @@ def k8s_install_cli(client_version="1.5.1", install_location=None):
 
 
 def _validate_service_principal(client, sp_id):
-    from azure.cli.command_modules.role.custom import (
-        show_service_principal,
-    )
     # discard the result, we're trusting this to throw if it can't find something
     try:
         show_service_principal(client.service_principals, sp_id)
@@ -293,11 +301,6 @@ def _validate_service_principal(client, sp_id):
 
 
 def _build_service_principal(client, name, url, client_secret):
-    from azure.cli.command_modules.role.custom import (
-        create_application,
-        create_service_principal,
-    )
-
     sys.stdout.write('creating service principal')
     result = create_application(client.applications, name, url, [url], password=client_secret)
     service_principal = result.app_id  # pylint: disable=no-member
@@ -318,7 +321,6 @@ def _add_role_assignment(role, service_principal, delay=2, output=True):
     if output:
         sys.stdout.write('waiting for AAD role to propagate.')
     for x in range(0, 10):
-        from azure.cli.command_modules.role.custom import create_role_assignment
         try:
             # TODO: break this out into a shared utility library
             create_role_assignment(role, service_principal)
@@ -421,7 +423,6 @@ def acs_create(resource_group_name, deployment_name, name, ssh_key_value, dns_na
     groups.get(resource_group_name)
 
     if orchestrator_type == 'Kubernetes' or orchestrator_type == 'kubernetes':
-        from azure.cli.command_modules.role.custom import _graph_client_factory
         # TODO: This really needs to be broken out and unit tested.
         client = _graph_client_factory()
         if not service_principal:
@@ -690,3 +691,168 @@ def _mkdir_p(path):
             pass
         else:
             raise
+
+
+def show_service_principal(client, identifier):
+    object_id = _resolve_service_principal(client, identifier)
+    return client.get(object_id)
+
+
+def _resolve_service_principal(client, identifier):
+    # todo: confirm with graph team that a service principal name must be unique
+    result = list(client.list(filter="servicePrincipalNames/any(c:c eq '{}')".format(identifier)))
+    if result:
+        return result[0].object_id
+    try:
+        uuid.UUID(identifier)
+        return identifier  # assume an object id
+    except ValueError:
+        raise CLIError("service principal '{}' doesn't exist".format(identifier))
+
+
+def create_application(client, display_name, homepage, identifier_uris,  # pylint: disable=too-many-arguments
+                       available_to_other_tenants=False, password=None, reply_urls=None,
+                       key_value=None, key_type=None, key_usage=None, start_date=None,
+                       end_date=None):
+    password_creds, key_creds = _build_application_creds(password, key_value, key_type,
+                                                         key_usage, start_date, end_date)
+
+    app_create_param = ApplicationCreateParameters(available_to_other_tenants,
+                                                   display_name,
+                                                   identifier_uris,
+                                                   homepage=homepage,
+                                                   reply_urls=reply_urls,
+                                                   key_credentials=key_creds,
+                                                   password_credentials=password_creds)
+    return client.create(app_create_param)
+
+
+def _build_application_creds(password=None, key_value=None, key_type=None,  # pylint: disable=too-many-arguments
+                             key_usage=None, start_date=None, end_date=None):
+    if password and key_value:
+        raise CLIError('specify either --password or --key-value, but not both.')
+
+    if not start_date:
+        start_date = datetime.datetime.utcnow()
+    elif isinstance(start_date, str):
+        start_date = dateutil.parser.parse(start_date)
+
+    if not end_date:
+        end_date = start_date + relativedelta(years=1)
+    elif isinstance(end_date, str):
+        end_date = dateutil.parser.parse(end_date)  # pylint: disable=redefined-variable-type
+
+    key_type = key_type or 'AsymmetricX509Cert'
+    key_usage = key_usage or 'Verify'
+
+    password_creds = None
+    key_creds = None
+    if password:
+        password_creds = [PasswordCredential(start_date, end_date, str(uuid.uuid4()), password)]
+    elif key_value:
+        key_creds = [KeyCredential(start_date, end_date, key_value, str(uuid.uuid4()),
+                                   key_usage, key_type)]
+
+    return (password_creds, key_creds)
+
+
+def create_service_principal(identifier):
+    return _create_service_principal(identifier)
+
+
+def _create_service_principal(identifier, resolve_app=True):
+    client = _graph_client_factory()
+
+    if resolve_app:
+        try:
+            uuid.UUID(identifier)
+            result = list(client.applications.list(filter="appId eq '{}'".format(identifier)))
+        except ValueError:
+            result = list(client.applications.list(
+                filter="identifierUris/any(s:s eq '{}')".format(identifier)))
+
+        if not result:  # assume we get an object id
+            result = [client.applications.get(identifier)]
+        app_id = result[0].app_id
+    else:
+        app_id = identifier
+
+    return client.service_principals.create(ServicePrincipalCreateParameters(app_id, True))
+
+
+def create_role_assignment(role, assignee, resource_group_name=None, scope=None):
+    return _create_role_assignment(role, assignee, resource_group_name, scope)
+
+
+def _create_role_assignment(role, assignee, resource_group_name=None, scope=None,  # pylint: disable=too-many-arguments
+                            resolve_assignee=True):
+    factory = _auth_client_factory(scope)
+    assignments_client = factory.role_assignments
+    definitions_client = factory.role_definitions
+
+    scope = _build_role_scope(resource_group_name, scope,
+                              assignments_client.config.subscription_id)
+
+    role_id = _resolve_role_id(role, scope, definitions_client)
+    object_id = _resolve_object_id(assignee) if resolve_assignee else assignee
+    properties = RoleAssignmentProperties(role_id, object_id)
+    assignment_name = uuid.uuid4()
+    custom_headers = None
+    return assignments_client.create(scope, assignment_name, properties,
+                                     custom_headers=custom_headers)
+
+
+def _build_role_scope(resource_group_name, scope, subscription_id):
+    subscription_scope = '/subscriptions/' + subscription_id
+    if scope:
+        if resource_group_name:
+            err = 'Resource group "{}" is redundant because scope is supplied'
+            raise CLIError(err.format(resource_group_name))
+    elif resource_group_name:
+        scope = subscription_scope + '/resourceGroups/' + resource_group_name
+    else:
+        scope = subscription_scope
+    return scope
+
+
+def _resolve_role_id(role, scope, definitions_client):
+    role_id = None
+    try:
+        uuid.UUID(role)
+        role_id = role
+    except ValueError:
+        pass
+    if not role_id:  # retrieve role id
+        role_defs = list(definitions_client.list(scope, "roleName eq '{}'".format(role)))
+        if not role_defs:
+            raise CLIError("Role '{}' doesn't exist.".format(role))
+        elif len(role_defs) > 1:
+            ids = [r.id for r in role_defs]
+            err = "More than one role matches the given name '{}'. Please pick a value from '{}'"
+            raise CLIError(err.format(role, ids))
+        role_id = role_defs[0].id
+    return role_id
+
+
+def _resolve_object_id(assignee):
+    client = _graph_client_factory()
+    result = None
+    if assignee.find('@') >= 0:  # looks like a user principal name
+        result = list(client.users.list(filter="userPrincipalName eq '{}'".format(assignee)))
+    if not result:
+        result = list(client.service_principals.list(
+            filter="servicePrincipalNames/any(c:c eq '{}')".format(assignee)))
+    if not result:  # assume an object id, let us verify it
+        result = _get_object_stubs(client, [assignee])
+
+    # 2+ matches should never happen, so we only check 'no match' here
+    if not result:
+        raise CLIError("No matches in graph database for '{}'".format(assignee))
+
+    return result[0].object_id
+
+
+def _get_object_stubs(graph_client, assignees):
+    params = GetObjectsParameters(include_directory_object_references=True,
+                                  object_ids=assignees)
+    return list(graph_client.objects.get_objects_by_object_ids(params))

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/tests/test_custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/tests/test_custom.py
@@ -25,7 +25,7 @@ class AcsCustomCommandTest(unittest.TestCase):
         sp = '1234567'
 
         with mock.patch(
-                'azure.cli.command_modules.role.custom.create_role_assignment') as create_role_assignment:
+                'azure.cli.command_modules.acs.custom.create_role_assignment') as create_role_assignment:
             ok = _add_role_assignment(role, sp, delay=0, output=False)
             create_role_assignment.assert_called_with(role, sp)
             self.assertTrue(ok, 'Expected _add_role_assignment to succeed')
@@ -35,7 +35,7 @@ class AcsCustomCommandTest(unittest.TestCase):
         sp = '1234567'
 
         with mock.patch(
-                'azure.cli.command_modules.role.custom.create_role_assignment') as create_role_assignment:
+                'azure.cli.command_modules.acs.custom.create_role_assignment') as create_role_assignment:
             resp = mock.Mock()
             resp.status_code = 409
             resp.content = 'Conflict'
@@ -52,7 +52,7 @@ class AcsCustomCommandTest(unittest.TestCase):
         sp = '1234567'
 
         with mock.patch(
-                'azure.cli.command_modules.role.custom.create_role_assignment') as create_role_assignment:
+                'azure.cli.command_modules.acs.custom.create_role_assignment') as create_role_assignment:
             resp = mock.Mock()
             resp.status_code = 500
             resp.content = 'Internal Error'

--- a/src/command_modules/azure-cli-acs/setup.py
+++ b/src/command_modules/azure-cli-acs/setup.py
@@ -25,7 +25,10 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
+    'azure-mgmt-authorization==0.30.0rc6',
     'azure-mgmt-compute==0.33.0',
+    'azure-graphrbac==0.30.0rc6',
+    'azure-cli-core',
     'paramiko',
     'pyyaml',
     'six',


### PR DESCRIPTION
This is part of Task 2 of work Item #1329. 

1. Porting the logic from azure-cli-role to azure-cli-acs for `create_service_principal`, `create_role_assignment`, `create_application` & `show_service_principal`. 
2. Taking dependency on `azure-mgmt-authorization` & `azure-graphrbac` SDKs for `azure-cli-acs` command module.

@yugangw-msft @derekbekoe @tjprescott @troydai Please review this as you get a chance. 

**CC:** 
@brendandburns, @@yugangw-msft

Thanks!