### PR TITLE
[Network] Restructure DNS Commands

### DIFF
--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_help.py
@@ -453,82 +453,82 @@ helps['network application-gateway waf-config show'] = """
 
 helps['network dns record-set'] = """
     type: group
-    short-summary: Manage DNS record sets.
+    short-summary: Manage DNS records and record sets.
 """
 
-helps['network dns record-set create'] = """
-    type: command
-    short-summary: Create an empty record set within a DNS zone.
-    long-summary: |
-        If a matching record set already exists, it will be overwritten unless --if-none-match is supplied.
-"""
-
-helps['network dns record-set delete'] = """
-    type: command
-    short-summary: Deletes a record set within a DNS zone.
-"""
-
-helps['network dns record-set list'] = """
-    type: command
-    short-summary: Lists all record sets within a DNS zone.
-"""
-
-helps['network dns record-set show'] = """
-    type: command
-    short-summary: Show details of a record set within a DNS zone.
-"""
-
-helps['network dns record-set update'] = """
-    type: command
-    short-summary: Update properties of a record set within a DNS zone.
-"""
 # endregion
 
 # region DNS records
 
-helps['network dns record'] = """
-    type: group
-    short-summary: Manage DNS records contained in a record set
+for record in ['a', 'aaaa', 'cname', 'mx', 'ns', 'ptr', 'srv', 'txt']:
+    helps['network dns record-set {}'.format(record)] = """
+        type: group
+        short-summary: Manage DNS {} records.
+    """.format(record.upper())
+
+for record in ['a', 'aaaa', 'cname', 'mx', 'ns', 'ptr', 'srv', 'txt']:
+
+    helps['network dns record-set {} remove-record'.format(record)] = """
+        type: command
+        short-summary: Remove {} record from its record set.
+    """.format(record.upper())
+
+    helps['network dns record-set {} create'.format(record)] = """
+        type: command
+        short-summary: Create an empty {} record set.
+    """.format(record.upper())
+
+    helps['network dns record-set {} delete'.format(record)] = """
+        type: command
+        short-summary: Delete a {} record set and all records within.
+    """.format(record.upper())
+
+    helps['network dns record-set {} list'.format(record)] = """
+        type: command
+        short-summary: List all {} record sets in a zone.
+    """.format(record.upper())
+
+    helps['network dns record-set {} show'.format(record)] = """
+        type: command
+        short-summary: Show details of {} record set.
+    """.format(record.upper())
+
+for item in ['a', 'aaaa', 'mx', 'ns', 'ptr', 'srv', 'txt']:
+
+    helps['network dns record-set {} update'.format(record)] = """
+        type: command
+        short-summary: Update {} record set.
+    """.format(record.upper())
+
+    helps['network dns record-set {} add-record'.format(record)] = """
+        type: command
+        short-summary: Add {} record.
+    """.format(record.upper())
+
+helps['network dns record-set cname set-record'] = """
+    type: command
+    short-summary: Sets the value of the CNAME record.
 """
 
-helps['network dns record a'] = """
+helps['network dns record-set soa'] = """
     type: group
-    short-summary: Manage DNS A records
+    short-summary: Manage DNS zone SOA record.
 """
 
-helps['network dns record aaaa'] = """
-    type: group
-    short-summary: Manage DNS AAAA records
+helps['network dns record-set soa show'] = """
+    type: command
+    short-summary: Show details of the DNS zone's SOA record.
 """
 
-helps['network dns record cname'] = """
-    type: group
-    short-summary: Manage DNS CNAME records
+helps['network dns record-set soa update'] = """
+    type: command
+    short-summary: Update properties of the zone's SOA re.
 """
 
-helps['network dns record mx'] = """
-    type: group
-    short-summary: Manage DNS MX (mail) records
-"""
 
-helps['network dns record ns'] = """
-    type: group
-    short-summary: Manage DNS NS (nameserver) records
-"""
-
-helps['network dns record ptr'] = """
-    type: group
-    short-summary: Manage DNS PTR (pointer) records
-"""
-
-helps['network dns record srv'] = """
-    type: group
-    short-summary: Manage DNS SRV records
-"""
-
-helps['network dns record txt'] = """
-    type: group
-    short-summary: Manage DNS TXT records
+helps['network dns record-set list'] = """
+    type: command
+    short-summary: List all record sets within a DNS zone.
 """
 
 #endregion

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_params.py
@@ -16,7 +16,6 @@ from azure.mgmt.network.models.network_management_client_enums import \
      ExpressRouteCircuitSkuTier, ExpressRouteCircuitPeeringType, IPVersion, LoadDistribution,
      ProbeProtocol, TransportProtocol, SecurityRuleAccess, SecurityRuleProtocol,
      SecurityRuleDirection)
-from azure.mgmt.dns.models.dns_management_client_enums import RecordType
 
 from azure.cli.core.commands import \
     (CliArgumentType, register_cli_argument, register_extra_cli_argument)
@@ -40,7 +39,7 @@ from azure.cli.command_modules.network._validators import \
      validate_auth_cert, validate_cert, validate_inbound_nat_rule_id_list,
      validate_address_pool_id_list, validate_inbound_nat_rule_name_or_id,
      validate_address_pool_name_or_id, validate_servers, load_cert_file, validate_metadata,
-     validate_peering_type,
+     validate_peering_type, validate_dns_record_type,
      get_public_ip_validator, get_nsg_validator, get_subnet_validator,
      get_virtual_network_validator)
 from azure.mgmt.network.models import ApplicationGatewaySslProtocol
