### PR TITLE
vm/av-set: remove domain count defaults

### DIFF
--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_params.py
@@ -73,11 +73,14 @@ register_cli_argument('vm disk', 'disk', validator=validate_vm_disk, help='disk 
 register_cli_argument('vm disk', 'new', action="store_true", help='create a new disk')
 register_cli_argument('vm disk', 'sku', arg_type=disk_sku)
 register_cli_argument('vm disk', 'size_gb', options_list=('--size-gb', '-z'), help='size in GB.')
+register_cli_argument('vm disk', 'lun', type=int, help='0-based logical unit number (LUN). Max value depends on the Virutal Machine size.')
 
 register_cli_argument('vm availability-set', 'availability_set_name', name_arg_type, id_part='name',
                       completer=get_resource_name_completion_list('Microsoft.Compute/availabilitySets'), help='Name of the availability set')
 register_cli_argument('vm availability-set create', 'availability_set_name', name_arg_type, validator=validate_location, help='Name of the availability set')
 register_cli_argument('vm availability-set create', 'unmanaged', action='store_true', help='contained VMs should use unmanaged disks')
+register_cli_argument('vm availability-set create', 'platform_update_domain_count', type=int, help='Update Domain count. Example: 2')
+register_cli_argument('vm availability-set create', 'platform_fault_domain_count', type=int, help='Fault Domain count. Example: 2')
 register_cli_argument('vm availability-set create', 'validate', help='Generate and validate the ARM template without creating any resources.', action='store_true')
 
 register_cli_argument('vm user', 'username', options_list=('--username', '-u'), help='The user name')

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/custom.py
@@ -323,14 +323,16 @@ def update_managed_disk(instance, size_gb=None, sku=None):
 
 
 def attach_managed_data_disk(resource_group_name, vm_name, disk,
-                             new=False, sku=None, size_gb=None):
+                             new=False, sku=None, size_gb=None, lun=None):
     '''attach a managed disk'''
     vm = get_vm(resource_group_name, vm_name)
     from azure.mgmt.compute.models import (CreationData, DiskCreateOptionTypes,
                                            ManagedDiskParameters, DataDisk)
     # pylint: disable=no-member
-    luns = [d.lun for d in vm.storage_profile.data_disks] if vm.storage_profile.data_disks else []
-    lun = max(luns) + 1 if luns else 0
+    if lun is None:
+        luns = ([d.lun for d in vm.storage_profile.data_disks]
+                if vm.storage_profile.data_disks else [])
+        lun = max(luns) + 1 if luns else 0
     if new:
         if not size_gb:
             raise CLIError('usage error: --size-gb required to create an empty disk for attach')
@@ -1736,8 +1738,9 @@ def create_vmss(vmss_name, resource_group_name, image,
     return client.create_or_update(resource_group_name, deployment_name, properties, raw=no_wait)
 
 
-def create_av_set(availability_set_name, resource_group_name, location=None, no_wait=False,
-                  platform_update_domain_count=5, platform_fault_domain_count=5,
+def create_av_set(availability_set_name, resource_group_name,
+                  platform_update_domain_count, platform_fault_domain_count,
+                  location=None, no_wait=False,
                   unmanaged=False, tags=None, validate=False):
     from azure.mgmt.resource.resources import ResourceManagementClient
     from azure.mgmt.resource.resources.models import DeploymentProperties, TemplateLink


### PR DESCRIPTION
Also, expose the `--lun` for attaching managed disk to VM. This is to be consistent with portal and  commands for unmanaged disk.
No test adjustment is needed