### PR TITLE
vm image: do not normalize casing on blob uri

### DIFF
--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/_validators.py
@@ -586,15 +586,14 @@ def process_image_create_namespace(namespace):
 
 
 def _figure_out_storage_source(resource_group_name, source):
-    source = source.lower()
     source_blob_uri = None
     source_disk = None
     source_snapshot = None
     if source.lower().endswith('.vhd'):
         source_blob_uri = source
-    elif '/disks/' in source:
+    elif '/disks/' in source.lower():
         source_disk = source
-    elif '/snapshots/' in source:
+    elif '/snapshots/' in source.lower():
         source_snapshot = source
     else:
         compute_client = _compute_client_factory()

--- a/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_actions.py
+++ b/src/command_modules/azure-cli-vm/azure/cli/command_modules/vm/tests/test_vm_actions.py
@@ -11,7 +11,8 @@ import mock
 from azure.cli.core._util import CLIError
 
 from azure.cli.command_modules.vm._validators import (validate_ssh_key,
-                                                      _is_valid_ssh_rsa_public_key)
+                                                      _is_valid_ssh_rsa_public_key,
+                                                      _figure_out_storage_source)
 
 
 class TestActions(unittest.TestCase):
@@ -57,3 +58,10 @@ class TestActions(unittest.TestCase):
         validate_ssh_key(args4)
         self.assertTrue(os.path.isfile(public_key_file4 + '.private'))
         self.assertTrue(os.path.isfile(public_key_file4))
+
+    def test_figure_out_storage_source(self):
+        test_data = 'https://av123images.blob.core.windows.net/images/TDAZBET.vhd'
+        src_blob_uri, src_disk, src_snapshot = _figure_out_storage_source('tg1', test_data)
+        self.assertFalse(src_disk)
+        self.assertFalse(src_snapshot)
+        self.assertEqual(src_blob_uri, test_data)


### PR DESCRIPTION
Reported by an internal customer. It turned out the blob uri is handled in case sensitive manner at server side.