@@ -125,7 +124,6 @@ load_balancer_name_type = CliArgumentType(options_list=('--lb-name',), metavar='
 private_ip_address_type = CliArgumentType(help='Static private IP address to use.', validator=validate_private_ip_address)
 cookie_based_affinity_type = CliArgumentType(**enum_choice_list(ApplicationGatewayCookieBasedAffinity))
 http_protocol_type = CliArgumentType(**enum_choice_list(ApplicationGatewayProtocol))
-modified_record_type = CliArgumentType(options_list=('--type', '-t'), help='The type of DNS records in the record set.', **enum_choice_list([x.value for x in RecordType if x.value != 'SOA']))
 
 # ARGUMENT REGISTRATION
 
@@ -557,8 +555,6 @@ register_cli_argument('network dns', 'relative_record_set_name', name_arg_type, 
 register_cli_argument('network dns', 'zone_name', options_list=('--zone-name', '-z'), help='The name of the zone.', type=dns_zone_name_type)
 register_cli_argument('network dns', 'metadata', nargs='+', help='Metadata in space-separated key=value pairs. This overwrites any existing metadata.', validator=validate_metadata)
 
-register_cli_argument('network dns', 'record_type', modified_record_type)
-
 register_cli_argument('network dns zone', 'zone_name', name_arg_type)
 register_cli_argument('network dns zone', 'location', ignore_type)
 
@@ -566,37 +562,35 @@ register_cli_argument('network dns zone import', 'file_name', options_list=('--f
 register_cli_argument('network dns zone export', 'file_name', options_list=('--file-name', '-f'), type=file_type, completer=FilesCompleter(), help='Path to the DNS zone file to save')
 register_cli_argument('network dns zone update', 'if_none_match', ignore_type)
 
-register_cli_argument('network dns record txt add', 'value', nargs='+')
-register_cli_argument('network dns record txt remove', 'value', nargs='+')
+for item in ['record_type', 'record_set_type']:
+    register_cli_argument('network dns record-set', item, ignore_type, validator=validate_dns_record_type)
 
-register_cli_argument('network dns record-set create', 'record_set_type', modified_record_type)
 register_cli_argument('network dns record-set create', 'ttl', help='Record set TTL (time-to-live)')
 register_cli_argument('network dns record-set create', 'if_none_match', help='Create the record set only if it does not already exist.', action='store_true')
 
-for item in ['list', 'show']:
-    register_cli_argument('network dns record-set {}'.format(item), 'record_type', options_list=('--type', '-t'), **enum_choice_list(RecordType))
-
 for item in ['a', 'aaaa', 'cname', 'mx', 'ns', 'ptr', 'srv', 'txt']:
-    register_cli_argument('network dns record {} add'.format(item), 'record_set_name', options_list=('--record-set-name', '-n'), help='The name of the record set relative to the zone. Creates a new record set if one does not exist.')
-    register_cli_argument('network dns record {} remove'.format(item), 'record_set_name', options_list=('--record-set-name', '-n'), help='The name of the record set relative to the zone.')
-register_cli_argument('network dns record cname add', 'record_set_name', options_list=('--record-set-name', '-n'), help='The name of the record set relative to the zone. Creates a new record set if one does not exist. If a matching record already exists, it is replaced.')
+    register_cli_argument('network dns record-set {} add-record'.format(item), 'record_set_name', options_list=('--record-set-name', '-n'), help='The name of the record set relative to the zone. Creates a new record set if one does not exist.')
+    register_cli_argument('network dns record-set {} remove-record'.format(item), 'record_set_name', options_list=('--record-set-name', '-n'), help='The name of the record set relative to the zone.')
+register_cli_argument('network dns record-set cname set-record', 'record_set_name', options_list=('--record-set-name', '-n'), help='The name of the record set relative to the zone. Creates a new record set if one does not exist.')
 
-register_cli_argument('network dns record a', 'ipv4_address', options_list=('--ipv4-address', '-a'), help='IPV4 address in string notation.')
-register_cli_argument('network dns record aaaa', 'ipv6_address', options_list=('--ipv6-address', '-a'), help='IPV6 address in string notation.')
-register_cli_argument('network dns record cname', 'cname', options_list=('--cname', '-c'), help='Canonical name.')
-register_cli_argument('network dns record mx', 'exchange', options_list=('--exchange', '-e'), help='Exchange metric.')
-register_cli_argument('network dns record mx', 'preference', options_list=('--preference', '-p'), help='Preference metric.')
-register_cli_argument('network dns record ns', 'dname', options_list=('--nsdname', '-d'), help='Name server domain name.')
-register_cli_argument('network dns record ptr', 'dname', options_list=('--ptrdname', '-d'), help='PTR target domain name.')
-register_cli_argument('network dns record update-soa', 'host', options_list=('--host', '-t'), help='Host name.')
-register_cli_argument('network dns record update-soa', 'email', options_list=('--email', '-e'), help='Email address.')
-register_cli_argument('network dns record update-soa', 'expire_time', options_list=('--expire-time', '-x'), help='Expire time (seconds).')
-register_cli_argument('network dns record update-soa', 'minimum_ttl', options_list=('--minimum-ttl', '-m'), help='Minimum TTL (time-to-live, seconds).')
-register_cli_argument('network dns record update-soa', 'refresh_time', options_list=('--refresh-time', '-f'), help='Refresh value (seconds).')
-register_cli_argument('network dns record update-soa', 'retry_time', options_list=('--retry-time', '-r'), help='Retry time (seconds).')
-register_cli_argument('network dns record update-soa', 'serial_number', options_list=('--serial-number', '-s'), help='Serial number.')
-register_cli_argument('network dns record srv', 'priority', options_list=('--priority', '-p'), help='Priority metric.')
-register_cli_argument('network dns record srv', 'weight', options_list=('--weight', '-w'), help='Weight metric.')
-register_cli_argument('network dns record srv', 'port', options_list=('--port', '-r'), help='Service port.')
-register_cli_argument('network dns record srv', 'target', options_list=('--target', '-t'), help='Target domain name.')
-register_cli_argument('network dns record txt', 'value', options_list=('--value', '-v'), nargs='+', help='Space separated list of text values which will be concatenated together.')
+register_cli_argument('network dns record-set soa', 'relative_record_set_name', ignore_type, default='@')
+
+register_cli_argument('network dns record-set a', 'ipv4_address', options_list=('--ipv4-address', '-a'), help='IPV4 address in string notation.')
+register_cli_argument('network dns record-set aaaa', 'ipv6_address', options_list=('--ipv6-address', '-a'), help='IPV6 address in string notation.')
+register_cli_argument('network dns record-set cname', 'cname', options_list=('--cname', '-c'), help='Canonical name.')
+register_cli_argument('network dns record-set mx', 'exchange', options_list=('--exchange', '-e'), help='Exchange metric.')
+register_cli_argument('network dns record-set mx', 'preference', options_list=('--preference', '-p'), help='Preference metric.')
+register_cli_argument('network dns record-set ns', 'dname', options_list=('--nsdname', '-d'), help='Name server domain name.')
+register_cli_argument('network dns record-set ptr', 'dname', options_list=('--ptrdname', '-d'), help='PTR target domain name.')
+register_cli_argument('network dns record-set soa', 'host', options_list=('--host', '-t'), help='Host name.')
+register_cli_argument('network dns record-set soa', 'email', options_list=('--email', '-e'), help='Email address.')
+register_cli_argument('network dns record-set soa', 'expire_time', options_list=('--expire-time', '-x'), help='Expire time (seconds).')
+register_cli_argument('network dns record-set soa', 'minimum_ttl', options_list=('--minimum-ttl', '-m'), help='Minimum TTL (time-to-live, seconds).')
+register_cli_argument('network dns record-set soa', 'refresh_time', options_list=('--refresh-time', '-f'), help='Refresh value (seconds).')
+register_cli_argument('network dns record-set soa', 'retry_time', options_list=('--retry-time', '-r'), help='Retry time (seconds).')
+register_cli_argument('network dns record-set soa', 'serial_number', options_list=('--serial-number', '-s'), help='Serial number.')
+register_cli_argument('network dns record-set srv', 'priority', options_list=('--priority', '-p'), help='Priority metric.')
+register_cli_argument('network dns record-set srv', 'weight', options_list=('--weight', '-w'), help='Weight metric.')
+register_cli_argument('network dns record-set srv', 'port', options_list=('--port', '-r'), help='Service port.')
+register_cli_argument('network dns record-set srv', 'target', options_list=('--target', '-t'), help='Target domain name.')
+register_cli_argument('network dns record-set txt', 'value', options_list=('--value', '-v'), nargs='+', help='Space separated list of text values which will be concatenated together.')

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/_validators.py
@@ -127,6 +127,17 @@ def validate_cert(namespace):
             # app-gateway ssl-cert create does not have these fields and that is okay
             pass
 
+def validate_dns_record_type(namespace):
+    tokens = namespace.command.split(' ')
+    types = ['a', 'aaaa', 'cname', 'mx', 'ns', 'ptr', 'soa', 'srv', 'txt']
+    for token in tokens:
+        if token in types:
+            if hasattr(namespace, 'record_type'):
+                namespace.record_type = token
+            else:
+                namespace.record_set_type = token
+            return
+
 def validate_inbound_nat_rule_id_list(namespace):
     _generate_lb_id_list_from_names_or_ids(
         namespace, 'load_balancer_inbound_nat_rule_ids', 'inboundNatRules')

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/commands.py
@@ -398,44 +398,41 @@ cli_generic_update_command(__name__, 'network traffic-manager endpoint update',
                            custom_function_op=custom_path.format('update_traffic_manager_endpoint'))
 
 # DNS ZonesOperations
-cli_command(__name__, 'network dns zone show', 'azure.mgmt.dns.operations.zones_operations#ZonesOperations.get', cf_dns_mgmt_zones, table_transformer=transform_dns_zone_table_output)
-cli_command(__name__, 'network dns zone delete', 'azure.mgmt.dns.operations.zones_operations#ZonesOperations.delete', cf_dns_mgmt_zones, confirmation=True)
+dns_zone_path = 'azure.mgmt.dns.operations.zones_operations#ZonesOperations.'
+cli_command(__name__, 'network dns zone show', dns_zone_path + 'get', cf_dns_mgmt_zones, table_transformer=transform_dns_zone_table_output)
+cli_command(__name__, 'network dns zone delete', dns_zone_path + 'delete', cf_dns_mgmt_zones, confirmation=True)
 cli_command(__name__, 'network dns zone list', custom_path.format('list_dns_zones'), table_transformer=transform_dns_zone_table_output)
 cli_generic_update_command(__name__, 'network dns zone update',
-                           'azure.mgmt.dns.operations.zones_operations#ZonesOperations.get',
-                           'azure.mgmt.dns.operations.zones_operations#ZonesOperations.create_or_update',
+                           dns_zone_path + 'get',
+                           dns_zone_path + 'create_or_update',
                            cf_dns_mgmt_zones)
 cli_command(__name__, 'network dns zone import', custom_path.format('import_zone'))
 cli_command(__name__, 'network dns zone export', custom_path.format('export_zone'))
 cli_command(__name__, 'network dns zone create', custom_path.format('create_dns_zone'), cf_dns_mgmt_zones)
 
 # DNS RecordSetsOperations
-cli_command(__name__, 'network dns record-set show', 'azure.mgmt.dns.operations.record_sets_operations#RecordSetsOperations.get', cf_dns_mgmt_record_sets, transform=transform_dns_record_set_output)
-cli_command(__name__, 'network dns record-set delete', 'azure.mgmt.dns.operations.record_sets_operations#RecordSetsOperations.delete', cf_dns_mgmt_record_sets)
-cli_command(__name__, 'network dns record-set list', custom_path.format('list_dns_record_set'), cf_dns_mgmt_record_sets, transform=transform_dns_record_set_output, table_transformer=transform_dns_record_set_table_output)
-cli_command(__name__, 'network dns record-set create', custom_path.format('create_dns_record_set'), transform=transform_dns_record_set_output)
-cli_generic_update_command(__name__, 'network dns record-set update',
-                           'azure.mgmt.dns.operations.record_sets_operations#RecordSetsOperations.get',
-                           'azure.mgmt.dns.operations.record_sets_operations#RecordSetsOperations.create_or_update',
-                           cf_dns_mgmt_record_sets,
-                           custom_function_op=custom_path.format('update_dns_record_set'),
-                           transform=transform_dns_record_set_output)
+dns_record_set_path = 'azure.mgmt.dns.operations.record_sets_operations#RecordSetsOperations.'
+cli_command(__name__, 'network dns record-set list', custom_path.format('list_dns_record_set'), cf_dns_mgmt_record_sets, transform=transform_dns_record_set_output)
+for record in ['a', 'aaaa', 'mx', 'ns', 'ptr', 'srv', 'txt']:
+    cli_command(__name__, 'network dns record-set {} show'.format(record), dns_record_set_path + 'get', cf_dns_mgmt_record_sets, transform=transform_dns_record_set_output)
+    cli_command(__name__, 'network dns record-set {} delete'.format(record), dns_record_set_path + 'delete', cf_dns_mgmt_record_sets)
+    cli_command(__name__, 'network dns record-set {} list'.format(record), custom_path.format('list_dns_record_set'), cf_dns_mgmt_record_sets, transform=transform_dns_record_set_output, table_transformer=transform_dns_record_set_table_output)
+    cli_command(__name__, 'network dns record-set {} create'.format(record), custom_path.format('create_dns_record_set'), transform=transform_dns_record_set_output)
+    cli_command(__name__, 'network dns record-set {} add-record'.format(record), custom_path.format('add_dns_{}_record'.format(record)), transform=transform_dns_record_set_output)
+    cli_command(__name__, 'network dns record-set {} remove-record'.format(record), custom_path.format('remove_dns_{}_record'.format(record)), transform=transform_dns_record_set_output)
+    cli_generic_update_command(__name__, 'network dns record-set {} update'.format(record),
+                               dns_record_set_path + 'get',
+                               dns_record_set_path + 'create_or_update',
+                               cf_dns_mgmt_record_sets,
+                               custom_function_op=custom_path.format('update_dns_record_set'),
+                               transform=transform_dns_record_set_output)
 
-# DNS RecordOperations
-cli_command(__name__, 'network dns record aaaa add', custom_path.format('add_dns_aaaa_record'), transform=transform_dns_record_set_output)
-cli_command(__name__, 'network dns record a add', custom_path.format('add_dns_a_record'), transform=transform_dns_record_set_output)
-cli_command(__name__, 'network dns record cname add', custom_path.format('add_dns_cname_record'), transform=transform_dns_record_set_output)
-cli_command(__name__, 'network dns record ns add', custom_path.format('add_dns_ns_record'), transform=transform_dns_record_set_output)
-cli_command(__name__, 'network dns record mx add', custom_path.format('add_dns_mx_record'), transform=transform_dns_record_set_output)
-cli_command(__name__, 'network dns record ptr add', custom_path.format('add_dns_ptr_record'), transform=transform_dns_record_set_output)
-cli_command(__name__, 'network dns record srv add', custom_path.format('add_dns_srv_record'), transform=transform_dns_record_set_output)
-cli_command(__name__, 'network dns record txt add', custom_path.format('add_dns_txt_record'), transform=transform_dns_record_set_output)
-cli_command(__name__, 'network dns record update-soa', custom_path.format('update_dns_soa_record'), transform=transform_dns_record_set_output)
-cli_command(__name__, 'network dns record aaaa remove', custom_path.format('remove_dns_aaaa_record'), transform=transform_dns_record_set_output)
-cli_command(__name__, 'network dns record a remove', custom_path.format('remove_dns_a_record'), transform=transform_dns_record_set_output)
-cli_command(__name__, 'network dns record cname remove', custom_path.format('remove_dns_cname_record'), transform=transform_dns_record_set_output)
-cli_command(__name__, 'network dns record ns remove', custom_path.format('remove_dns_ns_record'), transform=transform_dns_record_set_output)
-cli_command(__name__, 'network dns record mx remove', custom_path.format('remove_dns_mx_record'), transform=transform_dns_record_set_output)
-cli_command(__name__, 'network dns record ptr remove', custom_path.format('remove_dns_ptr_record'), transform=transform_dns_record_set_output)
-cli_command(__name__, 'network dns record srv remove', custom_path.format('remove_dns_srv_record'), transform=transform_dns_record_set_output)
-cli_command(__name__, 'network dns record txt remove', custom_path.format('remove_dns_txt_record'), transform=transform_dns_record_set_output)
+cli_command(__name__, 'network dns record-set soa show', dns_record_set_path + 'get', cf_dns_mgmt_record_sets, transform=transform_dns_record_set_output)
+cli_command(__name__, 'network dns record-set soa update', custom_path.format('update_dns_soa_record'), transform=transform_dns_record_set_output)
+
+cli_command(__name__, 'network dns record-set cname show', dns_record_set_path + 'get', cf_dns_mgmt_record_sets, transform=transform_dns_record_set_output)
+cli_command(__name__, 'network dns record-set cname delete', dns_record_set_path + 'delete', cf_dns_mgmt_record_sets)
+cli_command(__name__, 'network dns record-set cname list', custom_path.format('list_dns_record_set'), cf_dns_mgmt_record_sets, transform=transform_dns_record_set_output, table_transformer=transform_dns_record_set_table_output)
+cli_command(__name__, 'network dns record-set cname create', custom_path.format('create_dns_record_set'), transform=transform_dns_record_set_output)
+cli_command(__name__, 'network dns record-set cname set-record', custom_path.format('add_dns_cname_record'), transform=transform_dns_record_set_output)
+cli_command(__name__, 'network dns record-set cname remove-record', custom_path.format('remove_dns_cname_record'), transform=transform_dns_record_set_output)

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_dns.yaml
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/recordings/test_network_dns.yaml
@@ -10,17 +10,17 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a4561a5c-f482-11e6-9ff3-a0b3ccf7272a]
+      x-ms-client-request-id: [8193d8c2-f498-11e6-9e0d-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-f415-d5678f88d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-01.azure-dns.com.","ns2-01.azure-dns.net.","ns3-01.azure-dns.org.","ns4-01.azure-dns.info."],"numberOfRecordSets":2}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-364a-ed42a588d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-04.azure-dns.com.","ns2-04.azure-dns.net.","ns3-04.azure-dns.org.","ns4-04.azure-dns.info."],"numberOfRecordSets":2}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['463']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:05 GMT']
-      ETag: [00000002-0000-0000-f415-d5678f88d201]
+      Date: ['Thu, 16 Feb 2017 22:37:33 GMT']
+      ETag: [00000002-0000-0000-364a-ed42a588d201]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
@@ -38,16 +38,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a6e1ccf4-f482-11e6-a33c-a0b3ccf7272a]
+      x-ms-client-request-id: [829ff686-f498-11e6-af40-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-f415-d5678f88d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-01.azure-dns.com.","ns2-01.azure-dns.net.","ns3-01.azure-dns.org.","ns4-01.azure-dns.info."],"numberOfRecordSets":2}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-364a-ed42a588d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-04.azure-dns.com.","ns2-04.azure-dns.net.","ns3-04.azure-dns.org.","ns4-04.azure-dns.info."],"numberOfRecordSets":2}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:06 GMT']
-      ETag: [00000002-0000-0000-f415-d5678f88d201]
+      Date: ['Thu, 16 Feb 2017 22:37:34 GMT']
+      ETag: [00000002-0000-0000-364a-ed42a588d201]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -59,7 +59,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: '{"name": "myrsa", "type": "A", "properties": {"TTL": 3600}}'
+    body: '{"properties": {"TTL": 3600}, "type": "a", "name": "myrsa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -69,23 +69,23 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a75daa0a-f482-11e6-81b7-a0b3ccf7272a]
+      x-ms-client-request-id: [83599228-f498-11e6-9d04-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"eac70b5f-ff5d-429b-9b74-b79670f25ce3","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"d7289747-55d5-4f2e-b11e-54c1e1def441","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['328']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:07 GMT']
-      ETag: [eac70b5f-ff5d-429b-9b74-b79670f25ce3]
+      Date: ['Thu, 16 Feb 2017 22:37:36 GMT']
+      ETag: [d7289747-55d5-4f2e-b11e-54c1e1def441]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -97,16 +97,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a821b93a-f482-11e6-a429-a0b3ccf7272a]
+      x-ms-client-request-id: [842032c0-f498-11e6-8461-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"eac70b5f-ff5d-429b-9b74-b79670f25ce3","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"d7289747-55d5-4f2e-b11e-54c1e1def441","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:08 GMT']
-      ETag: [eac70b5f-ff5d-429b-9b74-b79670f25ce3]
+      Date: ['Thu, 16 Feb 2017 22:37:36 GMT']
+      ETag: [d7289747-55d5-4f2e-b11e-54c1e1def441]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -118,9 +118,9 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: '{"etag": "eac70b5f-ff5d-429b-9b74-b79670f25ce3", "name": "myrsa", "type":
-      "Microsoft.Network/dnszones/A", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa",
-      "properties": {"ARecords": [{"ipv4Address": "10.0.0.10"}], "TTL": 3600}}'
+    body: '{"properties": {"ARecords": [{"ipv4Address": "10.0.0.10"}], "TTL": 3600},
+      "type": "Microsoft.Network/dnszones/A", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa",
+      "etag": "d7289747-55d5-4f2e-b11e-54c1e1def441", "name": "myrsa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -130,16 +130,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a8805458-f482-11e6-bb94-a0b3ccf7272a]
+      x-ms-client-request-id: [846280ca-f498-11e6-80d5-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"17019ad8-4c28-4107-92e0-fcfbd198a66b","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"48ca7c67-4f9c-4e81-8574-57271cbc8fe6","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:08 GMT']
-      ETag: [17019ad8-4c28-4107-92e0-fcfbd198a66b]
+      Date: ['Thu, 16 Feb 2017 22:37:37 GMT']
+      ETag: [48ca7c67-4f9c-4e81-8574-57271cbc8fe6]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -148,7 +148,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['355']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11996']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -160,7 +160,7 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a95b04dc-f482-11e6-bfc1-a0b3ccf7272a]
+      x-ms-client-request-id: [854e04d2-f498-11e6-acc5-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsaalt?api-version=2016-04-01
   response:
@@ -170,17 +170,17 @@ interactions:
       Cache-Control: [private]
       Content-Length: ['172']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:11 GMT']
+      Date: ['Thu, 16 Feb 2017 22:37:39 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"name": "myrsaalt", "type": "a", "properties": {"ARecords": [{"ipv4Address":
-      "10.0.0.10"}], "TTL": 3600}}'
+    body: '{"properties": {"ARecords": [{"ipv4Address": "10.0.0.10"}], "TTL": 3600},
+      "type": "a", "name": "myrsaalt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -190,26 +190,26 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [a9dd063e-f482-11e6-be63-a0b3ccf7272a]
+      x-ms-client-request-id: [859a5cee-f498-11e6-a8be-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsaalt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsaalt","name":"myrsaalt","type":"Microsoft.Network\/dnszones\/A","etag":"67bbf38b-68d0-4d61-a9fb-461bf157cf3e","properties":{"fqdn":"myrsaalt.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsaalt","name":"myrsaalt","type":"Microsoft.Network\/dnszones\/A","etag":"7b98d8ff-b2ec-4bf8-a55a-95474ed026f9","properties":{"fqdn":"myrsaalt.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['364']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:11 GMT']
-      ETag: [67bbf38b-68d0-4d61-a9fb-461bf157cf3e]
+      Date: ['Thu, 16 Feb 2017 22:37:39 GMT']
+      ETag: [7b98d8ff-b2ec-4bf8-a55a-95474ed026f9]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 201, message: Created}
 - request:
-    body: '{"name": "myrsaaaa", "type": "AAAA", "properties": {"TTL": 3600}}'
+    body: '{"properties": {"TTL": 3600}, "type": "aaaa", "name": "myrsaaaa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -219,17 +219,17 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [aa9c0dcc-f482-11e6-a384-a0b3ccf7272a]
+      x-ms-client-request-id: [866cc5a4-f498-11e6-af7b-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"f8bedb59-a70e-422f-8b85-c5eec7a66047","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"e4d9536c-ac5b-42b1-b4b4-faa923d72a19","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['346']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:15 GMT']
-      ETag: [f8bedb59-a70e-422f-8b85-c5eec7a66047]
+      Date: ['Thu, 16 Feb 2017 22:37:42 GMT']
+      ETag: [e4d9536c-ac5b-42b1-b4b4-faa923d72a19]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
@@ -247,16 +247,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ad506806-f482-11e6-b97b-a0b3ccf7272a]
+      x-ms-client-request-id: [87a8b252-f498-11e6-952d-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"f8bedb59-a70e-422f-8b85-c5eec7a66047","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"e4d9536c-ac5b-42b1-b4b4-faa923d72a19","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:17 GMT']
-      ETag: [f8bedb59-a70e-422f-8b85-c5eec7a66047]
+      Date: ['Thu, 16 Feb 2017 22:37:43 GMT']
+      ETag: [e4d9536c-ac5b-42b1-b4b4-faa923d72a19]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -268,10 +268,9 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: '{"etag": "f8bedb59-a70e-422f-8b85-c5eec7a66047", "name": "myrsaaaa", "type":
-      "Microsoft.Network/dnszones/AAAA", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa",
-      "properties": {"AAAARecords": [{"ipv6Address": "2001:db8:0:1:1:1:1:1"}], "TTL":
-      3600}}'
+    body: '{"properties": {"TTL": 3600, "AAAARecords": [{"ipv6Address": "2001:db8:0:1:1:1:1:1"}]},
+      "type": "Microsoft.Network/dnszones/AAAA", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa",
+      "etag": "e4d9536c-ac5b-42b1-b4b4-faa923d72a19", "name": "myrsaaaa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -281,16 +280,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ad90b766-f482-11e6-a3d3-a0b3ccf7272a]
+      x-ms-client-request-id: [88265cb0-f498-11e6-89a1-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"29b84cf4-54ac-45f4-9992-d600337209f2","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"188f3b1d-e078-489d-8be5-f086455251d6","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:18 GMT']
-      ETag: [29b84cf4-54ac-45f4-9992-d600337209f2]
+      Date: ['Thu, 16 Feb 2017 22:37:44 GMT']
+      ETag: [188f3b1d-e078-489d-8be5-f086455251d6]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -311,7 +310,7 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ae54a548-f482-11e6-8108-a0b3ccf7272a]
+      x-ms-client-request-id: [8935e112-f498-11e6-acdc-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaaalt?api-version=2016-04-01
   response:
@@ -321,17 +320,17 @@ interactions:
       Cache-Control: [private]
       Content-Length: ['175']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:19 GMT']
+      Date: ['Thu, 16 Feb 2017 22:37:45 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"name": "myrsaaaaalt", "type": "aaaa", "properties": {"AAAARecords": [{"ipv6Address":
-      "2001:db8:0:1:1:1:1:1"}], "TTL": 3600}}'
+    body: '{"properties": {"TTL": 3600, "AAAARecords": [{"ipv6Address": "2001:db8:0:1:1:1:1:1"}]},
+      "type": "aaaa", "name": "myrsaaaaalt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -341,26 +340,26 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ae975c7e-f482-11e6-b3bc-a0b3ccf7272a]
+      x-ms-client-request-id: [898bf710-f498-11e6-bfd2-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaaalt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaaalt","name":"myrsaaaaalt","type":"Microsoft.Network\/dnszones\/AAAA","etag":"c85fa146-81a7-4393-8df2-fd6e42c84c8c","properties":{"fqdn":"myrsaaaaalt.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaaalt","name":"myrsaaaaalt","type":"Microsoft.Network\/dnszones\/AAAA","etag":"bb4af783-4e50-4789-a221-6d9720fb7906","properties":{"fqdn":"myrsaaaaalt.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['393']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:19 GMT']
-      ETag: [c85fa146-81a7-4393-8df2-fd6e42c84c8c]
+      Date: ['Thu, 16 Feb 2017 22:37:46 GMT']
+      ETag: [bb4af783-4e50-4789-a221-6d9720fb7906]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 201, message: Created}
 - request:
-    body: '{"name": "myrscname", "type": "CNAME", "properties": {"TTL": 3600}}'
+    body: '{"properties": {"TTL": 3600}, "type": "cname", "name": "myrscname"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -370,23 +369,23 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [af42731a-f482-11e6-b47b-a0b3ccf7272a]
+      x-ms-client-request-id: [8a757a06-f498-11e6-bf41-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"a77e9d56-56ba-4628-8a21-e6f7db9eb868","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"61720286-95d3-4d7a-9d8e-1c879a35c472","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['334']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:20 GMT']
-      ETag: [a77e9d56-56ba-4628-8a21-e6f7db9eb868]
+      Date: ['Thu, 16 Feb 2017 22:37:48 GMT']
+      ETag: [61720286-95d3-4d7a-9d8e-1c879a35c472]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -398,16 +397,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [affd4812-f482-11e6-87f1-a0b3ccf7272a]
+      x-ms-client-request-id: [8b7b93b6-f498-11e6-863f-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"a77e9d56-56ba-4628-8a21-e6f7db9eb868","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"61720286-95d3-4d7a-9d8e-1c879a35c472","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:21 GMT']
-      ETag: [a77e9d56-56ba-4628-8a21-e6f7db9eb868]
+      Date: ['Thu, 16 Feb 2017 22:37:49 GMT']
+      ETag: [61720286-95d3-4d7a-9d8e-1c879a35c472]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -419,9 +418,9 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: '{"etag": "a77e9d56-56ba-4628-8a21-e6f7db9eb868", "name": "myrscname", "type":
+    body: '{"properties": {"CNAMERecord": {"cname": "mycname"}, "TTL": 3600}, "type":
       "Microsoft.Network/dnszones/CNAME", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname",
-      "properties": {"CNAMERecord": {"cname": "mycname"}, "TTL": 3600}}'
+      "etag": "61720286-95d3-4d7a-9d8e-1c879a35c472", "name": "myrscname"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -431,16 +430,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b034890a-f482-11e6-803b-a0b3ccf7272a]
+      x-ms-client-request-id: [8bdf6fc8-f498-11e6-b3f5-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"bca95fc8-060b-45f5-abe4-5d12ecd2856e","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"d3ca537b-0e21-42fd-9aeb-5e6f69437c3d","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:22 GMT']
-      ETag: [bca95fc8-060b-45f5-abe4-5d12ecd2856e]
+      Date: ['Thu, 16 Feb 2017 22:37:50 GMT']
+      ETag: [d3ca537b-0e21-42fd-9aeb-5e6f69437c3d]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -449,7 +448,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['368']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -461,7 +460,7 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b0ed3d58-f482-11e6-813b-a0b3ccf7272a]
+      x-ms-client-request-id: [8cd264a6-f498-11e6-b68f-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscnamealt?api-version=2016-04-01
   response:
@@ -471,17 +470,17 @@ interactions:
       Cache-Control: [private]
       Content-Length: ['176']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:23 GMT']
+      Date: ['Thu, 16 Feb 2017 22:37:54 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"name": "myrscnamealt", "type": "cname", "properties": {"CNAMERecord":
-      {"cname": "mycname"}, "TTL": 3600}}'
+    body: '{"properties": {"CNAMERecord": {"cname": "mycname"}, "TTL": 3600}, "type":
+      "cname", "name": "myrscnamealt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -491,26 +490,26 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b156c7d8-f482-11e6-b262-a0b3ccf7272a]
+      x-ms-client-request-id: [8f49d5b8-f498-11e6-aec1-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscnamealt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscnamealt","name":"myrscnamealt","type":"Microsoft.Network\/dnszones\/CNAME","etag":"9af59adb-5b8b-40e5-ae0d-5fde6f2aec12","properties":{"fqdn":"myrscnamealt.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscnamealt","name":"myrscnamealt","type":"Microsoft.Network\/dnszones\/CNAME","etag":"22477145-0695-49fd-bedf-5e7c814fe6e4","properties":{"fqdn":"myrscnamealt.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['377']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:23 GMT']
-      ETag: [9af59adb-5b8b-40e5-ae0d-5fde6f2aec12]
+      Date: ['Thu, 16 Feb 2017 22:37:55 GMT']
+      ETag: [22477145-0695-49fd-bedf-5e7c814fe6e4]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 201, message: Created}
 - request:
-    body: '{"name": "myrsmx", "type": "MX", "properties": {"TTL": 3600}}'
+    body: '{"properties": {"TTL": 3600}, "type": "mx", "name": "myrsmx"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -520,23 +519,23 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b20b6a92-f482-11e6-8c4d-a0b3ccf7272a]
+      x-ms-client-request-id: [900503d4-f498-11e6-b89a-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"9736013f-9d46-4223-9934-51067b8fea40","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"3bb9d092-ce4f-4935-add7-e3ef79b52986","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['334']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:25 GMT']
-      ETag: [9736013f-9d46-4223-9934-51067b8fea40]
+      Date: ['Thu, 16 Feb 2017 22:37:56 GMT']
+      ETag: [3bb9d092-ce4f-4935-add7-e3ef79b52986]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -548,16 +547,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b2bc3a12-f482-11e6-8bee-a0b3ccf7272a]
+      x-ms-client-request-id: [90d42868-f498-11e6-bd41-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"9736013f-9d46-4223-9934-51067b8fea40","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"3bb9d092-ce4f-4935-add7-e3ef79b52986","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:25 GMT']
-      ETag: [9736013f-9d46-4223-9934-51067b8fea40]
+      Date: ['Thu, 16 Feb 2017 22:37:58 GMT']
+      ETag: [3bb9d092-ce4f-4935-add7-e3ef79b52986]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -566,12 +565,12 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['334']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: '{"etag": "9736013f-9d46-4223-9934-51067b8fea40", "name": "myrsmx", "type":
-      "Microsoft.Network/dnszones/MX", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx",
-      "properties": {"TTL": 3600, "MXRecords": [{"exchange": "12", "preference": 13}]}}'
+    body: '{"properties": {"TTL": 3600, "MXRecords": [{"exchange": "12", "preference":
+      13}]}, "type": "Microsoft.Network/dnszones/MX", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx",
+      "etag": "3bb9d092-ce4f-4935-add7-e3ef79b52986", "name": "myrsmx"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -581,16 +580,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b2f9717a-f482-11e6-8198-a0b3ccf7272a]
+      x-ms-client-request-id: [913e829e-f498-11e6-9296-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"ab979abd-f398-463f-92cd-0da2b2b40918","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"c7a5da5c-a17a-4759-8fc6-bc182a17a254","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:27 GMT']
-      ETag: [ab979abd-f398-463f-92cd-0da2b2b40918]
+      Date: ['Thu, 16 Feb 2017 22:37:59 GMT']
+      ETag: [c7a5da5c-a17a-4759-8fc6-bc182a17a254]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -599,7 +598,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['367']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -611,7 +610,7 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b3ac6d48-f482-11e6-8181-a0b3ccf7272a]
+      x-ms-client-request-id: [91fac7a6-f498-11e6-82cc-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmxalt?api-version=2016-04-01
   response:
@@ -621,7 +620,7 @@ interactions:
       Cache-Control: [private]
       Content-Length: ['173']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:27 GMT']
+      Date: ['Thu, 16 Feb 2017 22:38:00 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
@@ -630,8 +629,8 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"name": "myrsmxalt", "type": "mx", "properties": {"TTL": 3600, "MXRecords":
-      [{"exchange": "12", "preference": 13}]}}'
+    body: '{"properties": {"TTL": 3600, "MXRecords": [{"exchange": "12", "preference":
+      13}]}, "type": "mx", "name": "myrsmxalt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -641,17 +640,17 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b3ead04c-f482-11e6-b37c-a0b3ccf7272a]
+      x-ms-client-request-id: [9244610a-f498-11e6-9431-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmxalt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmxalt","name":"myrsmxalt","type":"Microsoft.Network\/dnszones\/MX","etag":"5ef72ec1-f2df-46db-a7dd-bddf50ac955d","properties":{"fqdn":"myrsmxalt.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmxalt","name":"myrsmxalt","type":"Microsoft.Network\/dnszones\/MX","etag":"abb6c9dd-42c5-41d5-9d90-402b85100832","properties":{"fqdn":"myrsmxalt.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['376']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:28 GMT']
-      ETag: [5ef72ec1-f2df-46db-a7dd-bddf50ac955d]
+      Date: ['Thu, 16 Feb 2017 22:38:00 GMT']
+      ETag: [abb6c9dd-42c5-41d5-9d90-402b85100832]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
@@ -660,7 +659,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 201, message: Created}
 - request:
-    body: '{"name": "myrsns", "type": "NS", "properties": {"TTL": 3600}}'
+    body: '{"properties": {"TTL": 3600}, "type": "ns", "name": "myrsns"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -670,23 +669,23 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b4b36042-f482-11e6-b71b-a0b3ccf7272a]
+      x-ms-client-request-id: [93166aae-f498-11e6-a794-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"5c267d0b-33b7-4b1e-8933-7ead13085bf6","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"fe9e605c-884f-48b9-88b1-439daf254c52","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['334']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:29 GMT']
-      ETag: [5c267d0b-33b7-4b1e-8933-7ead13085bf6]
+      Date: ['Thu, 16 Feb 2017 22:38:02 GMT']
+      ETag: [fe9e605c-884f-48b9-88b1-439daf254c52]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -698,16 +697,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b5619214-f482-11e6-a494-a0b3ccf7272a]
+      x-ms-client-request-id: [93d4b12c-f498-11e6-bf10-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"5c267d0b-33b7-4b1e-8933-7ead13085bf6","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"fe9e605c-884f-48b9-88b1-439daf254c52","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:30 GMT']
-      ETag: [5c267d0b-33b7-4b1e-8933-7ead13085bf6]
+      Date: ['Thu, 16 Feb 2017 22:38:03 GMT']
+      ETag: [fe9e605c-884f-48b9-88b1-439daf254c52]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -718,9 +717,9 @@ interactions:
       content-length: ['334']
     status: {code: 200, message: OK}
 - request:
-    body: '{"etag": "5c267d0b-33b7-4b1e-8933-7ead13085bf6", "name": "myrsns", "type":
-      "Microsoft.Network/dnszones/NS", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns",
-      "properties": {"NSRecords": [{"nsdname": "foobar.com"}], "TTL": 3600}}'
+    body: '{"properties": {"NSRecords": [{"nsdname": "foobar.com"}], "TTL": 3600},
+      "type": "Microsoft.Network/dnszones/NS", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns",
+      "etag": "fe9e605c-884f-48b9-88b1-439daf254c52", "name": "myrsns"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -730,16 +729,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b5af695a-f482-11e6-928c-a0b3ccf7272a]
+      x-ms-client-request-id: [93fdb3fa-f498-11e6-8c1e-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"5f236f16-7ae4-4c76-b037-57a97a8eb1d3","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"e1774943-72fa-4c2d-b8a2-c381216df40f","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:31 GMT']
-      ETag: [5f236f16-7ae4-4c76-b037-57a97a8eb1d3]
+      Date: ['Thu, 16 Feb 2017 22:38:03 GMT']
+      ETag: [e1774943-72fa-4c2d-b8a2-c381216df40f]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -760,7 +759,7 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b676958a-f482-11e6-9760-a0b3ccf7272a]
+      x-ms-client-request-id: [94cfd77e-f498-11e6-8bd1-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsnsalt?api-version=2016-04-01
   response:
@@ -770,7 +769,7 @@ interactions:
       Cache-Control: [private]
       Content-Length: ['173']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:32 GMT']
+      Date: ['Thu, 16 Feb 2017 22:38:09 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
@@ -778,8 +777,8 @@ interactions:
       X-Powered-By: [ASP.NET]
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"name": "myrsnsalt", "type": "ns", "properties": {"NSRecords": [{"nsdname":
-      "foobar.com"}], "TTL": 3600}}'
+    body: '{"properties": {"NSRecords": [{"nsdname": "foobar.com"}], "TTL": 3600},
+      "type": "ns", "name": "myrsnsalt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -789,17 +788,17 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b6bc2074-f482-11e6-b15d-a0b3ccf7272a]
+      x-ms-client-request-id: [97d2e75c-f498-11e6-83e6-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsnsalt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsnsalt","name":"myrsnsalt","type":"Microsoft.Network\/dnszones\/NS","etag":"2189e7b7-8113-4f8c-be41-bdbc8f834484","properties":{"fqdn":"myrsnsalt.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsnsalt","name":"myrsnsalt","type":"Microsoft.Network\/dnszones\/NS","etag":"b170e487-a2a6-4172-961a-604139a6f7e7","properties":{"fqdn":"myrsnsalt.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['367']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:33 GMT']
-      ETag: [2189e7b7-8113-4f8c-be41-bdbc8f834484]
+      Date: ['Thu, 16 Feb 2017 22:38:10 GMT']
+      ETag: [b170e487-a2a6-4172-961a-604139a6f7e7]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
@@ -808,7 +807,7 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 201, message: Created}
 - request:
-    body: '{"name": "myrsptr", "type": "PTR", "properties": {"TTL": 3600}}'
+    body: '{"properties": {"TTL": 3600}, "type": "ptr", "name": "myrsptr"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -818,17 +817,17 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b779e150-f482-11e6-9c77-a0b3ccf7272a]
+      x-ms-client-request-id: [9893451c-f498-11e6-9397-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"dd9b1c7a-d0dc-415f-9796-96fcadd667d2","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"ed47aeda-3653-4c66-b99d-b1a9f8eb5920","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['340']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:34 GMT']
-      ETag: [dd9b1c7a-d0dc-415f-9796-96fcadd667d2]
+      Date: ['Thu, 16 Feb 2017 22:38:12 GMT']
+      ETag: [ed47aeda-3653-4c66-b99d-b1a9f8eb5920]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
@@ -846,16 +845,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b84cf18c-f482-11e6-8b97-a0b3ccf7272a]
+      x-ms-client-request-id: [995c2cc8-f498-11e6-a68e-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"dd9b1c7a-d0dc-415f-9796-96fcadd667d2","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"ed47aeda-3653-4c66-b99d-b1a9f8eb5920","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:35 GMT']
-      ETag: [dd9b1c7a-d0dc-415f-9796-96fcadd667d2]
+      Date: ['Thu, 16 Feb 2017 22:38:12 GMT']
+      ETag: [ed47aeda-3653-4c66-b99d-b1a9f8eb5920]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -867,9 +866,9 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: '{"etag": "dd9b1c7a-d0dc-415f-9796-96fcadd667d2", "name": "myrsptr", "type":
-      "Microsoft.Network/dnszones/PTR", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr",
-      "properties": {"TTL": 3600, "PTRRecords": [{"ptrdname": "foobar.com"}]}}'
+    body: '{"properties": {"PTRRecords": [{"ptrdname": "foobar.com"}], "TTL": 3600},
+      "type": "Microsoft.Network/dnszones/PTR", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr",
+      "etag": "ed47aeda-3653-4c66-b99d-b1a9f8eb5920", "name": "myrsptr"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -879,16 +878,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b894c282-f482-11e6-ad50-a0b3ccf7272a]
+      x-ms-client-request-id: [99a48b6e-f498-11e6-8de0-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"dbf1445b-687a-46d9-b690-508dcc67cf92","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"05f53f84-a98d-416c-b1d8-a06865ab0068","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:36 GMT']
-      ETag: [dbf1445b-687a-46d9-b690-508dcc67cf92]
+      Date: ['Thu, 16 Feb 2017 22:38:13 GMT']
+      ETag: [05f53f84-a98d-416c-b1d8-a06865ab0068]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -897,7 +896,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['365']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -909,7 +908,7 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b94d2602-f482-11e6-9f30-a0b3ccf7272a]
+      x-ms-client-request-id: [9a742b1c-f498-11e6-b9d2-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptralt?api-version=2016-04-01
   response:
@@ -919,7 +918,7 @@ interactions:
       Cache-Control: [private]
       Content-Length: ['174']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:36 GMT']
+      Date: ['Thu, 16 Feb 2017 22:38:14 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
@@ -928,8 +927,8 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"name": "myrsptralt", "type": "ptr", "properties": {"TTL": 3600, "PTRRecords":
-      [{"ptrdname": "foobar.com"}]}}'
+    body: '{"properties": {"PTRRecords": [{"ptrdname": "foobar.com"}], "TTL": 3600},
+      "type": "ptr", "name": "myrsptralt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -939,26 +938,26 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [b9742818-f482-11e6-85a2-a0b3ccf7272a]
+      x-ms-client-request-id: [9abbf148-f498-11e6-a484-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptralt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptralt","name":"myrsptralt","type":"Microsoft.Network\/dnszones\/PTR","etag":"1ef193c3-848e-4167-aba1-adac705382f3","properties":{"fqdn":"myrsptralt.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptralt","name":"myrsptralt","type":"Microsoft.Network\/dnszones\/PTR","etag":"b0e6755b-bada-4396-a94f-e58a3c404f58","properties":{"fqdn":"myrsptralt.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['374']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:37 GMT']
-      ETag: [1ef193c3-848e-4167-aba1-adac705382f3]
+      Date: ['Thu, 16 Feb 2017 22:38:15 GMT']
+      ETag: [b0e6755b-bada-4396-a94f-e58a3c404f58]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 201, message: Created}
 - request:
-    body: '{"name": "myrssrv", "type": "SRV", "properties": {"TTL": 3600}}'
+    body: '{"properties": {"TTL": 3600}, "type": "srv", "name": "myrssrv"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -968,23 +967,23 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ba1adc4c-f482-11e6-9b3a-a0b3ccf7272a]
+      x-ms-client-request-id: [9b78d70a-f498-11e6-919d-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"f21b1a8e-4032-4a85-a3ed-22cffc632cdc","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"729d4a26-b7fe-47bd-add5-6f3240bd8719","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['340']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:38 GMT']
-      ETag: [f21b1a8e-4032-4a85-a3ed-22cffc632cdc]
+      Date: ['Thu, 16 Feb 2017 22:38:16 GMT']
+      ETag: [729d4a26-b7fe-47bd-add5-6f3240bd8719]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -996,16 +995,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [badecd78-f482-11e6-9954-a0b3ccf7272a]
+      x-ms-client-request-id: [9c5b4e98-f498-11e6-bc7a-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"f21b1a8e-4032-4a85-a3ed-22cffc632cdc","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"729d4a26-b7fe-47bd-add5-6f3240bd8719","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:39 GMT']
-      ETag: [f21b1a8e-4032-4a85-a3ed-22cffc632cdc]
+      Date: ['Thu, 16 Feb 2017 22:38:18 GMT']
+      ETag: [729d4a26-b7fe-47bd-add5-6f3240bd8719]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1014,13 +1013,13 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['340']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: '{"etag": "f21b1a8e-4032-4a85-a3ed-22cffc632cdc", "name": "myrssrv", "type":
-      "Microsoft.Network/dnszones/SRV", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv",
-      "properties": {"TTL": 3600, "SRVRecords": [{"port": 1234, "priority": 1, "target":
-      "target.com", "weight": 50}]}}'
+    body: '{"properties": {"TTL": 3600, "SRVRecords": [{"port": 1234, "priority":
+      1, "weight": 50, "target": "target.com"}]}, "type": "Microsoft.Network/dnszones/SRV",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv",
+      "etag": "729d4a26-b7fe-47bd-add5-6f3240bd8719", "name": "myrssrv"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1030,16 +1029,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [bb1f98ec-f482-11e6-92ce-a0b3ccf7272a]
+      x-ms-client-request-id: [9cc442e2-f498-11e6-a66c-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"d068d744-dbdc-4367-b9c5-2c59f76d3a0e","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"e2760f4e-601c-4aad-a2ad-815bd4b75b8b","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:40 GMT']
-      ETag: [d068d744-dbdc-4367-b9c5-2c59f76d3a0e]
+      Date: ['Thu, 16 Feb 2017 22:38:18 GMT']
+      ETag: [e2760f4e-601c-4aad-a2ad-815bd4b75b8b]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1048,7 +1047,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['400']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1060,7 +1059,7 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [bbdccd0c-f482-11e6-898e-a0b3ccf7272a]
+      x-ms-client-request-id: [9d9e8f18-f498-11e6-9c1b-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrvalt?api-version=2016-04-01
   response:
@@ -1070,7 +1069,7 @@ interactions:
       Cache-Control: [private]
       Content-Length: ['174']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:41 GMT']
+      Date: ['Thu, 16 Feb 2017 22:38:19 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
@@ -1079,8 +1078,8 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"name": "myrssrvalt", "type": "srv", "properties": {"TTL": 3600, "SRVRecords":
-      [{"port": 1234, "priority": 1, "target": "target.com", "weight": 50}]}}'
+    body: '{"properties": {"TTL": 3600, "SRVRecords": [{"port": 1234, "priority":
+      1, "weight": 50, "target": "target.com"}]}, "type": "srv", "name": "myrssrvalt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1090,26 +1089,26 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [bc1e6b90-f482-11e6-9799-a0b3ccf7272a]
+      x-ms-client-request-id: [9e0a2e54-f498-11e6-bc5c-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrvalt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrvalt","name":"myrssrvalt","type":"Microsoft.Network\/dnszones\/SRV","etag":"89c8cb7a-8185-4001-89d3-dbd906db28b2","properties":{"fqdn":"myrssrvalt.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrvalt","name":"myrssrvalt","type":"Microsoft.Network\/dnszones\/SRV","etag":"dc74cba5-3626-40c6-815b-a6321e6439a7","properties":{"fqdn":"myrssrvalt.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['409']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:41 GMT']
-      ETag: [89c8cb7a-8185-4001-89d3-dbd906db28b2]
+      Date: ['Thu, 16 Feb 2017 22:38:20 GMT']
+      ETag: [dc74cba5-3626-40c6-815b-a6321e6439a7]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 201, message: Created}
 - request:
-    body: '{"name": "myrstxt", "type": "TXT", "properties": {"TTL": 3600}}'
+    body: '{"properties": {"TTL": 3600}, "type": "txt", "name": "myrstxt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1119,23 +1118,23 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [bcd7f718-f482-11e6-8e82-a0b3ccf7272a]
+      x-ms-client-request-id: [9f1113dc-f498-11e6-bc97-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"db03f812-fad8-46f0-bae2-b0063b65fb2a","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"a396d329-6448-45c4-a629-ecbd7cfeef12","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['340']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:43 GMT']
-      ETag: [db03f812-fad8-46f0-bae2-b0063b65fb2a]
+      Date: ['Thu, 16 Feb 2017 22:38:23 GMT']
+      ETag: [a396d329-6448-45c4-a629-ecbd7cfeef12]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -1147,16 +1146,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [bd85f786-f482-11e6-94be-a0b3ccf7272a]
+      x-ms-client-request-id: [a090ae06-f498-11e6-952f-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"db03f812-fad8-46f0-bae2-b0063b65fb2a","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"a396d329-6448-45c4-a629-ecbd7cfeef12","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:44 GMT']
-      ETag: [db03f812-fad8-46f0-bae2-b0063b65fb2a]
+      Date: ['Thu, 16 Feb 2017 22:38:24 GMT']
+      ETag: [a396d329-6448-45c4-a629-ecbd7cfeef12]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1165,12 +1164,12 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['340']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: '{"etag": "db03f812-fad8-46f0-bae2-b0063b65fb2a", "name": "myrstxt", "type":
-      "Microsoft.Network/dnszones/TXT", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt",
-      "properties": {"TTL": 3600, "TXTRecords": [{"value": ["some_text"]}]}}'
+    body: '{"properties": {"TTL": 3600, "TXTRecords": [{"value": ["some_text"]}]},
+      "type": "Microsoft.Network/dnszones/TXT", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt",
+      "etag": "a396d329-6448-45c4-a629-ecbd7cfeef12", "name": "myrstxt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1180,16 +1179,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [bdc49522-f482-11e6-b800-a0b3ccf7272a]
+      x-ms-client-request-id: [a0dd20ec-f498-11e6-9805-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"13d16c46-68f3-4f5f-8f55-de9a2d5ea7b7","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"fd71221b-1134-4a6b-877f-b6b0b0c12f4c","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:45 GMT']
-      ETag: [13d16c46-68f3-4f5f-8f55-de9a2d5ea7b7]
+      Date: ['Thu, 16 Feb 2017 22:38:25 GMT']
+      ETag: [fd71221b-1134-4a6b-877f-b6b0b0c12f4c]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1198,7 +1197,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['363']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1210,7 +1209,7 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [be7873f4-f482-11e6-961f-a0b3ccf7272a]
+      x-ms-client-request-id: [a1b26f80-f498-11e6-8301-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxtalt?api-version=2016-04-01
   response:
@@ -1220,17 +1219,17 @@ interactions:
       Cache-Control: [private]
       Content-Length: ['174']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:46 GMT']
+      Date: ['Thu, 16 Feb 2017 22:38:26 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"name": "myrstxtalt", "type": "txt", "properties": {"TTL": 3600, "TXTRecords":
-      [{"value": ["some_text"]}]}}'
+    body: '{"properties": {"TTL": 3600, "TXTRecords": [{"value": ["some_text"]}]},
+      "type": "txt", "name": "myrstxtalt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1240,17 +1239,17 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [beb73226-f482-11e6-b89d-a0b3ccf7272a]
+      x-ms-client-request-id: [a1f31066-f498-11e6-a37d-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxtalt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxtalt","name":"myrstxtalt","type":"Microsoft.Network\/dnszones\/TXT","etag":"65de52a1-1242-4d86-81fd-10e1bafe5b45","properties":{"fqdn":"myrstxtalt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxtalt","name":"myrstxtalt","type":"Microsoft.Network\/dnszones\/TXT","etag":"b748c7bc-384a-48d0-a23a-cbc63a5cd148","properties":{"fqdn":"myrstxtalt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['372']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:46 GMT']
-      ETag: [65de52a1-1242-4d86-81fd-10e1bafe5b45]
+      Date: ['Thu, 16 Feb 2017 22:38:27 GMT']
+      ETag: [b748c7bc-384a-48d0-a23a-cbc63a5cd148]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
@@ -1268,16 +1267,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [bf7e19ac-f482-11e6-ac0f-a0b3ccf7272a]
+      x-ms-client-request-id: [a2ca8148-f498-11e6-8379-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"17019ad8-4c28-4107-92e0-fcfbd198a66b","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"48ca7c67-4f9c-4e81-8574-57271cbc8fe6","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:47 GMT']
-      ETag: [17019ad8-4c28-4107-92e0-fcfbd198a66b]
+      Date: ['Thu, 16 Feb 2017 22:38:28 GMT']
+      ETag: [48ca7c67-4f9c-4e81-8574-57271cbc8fe6]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1286,13 +1285,12 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['355']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 200, message: OK}
 - request:
-    body: '{"etag": "17019ad8-4c28-4107-92e0-fcfbd198a66b", "name": "myrsa", "type":
-      "Microsoft.Network/dnszones/A", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa",
-      "properties": {"ARecords": [{"ipv4Address": "10.0.0.10"}, {"ipv4Address": "10.0.0.11"}],
-      "TTL": 3600}}'
+    body: '{"properties": {"ARecords": [{"ipv4Address": "10.0.0.10"}, {"ipv4Address":
+      "10.0.0.11"}], "TTL": 3600}, "type": "Microsoft.Network/dnszones/A", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa",
+      "etag": "48ca7c67-4f9c-4e81-8574-57271cbc8fe6", "name": "myrsa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1302,16 +1300,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [bfbb0798-f482-11e6-8ac9-a0b3ccf7272a]
+      x-ms-client-request-id: [a30e4362-f498-11e6-b778-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"829ef375-c9da-43f6-9624-5c6981c715c8","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"8b5467df-7ef5-4572-93d7-f70fbed78754","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:48 GMT']
-      ETag: [829ef375-c9da-43f6-9624-5c6981c715c8]
+      Date: ['Thu, 16 Feb 2017 22:38:28 GMT']
+      ETag: [8b5467df-7ef5-4572-93d7-f70fbed78754]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1320,7 +1318,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['383']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1332,16 +1330,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c08dad66-f482-11e6-8193-a0b3ccf7272a]
+      x-ms-client-request-id: [a3ee47ec-f498-11e6-be8e-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SOA/@?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"60f0a9ca-05e9-4d2c-91e6-68a9556d4e2f","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"azuredns-hostmaster.microsoft.com","expireTime":2419200,"host":"ns1-01.azure-dns.com.","minimumTTL":300,"refreshTime":3600,"retryTime":300,"serialNumber":1}}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"6dfda12b-ea56-4b83-bd52-1737b5490ed3","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"azuredns-hostmaster.microsoft.com","expireTime":2419200,"host":"ns1-04.azure-dns.com.","minimumTTL":300,"refreshTime":3600,"retryTime":300,"serialNumber":1}}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:49 GMT']
-      ETag: [60f0a9ca-05e9-4d2c-91e6-68a9556d4e2f]
+      Date: ['Thu, 16 Feb 2017 22:38:29 GMT']
+      ETag: [6dfda12b-ea56-4b83-bd52-1737b5490ed3]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1361,16 +1359,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c0cf8934-f482-11e6-a669-a0b3ccf7272a]
+      x-ms-client-request-id: [a41927cc-f498-11e6-8fb9-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SOA/@?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"60f0a9ca-05e9-4d2c-91e6-68a9556d4e2f","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"azuredns-hostmaster.microsoft.com","expireTime":2419200,"host":"ns1-01.azure-dns.com.","minimumTTL":300,"refreshTime":3600,"retryTime":300,"serialNumber":1}}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"6dfda12b-ea56-4b83-bd52-1737b5490ed3","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"azuredns-hostmaster.microsoft.com","expireTime":2419200,"host":"ns1-04.azure-dns.com.","minimumTTL":300,"refreshTime":3600,"retryTime":300,"serialNumber":1}}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:50 GMT']
-      ETag: [60f0a9ca-05e9-4d2c-91e6-68a9556d4e2f]
+      Date: ['Thu, 16 Feb 2017 22:38:30 GMT']
+      ETag: [6dfda12b-ea56-4b83-bd52-1737b5490ed3]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1381,11 +1379,10 @@ interactions:
       content-length: ['483']
     status: {code: 200, message: OK}
 - request:
-    body: '{"etag": "60f0a9ca-05e9-4d2c-91e6-68a9556d4e2f", "name": "@", "type": "Microsoft.Network/dnszones/SOA",
-      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SOA/@",
-      "properties": {"TTL": 3600, "SOARecord": {"host": "ns1-01.azure-dns.com.", "minimumTTL":
-      20, "serialNumber": 123, "refreshTime": 60, "retryTime": 90, "expireTime": 30,
-      "email": "foo.com"}}}'
+    body: '{"properties": {"SOARecord": {"expireTime": 30, "refreshTime": 60, "minimumTTL":
+      20, "host": "ns1-04.azure-dns.com.", "retryTime": 90, "serialNumber": 123, "email":
+      "foo.com"}, "TTL": 3600}, "type": "Microsoft.Network/dnszones/SOA", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SOA/@",
+      "etag": "6dfda12b-ea56-4b83-bd52-1737b5490ed3", "name": "@"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1395,16 +1392,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c0f7f09e-f482-11e6-b326-a0b3ccf7272a]
+      x-ms-client-request-id: [a44610a4-f498-11e6-899b-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SOA/@?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"32bfcc94-4e2d-498b-a3b6-7065bfcd846f","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"foo.com","expireTime":30,"host":"ns1-01.azure-dns.com.","minimumTTL":20,"refreshTime":60,"retryTime":90,"serialNumber":123}}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"fb5a847a-980f-4d86-89aa-6234791b3416","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"foo.com","expireTime":30,"host":"ns1-04.azure-dns.com.","minimumTTL":20,"refreshTime":60,"retryTime":90,"serialNumber":123}}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:50 GMT']
-      ETag: [32bfcc94-4e2d-498b-a3b6-7065bfcd846f]
+      Date: ['Thu, 16 Feb 2017 22:38:31 GMT']
+      ETag: [fb5a847a-980f-4d86-89aa-6234791b3416]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1413,7 +1410,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['450']
-      x-ms-ratelimit-remaining-subscription-writes: ['1197']
+      x-ms-ratelimit-remaining-subscription-writes: ['1198']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1425,7 +1422,7 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c18e1f22-f482-11e6-b57c-a0b3ccf7272a]
+      x-ms-client-request-id: [a4e9439c-f498-11e6-8a1e-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/longtxt?api-version=2016-04-01
   response:
@@ -1435,18 +1432,18 @@ interactions:
       Cache-Control: [private]
       Content-Length: ['171']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:51 GMT']
+      Date: ['Thu, 16 Feb 2017 22:38:32 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 404, message: Not Found}
 - request:
-    body: '{"name": "longtxt", "type": "txt", "properties": {"TTL": 3600, "TXTRecords":
-      [{"value": ["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234",
-      "56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]}}'
+    body: '{"properties": {"TTL": 3600, "TXTRecords": [{"value": ["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234",
+      "56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]},
+      "type": "txt", "name": "longtxt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1456,23 +1453,23 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c1cbbcfa-f482-11e6-a0e5-a0b3ccf7272a]
+      x-ms-client-request-id: [a5cace94-f498-11e6-ad58-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/longtxt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"e4d436ad-9883-4875-a86b-a7a7d1196ade","properties":{"fqdn":"longtxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"1e4c14a0-626f-440a-8913-46ebe815a22e","properties":{"fqdn":"longtxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]}}'}
     headers:
       Cache-Control: [private]
       Content-Length: ['857']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:51 GMT']
-      ETag: [e4d436ad-9883-4875-a86b-a7a7d1196ade]
+      Date: ['Thu, 16 Feb 2017 22:38:33 GMT']
+      ETag: [1e4c14a0-626f-440a-8913-46ebe815a22e]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 201, message: Created}
 - request:
     body: null
@@ -1484,16 +1481,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c28da0f8-f482-11e6-9b10-a0b3ccf7272a]
+      x-ms-client-request-id: [a6a7df98-f498-11e6-b273-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-f415-d5678f88d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-01.azure-dns.com.","ns2-01.azure-dns.net.","ns3-01.azure-dns.org.","ns4-01.azure-dns.info."],"numberOfRecordSets":19}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com","name":"myzone.com","type":"Microsoft.Network\/dnszones","etag":"00000002-0000-0000-364a-ed42a588d201","location":"global","tags":{},"properties":{"maxNumberOfRecordSets":5000,"nameServers":["ns1-04.azure-dns.com.","ns2-04.azure-dns.net.","ns3-04.azure-dns.org.","ns4-04.azure-dns.info."],"numberOfRecordSets":19}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:52 GMT']
-      ETag: [00000002-0000-0000-f415-d5678f88d201]
+      Date: ['Thu, 16 Feb 2017 22:38:34 GMT']
+      ETag: [00000002-0000-0000-364a-ed42a588d201]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1514,16 +1511,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c31d8646-f482-11e6-a950-a0b3ccf7272a]
+      x-ms-client-request-id: [a731825e-f498-11e6-97fa-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"829ef375-c9da-43f6-9624-5c6981c715c8","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"8b5467df-7ef5-4572-93d7-f70fbed78754","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:53 GMT']
-      ETag: [829ef375-c9da-43f6-9624-5c6981c715c8]
+      Date: ['Thu, 16 Feb 2017 22:38:35 GMT']
+      ETag: [8b5467df-7ef5-4572-93d7-f70fbed78754]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1544,15 +1541,15 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c3abe874-f482-11e6-ba7f-a0b3ccf7272a]
+      x-ms-client-request-id: [a7b93e82-f498-11e6-9be7-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/recordsets?api-version=2016-04-01
   response:
-    body: {string: '{"value":[{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/@","name":"@","type":"Microsoft.Network\/dnszones\/NS","etag":"c9f3a482-362c-4282-825c-7a9c08312e89","properties":{"fqdn":"myzone.com.","TTL":172800,"NSRecords":[{"nsdname":"ns1-01.azure-dns.com."},{"nsdname":"ns2-01.azure-dns.net."},{"nsdname":"ns3-01.azure-dns.org."},{"nsdname":"ns4-01.azure-dns.info."}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"32bfcc94-4e2d-498b-a3b6-7065bfcd846f","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"foo.com","expireTime":30,"host":"ns1-01.azure-dns.com.","minimumTTL":20,"refreshTime":60,"retryTime":90,"serialNumber":123}}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"e4d436ad-9883-4875-a86b-a7a7d1196ade","properties":{"fqdn":"longtxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"829ef375-c9da-43f6-9624-5c6981c715c8","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"29b84cf4-54ac-45f4-9992-d600337209f2","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaaalt","name":"myrsaaaaalt","type":"Microsoft.Network\/dnszones\/AAAA","etag":"c85fa146-81a7-4393-8df2-fd6e42c84c8c","properties":{"fqdn":"myrsaaaaalt.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsaalt","name":"myrsaalt","type":"Microsoft.Network\/dnszones\/A","etag":"67bbf38b-68d0-4d61-a9fb-461bf157cf3e","properties":{"fqdn":"myrsaalt.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"bca95fc8-060b-45f5-abe4-5d12ecd2856e","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscnamealt","name":"myrscnamealt","type":"Microsoft.Network\/dnszones\/CNAME","etag":"9af59adb-5b8b-40e5-ae0d-5fde6f2aec12","properties":{"fqdn":"myrscnamealt.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"ab979abd-f398-463f-92cd-0da2b2b40918","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmxalt","name":"myrsmxalt","type":"Microsoft.Network\/dnszones\/MX","etag":"5ef72ec1-f2df-46db-a7dd-bddf50ac955d","properties":{"fqdn":"myrsmxalt.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"5f236f16-7ae4-4c76-b037-57a97a8eb1d3","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsnsalt","name":"myrsnsalt","type":"Microsoft.Network\/dnszones\/NS","etag":"2189e7b7-8113-4f8c-be41-bdbc8f834484","properties":{"fqdn":"myrsnsalt.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"dbf1445b-687a-46d9-b690-508dcc67cf92","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptralt","name":"myrsptralt","type":"Microsoft.Network\/dnszones\/PTR","etag":"1ef193c3-848e-4167-aba1-adac705382f3","properties":{"fqdn":"myrsptralt.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"d068d744-dbdc-4367-b9c5-2c59f76d3a0e","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrvalt","name":"myrssrvalt","type":"Microsoft.Network\/dnszones\/SRV","etag":"89c8cb7a-8185-4001-89d3-dbd906db28b2","properties":{"fqdn":"myrssrvalt.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"13d16c46-68f3-4f5f-8f55-de9a2d5ea7b7","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxtalt","name":"myrstxtalt","type":"Microsoft.Network\/dnszones\/TXT","etag":"65de52a1-1242-4d86-81fd-10e1bafe5b45","properties":{"fqdn":"myrstxtalt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}]}'}
+    body: {string: '{"value":[{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/@","name":"@","type":"Microsoft.Network\/dnszones\/NS","etag":"457f44cd-0da1-4b56-94da-01fe1211ec7b","properties":{"fqdn":"myzone.com.","TTL":172800,"NSRecords":[{"nsdname":"ns1-04.azure-dns.com."},{"nsdname":"ns2-04.azure-dns.net."},{"nsdname":"ns3-04.azure-dns.org."},{"nsdname":"ns4-04.azure-dns.info."}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SOA\/@","name":"@","type":"Microsoft.Network\/dnszones\/SOA","etag":"fb5a847a-980f-4d86-89aa-6234791b3416","properties":{"fqdn":"myzone.com.","TTL":3600,"SOARecord":{"email":"foo.com","expireTime":30,"host":"ns1-04.azure-dns.com.","minimumTTL":20,"refreshTime":60,"retryTime":90,"serialNumber":123}}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"1e4c14a0-626f-440a-8913-46ebe815a22e","properties":{"fqdn":"longtxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"8b5467df-7ef5-4572-93d7-f70fbed78754","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"188f3b1d-e078-489d-8be5-f086455251d6","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaaalt","name":"myrsaaaaalt","type":"Microsoft.Network\/dnszones\/AAAA","etag":"bb4af783-4e50-4789-a221-6d9720fb7906","properties":{"fqdn":"myrsaaaaalt.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsaalt","name":"myrsaalt","type":"Microsoft.Network\/dnszones\/A","etag":"7b98d8ff-b2ec-4bf8-a55a-95474ed026f9","properties":{"fqdn":"myrsaalt.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"d3ca537b-0e21-42fd-9aeb-5e6f69437c3d","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscnamealt","name":"myrscnamealt","type":"Microsoft.Network\/dnszones\/CNAME","etag":"22477145-0695-49fd-bedf-5e7c814fe6e4","properties":{"fqdn":"myrscnamealt.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"c7a5da5c-a17a-4759-8fc6-bc182a17a254","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmxalt","name":"myrsmxalt","type":"Microsoft.Network\/dnszones\/MX","etag":"abb6c9dd-42c5-41d5-9d90-402b85100832","properties":{"fqdn":"myrsmxalt.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"e1774943-72fa-4c2d-b8a2-c381216df40f","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsnsalt","name":"myrsnsalt","type":"Microsoft.Network\/dnszones\/NS","etag":"b170e487-a2a6-4172-961a-604139a6f7e7","properties":{"fqdn":"myrsnsalt.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"05f53f84-a98d-416c-b1d8-a06865ab0068","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptralt","name":"myrsptralt","type":"Microsoft.Network\/dnszones\/PTR","etag":"b0e6755b-bada-4396-a94f-e58a3c404f58","properties":{"fqdn":"myrsptralt.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"e2760f4e-601c-4aad-a2ad-815bd4b75b8b","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrvalt","name":"myrssrvalt","type":"Microsoft.Network\/dnszones\/SRV","etag":"dc74cba5-3626-40c6-815b-a6321e6439a7","properties":{"fqdn":"myrssrvalt.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"fd71221b-1134-4a6b-877f-b6b0b0c12f4c","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxtalt","name":"myrstxtalt","type":"Microsoft.Network\/dnszones\/TXT","etag":"b748c7bc-384a-48d0-a23a-cbc63a5cd148","properties":{"fqdn":"myrstxtalt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}]}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:54 GMT']
+      Date: ['Thu, 16 Feb 2017 22:38:36 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1572,15 +1569,15 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c4481d3e-f482-11e6-b6c5-a0b3ccf7272a]
+      x-ms-client-request-id: [a852d2b4-f498-11e6-af46-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT?api-version=2016-04-01
   response:
-    body: {string: '{"value":[{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"e4d436ad-9883-4875-a86b-a7a7d1196ade","properties":{"fqdn":"longtxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"13d16c46-68f3-4f5f-8f55-de9a2d5ea7b7","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxtalt","name":"myrstxtalt","type":"Microsoft.Network\/dnszones\/TXT","etag":"65de52a1-1242-4d86-81fd-10e1bafe5b45","properties":{"fqdn":"myrstxtalt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}]}'}
+    body: {string: '{"value":[{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/longtxt","name":"longtxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"1e4c14a0-626f-440a-8913-46ebe815a22e","properties":{"fqdn":"longtxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234","56789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"fd71221b-1134-4a6b-877f-b6b0b0c12f4c","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}},{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxtalt","name":"myrstxtalt","type":"Microsoft.Network\/dnszones\/TXT","etag":"b748c7bc-384a-48d0-a23a-cbc63a5cd148","properties":{"fqdn":"myrstxtalt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}]}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:55 GMT']
+      Date: ['Thu, 16 Feb 2017 22:38:37 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1589,7 +1586,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['1606']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1601,16 +1598,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c4cc1164-f482-11e6-a210-a0b3ccf7272a]
+      x-ms-client-request-id: [a8d6de0a-f498-11e6-8ba6-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"829ef375-c9da-43f6-9624-5c6981c715c8","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"8b5467df-7ef5-4572-93d7-f70fbed78754","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.10"},{"ipv4Address":"10.0.0.11"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:56 GMT']
-      ETag: [829ef375-c9da-43f6-9624-5c6981c715c8]
+      Date: ['Thu, 16 Feb 2017 22:38:39 GMT']
+      ETag: [8b5467df-7ef5-4572-93d7-f70fbed78754]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1619,12 +1616,12 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['383']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: '{"etag": "829ef375-c9da-43f6-9624-5c6981c715c8", "name": "myrsa", "type":
-      "Microsoft.Network/dnszones/A", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa",
-      "properties": {"ARecords": [{"ipv4Address": "10.0.0.11"}], "TTL": 3600}}'
+    body: '{"properties": {"ARecords": [{"ipv4Address": "10.0.0.11"}], "TTL": 3600},
+      "type": "Microsoft.Network/dnszones/A", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa",
+      "etag": "8b5467df-7ef5-4572-93d7-f70fbed78754", "name": "myrsa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1634,16 +1631,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c4f32fa2-f482-11e6-afef-a0b3ccf7272a]
+      x-ms-client-request-id: [a91ff054-f498-11e6-8a71-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"916e1019-722a-4541-a2a3-b375a1028afd","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"bad3346f-63a8-41d9-a4b3-b241bd0ba609","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:56 GMT']
-      ETag: [916e1019-722a-4541-a2a3-b375a1028afd]
+      Date: ['Thu, 16 Feb 2017 22:38:38 GMT']
+      ETag: [bad3346f-63a8-41d9-a4b3-b241bd0ba609]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1664,16 +1661,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c58b0940-f482-11e6-9416-a0b3ccf7272a]
+      x-ms-client-request-id: [a9c22282-f498-11e6-8957-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"29b84cf4-54ac-45f4-9992-d600337209f2","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"188f3b1d-e078-489d-8be5-f086455251d6","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[{"ipv6Address":"2001:db8:0:1:1:1:1:1"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:57 GMT']
-      ETag: [29b84cf4-54ac-45f4-9992-d600337209f2]
+      Date: ['Thu, 16 Feb 2017 22:38:39 GMT']
+      ETag: [188f3b1d-e078-489d-8be5-f086455251d6]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1682,12 +1679,12 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['384']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: '{"etag": "29b84cf4-54ac-45f4-9992-d600337209f2", "name": "myrsaaaa", "type":
-      "Microsoft.Network/dnszones/AAAA", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa",
-      "properties": {"AAAARecords": [], "TTL": 3600}}'
+    body: '{"properties": {"TTL": 3600, "AAAARecords": []}, "type": "Microsoft.Network/dnszones/AAAA",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa",
+      "etag": "188f3b1d-e078-489d-8be5-f086455251d6", "name": "myrsaaaa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1697,16 +1694,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c5d0bc4a-f482-11e6-ba69-a0b3ccf7272a]
+      x-ms-client-request-id: [aa09bf6e-f498-11e6-96df-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/AAAA/myrsaaaa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"391195d6-68e3-4f4c-89c5-189649c05c24","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/AAAA\/myrsaaaa","name":"myrsaaaa","type":"Microsoft.Network\/dnszones\/AAAA","etag":"fb8e0b40-dca8-48d3-ae11-93a0a976be8e","properties":{"fqdn":"myrsaaaa.myzone.com.","TTL":3600,"AAAARecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:58 GMT']
-      ETag: [391195d6-68e3-4f4c-89c5-189649c05c24]
+      Date: ['Thu, 16 Feb 2017 22:38:40 GMT']
+      ETag: [fb8e0b40-dca8-48d3-ae11-93a0a976be8e]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1715,7 +1712,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['346']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1727,16 +1724,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c684b40a-f482-11e6-9263-a0b3ccf7272a]
+      x-ms-client-request-id: [aac7b2a2-f498-11e6-b0a7-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"bca95fc8-060b-45f5-abe4-5d12ecd2856e","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"d3ca537b-0e21-42fd-9aeb-5e6f69437c3d","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600,"CNAMERecord":{"cname":"mycname"}}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:59 GMT']
-      ETag: [bca95fc8-060b-45f5-abe4-5d12ecd2856e]
+      Date: ['Thu, 16 Feb 2017 22:38:41 GMT']
+      ETag: [d3ca537b-0e21-42fd-9aeb-5e6f69437c3d]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1748,9 +1745,9 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 200, message: OK}
 - request:
-    body: '{"etag": "bca95fc8-060b-45f5-abe4-5d12ecd2856e", "name": "myrscname", "type":
-      "Microsoft.Network/dnszones/CNAME", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname",
-      "properties": {"TTL": 3600}}'
+    body: '{"properties": {"TTL": 3600}, "type": "Microsoft.Network/dnszones/CNAME",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname",
+      "etag": "d3ca537b-0e21-42fd-9aeb-5e6f69437c3d", "name": "myrscname"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1760,16 +1757,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c6a531e2-f482-11e6-839e-a0b3ccf7272a]
+      x-ms-client-request-id: [aaeebd7a-f498-11e6-94d1-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/CNAME/myrscname?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"f21de5fb-1760-49c0-9fd0-9006ca15b9e4","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/CNAME\/myrscname","name":"myrscname","type":"Microsoft.Network\/dnszones\/CNAME","etag":"c1ee49dd-f0d8-4908-8ac6-9ae637127e25","properties":{"fqdn":"myrscname.myzone.com.","TTL":3600}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:01:59 GMT']
-      ETag: [f21de5fb-1760-49c0-9fd0-9006ca15b9e4]
+      Date: ['Thu, 16 Feb 2017 22:38:42 GMT']
+      ETag: [c1ee49dd-f0d8-4908-8ac6-9ae637127e25]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1778,7 +1775,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['334']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1790,16 +1787,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c754d706-f482-11e6-bef1-a0b3ccf7272a]
+      x-ms-client-request-id: [abba4674-f498-11e6-9fce-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"ab979abd-f398-463f-92cd-0da2b2b40918","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"c7a5da5c-a17a-4759-8fc6-bc182a17a254","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[{"exchange":"12","preference":13}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:02:00 GMT']
-      ETag: [ab979abd-f398-463f-92cd-0da2b2b40918]
+      Date: ['Thu, 16 Feb 2017 22:38:43 GMT']
+      ETag: [c7a5da5c-a17a-4759-8fc6-bc182a17a254]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1808,12 +1805,12 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['367']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: '{"etag": "ab979abd-f398-463f-92cd-0da2b2b40918", "name": "myrsmx", "type":
-      "Microsoft.Network/dnszones/MX", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx",
-      "properties": {"TTL": 3600, "MXRecords": []}}'
+    body: '{"properties": {"TTL": 3600, "MXRecords": []}, "type": "Microsoft.Network/dnszones/MX",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx",
+      "etag": "c7a5da5c-a17a-4759-8fc6-bc182a17a254", "name": "myrsmx"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1823,16 +1820,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c79ed110-f482-11e6-aef4-a0b3ccf7272a]
+      x-ms-client-request-id: [abe02a5c-f498-11e6-a204-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/MX/myrsmx?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"986608d6-1ea0-4427-8a44-4d1e9e5f7fe5","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/MX\/myrsmx","name":"myrsmx","type":"Microsoft.Network\/dnszones\/MX","etag":"929a2d35-ed5a-472e-9f99-cc57bccc1d5b","properties":{"fqdn":"myrsmx.myzone.com.","TTL":3600,"MXRecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:02:01 GMT']
-      ETag: [986608d6-1ea0-4427-8a44-4d1e9e5f7fe5]
+      Date: ['Thu, 16 Feb 2017 22:38:43 GMT']
+      ETag: [929a2d35-ed5a-472e-9f99-cc57bccc1d5b]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1841,7 +1838,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['334']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11997']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1853,16 +1850,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c858314c-f482-11e6-8503-a0b3ccf7272a]
+      x-ms-client-request-id: [ac91006e-f498-11e6-b854-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"5f236f16-7ae4-4c76-b037-57a97a8eb1d3","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"e1774943-72fa-4c2d-b8a2-c381216df40f","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[{"nsdname":"foobar.com"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:02:01 GMT']
-      ETag: [5f236f16-7ae4-4c76-b037-57a97a8eb1d3]
+      Date: ['Thu, 16 Feb 2017 22:38:45 GMT']
+      ETag: [e1774943-72fa-4c2d-b8a2-c381216df40f]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1873,9 +1870,9 @@ interactions:
       content-length: ['358']
     status: {code: 200, message: OK}
 - request:
-    body: '{"etag": "5f236f16-7ae4-4c76-b037-57a97a8eb1d3", "name": "myrsns", "type":
-      "Microsoft.Network/dnszones/NS", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns",
-      "properties": {"NSRecords": [], "TTL": 3600}}'
+    body: '{"properties": {"NSRecords": [], "TTL": 3600}, "type": "Microsoft.Network/dnszones/NS",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns",
+      "etag": "e1774943-72fa-4c2d-b8a2-c381216df40f", "name": "myrsns"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1885,16 +1882,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c87f16a2-f482-11e6-878e-a0b3ccf7272a]
+      x-ms-client-request-id: [acba5c2c-f498-11e6-9ff3-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/NS/myrsns?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"84698dc9-cc45-4249-8cb8-62d5b5ec6392","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/NS\/myrsns","name":"myrsns","type":"Microsoft.Network\/dnszones\/NS","etag":"6e36bc0f-8c91-4089-bef6-013019bf1425","properties":{"fqdn":"myrsns.myzone.com.","TTL":3600,"NSRecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:02:02 GMT']
-      ETag: [84698dc9-cc45-4249-8cb8-62d5b5ec6392]
+      Date: ['Thu, 16 Feb 2017 22:38:45 GMT']
+      ETag: [6e36bc0f-8c91-4089-bef6-013019bf1425]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1903,7 +1900,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['334']
-      x-ms-ratelimit-remaining-subscription-writes: ['1196']
+      x-ms-ratelimit-remaining-subscription-writes: ['1197']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1915,16 +1912,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c9224926-f482-11e6-b95b-a0b3ccf7272a]
+      x-ms-client-request-id: [ad89ae7a-f498-11e6-82bc-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"dbf1445b-687a-46d9-b690-508dcc67cf92","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"05f53f84-a98d-416c-b1d8-a06865ab0068","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[{"ptrdname":"foobar.com"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:02:04 GMT']
-      ETag: [dbf1445b-687a-46d9-b690-508dcc67cf92]
+      Date: ['Thu, 16 Feb 2017 22:38:46 GMT']
+      ETag: [05f53f84-a98d-416c-b1d8-a06865ab0068]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1936,9 +1933,9 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: '{"etag": "dbf1445b-687a-46d9-b690-508dcc67cf92", "name": "myrsptr", "type":
-      "Microsoft.Network/dnszones/PTR", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr",
-      "properties": {"TTL": 3600, "PTRRecords": []}}'
+    body: '{"properties": {"PTRRecords": [], "TTL": 3600}, "type": "Microsoft.Network/dnszones/PTR",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr",
+      "etag": "05f53f84-a98d-416c-b1d8-a06865ab0068", "name": "myrsptr"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -1948,16 +1945,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [c961c080-f482-11e6-a000-a0b3ccf7272a]
+      x-ms-client-request-id: [add40aba-f498-11e6-b471-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/PTR/myrsptr?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"0c407d70-8863-481c-945a-3bea7700117d","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/PTR\/myrsptr","name":"myrsptr","type":"Microsoft.Network\/dnszones\/PTR","etag":"af69ac14-b26f-4cc2-97b3-4279ef08257a","properties":{"fqdn":"myrsptr.myzone.com.","TTL":3600,"PTRRecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:02:04 GMT']
-      ETag: [0c407d70-8863-481c-945a-3bea7700117d]
+      Date: ['Thu, 16 Feb 2017 22:38:47 GMT']
+      ETag: [af69ac14-b26f-4cc2-97b3-4279ef08257a]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1978,16 +1975,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ca3fb4a8-f482-11e6-a8f9-a0b3ccf7272a]
+      x-ms-client-request-id: [ae9de8dc-f498-11e6-ae84-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"d068d744-dbdc-4367-b9c5-2c59f76d3a0e","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"e2760f4e-601c-4aad-a2ad-815bd4b75b8b","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[{"port":1234,"priority":1,"target":"target.com","weight":50}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:02:05 GMT']
-      ETag: [d068d744-dbdc-4367-b9c5-2c59f76d3a0e]
+      Date: ['Thu, 16 Feb 2017 22:38:47 GMT']
+      ETag: [e2760f4e-601c-4aad-a2ad-815bd4b75b8b]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -1996,12 +1993,12 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['400']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: '{"etag": "d068d744-dbdc-4367-b9c5-2c59f76d3a0e", "name": "myrssrv", "type":
-      "Microsoft.Network/dnszones/SRV", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv",
-      "properties": {"TTL": 3600, "SRVRecords": []}}'
+    body: '{"properties": {"TTL": 3600, "SRVRecords": []}, "type": "Microsoft.Network/dnszones/SRV",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv",
+      "etag": "e2760f4e-601c-4aad-a2ad-815bd4b75b8b", "name": "myrssrv"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -2011,16 +2008,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ca771088-f482-11e6-8209-a0b3ccf7272a]
+      x-ms-client-request-id: [aee63a46-f498-11e6-b582-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/SRV/myrssrv?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"ce4d8fd5-d1c4-4226-b0b1-1b459860fab5","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/SRV\/myrssrv","name":"myrssrv","type":"Microsoft.Network\/dnszones\/SRV","etag":"dabaf73c-9c8d-435b-9e34-2ff1fd00b952","properties":{"fqdn":"myrssrv.myzone.com.","TTL":3600,"SRVRecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:02:06 GMT']
-      ETag: [ce4d8fd5-d1c4-4226-b0b1-1b459860fab5]
+      Date: ['Thu, 16 Feb 2017 22:38:48 GMT']
+      ETag: [dabaf73c-9c8d-435b-9e34-2ff1fd00b952]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -2029,7 +2026,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['340']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2041,16 +2038,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [cb4caf6e-f482-11e6-9fa9-a0b3ccf7272a]
+      x-ms-client-request-id: [afb3c04c-f498-11e6-bc01-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"13d16c46-68f3-4f5f-8f55-de9a2d5ea7b7","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"fd71221b-1134-4a6b-877f-b6b0b0c12f4c","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[{"value":["some_text"]}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:02:07 GMT']
-      ETag: [13d16c46-68f3-4f5f-8f55-de9a2d5ea7b7]
+      Date: ['Thu, 16 Feb 2017 22:38:49 GMT']
+      ETag: [fd71221b-1134-4a6b-877f-b6b0b0c12f4c]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -2062,9 +2059,9 @@ interactions:
       x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
     status: {code: 200, message: OK}
 - request:
-    body: '{"etag": "13d16c46-68f3-4f5f-8f55-de9a2d5ea7b7", "name": "myrstxt", "type":
-      "Microsoft.Network/dnszones/TXT", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt",
-      "properties": {"TTL": 3600, "TXTRecords": []}}'
+    body: '{"properties": {"TTL": 3600, "TXTRecords": []}, "type": "Microsoft.Network/dnszones/TXT",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt",
+      "etag": "fd71221b-1134-4a6b-877f-b6b0b0c12f4c", "name": "myrstxt"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -2074,16 +2071,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [cb722aa4-f482-11e6-b15e-a0b3ccf7272a]
+      x-ms-client-request-id: [b0011f52-f498-11e6-b843-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/TXT/myrstxt?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"55528656-3f8a-4b34-b2aa-2f64c07c3a54","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/TXT\/myrstxt","name":"myrstxt","type":"Microsoft.Network\/dnszones\/TXT","etag":"e38648b8-5788-4796-b376-cdebfa14cc66","properties":{"fqdn":"myrstxt.myzone.com.","TTL":3600,"TXTRecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:02:07 GMT']
-      ETag: [55528656-3f8a-4b34-b2aa-2f64c07c3a54]
+      Date: ['Thu, 16 Feb 2017 22:38:50 GMT']
+      ETag: [e38648b8-5788-4796-b376-cdebfa14cc66]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -2104,16 +2101,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [cc1c7662-f482-11e6-b4b2-a0b3ccf7272a]
+      x-ms-client-request-id: [b0ce9d36-f498-11e6-8b63-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"916e1019-722a-4541-a2a3-b375a1028afd","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"bad3346f-63a8-41d9-a4b3-b241bd0ba609","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:02:08 GMT']
-      ETag: [916e1019-722a-4541-a2a3-b375a1028afd]
+      Date: ['Thu, 16 Feb 2017 22:38:51 GMT']
+      ETag: [bad3346f-63a8-41d9-a4b3-b241bd0ba609]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -2134,16 +2131,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ccad22c8-f482-11e6-9b09-a0b3ccf7272a]
+      x-ms-client-request-id: [b159a948-f498-11e6-87d9-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"916e1019-722a-4541-a2a3-b375a1028afd","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"bad3346f-63a8-41d9-a4b3-b241bd0ba609","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[{"ipv4Address":"10.0.0.11"}]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:02:09 GMT']
-      ETag: [916e1019-722a-4541-a2a3-b375a1028afd]
+      Date: ['Thu, 16 Feb 2017 22:38:52 GMT']
+      ETag: [bad3346f-63a8-41d9-a4b3-b241bd0ba609]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -2152,12 +2149,12 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['355']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 200, message: OK}
 - request:
-    body: '{"etag": "916e1019-722a-4541-a2a3-b375a1028afd", "name": "myrsa", "type":
-      "Microsoft.Network/dnszones/A", "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa",
-      "properties": {"ARecords": [], "TTL": 3600}}'
+    body: '{"properties": {"ARecords": [], "TTL": 3600}, "type": "Microsoft.Network/dnszones/A",
+      "id": "/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa",
+      "etag": "bad3346f-63a8-41d9-a4b3-b241bd0ba609", "name": "myrsa"}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
@@ -2167,16 +2164,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ccf31152-f482-11e6-ab51-a0b3ccf7272a]
+      x-ms-client-request-id: [b19ce99c-f498-11e6-839d-a0b3ccf7272a]
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"98ae9678-f4bc-4c75-bba9-06ebe0e9ed26","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"733c8f1a-14e9-43f2-bb84-2ece6ac1c226","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:02:10 GMT']
-      ETag: [98ae9678-f4bc-4c75-bba9-06ebe0e9ed26]
+      Date: ['Thu, 16 Feb 2017 22:38:53 GMT']
+      ETag: [733c8f1a-14e9-43f2-bb84-2ece6ac1c226]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -2185,7 +2182,7 @@ interactions:
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
       content-length: ['328']
-      x-ms-ratelimit-remaining-subscription-resource-requests: ['11999']
+      x-ms-ratelimit-remaining-subscription-resource-requests: ['11998']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -2197,16 +2194,16 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [cdb2eb24-f482-11e6-aad8-a0b3ccf7272a]
+      x-ms-client-request-id: [b260b95a-f498-11e6-8ef5-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
-    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"98ae9678-f4bc-4c75-bba9-06ebe0e9ed26","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
+    body: {string: '{"id":"\/subscriptions\/0b1f6471-1bf0-4dda-aec3-cb9272f09590\/resourceGroups\/cli_test_dns\/providers\/Microsoft.Network\/dnszones\/myzone.com\/A\/myrsa","name":"myrsa","type":"Microsoft.Network\/dnszones\/A","etag":"733c8f1a-14e9-43f2-bb84-2ece6ac1c226","properties":{"fqdn":"myrsa.myzone.com.","TTL":3600,"ARecords":[]}}'}
     headers:
       Cache-Control: [private]
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:02:11 GMT']
-      ETag: [98ae9678-f4bc-4c75-bba9-06ebe0e9ed26]
+      Date: ['Thu, 16 Feb 2017 22:38:54 GMT']
+      ETag: [733c8f1a-14e9-43f2-bb84-2ece6ac1c226]
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Transfer-Encoding: [chunked]
@@ -2228,7 +2225,7 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [ce253ab6-f482-11e6-ae40-a0b3ccf7272a]
+      x-ms-client-request-id: [b2e6b4d4-f498-11e6-9ab6-a0b3ccf7272a]
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
@@ -2236,7 +2233,7 @@ interactions:
     headers:
       Cache-Control: [private]
       Content-Length: ['0']
-      Date: ['Thu, 16 Feb 2017 20:02:12 GMT']
+      Date: ['Thu, 16 Feb 2017 22:38:56 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]
@@ -2254,7 +2251,7 @@ interactions:
       User-Agent: [python/3.5.1 (Windows-10-10.0.14393-SP0) requests/2.9.1 msrest/0.4.4
           msrest_azure/0.4.7 dnsmanagementclient/0.30.0rc6 Azure-SDK-For-Python AZURECLI/TEST/0.1.1b3+dev]
       accept-language: [en-US]
-      x-ms-client-request-id: [cefc93da-f482-11e6-82c1-a0b3ccf7272a]
+      x-ms-client-request-id: [b3b7eec2-f498-11e6-a480-a0b3ccf7272a]
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_dns/providers/Microsoft.Network/dnszones/myzone.com/A/myrsa?api-version=2016-04-01
   response:
@@ -2264,7 +2261,7 @@ interactions:
       Cache-Control: [private]
       Content-Length: ['169']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 16 Feb 2017 20:02:13 GMT']
+      Date: ['Thu, 16 Feb 2017 22:38:56 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       X-AspNet-Version: [4.0.30319]

--- a/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/test_network_commands.py
+++ b/src/command_modules/azure-cli-network/azure/cli/command_modules/network/tests/test_network_commands.py
@@ -1177,7 +1177,7 @@ class NetworkTrafficManagerScenarioTest(ResourceGroupVCRTestBase):
 class NetworkDnsScenarioTest(ResourceGroupVCRTestBase):
 
     def __init__(self, test_method):
-        super(NetworkDnsScenarioTest, self).__init__(__file__, test_method, resource_group='cli_test_dns', debug=True)
+        super(NetworkDnsScenarioTest, self).__init__(__file__, test_method, resource_group='cli_test_dns')
 
     def test_network_dns(self):
         self.execute()


### PR DESCRIPTION
Fixes #2087. Fixes #1134.

Restructures the DNS command tree. cc/ @jtuliani

**Breaking Changes**
- The `record` subgroup has been removed.
- A subgroup for each record type has been added to the `record-set` subgroup.
- The add/remove commands that were previously in `record` are now listed in `record-type <type>` as `add-record`/`remove-record`.
- A new command `record-set list` was added that lists all record sets in the zone. This was previously triggered by an optional parameter.
- The show/delete/update/etc. commands for each type of record set no longer require the type parameter. It is determined behind the scenes.
- The `soa` subgroup now has two commands: show and update. Name is no longer required (it is always '@').
- The `add` command for CNAME records has been renamed `set-record` because there can only be one value in a given CNAME record set.
